### PR TITLE
[FEAT] 온보딩 1단계 부서 체계 화면 #12

### DIFF
--- a/src/app/(onboarding)/onboarding/1/error.tsx
+++ b/src/app/(onboarding)/onboarding/1/error.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { RotateCw } from "lucide-react";
+import { useEffect } from "react";
+
+import { Button } from "@/components/ui/button";
+
+/** 부서를 불러오지 못했을 때. 조용히 빈 화면을 보여주지 않는다(CLAUDE.md: 정직성). */
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="bg-background flex min-h-dvh flex-col items-center justify-center gap-4 px-6 text-center">
+      <div className="flex flex-col gap-2">
+        <h1 className="text-lg font-semibold tracking-tight">부서를 불러오지 못했어요</h1>
+        <p className="text-muted-foreground text-[13px] leading-[21px]">
+          잠시 후 다시 시도해 주세요. 계속 안 되면 담당자에게 알려주세요.
+        </p>
+      </div>
+      <Button type="button" onClick={reset}>
+        <RotateCw />
+        다시 시도
+      </Button>
+    </div>
+  );
+}

--- a/src/app/(onboarding)/onboarding/1/loading.tsx
+++ b/src/app/(onboarding)/onboarding/1/loading.tsx
@@ -1,0 +1,26 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { OnboardingShell } from "@/features/onboarding/components/onboarding-shell";
+import { ONBOARDING_STEP } from "@/features/onboarding/types";
+
+/** 부서를 불러오는 동안. 실제 화면과 같은 골격을 보여줘서 레이아웃이 흔들리지 않게 한다. */
+export default function Loading() {
+  return (
+    <OnboardingShell step={ONBOARDING_STEP.DEPARTMENT}>
+      <div className="flex flex-col gap-[21px]">
+        <div className="flex flex-col gap-7 lg:h-[560px] lg:flex-row">
+          <div className="flex w-full flex-col gap-[17.5px] lg:w-[300px] lg:shrink-0">
+            <Skeleton className="h-7 w-7 rounded-full" />
+            <Skeleton className="h-6 w-52" />
+            <Skeleton className="h-16 w-full" />
+            <Skeleton className="h-20 w-full" />
+            <Skeleton className="flex-1" />
+          </div>
+          <Skeleton className="h-[440px] flex-1 lg:h-full" />
+        </div>
+        <div className="border-border flex justify-end border-t pt-[17.5px]">
+          <Skeleton className="h-[34px] w-[68px]" />
+        </div>
+      </div>
+    </OnboardingShell>
+  );
+}

--- a/src/app/(onboarding)/onboarding/1/page.tsx
+++ b/src/app/(onboarding)/onboarding/1/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+
+import { DepartmentSetup } from "@/features/onboarding/components/department-setup";
+import { OnboardingShell } from "@/features/onboarding/components/onboarding-shell";
+import { getDepartments } from "@/features/onboarding/server";
+import { ONBOARDING_STEP } from "@/features/onboarding/types";
+
+export const metadata: Metadata = {
+  title: "부서 체계 만들기 — Z",
+};
+
+export default async function OnboardingDepartmentPage() {
+  const departments = await getDepartments();
+
+  return (
+    <OnboardingShell step={ONBOARDING_STEP.DEPARTMENT}>
+      <DepartmentSetup initialDepartments={departments} />
+    </OnboardingShell>
+  );
+}

--- a/src/features/onboarding/components/department-add-row.tsx
+++ b/src/features/onboarding/components/department-add-row.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Plus } from "lucide-react";
+
+import { Input } from "@/components/ui/input";
+
+interface DepartmentAddRowProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+}
+
+/** 카드 하단 — 최상위(상위) 부서 추가 줄. */
+export function DepartmentAddRow({ value, onChange, onSubmit }: DepartmentAddRowProps) {
+  return (
+    <div className="border-border bg-muted flex h-[54px] shrink-0 items-center gap-2 border-t px-4">
+      <label htmlFor="root-department" className="sr-only">
+        상위 부서 이름
+      </label>
+      <Input
+        id="root-department"
+        value={value}
+        placeholder="상위 부서 추가 (Enter)"
+        onChange={(event) => onChange(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            event.preventDefault();
+            onSubmit();
+          }
+        }}
+        className="h-8 flex-1 rounded-md border border-dashed bg-transparent px-2.5 text-[13px]"
+      />
+      <button
+        type="button"
+        onClick={onSubmit}
+        className="text-muted-foreground bg-foreground/5 hover:bg-foreground/10 focus-visible:ring-ring flex h-8 shrink-0 items-center gap-1 rounded-md px-2.5 text-[13px] transition-colors focus-visible:ring-2 focus-visible:outline-none"
+      >
+        <Plus className="size-3.5" />
+        추가
+      </button>
+    </div>
+  );
+}

--- a/src/features/onboarding/components/department-delete-dialog.tsx
+++ b/src/features/onboarding/components/department-delete-dialog.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+import { countDepartments } from "../tree";
+import type { DepartmentNode } from "../types";
+
+interface DepartmentDeleteDialogProps {
+  /** 지울 대상. null이면 닫힌 상태다. */
+  target: DepartmentNode | null;
+  onCancel: () => void;
+  onConfirm: (id: string) => void;
+}
+
+/** 하위까지 함께 사라지므로 확인을 받는다(CLAUDE.md: 파괴적 작업은 토스트가 아니라 Dialog). */
+export function DepartmentDeleteDialog({
+  target,
+  onCancel,
+  onConfirm,
+}: DepartmentDeleteDialogProps) {
+  const childCount = target ? countDepartments(target.children) : 0;
+
+  return (
+    <Dialog open={target !== null} onOpenChange={onCancel}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>&lsquo;{target?.name}&rsquo; 부서를 지울까요?</DialogTitle>
+          <DialogDescription>
+            하위 부서 {childCount}개도 함께 사라져요. 되돌릴 수 없습니다.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={onCancel}>
+            취소
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={() => target && onConfirm(target.id)}
+          >
+            지우기
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/onboarding/components/department-intro.tsx
+++ b/src/features/onboarding/components/department-intro.tsx
@@ -1,0 +1,62 @@
+import type { DepartmentNode } from "../types";
+import { DepartmentPreview } from "./department-preview";
+
+const BENEFITS = [
+  "회의를 만들 때 부서 전체를 한 번에 초대",
+  "인수인계 대상자를 부서 기준으로 추리기",
+  "부서별 활동 통계 자동 집계",
+];
+
+/** 온보딩 1단계 좌측 — 설명과 축약 미리보기. */
+export function DepartmentIntro({ departments }: { departments: DepartmentNode[] }) {
+  return (
+    <section className="flex w-full flex-col gap-[17.5px] lg:h-full lg:w-[300px] lg:shrink-0">
+      <div className="flex items-center gap-[10.5px]">
+        <span className="bg-foreground text-background flex size-7 items-center justify-center rounded-full text-[13px] leading-5">
+          1
+        </span>
+        <span className="bg-border h-px flex-1" aria-hidden />
+      </div>
+
+      <div>
+        <h1 className="text-xl leading-[25px] font-semibold tracking-[-0.4px]">
+          부서 체계를 만들어 주세요
+        </h1>
+        <p className="text-muted-foreground pt-[7px] text-[13px] leading-[21px]">
+          회의 참석자, 알림 대상, 인수인계 범위를 부서 단위로 관리해요. 지금 만들어 두면 사원이
+          합류할 때 바로 배정할 수 있습니다.
+        </p>
+      </div>
+
+      <ul className="flex flex-col gap-[7px]">
+        {BENEFITS.map((benefit) => (
+          <li key={benefit} className="text-muted-foreground flex gap-[7px] text-xs leading-[19px]">
+            <span
+              className="bg-foreground mt-[7px] size-[3.5px] shrink-0 rounded-full"
+              aria-hidden
+            />
+            {benefit}
+          </li>
+        ))}
+      </ul>
+
+      <div className="border-border bg-background/80 text-muted-foreground/70 flex flex-col gap-1.5 rounded-md border p-[10.5px] text-[11px] leading-[18px]">
+        <p>이름을 더블클릭하면 바꿀 수 있어요. 나중에 설정에서 언제든 수정할 수 있습니다.</p>
+        <p>
+          부서는 <span className="text-muted-foreground">상위 · 하위 2단계</span>까지 만들 수
+          있어요.
+        </p>
+        <p>
+          손잡이를 끌면 순서를 바꾸거나{" "}
+          <span className="text-muted-foreground">다른 상위 부서로 옮길</span> 수 있어요.
+        </p>
+        <p>
+          <span className="text-muted-foreground">하위 부서가 있는 곳은 묶음</span>이라 사원이 직접
+          소속되지 않아요. 사원은 가장 아래 부서에 배정됩니다.
+        </p>
+      </div>
+
+      <DepartmentPreview departments={departments} />
+    </section>
+  );
+}

--- a/src/features/onboarding/components/department-node-actions.tsx
+++ b/src/features/onboarding/components/department-node-actions.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Plus, Trash2 } from "lucide-react";
+import type { ReactNode } from "react";
+
+interface DepartmentNodeActionsProps {
+  name: string;
+  canAddChild: boolean;
+  onAddChild: () => void;
+  onRemove: () => void;
+}
+
+/** 부서 한 줄의 우측 버튼 묶음. 마우스를 올리거나 포커스가 들어오면 나타난다. */
+export function DepartmentNodeActions({
+  name,
+  canAddChild,
+  onAddChild,
+  onRemove,
+}: DepartmentNodeActionsProps) {
+  return (
+    <span className="absolute right-2 flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
+      {canAddChild && (
+        <IconButton label={`${name}의 하위 부서 추가`} onClick={onAddChild}>
+          <Plus className="size-3.5" />
+        </IconButton>
+      )}
+      <IconButton label={`${name} 삭제`} onClick={onRemove}>
+        <Trash2 className="size-3.5" />
+      </IconButton>
+    </span>
+  );
+}
+
+function IconButton({
+  label,
+  onClick,
+  children,
+}: {
+  label: string;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      onClick={onClick}
+      className="text-muted-foreground hover:text-foreground hover:bg-foreground/10 focus-visible:ring-ring flex size-6 items-center justify-center rounded transition-colors focus-visible:ring-2 focus-visible:outline-none"
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/features/onboarding/components/department-node.tsx
+++ b/src/features/onboarding/components/department-node.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { ChevronRight, Folder, GripVertical } from "lucide-react";
+import { useRef, useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+import {
+  type DepartmentNode as DepartmentNodeType,
+  getDepthLabel,
+  MAX_DEPARTMENT_DEPTH,
+} from "../types";
+import { type DraggingInfo, type DropZone, useDepartmentDrag } from "../use-department-drag";
+import { DepartmentNodeActions } from "./department-node-actions";
+
+export interface DepartmentNodeHandlers {
+  onRename: (id: string, name: string) => void;
+  onAddChild: (parentId: string) => void;
+  onRemove: (id: string) => void;
+  /** 순서 변경과 다른 상위 부서로 옮기기를 모두 처리한다 */
+  onMove: (draggedId: string, targetId: string, position: DropZone) => void;
+  /** 키보드 대체 경로 — Alt + ↑/↓ 순서, Alt + ←/→ 계층 */
+  onShift: (id: string, offset: 1 | -1) => void;
+  onPromote: (id: string) => void;
+  onDemote: (id: string) => void;
+  /** 새로 만든 부서는 바로 편집 상태로 열린다 */
+  editingId: string | null;
+  onEditingChange: (id: string | null) => void;
+  dragging: DraggingInfo | null;
+  onDraggingChange: (info: DraggingInfo | null) => void;
+}
+
+interface DepartmentNodeProps extends DepartmentNodeHandlers {
+  node: DepartmentNodeType;
+  depth: number;
+  parentId: string | null;
+}
+
+export function DepartmentNode({ node, depth, parentId, ...handlers }: DepartmentNodeProps) {
+  const { onRename, onAddChild, onRemove, onShift, onPromote, onDemote } = handlers;
+  const { editingId, onEditingChange } = handlers;
+
+  const rowRef = useRef<HTMLDivElement>(null);
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  const hasChildren = node.children.length > 0;
+  const isEditing = editingId === node.id;
+
+  const { isDragged, dropZone, handleProps, rowProps } = useDepartmentDrag({
+    nodeId: node.id,
+    parentId,
+    depth,
+    hasChildren,
+    rowRef,
+    dragging: handlers.dragging,
+    onDraggingChange: handlers.onDraggingChange,
+    onMove: handlers.onMove,
+  });
+
+  const submitName = (value: string) => {
+    const name = value.trim();
+    if (name) onRename(node.id, name);
+    onEditingChange(null);
+  };
+
+  const handleKeyMove = (event: React.KeyboardEvent) => {
+    if (!event.altKey) return;
+    const actions: Record<string, () => void> = {
+      ArrowUp: () => onShift(node.id, -1),
+      ArrowDown: () => onShift(node.id, 1),
+      ArrowLeft: () => onPromote(node.id),
+      ArrowRight: () => onDemote(node.id),
+    };
+    const action = actions[event.key];
+    if (!action) return;
+    event.preventDefault();
+    action();
+  };
+
+  return (
+    <>
+      <div
+        ref={rowRef}
+        {...rowProps}
+        className={cn(
+          "group relative flex h-[38px] items-center gap-2 rounded-md px-2 transition-[background-color,opacity]",
+          isDragged ? "opacity-40" : "hover:bg-secondary",
+          // 점선 = 여기 들어온다. 아래 "부서 추가" 입력창의 점선과 같은 표현을 쓴다.
+          dropZone === "before" &&
+            "before:border-ring before:absolute before:inset-x-0 before:-top-0.5 before:border-t-2 before:border-dashed before:content-['']",
+          dropZone === "after" &&
+            "after:border-ring after:absolute after:inset-x-0 after:-bottom-0.5 after:border-t-2 after:border-dashed after:content-['']",
+          dropZone === "inside" && "bg-secondary outline-ring outline-2 outline-dashed",
+        )}
+      >
+        <span
+          {...handleProps}
+          role="button"
+          tabIndex={0}
+          aria-label={`${node.name} 위치 이동 — Alt와 방향키로도 옮길 수 있어요(위아래: 순서, 왼쪽: 상위로 빼기, 오른쪽: 바로 위 부서의 하위로)`}
+          onKeyDown={handleKeyMove}
+          className="text-muted-foreground/40 hover:text-muted-foreground focus-visible:ring-ring shrink-0 cursor-grab rounded opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none active:cursor-grabbing"
+        >
+          <GripVertical className="size-3.5" />
+        </span>
+
+        {hasChildren ? (
+          <button
+            type="button"
+            onClick={() => setIsExpanded((prev) => !prev)}
+            aria-label={`${node.name} ${isExpanded ? "접기" : "펼치기"}`}
+            aria-expanded={isExpanded}
+            className="text-muted-foreground hover:text-foreground shrink-0"
+          >
+            <ChevronRight
+              className={cn("size-3.5 transition-transform", isExpanded && "rotate-90")}
+            />
+          </button>
+        ) : (
+          <span className="size-3.5 shrink-0" aria-hidden />
+        )}
+
+        <Folder className="text-muted-foreground/60 size-3.5 shrink-0" aria-hidden />
+
+        {isEditing ? (
+          <input
+            autoFocus
+            defaultValue={node.name}
+            aria-label="부서 이름"
+            onFocus={(event) => event.currentTarget.select()}
+            onBlur={(event) => submitName(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") submitName(event.currentTarget.value);
+              if (event.key === "Escape") onEditingChange(null);
+            }}
+            className="border-ring bg-background min-w-0 flex-1 rounded border px-1.5 text-[13px] leading-5 outline-none"
+          />
+        ) : (
+          <button
+            type="button"
+            onDoubleClick={() => onEditingChange(node.id)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                onEditingChange(node.id);
+              }
+            }}
+            aria-label={`${node.name} 이름 바꾸기`}
+            className="min-w-0 flex-1 truncate text-left text-[13px] leading-5"
+          >
+            {node.name}
+          </button>
+        )}
+
+        {/* 하위가 있으면 묶음이라 사원이 직접 소속되지 않는다(DECISIONS: 부서 계층·사원 소속) */}
+        <span className="text-muted-foreground/50 shrink-0 text-[11px] transition-opacity group-focus-within:opacity-0 group-hover:opacity-0">
+          {hasChildren ? "묶음" : getDepthLabel(depth)}
+        </span>
+
+        <DepartmentNodeActions
+          name={node.name}
+          canAddChild={depth + 1 < MAX_DEPARTMENT_DEPTH}
+          onAddChild={() => {
+            setIsExpanded(true);
+            onAddChild(node.id);
+          }}
+          onRemove={() => onRemove(node.id)}
+        />
+      </div>
+
+      {hasChildren && isExpanded && (
+        <div className="ml-4">
+          <ul className="border-border border-l pl-3">
+            {node.children.map((child, index) => (
+              <li key={child.id} className={index > 0 ? "pt-[1.75px]" : undefined}>
+                <DepartmentNode node={child} depth={depth + 1} parentId={node.id} {...handlers} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/features/onboarding/components/department-preview.tsx
+++ b/src/features/onboarding/components/department-preview.tsx
@@ -1,0 +1,46 @@
+import { flattenDepartments } from "../tree";
+import type { DepartmentNode } from "../types";
+
+/** 좌측 축약 미리보기 — 트리와 같은 상태를 보고 그린다. */
+export function DepartmentPreview({ departments }: { departments: DepartmentNode[] }) {
+  const rows = flattenDepartments(departments);
+
+  if (rows.length === 0) {
+    return (
+      <div className="border-border bg-background/50 flex min-h-20 flex-1 items-center justify-center rounded-lg border p-3">
+        <p className="text-muted-foreground/70 text-[11px]">아직 부서가 없어요</p>
+      </div>
+    );
+  }
+
+  return (
+    // 남는 세로 공간을 채운다. 부서가 많아지면 안에서만 스크롤한다(스크롤바 숨김)
+    <ul className="border-border bg-background/50 flex min-h-20 flex-1 [scrollbar-width:none] flex-col gap-1.5 overflow-auto rounded-lg border p-3 [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
+      {rows.map(({ id, name, depth }) => (
+        <li
+          key={id}
+          className="flex items-center gap-1.5"
+          style={{ paddingLeft: `${depth * 14}px` }}
+        >
+          <span
+            className={
+              depth === 0
+                ? "bg-foreground size-[7px] shrink-0 rounded-full"
+                : "bg-muted-foreground/60 size-[5px] shrink-0 rounded-full"
+            }
+            aria-hidden
+          />
+          <span
+            className={
+              depth === 0
+                ? "text-muted-foreground truncate text-[10px]"
+                : "text-muted-foreground/70 truncate text-[9px]"
+            }
+          >
+            {name}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/features/onboarding/components/department-setup.tsx
+++ b/src/features/onboarding/components/department-setup.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { ChevronRight } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+import { countDepartments } from "../tree";
+import type { DepartmentNode as DepartmentNodeType } from "../types";
+import type { DraggingInfo } from "../use-department-drag";
+import { useDepartmentTree } from "../use-department-tree";
+import { DepartmentAddRow } from "./department-add-row";
+import { DepartmentDeleteDialog } from "./department-delete-dialog";
+import { DepartmentIntro } from "./department-intro";
+import { DepartmentNode, type DepartmentNodeHandlers } from "./department-node";
+
+/**
+ * 온보딩 1단계 — 부서 체계.
+ * ⚠️ 저장은 미구현이다. 지금 편집 내용은 브라우저 메모리에만 있고 새로고침하면 사라진다.
+ *    BE 연동 후 Server Action으로 붙인다.
+ */
+export function DepartmentSetup({
+  initialDepartments,
+}: {
+  initialDepartments: DepartmentNodeType[];
+}) {
+  const tree = useDepartmentTree(initialDepartments);
+  const [draftName, setDraftName] = useState("");
+  const [dragging, setDragging] = useState<DraggingInfo | null>(null);
+
+  const total = countDepartments(tree.departments);
+
+  const handleAddRoot = () => {
+    if (tree.addRoot(draftName)) setDraftName("");
+  };
+
+  const handlers: DepartmentNodeHandlers = {
+    onRename: tree.rename,
+    onAddChild: tree.addChild,
+    onRemove: tree.requestRemove,
+    onMove: tree.move,
+    onShift: tree.shift,
+    onPromote: tree.promote,
+    onDemote: tree.demote,
+    editingId: tree.editingId,
+    onEditingChange: tree.setEditingId,
+    dragging,
+    onDraggingChange: setDragging,
+  };
+
+  return (
+    <div className="flex flex-col gap-[21px]">
+      {/* 높이를 여기서 한 번만 정한다 — 좌우 두 칸이 같은 높이를 나눠 쓴다 */}
+      <div className="flex flex-col gap-7 lg:h-[560px] lg:flex-row">
+        <DepartmentIntro departments={tree.departments} />
+
+        {/* 높이 고정 — 부서를 아무리 추가해도 카드 크기는 그대로고 안에서만 스크롤된다 */}
+        <section className="border-border bg-card flex h-[440px] flex-1 flex-col overflow-hidden rounded-xl border shadow-sm lg:h-full">
+          <header className="border-border bg-muted flex h-12 shrink-0 items-center justify-between border-b px-4">
+            <h2 className="flex items-center gap-2 text-[13px] leading-5">
+              <span className="bg-foreground size-2 rounded-full" aria-hidden />
+              부서 구조 미리보기
+            </h2>
+            {/* 계층 제약 안내는 좌측 안내문에 있다 — 헤더에 겹쳐 쓰면 지저분해진다 */}
+            <span className="text-muted-foreground/70 text-xs leading-4 tabular-nums">
+              부서 {total}개
+            </span>
+          </header>
+
+          {/* 스크롤바는 숨긴다(스크롤 자체는 된다) */}
+          <div className="flex-1 [scrollbar-width:none] overflow-auto px-4 pt-4 pb-3 [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
+            {tree.departments.length === 0 ? (
+              <p className="text-muted-foreground/70 py-12 text-center text-[13px]">
+                아래에서 첫 부서를 추가해 주세요
+              </p>
+            ) : (
+              <ul>
+                {tree.departments.map((node, index) => (
+                  <li key={node.id} className={index > 0 ? "pt-[1.75px]" : undefined}>
+                    <DepartmentNode node={node} depth={0} parentId={null} {...handlers} />
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <DepartmentAddRow value={draftName} onChange={setDraftName} onSubmit={handleAddRoot} />
+        </section>
+      </div>
+
+      <div className="border-border flex items-center justify-end border-t pt-[17.5px]">
+        {/* 시안의 주 버튼은 액센트(파랑)가 아니라 먹색이다(토큰 충돌 — 팀 확인 필요) */}
+        <Link
+          href="/onboarding/2"
+          className={cn(
+            buttonVariants(),
+            "bg-foreground text-background hover:bg-foreground/90 h-[34px] gap-[5.25px] rounded-md px-[12.25px] text-[13px] leading-5",
+          )}
+        >
+          다음
+          <ChevronRight className="size-3.5" />
+        </Link>
+      </div>
+
+      <DepartmentDeleteDialog
+        target={tree.pendingDelete}
+        onCancel={tree.cancelRemove}
+        onConfirm={tree.confirmRemove}
+      />
+    </div>
+  );
+}

--- a/src/features/onboarding/components/onboarding-shell.tsx
+++ b/src/features/onboarding/components/onboarding-shell.tsx
@@ -1,0 +1,85 @@
+import { Check } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { ZLogo } from "@/components/icons/z-logo";
+import { cn } from "@/lib/utils";
+
+import { ONBOARDING_STEP_LABEL, ONBOARDING_TOTAL_STEPS, type OnboardingStep } from "../types";
+
+const STEPS = Object.keys(ONBOARDING_STEP_LABEL).map(Number) as OnboardingStep[];
+
+interface OnboardingShellProps {
+  step: OnboardingStep;
+  children: ReactNode;
+}
+
+/** 온보딩 3단계가 공유하는 헤더·스텝퍼 프레임. */
+export function OnboardingShell({ step, children }: OnboardingShellProps) {
+  return (
+    // 배경 점 그리드 — 토큰(--border)을 그대로 써서 다크에서도 따라온다
+    <div className="bg-background flex min-h-dvh flex-col bg-[radial-gradient(var(--border)_1px,transparent_1px)] [background-size:18px_18px]">
+      <header className="border-border bg-background/90 flex h-[52px] shrink-0 items-center gap-[7px] border-b px-[21px] backdrop-blur">
+        <ZLogo className="text-foreground size-[18px]" title="Z" />
+        <span className="text-muted-foreground/70 ml-auto text-xs leading-[18px] tabular-nums">
+          단계 <span className="text-foreground">{step}</span> / {ONBOARDING_TOTAL_STEPS}
+        </span>
+      </header>
+
+      {/* 세로 가운데 정렬 — 콘텐츠가 화면 위쪽에만 몰리지 않게 한다 */}
+      <main className="flex flex-1 flex-col justify-center px-[21px] py-10">
+        <div className="mx-auto w-full max-w-[1160px]">{children}</div>
+      </main>
+
+      <footer className="border-border bg-background/90 flex h-16 shrink-0 items-center justify-center border-t px-[21px]">
+        <ol className="flex flex-wrap items-center">
+          {STEPS.map((value) => (
+            <li key={value} className="flex items-center">
+              <StepBadge
+                label={ONBOARDING_STEP_LABEL[value]}
+                value={String(value)}
+                isActive={value === step}
+              />
+              <span className="bg-border mx-[14px] h-px w-[35px]" aria-hidden />
+            </li>
+          ))}
+          <li className="pl-[14px]">
+            <StepBadge label="완료" value={<Check className="size-3" />} isActive={false} isDone />
+          </li>
+        </ol>
+      </footer>
+    </div>
+  );
+}
+
+function StepBadge({
+  label,
+  value,
+  isActive,
+  isDone = false,
+}: {
+  label: string;
+  value: ReactNode;
+  isActive: boolean;
+  isDone?: boolean;
+}) {
+  return (
+    <span
+      className={cn(
+        "flex items-center gap-[7px] text-xs leading-[18px]",
+        isActive ? "text-foreground" : "text-muted-foreground/70",
+      )}
+      aria-current={isActive ? "step" : undefined}
+    >
+      <span
+        className={cn(
+          "flex items-center justify-center rounded-full text-[11px] leading-4 tabular-nums",
+          isDone ? "size-7" : "size-[21px]",
+          isActive ? "bg-foreground text-background" : "bg-secondary",
+        )}
+      >
+        {value}
+      </span>
+      {label}
+    </span>
+  );
+}

--- a/src/features/onboarding/mock/departments.ts
+++ b/src/features/onboarding/mock/departments.ts
@@ -1,0 +1,22 @@
+import type { DepartmentNode } from "../types";
+
+/**
+ * ⚠️ 목 데이터 — BE 연동 전. 온보딩 진입 시 보여줄 기본 예시 부서다.
+ * 실제로는 기업 생성 시 서버가 내려주거나 빈 트리로 시작한다.
+ */
+export const INITIAL_DEPARTMENTS: DepartmentNode[] = [
+  {
+    id: "dev",
+    name: "개발팀",
+    children: [
+      { id: "dev-fe", name: "프론트엔드", children: [] },
+      { id: "dev-be", name: "백엔드", children: [] },
+    ],
+  },
+  { id: "design", name: "디자인팀", children: [] },
+  {
+    id: "ops",
+    name: "경영지원",
+    children: [{ id: "ops-hr", name: "인사", children: [] }],
+  },
+];

--- a/src/features/onboarding/server.ts
+++ b/src/features/onboarding/server.ts
@@ -1,0 +1,18 @@
+import "server-only";
+
+import { isMock } from "@/mocks/config";
+
+import { INITIAL_DEPARTMENTS } from "./mock/departments";
+import type { DepartmentNode } from "./types";
+
+/**
+ * 부서 트리 조회 — **격리막**(CLAUDE.md).
+ * 컴포넌트는 `DepartmentNode`(UI 계약)만 알고, 목/실서버 분기는 여기서 끝낸다.
+ * 연동할 때 고칠 곳은 이 파일과 매퍼뿐이고 컴포넌트는 건드리지 않는다.
+ */
+export async function getDepartments(): Promise<DepartmentNode[]> {
+  if (isMock) return INITIAL_DEPARTMENTS;
+
+  // ⚠️ 미구현 — API 스펙 확정 후 BFF 경로(`ep.departments()`)로 fetch하고 매퍼로 UI 계약에 맞춘다.
+  throw new Error("부서 조회 API가 아직 연결되지 않았습니다.");
+}

--- a/src/features/onboarding/tree.test.ts
+++ b/src/features/onboarding/tree.test.ts
@@ -1,0 +1,217 @@
+import {
+  appendChild,
+  countDepartments,
+  createDepartment,
+  demoteNode,
+  findNode,
+  findSiblings,
+  flattenDepartments,
+  moveNodeTo,
+  nextAvailableName,
+  promoteNode,
+  removeDepartment,
+  renameDepartment,
+  shiftNode,
+} from "./tree";
+import type { DepartmentNode } from "./types";
+
+/**
+ * 개발팀
+ * ├─ 프론트엔드
+ * └─ 백엔드
+ * 디자인팀
+ * 경영지원
+ * └─ 인사
+ */
+const makeTree = (): DepartmentNode[] => [
+  {
+    id: "dev",
+    name: "개발팀",
+    children: [
+      { id: "fe", name: "프론트엔드", children: [] },
+      { id: "be", name: "백엔드", children: [] },
+    ],
+  },
+  { id: "design", name: "디자인팀", children: [] },
+  { id: "ops", name: "경영지원", children: [{ id: "hr", name: "인사", children: [] }] },
+];
+
+const names = (nodes: DepartmentNode[]) => flattenDepartments(nodes).map((row) => row.name);
+const childrenOf = (nodes: DepartmentNode[], id: string) =>
+  (findNode(nodes, id)?.children ?? []).map((node) => node.name);
+
+describe("countDepartments", () => {
+  it("하위까지 모두 센다", () => {
+    expect(countDepartments(makeTree())).toBe(6);
+  });
+
+  it("빈 트리는 0이다", () => {
+    expect(countDepartments([])).toBe(0);
+  });
+});
+
+describe("createDepartment", () => {
+  it("이름을 그대로 쓰고 하위 없이 만든다", () => {
+    const node = createDepartment("영업팀");
+    expect(node.name).toBe("영업팀");
+    expect(node.children).toEqual([]);
+    expect(node.id).toEqual(expect.any(String));
+  });
+});
+
+describe("nextAvailableName", () => {
+  it("겹치지 않으면 그대로 쓴다", () => {
+    expect(nextAvailableName(makeTree(), "새 하위 부서")).toBe("새 하위 부서");
+  });
+
+  it("겹치면 2부터 번호를 붙인다", () => {
+    const siblings = [createDepartment("새 하위 부서")];
+    expect(nextAvailableName(siblings, "새 하위 부서")).toBe("새 하위 부서 2");
+  });
+
+  it("이미 쓰인 번호는 건너뛴다", () => {
+    const siblings = [createDepartment("새 하위 부서"), createDepartment("새 하위 부서 2")];
+    expect(nextAvailableName(siblings, "새 하위 부서")).toBe("새 하위 부서 3");
+  });
+});
+
+describe("appendChild / renameDepartment / removeDepartment", () => {
+  it("하위를 맨 뒤에 붙인다", () => {
+    const next = appendChild(makeTree(), "dev", createDepartment("플랫폼"));
+    expect(childrenOf(next, "dev")).toEqual(["프론트엔드", "백엔드", "플랫폼"]);
+  });
+
+  it("이름만 바꾸고 구조는 그대로 둔다", () => {
+    const next = renameDepartment(makeTree(), "fe", "웹프론트");
+    expect(findNode(next, "fe")?.name).toBe("웹프론트");
+    expect(countDepartments(next)).toBe(6);
+  });
+
+  it("지우면 하위도 함께 사라진다", () => {
+    const next = removeDepartment(makeTree(), "dev");
+    expect(names(next)).toEqual(["디자인팀", "경영지원", "인사"]);
+  });
+
+  it("원본을 바꾸지 않는다", () => {
+    const original = makeTree();
+    removeDepartment(original, "dev");
+    expect(countDepartments(original)).toBe(6);
+  });
+});
+
+describe("findNode / findSiblings", () => {
+  it("하위에 있는 것도 찾는다", () => {
+    expect(findNode(makeTree(), "hr")?.name).toBe("인사");
+  });
+
+  it("없으면 null이다", () => {
+    expect(findNode(makeTree(), "없는id")).toBeNull();
+  });
+
+  it("부모가 null이면 최상위 목록을 준다", () => {
+    expect(findSiblings(makeTree(), null).map((node) => node.name)).toEqual([
+      "개발팀",
+      "디자인팀",
+      "경영지원",
+    ]);
+  });
+
+  it("부모 id를 주면 그 하위 목록을 준다", () => {
+    expect(findSiblings(makeTree(), "dev").map((node) => node.name)).toEqual([
+      "프론트엔드",
+      "백엔드",
+    ]);
+  });
+});
+
+describe("shiftNode", () => {
+  it("최상위끼리 순서를 바꾼다", () => {
+    const next = shiftNode(makeTree(), "design", -1);
+    expect(next.map((node) => node.name)).toEqual(["디자인팀", "개발팀", "경영지원"]);
+  });
+
+  it("하위끼리도 순서를 바꾼다", () => {
+    const next = shiftNode(makeTree(), "be", -1);
+    expect(childrenOf(next, "dev")).toEqual(["백엔드", "프론트엔드"]);
+  });
+
+  it("끝에서 더 나가면 그대로 둔다", () => {
+    const tree = makeTree();
+    expect(shiftNode(tree, "dev", -1)).toEqual(tree);
+    expect(shiftNode(tree, "ops", 1)).toEqual(tree);
+  });
+});
+
+describe("moveNodeTo", () => {
+  it("다른 상위 부서의 하위로 옮긴다", () => {
+    const next = moveNodeTo(makeTree(), "hr", "dev", "inside");
+    expect(childrenOf(next, "dev")).toEqual(["프론트엔드", "백엔드", "인사"]);
+    expect(childrenOf(next, "ops")).toEqual([]);
+  });
+
+  it("대상 앞/뒤에 형제로 끼운다", () => {
+    const before = moveNodeTo(makeTree(), "hr", "design", "before");
+    expect(before.map((node) => node.name)).toEqual(["개발팀", "인사", "디자인팀", "경영지원"]);
+
+    const after = moveNodeTo(makeTree(), "hr", "design", "after");
+    expect(after.map((node) => node.name)).toEqual(["개발팀", "디자인팀", "인사", "경영지원"]);
+  });
+
+  it("자기 자신으로는 옮기지 않는다", () => {
+    const tree = makeTree();
+    expect(moveNodeTo(tree, "dev", "dev", "inside")).toEqual(tree);
+  });
+
+  it("자기 하위로는 옮기지 않는다 — 트리가 끊긴다", () => {
+    const tree = makeTree();
+    expect(moveNodeTo(tree, "dev", "fe", "inside")).toEqual(tree);
+  });
+
+  it("옮겨도 전체 개수는 그대로다", () => {
+    expect(countDepartments(moveNodeTo(makeTree(), "hr", "dev", "inside"))).toBe(6);
+  });
+});
+
+describe("promoteNode", () => {
+  it("하위를 최상위로 빼내고 원래 부모 바로 뒤에 둔다", () => {
+    const next = promoteNode(makeTree(), "fe");
+    expect(next.map((node) => node.name)).toEqual(["개발팀", "프론트엔드", "디자인팀", "경영지원"]);
+    expect(childrenOf(next, "dev")).toEqual(["백엔드"]);
+  });
+
+  it("이미 최상위면 그대로 둔다", () => {
+    const tree = makeTree();
+    expect(promoteNode(tree, "dev")).toEqual(tree);
+  });
+});
+
+describe("demoteNode", () => {
+  it("바로 위 형제의 하위로 넣는다", () => {
+    const next = demoteNode(makeTree(), "design");
+    expect(next.map((node) => node.name)).toEqual(["개발팀", "경영지원"]);
+    expect(childrenOf(next, "dev")).toEqual(["프론트엔드", "백엔드", "디자인팀"]);
+  });
+
+  it("맨 앞이면 내려갈 곳이 없다", () => {
+    const tree = makeTree();
+    expect(demoteNode(tree, "dev")).toEqual(tree);
+  });
+
+  it("하위를 가진 부서는 내리지 않는다 — 3계층이 된다", () => {
+    const tree = makeTree();
+    expect(demoteNode(tree, "ops")).toEqual(tree);
+  });
+});
+
+describe("flattenDepartments", () => {
+  it("깊이를 붙여 평탄화한다", () => {
+    expect(flattenDepartments(makeTree())).toEqual([
+      { id: "dev", name: "개발팀", depth: 0 },
+      { id: "fe", name: "프론트엔드", depth: 1 },
+      { id: "be", name: "백엔드", depth: 1 },
+      { id: "design", name: "디자인팀", depth: 0 },
+      { id: "ops", name: "경영지원", depth: 0 },
+      { id: "hr", name: "인사", depth: 1 },
+    ]);
+  });
+});

--- a/src/features/onboarding/tree.ts
+++ b/src/features/onboarding/tree.ts
@@ -1,0 +1,189 @@
+import type { DepartmentNode } from "./types";
+
+/** 부서 트리 조작 — 전부 순수 함수다(원본을 바꾸지 않는다). */
+
+export function countDepartments(nodes: DepartmentNode[]): number {
+  return nodes.reduce((total, node) => total + 1 + countDepartments(node.children), 0);
+}
+
+export function createDepartment(name: string): DepartmentNode {
+  return { id: crypto.randomUUID(), name, children: [] };
+}
+
+/** 같은 계층에 이름이 겹치지 않게 뒤에 번호를 붙인다 — `새 팀` → `새 팀 2`. */
+export function nextAvailableName(siblings: DepartmentNode[], base: string): string {
+  const taken = new Set(siblings.map((node) => node.name));
+  if (!taken.has(base)) return base;
+
+  let index = 2;
+  while (taken.has(`${base} ${index}`)) index += 1;
+  return `${base} ${index}`;
+}
+
+export function findNode(nodes: DepartmentNode[], id: string): DepartmentNode | null {
+  for (const node of nodes) {
+    if (node.id === id) return node;
+    const found = findNode(node.children, id);
+    if (found) return found;
+  }
+  return null;
+}
+
+/** 특정 부모의 자식 목록을 찾는다(없으면 최상위). */
+export function findSiblings(nodes: DepartmentNode[], parentId: string | null): DepartmentNode[] {
+  if (parentId === null) return nodes;
+
+  for (const node of nodes) {
+    if (node.id === parentId) return node.children;
+    const found = findSiblings(node.children, parentId);
+    if (found.length > 0) return found;
+  }
+  return [];
+}
+
+export function appendChild(
+  nodes: DepartmentNode[],
+  parentId: string,
+  child: DepartmentNode,
+): DepartmentNode[] {
+  return nodes.map((node) =>
+    node.id === parentId
+      ? { ...node, children: [...node.children, child] }
+      : { ...node, children: appendChild(node.children, parentId, child) },
+  );
+}
+
+export function renameDepartment(
+  nodes: DepartmentNode[],
+  id: string,
+  name: string,
+): DepartmentNode[] {
+  return nodes.map((node) =>
+    node.id === id
+      ? { ...node, name }
+      : { ...node, children: renameDepartment(node.children, id, name) },
+  );
+}
+
+/** 하위 부서도 함께 사라진다. 호출부에서 확인을 받는다. */
+export function removeDepartment(nodes: DepartmentNode[], id: string): DepartmentNode[] {
+  return nodes
+    .filter((node) => node.id !== id)
+    .map((node) => ({ ...node, children: removeDepartment(node.children, id) }));
+}
+
+/**
+ * 부서를 **다른 상위 부서로** 옮긴다. 조직 개편은 흔하므로 지우고 다시 만들게 하지 않는다.
+ * `position`이 `inside`면 대상의 하위로 들어가고, `before`/`after`면 대상의 형제가 된다.
+ * ⚠️ 계층 제한(2단계)은 호출부에서 검사한다 — 여기서는 트리 조작만 한다.
+ */
+export function moveNodeTo(
+  nodes: DepartmentNode[],
+  draggedId: string,
+  targetId: string,
+  position: "before" | "after" | "inside",
+): DepartmentNode[] {
+  if (draggedId === targetId) return nodes;
+
+  // 자기 자손 안으로는 못 들어간다(트리가 끊긴다)
+  const dragged = findNode(nodes, draggedId);
+  if (!dragged || findNode(dragged.children, targetId)) return nodes;
+
+  const detached = removeDepartment(nodes, draggedId);
+  return position === "inside"
+    ? insertInside(detached, targetId, dragged)
+    : insertBeside(detached, targetId, dragged, position);
+}
+
+function insertInside(
+  nodes: DepartmentNode[],
+  parentId: string,
+  node: DepartmentNode,
+): DepartmentNode[] {
+  return nodes.map((current) =>
+    current.id === parentId
+      ? { ...current, children: [...current.children, node] }
+      : { ...current, children: insertInside(current.children, parentId, node) },
+  );
+}
+
+function insertBeside(
+  nodes: DepartmentNode[],
+  targetId: string,
+  node: DepartmentNode,
+  position: "before" | "after",
+): DepartmentNode[] {
+  const index = nodes.findIndex((current) => current.id === targetId);
+  if (index !== -1) {
+    const next = [...nodes];
+    next.splice(position === "before" ? index : index + 1, 0, node);
+    return next;
+  }
+  return nodes.map((current) => ({
+    ...current,
+    children: insertBeside(current.children, targetId, node, position),
+  }));
+}
+
+/** 키보드용 — 하위 부서를 최상위로 빼낸다(원래 상위 부서 바로 아래에 놓는다). */
+export function promoteNode(nodes: DepartmentNode[], id: string): DepartmentNode[] {
+  for (let index = 0; index < nodes.length; index += 1) {
+    const parent = nodes[index];
+    if (!parent) continue;
+
+    const child = parent.children.find((node) => node.id === id);
+    if (!child) continue;
+
+    const next = [...nodes];
+    next[index] = { ...parent, children: parent.children.filter((node) => node.id !== id) };
+    next.splice(index + 1, 0, child);
+    return next;
+  }
+  return nodes;
+}
+
+/** 키보드용 — 바로 위 형제의 하위로 넣는다. 최상위에서만 가능하다(2계층). */
+export function demoteNode(nodes: DepartmentNode[], id: string): DepartmentNode[] {
+  const index = nodes.findIndex((node) => node.id === id);
+  if (index <= 0) return nodes;
+
+  const node = nodes[index];
+  const previous = nodes[index - 1];
+  if (!node || !previous || node.children.length > 0) return nodes;
+
+  const next = [...nodes];
+  next.splice(index, 1);
+  next[index - 1] = { ...previous, children: [...previous.children, node] };
+  return next;
+}
+
+/** 키보드용 — 형제 안에서 한 칸 위/아래로 옮긴다. */
+export function shiftNode(nodes: DepartmentNode[], id: string, offset: 1 | -1): DepartmentNode[] {
+  const from = nodes.findIndex((node) => node.id === id);
+
+  if (from !== -1) {
+    const to = from + offset;
+    return to < 0 || to >= nodes.length ? nodes : reorder(nodes, from, to);
+  }
+
+  return nodes.map((node) => ({ ...node, children: shiftNode(node.children, id, offset) }));
+}
+
+function reorder(nodes: DepartmentNode[], from: number, to: number): DepartmentNode[] {
+  const next = [...nodes];
+  const [moved] = next.splice(from, 1);
+  if (!moved) return nodes;
+  next.splice(to, 0, moved);
+  return next;
+}
+
+/** 트리를 평탄화해 미리보기 목록으로 만든다. */
+export function flattenDepartments(
+  nodes: DepartmentNode[],
+  depth = 0,
+): Array<{ id: string; name: string; depth: number }> {
+  return nodes.flatMap((node) => [
+    { id: node.id, name: node.name, depth },
+    ...flattenDepartments(node.children, depth + 1),
+  ]);
+}

--- a/src/features/onboarding/types.ts
+++ b/src/features/onboarding/types.ts
@@ -1,0 +1,35 @@
+/** 부서 트리 노드. 부서는 3계층까지 쓴다(CONVENTIONS §6). */
+export interface DepartmentNode {
+  id: string;
+  name: string;
+  children: DepartmentNode[];
+}
+
+/** 부서 트리 최대 깊이 — **2계층**(상위 > 하위). DECISIONS 참고. */
+export const MAX_DEPARTMENT_DEPTH = 2;
+
+/**
+ * 계층 표기는 **상위/하위 관계로만** 말한다.
+ * ⚠️ 본부·팀·파트 같은 조직 용어는 기업마다 달라서 기획 확정 전까지 쓰지 않는다.
+ */
+const DEPTH_LABEL = ["상위", "하위"] as const;
+
+export function getDepthLabel(depth: number): string {
+  return DEPTH_LABEL[depth] ?? "하위";
+}
+
+/** 온보딩 단계 — 화면 하단 스텝퍼와 헤더 `단계 n / 3`에 함께 쓴다. */
+export const ONBOARDING_STEP = {
+  DEPARTMENT: 1,
+  POSITION: 2,
+  INVITE: 3,
+} as const;
+export type OnboardingStep = (typeof ONBOARDING_STEP)[keyof typeof ONBOARDING_STEP];
+
+export const ONBOARDING_STEP_LABEL: Record<OnboardingStep, string> = {
+  1: "부서 체계",
+  2: "직급 체계",
+  3: "사원 초대",
+};
+
+export const ONBOARDING_TOTAL_STEPS = 3;

--- a/src/features/onboarding/use-department-drag.ts
+++ b/src/features/onboarding/use-department-drag.ts
@@ -1,0 +1,106 @@
+"use client";
+
+import { type RefObject, useState } from "react";
+
+import { MAX_DEPARTMENT_DEPTH } from "./types";
+
+/** 지금 끌고 있는 부서. 계층 제한을 판정하려면 하위 보유 여부가 필요하다. */
+export interface DraggingInfo {
+  id: string;
+  parentId: string | null;
+  hasChildren: boolean;
+}
+
+/** 놓는 자리 — 위/아래는 형제로 끼우기, 가운데는 그 부서의 하위로 넣기. */
+export type DropZone = "before" | "after" | "inside";
+
+interface UseDepartmentDragParams {
+  nodeId: string;
+  parentId: string | null;
+  depth: number;
+  hasChildren: boolean;
+  rowRef: RefObject<HTMLDivElement | null>;
+  dragging: DraggingInfo | null;
+  onDraggingChange: (info: DraggingInfo | null) => void;
+  onMove: (draggedId: string, targetId: string, position: DropZone) => void;
+}
+
+/**
+ * 부서 한 줄의 드래그 처리.
+ * 순서 변경과 **다른 상위 부서로 옮기기**를 모두 다루고, 2계층 제한을 여기서 막는다.
+ */
+export function useDepartmentDrag({
+  nodeId,
+  parentId,
+  depth,
+  hasChildren,
+  rowRef,
+  dragging,
+  onDraggingChange,
+  onMove,
+}: UseDepartmentDragParams) {
+  const [dropZone, setDropZone] = useState<DropZone | null>(null);
+
+  const isDragged = dragging?.id === nodeId;
+  /** 자기 자신·자기 하위로는 못 간다(트리가 끊긴다) */
+  const canDrop = dragging !== null && !isDragged && parentId !== dragging.id;
+  /** 옆에 놓기 — 하위를 데리고 오면 최상위 자리에만 놓을 수 있다 */
+  const canPlaceBeside =
+    dragging !== null && depth + (dragging.hasChildren ? 1 : 0) < MAX_DEPARTMENT_DEPTH;
+  /** 안에 넣기 — 최상위 부서만 하위를 받는다 */
+  const canPlaceInside = dragging !== null && depth === 0 && !dragging.hasChildren;
+
+  const resolveZone = (offsetY: number, height: number): DropZone | null => {
+    const zone: DropZone =
+      offsetY < height * 0.28 ? "before" : offsetY > height * 0.72 ? "after" : "inside";
+
+    if (zone === "inside") {
+      if (canPlaceInside) return "inside";
+      return canPlaceBeside ? (offsetY < height / 2 ? "before" : "after") : null;
+    }
+    if (canPlaceBeside) return zone;
+    return canPlaceInside ? "inside" : null;
+  };
+
+  return {
+    isDragged,
+    dropZone,
+    /** 손잡이(grip)에 붙인다 */
+    handleProps: {
+      draggable: true,
+      onDragStart: (event: React.DragEvent) => {
+        event.dataTransfer.setData("text/plain", nodeId);
+        event.dataTransfer.effectAllowed = "move";
+        // 기본 미리보기는 손잡이 아이콘뿐이라 뭘 옮기는지 안 보인다 → 행 전체를 쓴다
+        if (rowRef.current) event.dataTransfer.setDragImage(rowRef.current, 12, 19);
+        onDraggingChange({ id: nodeId, parentId, hasChildren });
+      },
+      onDragEnd: () => {
+        onDraggingChange(null);
+        setDropZone(null);
+      },
+    },
+    /** 행 전체에 붙인다 */
+    rowProps: {
+      onDragOver: (event: React.DragEvent) => {
+        if (!canDrop) return;
+        const { top, height } = event.currentTarget.getBoundingClientRect();
+        const zone = resolveZone(event.clientY - top, height);
+        if (!zone) return;
+        event.preventDefault();
+        event.dataTransfer.dropEffect = "move";
+        setDropZone(zone);
+      },
+      onDragLeave: () => setDropZone(null),
+      onDrop: (event: React.DragEvent) => {
+        if (!canDrop || !dropZone) return;
+        event.preventDefault();
+        onMove(event.dataTransfer.getData("text/plain"), nodeId, dropZone);
+        setDropZone(null);
+        // 옮긴 행은 원래 자리에서 사라지므로 그 행의 dragend가 오지 않는다.
+        // 여기서 직접 끝내지 않으면 "끌고 있는 중" 표시(흐림)가 그대로 남는다.
+        onDraggingChange(null);
+      },
+    },
+  };
+}

--- a/src/features/onboarding/use-department-tree.ts
+++ b/src/features/onboarding/use-department-tree.ts
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+
+import {
+  appendChild,
+  createDepartment,
+  demoteNode,
+  findNode,
+  findSiblings,
+  moveNodeTo,
+  nextAvailableName,
+  promoteNode,
+  removeDepartment,
+  renameDepartment,
+  shiftNode,
+} from "./tree";
+import type { DepartmentNode } from "./types";
+
+const NEW_CHILD_NAME = "새 하위 부서";
+
+/**
+ * 부서 트리 편집 상태.
+ * 트리 조작 자체는 `tree.ts`의 순수 함수가 하고, 여기서는 **무엇을 언제 부를지**만 정한다.
+ */
+export function useDepartmentTree(initial: DepartmentNode[]) {
+  const [departments, setDepartments] = useState(initial);
+  /** 이름을 편집 중인 부서 — 새로 만든 부서는 바로 편집 상태로 연다 */
+  const [editingId, setEditingId] = useState<string | null>(null);
+  /** 하위까지 사라지는 삭제는 확인을 받는다 */
+  const [pendingDelete, setPendingDelete] = useState<DepartmentNode | null>(null);
+
+  const addRoot = (name: string) => {
+    const trimmed = name.trim();
+    if (!trimmed) return false;
+    setDepartments((prev) => [...prev, createDepartment(trimmed)]);
+    return true;
+  };
+
+  const addChild = (parentId: string) => {
+    const name = nextAvailableName(findSiblings(departments, parentId), NEW_CHILD_NAME);
+    const child = createDepartment(name);
+    setDepartments((prev) => appendChild(prev, parentId, child));
+    setEditingId(child.id);
+  };
+
+  const requestRemove = (id: string) => {
+    const target = findNode(departments, id);
+    if (!target) return;
+    if (target.children.length > 0) setPendingDelete(target);
+    else setDepartments((prev) => removeDepartment(prev, id));
+  };
+
+  const confirmRemove = (id: string) => {
+    setDepartments((prev) => removeDepartment(prev, id));
+    setPendingDelete(null);
+  };
+
+  return {
+    departments,
+    editingId,
+    setEditingId,
+    pendingDelete,
+    cancelRemove: () => setPendingDelete(null),
+    addRoot,
+    addChild,
+    requestRemove,
+    confirmRemove,
+    rename: (id: string, name: string) =>
+      setDepartments((prev) => renameDepartment(prev, id, name)),
+    move: (draggedId: string, targetId: string, position: "before" | "after" | "inside") =>
+      setDepartments((prev) => moveNodeTo(prev, draggedId, targetId, position)),
+    shift: (id: string, offset: 1 | -1) => setDepartments((prev) => shiftNode(prev, id, offset)),
+    promote: (id: string) => setDepartments((prev) => promoteNode(prev, id)),
+    demote: (id: string) => setDepartments((prev) => demoteNode(prev, id)),
+  };
+}

--- a/src/mocks/config.ts
+++ b/src/mocks/config.ts
@@ -1,0 +1,7 @@
+/**
+ * 목 / 실서버 전환 스위치.
+ *
+ * ⚠️ ERD·API 스펙이 없어 지금은 목으로 개발한다(DECISIONS). BE가 붙으면 이 값만 끄면 된다.
+ * 분기는 각 도메인의 `server.ts`와 `actions.ts`에서만 한다 — 컴포넌트는 이 값을 몰라야 한다.
+ */
+export const isMock = process.env.NEXT_PUBLIC_USE_MOCK !== "false";


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가
- [x] design — UI/UX 변경
- [x] test — 테스트 코드

---

## 🗂 작업 영역

- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독

---

## 🙋 관련 역할

- [x] OWNER (대표)

---

## 📝 작업 내용

**무엇을** — 온보딩 1단계 **부서 체계** 화면(`/onboarding/1`)을 만들었습니다. OWNER가 기업 생성 직후 부서 트리를 구성합니다.

**되는 것**

- 부서 추가 / 이름 변경(더블클릭 · Enter · Esc) / 삭제
- **드래그로 순서 변경 + 다른 상위 부서로 이동** — 위/아래 끝에 놓으면 그 자리에 끼우고, 가운데에 놓으면 그 부서의 하위로 들어갑니다
- 좌측 축약 미리보기 — 트리와 **같은 상태 하나**를 보고 그려서 동기화 코드가 없습니다
- 부서를 아무리 추가해도 카드 크기가 그대로고 **안에서만 스크롤**됩니다

**설계 판단**

- **트리 조작을 React 밖으로 뺐습니다.** `tree.ts`는 순수 함수만 있어 컴포넌트 없이 테스트합니다 → **테스트 28개**
- **상태는 한 곳(`useDepartmentTree`)** — 좌우가 같은 배열을 봅니다. 부서 개수도 상태로 두지 않고 계산합니다(어긋날 여지 제거)
- **격리막** — `server.ts`가 `isMock`을 분기하고, 컴포넌트는 `DepartmentNode` 타입만 압니다. **연동 시 `server.ts`만 고치면 됩니다**
- **드래그가 어색했던 원인 2개를 고쳤습니다** — ①기본 미리보기가 손잡이 아이콘뿐이라 뭘 옮기는지 안 보임 → 행 전체를 미리보기로 ②옮긴 행이 사라지면서 `dragend`를 못 받아 "끌고 있는 중" 표시가 남음 → 놓는 시점에 직접 해제

**#10 규칙 반영** — 하위가 있는 부서는 **"묶음"** 으로 표시하고, 2계층까지만 만들 수 있습니다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [ ] 🔐 권한 2축 — ⚠️ **미적용.** 라우트 가드는 `middleware.ts`가 생긴 뒤에 붙입니다(범위 밖)
- [ ] 🧬 zod — API 스펙 미확정이라 스키마 없음. `server.ts`에 자리만 잡아둠
- [x] 🕵️ **정직성** — 목 데이터 · 저장 미구현을 주석에 명시. 새로고침하면 사라집니다
- [x] 🎨 **디자인 토큰** — 생 hex 0건, 다크모드 확인 완료

**품질**

- [x] ⚡ 최적화 — 서버 컴포넌트 기본, `'use client'`는 상호작용 컴포넌트만
- [x] ♿ **a11y** — `label htmlFor` · 아이콘 버튼 `aria-label` · `aria-expanded` · `aria-current="step"` · **DnD 키보드 대체 경로**(`Alt`+↑↓ 순서, ←→ 계층)
- [x] ♻️ 재사용 확인 — `components/ui`의 Input · Dialog · Button · Skeleton 사용
- [x] 🧪 **loading / error / empty** 3상태 전부
- [ ] 브라우저 전용 API — 해당 없음

---

## 🔗 연관 이슈

Closes #12

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- ⚠️ **이 PR은 #11(로고) 위에 쌓여 있습니다.** 헤더에서 `ZLogo`를 쓰기 때문입니다. **#14를 먼저 머지**해 주세요 — 그러면 base가 develop으로 자동 전환됩니다.
- ⚠️ **저장이 안 됩니다.** `actions.ts`(Server Action)는 API 스펙 확정 후 별도 이슈입니다. 지금은 편집 내용이 브라우저 메모리에만 있습니다.
- ⚠️ **`/onboarding/2`가 없어 "다음" 버튼이 404입니다.** 직급 체계 화면은 시안 확정 후 별도 이슈입니다.
- ⚠️ **시안의 주 버튼이 먹색인데 토큰 액센트는 파랑(`#3B82F6`)입니다.** 일단 시안을 따랐고 주석을 남겼습니다 — 시안 전체가 먹색이면 토큰을 고치는 게 맞습니다.
- 드래그는 **실제 마우스로** 확인 부탁드립니다. 자동 테스트로는 HTML5 드래그의 실제 감각까지 검증이 안 됩니다.
- 계층 제한을 `use-department-drag.ts`에서 막는 구조가 맞는지 봐주세요. `tree.ts`는 트리 조작만 하고 정책을 모릅니다.


---

## 📝 추가 메모

-
