### PR TITLE
[FEAT] 온보딩 2단계 직급 체계 화면 #16

### DIFF
--- a/src/app/(onboarding)/onboarding/2/error.tsx
+++ b/src/app/(onboarding)/onboarding/2/error.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { RotateCw } from "lucide-react";
+import { useEffect } from "react";
+
+import { Button } from "@/components/ui/button";
+
+/** 직급을 불러오지 못했을 때. 조용히 빈 화면을 보여주지 않는다(CLAUDE.md: 정직성). */
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="bg-background flex min-h-dvh flex-col items-center justify-center gap-4 px-6 text-center">
+      <div className="flex flex-col gap-2">
+        <h1 className="text-lg font-semibold tracking-tight">직급을 불러오지 못했어요</h1>
+        <p className="text-muted-foreground text-[13px] leading-[21px]">
+          잠시 후 다시 시도해 주세요. 계속 안 되면 담당자에게 알려주세요.
+        </p>
+      </div>
+      <Button type="button" onClick={reset}>
+        <RotateCw />
+        다시 시도
+      </Button>
+    </div>
+  );
+}

--- a/src/app/(onboarding)/onboarding/2/loading.tsx
+++ b/src/app/(onboarding)/onboarding/2/loading.tsx
@@ -1,0 +1,26 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { OnboardingShell } from "@/features/onboarding/components/onboarding-shell";
+import { ONBOARDING_STEP } from "@/features/onboarding/types";
+
+/** 직급을 불러오는 동안. 실제 화면과 같은 골격이라 레이아웃이 흔들리지 않는다. */
+export default function Loading() {
+  return (
+    <OnboardingShell step={ONBOARDING_STEP.POSITION}>
+      <div className="flex flex-col gap-[21px]">
+        <div className="flex flex-col gap-7 lg:h-[560px] lg:flex-row">
+          <div className="flex w-full flex-col gap-[17.5px] lg:w-[300px] lg:shrink-0">
+            <Skeleton className="size-7 rounded-full" />
+            <Skeleton className="h-6 w-52" />
+            <Skeleton className="h-16 w-full" />
+            <Skeleton className="h-20 w-full" />
+            <Skeleton className="flex-1" />
+          </div>
+          <Skeleton className="h-[440px] flex-1 lg:h-full" />
+        </div>
+        <div className="border-border flex justify-end border-t pt-[17.5px]">
+          <Skeleton className="h-[34px] w-[130px]" />
+        </div>
+      </div>
+    </OnboardingShell>
+  );
+}

--- a/src/app/(onboarding)/onboarding/2/page.tsx
+++ b/src/app/(onboarding)/onboarding/2/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+
+import { OnboardingShell } from "@/features/onboarding/components/onboarding-shell";
+import { PositionSetup } from "@/features/onboarding/components/position-setup";
+import { getPositions } from "@/features/onboarding/server";
+import { ONBOARDING_STEP } from "@/features/onboarding/types";
+
+export const metadata: Metadata = {
+  title: "직급 체계 설정 — Z",
+};
+
+export default async function OnboardingPositionPage() {
+  const positions = await getPositions();
+
+  return (
+    <OnboardingShell step={ONBOARDING_STEP.POSITION}>
+      <PositionSetup initialPositions={positions} />
+    </OnboardingShell>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -42,6 +42,14 @@
   /* Z 추가 — shadcn 기본에 없는 시맨틱/상태 색. 이걸 등록해야 `bg-success`·`bg-status-todo`가 생긴다. */
   --color-success: var(--success);
   --color-warning: var(--warning);
+  --color-role-owner: var(--role-owner);
+  --color-role-owner-surface: var(--role-owner-surface);
+  --color-role-admin: var(--role-admin);
+  --color-role-admin-surface: var(--role-admin-surface);
+  --color-role-leader: var(--role-leader);
+  --color-role-leader-surface: var(--role-leader-surface);
+  --color-role-member: var(--role-member);
+  --color-role-member-surface: var(--role-member-surface);
   --color-status-todo: var(--status-todo);
   --color-status-progress: var(--status-progress);
   --color-status-done: var(--status-done);
@@ -89,6 +97,15 @@
   --success: #22c55e;
   --warning: #f59e0b;
   /* 상태 점: 대기=회색 · 진행중=초록 · 완료=보라 */
+  /* 역할 배지 — 권한 수준을 색으로 구분한다(직급·권한 매핑) */
+  --role-owner: #ea580c;
+  --role-owner-surface: #fff7ed;
+  --role-admin: #9333ea;
+  --role-admin-surface: #f3e8ff;
+  --role-leader: #0284c7;
+  --role-leader-surface: #e0f2fe;
+  --role-member: #78716c;
+  --role-member-surface: #f5f5f4;
   --status-todo: #a8a29e;
   --status-progress: #22c55e;
   --status-done: #8b5cf6;
@@ -128,6 +145,15 @@
   --success: #22c55e;
   --warning: #f59e0b;
   /* 상태 점은 배경이 밝아진 만큼 같이 올린다(대기 점이 배경에 묻히지 않게) */
+  /* 역할 배지 — 어두운 배경에서 읽히도록 글자는 밝게, 바탕은 낮은 채도로 */
+  --role-owner: #fb923c;
+  --role-owner-surface: #3a2010;
+  --role-admin: #c084fc;
+  --role-admin-surface: #2e1b3f;
+  --role-leader: #38bdf8;
+  --role-leader-surface: #10283a;
+  --role-member: #a8a29e;
+  --role-member-surface: #2e2a28;
   --status-todo: #8a827d;
   --status-progress: #22c55e;
   --status-done: #a78bfa;

--- a/src/constants/domain.ts
+++ b/src/constants/domain.ts
@@ -157,6 +157,36 @@ export const ROLE = {
 } as const;
 export type Role = (typeof ROLE)[keyof typeof ROLE];
 
+/** 화면 표기 — 역할은 한글로 번역하지 않는다. */
+export const ROLE_LABEL: Record<Role, string> = {
+  OWNER: "Owner",
+  ADMIN: "Admin",
+  LEADER: "Leader",
+  MEMBER: "Member",
+  SYSTEM: "System",
+};
+
+/** 권한 범위를 한 줄로 설명한 것. 직급·권한 매핑 화면의 범례에 쓴다. */
+export const ROLE_SCOPE_LABEL: Record<Role, string> = {
+  OWNER: "기업 전체 관리",
+  ADMIN: "구성원·조직·회의실 관리",
+  LEADER: "팀 현황·액션 관리",
+  MEMBER: "일반 사용",
+  SYSTEM: "Z 서비스 운영",
+};
+
+/** 사원에게 부여할 수 있는 역할. `SYSTEM`은 서비스 운영자라 기업이 고를 수 없다. */
+export const ASSIGNABLE_ROLES = [ROLE.OWNER, ROLE.ADMIN, ROLE.LEADER, ROLE.MEMBER] as const;
+
+/**
+ * **직급에 매핑할 수 있는 역할.**
+ *
+ * `OWNER`·`ADMIN`은 기업당 1명이고, **기업 승인 시 시스템이 두 계정을 발급해 대표에게 메일로 보낸다.**
+ * 여러 사원이 같은 직급을 쓰므로 직급에 매핑하면 인원이 늘어난다 — 그래서 직급 매핑 대상이 아니다.
+ * 한 사람에게 두 권한이 필요하면 계정을 따로 쓴다(예: 인사팀장 = Admin 계정 + Leader 계정).
+ */
+export const POSITION_ROLES = [ROLE.LEADER, ROLE.MEMBER] as const;
+
 /* ───────── 구독 · 기업 ───────── */
 export const PLAN = { FREE: "FREE", TEAM: "TEAM" } as const;
 export type Plan = (typeof PLAN)[keyof typeof PLAN];

--- a/src/features/onboarding/components/department-intro.tsx
+++ b/src/features/onboarding/components/department-intro.tsx
@@ -1,44 +1,24 @@
-import type { DepartmentNode } from "../types";
+import { type DepartmentNode, ONBOARDING_STEP } from "../types";
 import { DepartmentPreview } from "./department-preview";
+import { StepHeading } from "./step-heading";
+import { StepHintList } from "./step-hint-list";
 
 const BENEFITS = [
   "회의를 만들 때 부서 전체를 한 번에 초대",
   "인수인계 대상자를 부서 기준으로 추리기",
   "부서별 활동 통계 자동 집계",
-];
+] as const;
 
 /** 온보딩 1단계 좌측 — 설명과 축약 미리보기. */
 export function DepartmentIntro({ departments }: { departments: DepartmentNode[] }) {
   return (
     <section className="flex w-full flex-col gap-[17.5px] lg:h-full lg:w-[300px] lg:shrink-0">
-      <div className="flex items-center gap-[10.5px]">
-        <span className="bg-foreground text-background flex size-7 items-center justify-center rounded-full text-[13px] leading-5">
-          1
-        </span>
-        <span className="bg-border h-px flex-1" aria-hidden />
-      </div>
+      <StepHeading step={ONBOARDING_STEP.DEPARTMENT} title="부서 체계를 만들어 주세요">
+        회의 참석자, 알림 대상, 인수인계 범위를 부서 단위로 관리해요. 지금 만들어 두면 사원이 합류할
+        때 바로 배정할 수 있습니다.
+      </StepHeading>
 
-      <div>
-        <h1 className="text-xl leading-[25px] font-semibold tracking-[-0.4px]">
-          부서 체계를 만들어 주세요
-        </h1>
-        <p className="text-muted-foreground pt-[7px] text-[13px] leading-[21px]">
-          회의 참석자, 알림 대상, 인수인계 범위를 부서 단위로 관리해요. 지금 만들어 두면 사원이
-          합류할 때 바로 배정할 수 있습니다.
-        </p>
-      </div>
-
-      <ul className="flex flex-col gap-[7px]">
-        {BENEFITS.map((benefit) => (
-          <li key={benefit} className="text-muted-foreground flex gap-[7px] text-xs leading-[19px]">
-            <span
-              className="bg-foreground mt-[7px] size-[3.5px] shrink-0 rounded-full"
-              aria-hidden
-            />
-            {benefit}
-          </li>
-        ))}
-      </ul>
+      <StepHintList items={BENEFITS} />
 
       <div className="border-border bg-background/80 text-muted-foreground/70 flex flex-col gap-1.5 rounded-md border p-[10.5px] text-[11px] leading-[18px]">
         <p>이름을 더블클릭하면 바꿀 수 있어요. 나중에 설정에서 언제든 수정할 수 있습니다.</p>

--- a/src/features/onboarding/components/department-node-actions.tsx
+++ b/src/features/onboarding/components/department-node-actions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Plus, Trash2 } from "lucide-react";
+import { Plus, X } from "lucide-react";
 import type { ReactNode } from "react";
 
 interface DepartmentNodeActionsProps {
@@ -25,7 +25,7 @@ export function DepartmentNodeActions({
         </IconButton>
       )}
       <IconButton label={`${name} 삭제`} onClick={onRemove}>
-        <Trash2 className="size-3.5" />
+        <X className="size-3.5" />
       </IconButton>
     </span>
   );

--- a/src/features/onboarding/components/department-node.tsx
+++ b/src/features/onboarding/components/department-node.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ChevronRight, Folder, GripVertical } from "lucide-react";
-import { useRef, useState } from "react";
+import { useState } from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -40,7 +40,6 @@ export function DepartmentNode({ node, depth, parentId, ...handlers }: Departmen
   const { onRename, onAddChild, onRemove, onShift, onPromote, onDemote } = handlers;
   const { editingId, onEditingChange } = handlers;
 
-  const rowRef = useRef<HTMLDivElement>(null);
   const [isExpanded, setIsExpanded] = useState(true);
 
   const hasChildren = node.children.length > 0;
@@ -51,7 +50,7 @@ export function DepartmentNode({ node, depth, parentId, ...handlers }: Departmen
     parentId,
     depth,
     hasChildren,
-    rowRef,
+    nodeName: node.name,
     dragging: handlers.dragging,
     onDraggingChange: handlers.onDraggingChange,
     onMove: handlers.onMove,
@@ -80,7 +79,6 @@ export function DepartmentNode({ node, depth, parentId, ...handlers }: Departmen
   return (
     <>
       <div
-        ref={rowRef}
         {...rowProps}
         className={cn(
           "group relative flex h-[38px] items-center gap-2 rounded-md px-2 transition-[background-color,opacity]",

--- a/src/features/onboarding/components/department-preview.tsx
+++ b/src/features/onboarding/components/department-preview.tsx
@@ -26,15 +26,15 @@ export function DepartmentPreview({ departments }: { departments: DepartmentNode
             className={
               depth === 0
                 ? "bg-foreground size-[7px] shrink-0 rounded-full"
-                : "bg-muted-foreground/60 size-[5px] shrink-0 rounded-full"
+                : "bg-muted-foreground size-[5px] shrink-0 rounded-full"
             }
             aria-hidden
           />
           <span
             className={
               depth === 0
-                ? "text-muted-foreground truncate text-[10px]"
-                : "text-muted-foreground/70 truncate text-[9px]"
+                ? "text-foreground truncate text-[10px]"
+                : "text-muted-foreground truncate text-[10px]"
             }
           >
             {name}

--- a/src/features/onboarding/components/department-setup.tsx
+++ b/src/features/onboarding/components/department-setup.tsx
@@ -96,7 +96,7 @@ export function DepartmentSetup({
           href="/onboarding/2"
           className={cn(
             buttonVariants(),
-            "bg-foreground text-background hover:bg-foreground/90 h-[34px] gap-[5.25px] rounded-md px-[12.25px] text-[13px] leading-5",
+            "bg-foreground text-background hover:bg-foreground/90 h-[34px] gap-[5.25px] rounded-md px-[12.25px] text-[13px] leading-none",
           )}
         >
           다음

--- a/src/features/onboarding/components/onboarding-shell.tsx
+++ b/src/features/onboarding/components/onboarding-shell.tsx
@@ -5,6 +5,7 @@ import { ZLogo } from "@/components/icons/z-logo";
 import { cn } from "@/lib/utils";
 
 import { ONBOARDING_STEP_LABEL, ONBOARDING_TOTAL_STEPS, type OnboardingStep } from "../types";
+import { StepCircle } from "./step-circle";
 
 const STEPS = Object.keys(ONBOARDING_STEP_LABEL).map(Number) as OnboardingStep[];
 
@@ -34,16 +35,19 @@ export function OnboardingShell({ step, children }: OnboardingShellProps) {
         <ol className="flex flex-wrap items-center">
           {STEPS.map((value) => (
             <li key={value} className="flex items-center">
-              <StepBadge
-                label={ONBOARDING_STEP_LABEL[value]}
-                value={String(value)}
-                isActive={value === step}
+              <StepperItem label={ONBOARDING_STEP_LABEL[value]} step={value} current={step} />
+              {/* 지나온 구간은 선도 완료 색으로 이어진다 */}
+              <span
+                className={cn("mx-[14px] h-px w-[35px]", value < step ? "bg-success" : "bg-border")}
+                aria-hidden
               />
-              <span className="bg-border mx-[14px] h-px w-[35px]" aria-hidden />
             </li>
           ))}
-          <li className="pl-[14px]">
-            <StepBadge label="완료" value={<Check className="size-3" />} isActive={false} isDone />
+          <li className="flex items-center gap-[7px] pl-[14px]">
+            <StepCircle tone="idle" size={28}>
+              <Check className="size-3" />
+            </StepCircle>
+            <span className="text-muted-foreground/70 text-xs leading-[18px]">완료</span>
           </li>
         </ol>
       </footer>
@@ -51,34 +55,38 @@ export function OnboardingShell({ step, children }: OnboardingShellProps) {
   );
 }
 
-function StepBadge({
+function StepperItem({
   label,
-  value,
-  isActive,
-  isDone = false,
+  step,
+  current,
 }: {
   label: string;
-  value: ReactNode;
-  isActive: boolean;
-  isDone?: boolean;
+  step: OnboardingStep;
+  current: OnboardingStep;
 }) {
+  const isDone = step < current;
+  const isCurrent = step === current;
+
   return (
     <span
       className={cn(
         "flex items-center gap-[7px] text-xs leading-[18px]",
-        isActive ? "text-foreground" : "text-muted-foreground/70",
+        isDone && "text-success",
+        isCurrent && "text-foreground",
+        !isDone && !isCurrent && "text-muted-foreground/70",
       )}
-      aria-current={isActive ? "step" : undefined}
+      aria-current={isCurrent ? "step" : undefined}
     >
-      <span
-        className={cn(
-          "flex items-center justify-center rounded-full text-[11px] leading-4 tabular-nums",
-          isDone ? "size-7" : "size-[21px]",
-          isActive ? "bg-foreground text-background" : "bg-secondary",
+      <StepCircle tone={isDone ? "done" : isCurrent ? "current" : "idle"} size={21}>
+        {isDone ? (
+          <>
+            <Check className="size-[11px]" />
+            <span className="sr-only">완료됨</span>
+          </>
+        ) : (
+          <span className="text-[11px]">{step}</span>
         )}
-      >
-        {value}
-      </span>
+      </StepCircle>
       {label}
     </span>
   );

--- a/src/features/onboarding/components/position-add-row.tsx
+++ b/src/features/onboarding/components/position-add-row.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Plus } from "lucide-react";
+
+import { Input } from "@/components/ui/input";
+
+import type { AssignableRole } from "../types";
+import { RoleSelect } from "./role-select";
+
+interface PositionAddRowProps {
+  name: string;
+  role: AssignableRole;
+  onNameChange: (name: string) => void;
+  onRoleChange: (role: AssignableRole) => void;
+  onSubmit: () => void;
+}
+
+/** 카드 하단 — 직급 추가 줄(이름 + 권한). */
+export function PositionAddRow({
+  name,
+  role,
+  onNameChange,
+  onRoleChange,
+  onSubmit,
+}: PositionAddRowProps) {
+  return (
+    <div className="border-border bg-muted flex h-[54px] shrink-0 items-center gap-2 border-t px-4">
+      <label htmlFor="new-position" className="sr-only">
+        직급명
+      </label>
+      <Input
+        id="new-position"
+        value={name}
+        placeholder="직급명 입력 (Enter)"
+        onChange={(event) => onNameChange(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            event.preventDefault();
+            onSubmit();
+          }
+        }}
+        className="h-8 flex-1 rounded-md border border-dashed bg-transparent px-2.5 text-[13px]"
+      />
+      <RoleSelect value={role} onChange={onRoleChange} label="새 직급 권한" className="h-8" />
+      <button
+        type="button"
+        onClick={onSubmit}
+        className="text-muted-foreground bg-foreground/5 hover:bg-foreground/10 focus-visible:ring-ring flex h-8 shrink-0 items-center gap-1 rounded-md px-2.5 text-[13px] transition-colors focus-visible:ring-2 focus-visible:outline-none"
+      >
+        <Plus className="size-3.5" />
+        추가
+      </button>
+    </div>
+  );
+}

--- a/src/features/onboarding/components/position-intro.tsx
+++ b/src/features/onboarding/components/position-intro.tsx
@@ -1,0 +1,35 @@
+import { ASSIGNABLE_ROLES, ROLE_LABEL, ROLE_SCOPE_LABEL } from "@/constants/domain";
+
+import { ONBOARDING_STEP, type Position } from "../types";
+import { PositionPreview } from "./position-preview";
+import { StepHeading } from "./step-heading";
+import { StepHintList } from "./step-hint-list";
+
+const ROLE_HINTS = ASSIGNABLE_ROLES.map((role) => `${ROLE_LABEL[role]}: ${ROLE_SCOPE_LABEL[role]}`);
+
+/** 온보딩 2단계 좌측 — 설명과 축약 미리보기. */
+export function PositionIntro({ positions }: { positions: Position[] }) {
+  return (
+    <section className="flex w-full flex-col gap-[17.5px] lg:h-full lg:w-[300px] lg:shrink-0">
+      <StepHeading step={ONBOARDING_STEP.POSITION} title="직급 체계를 설정해 주세요">
+        직급마다 Z 내 권한 수준을 지정해요. 나중에 사원 프로필에서 개별 조정할 수 있습니다.
+      </StepHeading>
+
+      <StepHintList items={ROLE_HINTS} />
+
+      <div className="border-border bg-background/80 text-muted-foreground/70 flex flex-col gap-1.5 rounded-md border p-[10.5px] text-[11px] leading-[18px]">
+        <p>직급명은 회사마다 다르게 쓰세요. 권한은 직급명과 무관하게 직접 지정합니다.</p>
+        <p>
+          <span className="text-muted-foreground">Owner · Admin 계정</span>은 기업 승인 때 시스템이
+          발급해 대표 메일로 보내드려요. 여기서는 지정하지 않습니다.
+        </p>
+        <p>
+          한 사람에게 두 권한이 필요하면 <span className="text-muted-foreground">계정을 따로</span>{" "}
+          씁니다. 예를 들어 인사팀장은 Admin 계정과 Leader 계정을 각각 갖습니다.
+        </p>
+      </div>
+
+      <PositionPreview positions={positions} />
+    </section>
+  );
+}

--- a/src/features/onboarding/components/position-preview.tsx
+++ b/src/features/onboarding/components/position-preview.tsx
@@ -1,0 +1,36 @@
+import type { AssignableRole, Position } from "../types";
+import { SYSTEM_ISSUED_POSITIONS } from "../types";
+import { RoleBadge } from "./role-badge";
+
+/**
+ * 좌측 축약 미리보기.
+ * 위 두 줄(대표·관리자)은 **기업 승인 때 발급되는 계정**이고,
+ * 아래는 이 화면에서 매핑한 직급이 그대로 따라온다.
+ */
+export function PositionPreview({ positions }: { positions: Position[] }) {
+  return (
+    // 남는 세로 공간을 채운다. 직급이 많아지면 안에서만 스크롤한다(스크롤바 숨김)
+    <ul className="border-border bg-background/50 flex min-h-20 flex-1 [scrollbar-width:none] flex-col gap-2 overflow-auto rounded-lg border p-3 [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
+      {SYSTEM_ISSUED_POSITIONS.map((issued) => (
+        <PreviewRow key={issued.name} name={issued.name} role={issued.role} />
+      ))}
+      {positions.map((position) => (
+        <PreviewRow key={position.id} name={position.name} role={position.role} />
+      ))}
+      {positions.length === 0 && (
+        <li className="text-muted-foreground/70 py-1 text-center text-[10px]">
+          아직 직급이 없어요
+        </li>
+      )}
+    </ul>
+  );
+}
+
+function PreviewRow({ name, role }: { name: string; role: AssignableRole }) {
+  return (
+    <li className="flex h-[18px] items-center justify-between gap-2">
+      <span className="text-muted-foreground truncate text-[10px]">{name}</span>
+      <RoleBadge role={role} className="text-[9px]" />
+    </li>
+  );
+}

--- a/src/features/onboarding/components/position-row.tsx
+++ b/src/features/onboarding/components/position-row.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { GripVertical, X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+import type { AssignableRole, Position } from "../types";
+import {
+  type DraggingPositionId,
+  type PositionDropEdge,
+  usePositionDrag,
+} from "../use-position-drag";
+import { RoleSelect } from "./role-select";
+
+export interface PositionRowHandlers {
+  onRename: (id: string, name: string) => void;
+  onChangeRole: (id: string, role: AssignableRole) => void;
+  onRemove: (id: string) => void;
+  onMove: (draggedId: string, targetId: string, edge: PositionDropEdge) => void;
+  /** 키보드 대체 경로 — Alt + ↑/↓ */
+  onShift: (id: string, offset: 1 | -1) => void;
+  editingId: string | null;
+  onEditingChange: (id: string | null) => void;
+  draggingId: DraggingPositionId;
+  onDraggingChange: (id: DraggingPositionId) => void;
+}
+
+interface PositionRowProps extends PositionRowHandlers {
+  position: Position;
+  /** 서열 순서(0부터). 화면에는 1부터 보여준다. */
+  index: number;
+}
+
+export function PositionRow({ position, index, ...handlers }: PositionRowProps) {
+  const { onRename, onChangeRole, onRemove, onShift, editingId, onEditingChange } = handlers;
+
+  const isEditing = editingId === position.id;
+
+  const { isDragged, dropEdge, handleProps, rowProps } = usePositionDrag({
+    positionId: position.id,
+    positionName: position.name,
+    draggingId: handlers.draggingId,
+    onDraggingChange: handlers.onDraggingChange,
+    onMove: handlers.onMove,
+  });
+
+  const submitName = (value: string) => {
+    const name = value.trim();
+    if (name) onRename(position.id, name);
+    onEditingChange(null);
+  };
+
+  return (
+    <div
+      {...rowProps}
+      className={cn(
+        "group border-border relative flex h-[38px] items-center gap-2 border-t px-4 transition-[background-color,opacity]",
+        isDragged ? "opacity-40" : "hover:bg-secondary/60",
+        // 점선 = 여기 들어온다. 하단 "직급명 입력"의 점선과 같은 표현이다.
+        dropEdge === "before" &&
+          "before:border-ring before:absolute before:inset-x-0 before:-top-0.5 before:border-t-2 before:border-dashed before:content-['']",
+        dropEdge === "after" &&
+          "after:border-ring after:absolute after:inset-x-0 after:-bottom-0.5 after:border-t-2 after:border-dashed after:content-['']",
+      )}
+    >
+      {/* 평소엔 서열 번호, 마우스를 올리면 그 자리가 드래그 손잡이가 된다 */}
+      <span className="relative flex w-5 shrink-0 items-center justify-center">
+        <span className="text-muted-foreground/40 text-[11px] leading-none tabular-nums transition-opacity group-focus-within:opacity-0 group-hover:opacity-0">
+          {index + 1}
+        </span>
+        <span
+          {...handleProps}
+          role="button"
+          tabIndex={0}
+          aria-label={`${position.name} 순서 이동 — Alt와 위아래 방향키로도 옮길 수 있어요`}
+          onKeyDown={(event) => {
+            if (!event.altKey) return;
+            if (event.key === "ArrowUp") {
+              event.preventDefault();
+              onShift(position.id, -1);
+            }
+            if (event.key === "ArrowDown") {
+              event.preventDefault();
+              onShift(position.id, 1);
+            }
+          }}
+          className="text-muted-foreground/50 hover:text-muted-foreground focus-visible:ring-ring absolute inset-0 flex cursor-grab items-center justify-center rounded opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none active:cursor-grabbing"
+        >
+          <GripVertical className="size-3.5" />
+        </span>
+      </span>
+
+      {isEditing ? (
+        <input
+          autoFocus
+          defaultValue={position.name}
+          aria-label="직급명"
+          onFocus={(event) => event.currentTarget.select()}
+          onBlur={(event) => submitName(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") submitName(event.currentTarget.value);
+            if (event.key === "Escape") onEditingChange(null);
+          }}
+          className="border-ring bg-background w-[80px] shrink-0 rounded border px-1.5 text-center text-[13px] leading-5 outline-none"
+        />
+      ) : (
+        <button
+          type="button"
+          onDoubleClick={() => onEditingChange(position.id)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              onEditingChange(position.id);
+            }
+          }}
+          aria-label={`${position.name} 이름 바꾸기`}
+          className="w-[80px] shrink-0 truncate text-center text-[13px] leading-5"
+        >
+          {position.name}
+        </button>
+      )}
+
+      <span className="flex-1" aria-hidden />
+
+      <span className="shrink-0">
+        <RoleSelect
+          value={position.role}
+          onChange={(role) => onChangeRole(position.id, role)}
+          label={`${position.name} 권한`}
+        />
+      </span>
+
+      <button
+        type="button"
+        aria-label={`${position.name} 삭제`}
+        onClick={() => onRemove(position.id)}
+        className="text-muted-foreground hover:text-foreground hover:bg-foreground/10 focus-visible:ring-ring flex size-6 shrink-0 items-center justify-center rounded opacity-0 transition-[color,background-color,opacity] group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none"
+      >
+        <X className="size-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/src/features/onboarding/components/position-setup.tsx
+++ b/src/features/onboarding/components/position-setup.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+import type { AssignableRole, Position } from "../types";
+import type { DraggingPositionId } from "../use-position-drag";
+import { usePositionList } from "../use-position-list";
+import { PositionAddRow } from "./position-add-row";
+import { PositionIntro } from "./position-intro";
+import { PositionRow, type PositionRowHandlers } from "./position-row";
+
+/**
+ * 온보딩 2단계 — 직급 체계.
+ * ⚠️ 저장은 미구현이다. 편집 내용은 브라우저 메모리에만 있고 새로고침하면 사라진다.
+ *    BE 연동 후 Server Action으로 붙인다.
+ */
+export function PositionSetup({ initialPositions }: { initialPositions: Position[] }) {
+  const list = usePositionList(initialPositions);
+  const [draftName, setDraftName] = useState("");
+  const [draftRole, setDraftRole] = useState<AssignableRole>(list.defaultRole);
+  const [draggingId, setDraggingId] = useState<DraggingPositionId>(null);
+
+  const handleAdd = () => {
+    if (list.add(draftName, draftRole)) {
+      setDraftName("");
+      setDraftRole(list.defaultRole);
+    }
+  };
+
+  const handlers: PositionRowHandlers = {
+    onRename: list.rename,
+    onChangeRole: list.changeRole,
+    onRemove: list.remove,
+    onMove: list.move,
+    onShift: list.shift,
+    editingId: list.editingId,
+    onEditingChange: list.setEditingId,
+    draggingId,
+    onDraggingChange: setDraggingId,
+  };
+
+  return (
+    <div className="flex flex-col gap-[21px]">
+      {/* 높이를 여기서 한 번만 정한다 — 좌우 두 칸이 같은 높이를 나눠 쓴다 */}
+      <div className="flex flex-col gap-7 lg:h-[560px] lg:flex-row">
+        <PositionIntro positions={list.positions} />
+
+        {/* 높이 고정 — 직급을 아무리 추가해도 카드 크기는 그대로고 안에서만 스크롤된다 */}
+        <section className="border-border bg-card flex h-[440px] flex-1 flex-col overflow-hidden rounded-xl border shadow-sm lg:h-full">
+          <header className="border-border bg-muted flex h-12 shrink-0 items-center justify-between border-b px-4">
+            <h2 className="flex items-center gap-2 text-[13px] leading-5">
+              <span className="bg-foreground size-2 rounded-full" aria-hidden />
+              직급·권한 매핑
+            </h2>
+            <span className="text-muted-foreground/70 text-xs leading-4 tabular-nums">
+              직급 {list.positions.length}개
+            </span>
+          </header>
+
+          {/* 행(PositionRow)과 같은 padding·gap·칸 너비를 써야 열이 맞는다 */}
+          <div className="text-muted-foreground/60 border-border bg-card flex h-7 shrink-0 items-center gap-2 border-b px-4 text-[11px] leading-4">
+            <span className="w-5 shrink-0" aria-hidden />
+            <span className="w-[80px] shrink-0 text-center">직급명</span>
+            <span className="flex-1" aria-hidden />
+            <span className="w-[92px] shrink-0 text-center">권한</span>
+            <span className="size-6 shrink-0" aria-hidden />
+          </div>
+
+          {/* 스크롤바는 숨긴다(스크롤 자체는 된다) */}
+          <div className="flex-1 [scrollbar-width:none] overflow-auto [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
+            {list.positions.length === 0 ? (
+              <p className="text-muted-foreground/70 py-12 text-center text-[13px]">
+                아래에서 첫 직급을 추가해 주세요
+              </p>
+            ) : (
+              list.positions.map((position, index) => (
+                <PositionRow key={position.id} position={position} index={index} {...handlers} />
+              ))
+            )}
+          </div>
+
+          <PositionAddRow
+            name={draftName}
+            role={draftRole}
+            onNameChange={setDraftName}
+            onRoleChange={setDraftRole}
+            onSubmit={handleAdd}
+          />
+        </section>
+      </div>
+
+      <div className="border-border flex items-center justify-end gap-2 border-t pt-[17.5px]">
+        <Link
+          href="/onboarding/1"
+          className={cn(
+            buttonVariants({ variant: "outline" }),
+            "h-[34px] gap-1 text-[13px] leading-none",
+          )}
+        >
+          <ChevronLeft className="size-3.5" />
+          이전
+        </Link>
+        {/* ⚠️ 저장은 미구현 — BE 연동 후 Server Action으로 붙인다.
+            시안의 주 버튼은 액센트(파랑)가 아니라 먹색이다(토큰 충돌 — 팀 확인 필요). */}
+        <Link
+          href="/onboarding/3"
+          className={cn(
+            buttonVariants(),
+            "bg-foreground text-background hover:bg-foreground/90 h-[34px] gap-[5.25px] rounded-md px-[12.25px] text-[13px] leading-none",
+          )}
+        >
+          다음
+          <ChevronRight className="size-3.5" />
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/features/onboarding/components/role-badge.tsx
+++ b/src/features/onboarding/components/role-badge.tsx
@@ -1,0 +1,35 @@
+import { ROLE_LABEL } from "@/constants/domain";
+import { cn } from "@/lib/utils";
+
+import type { AssignableRole } from "../types";
+
+/**
+ * 권한별 배지 색 — 값은 `globals.css`의 토큰이라 다크모드가 따라온다.
+ * 배지와 권한 선택(`RoleSelect`)이 같은 색을 써야 표에서 눈이 이어진다.
+ */
+export const ROLE_TONE: Record<AssignableRole, string> = {
+  OWNER: "bg-role-owner-surface text-role-owner",
+  ADMIN: "bg-role-admin-surface text-role-admin",
+  LEADER: "bg-role-leader-surface text-role-leader",
+  MEMBER: "bg-role-member-surface text-role-member",
+};
+
+interface RoleBadgeProps {
+  role: AssignableRole;
+  className?: string;
+}
+
+/** 권한 배지. 역할 워딩은 한글로 번역하지 않는다(CLAUDE.md 카피 규칙). */
+export function RoleBadge({ role, className }: RoleBadgeProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-[11px] leading-none",
+        ROLE_TONE[role],
+        className,
+      )}
+    >
+      {ROLE_LABEL[role]}
+    </span>
+  );
+}

--- a/src/features/onboarding/components/role-select.tsx
+++ b/src/features/onboarding/components/role-select.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { POSITION_ROLES, ROLE_LABEL } from "@/constants/domain";
+import { cn } from "@/lib/utils";
+
+import type { AssignableRole } from "../types";
+
+interface RoleSelectProps {
+  value: AssignableRole;
+  onChange: (role: AssignableRole) => void;
+  /** 스크린리더용 이름 — 어느 직급의 권한인지 알려준다 */
+  label: string;
+  className?: string;
+}
+
+/** 직급 한 줄의 권한 선택. 폭을 고정해 어떤 권한이든 크기가 같다. */
+export function RoleSelect({ value, onChange, label, className }: RoleSelectProps) {
+  return (
+    <Select value={value} onValueChange={(next) => onChange(next as AssignableRole)}>
+      <SelectTrigger
+        aria-label={label}
+        className={cn("h-7 w-[92px] justify-between px-2 text-xs leading-none", className)}
+      >
+        {/* 원본 값(LEADER)이 아니라 표기용 라벨(Leader)을 보여준다 */}
+        <SelectValue>{(role) => ROLE_LABEL[role as AssignableRole]}</SelectValue>
+      </SelectTrigger>
+
+      {/*
+        `alignItemWithTrigger={false}` — 켜두면 고른 항목이 트리거 위로 겹쳐 올라온다.
+        끄면 트리거 아래로만 펼쳐진다.
+      */}
+      <SelectContent
+        side="bottom"
+        align="start"
+        sideOffset={4}
+        alignItemWithTrigger={false}
+        // 기본 min-w-36이 트리거보다 넓다 — 칸 폭에 맞춘다
+        className="w-[92px] min-w-0"
+      >
+        {POSITION_ROLES.map((role) => (
+          <SelectItem key={role} value={role} className="text-xs">
+            {ROLE_LABEL[role]}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/features/onboarding/components/step-circle.tsx
+++ b/src/features/onboarding/components/step-circle.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+type StepCircleTone = "current" | "done" | "idle";
+
+interface StepCircleProps {
+  children: ReactNode;
+  tone: StepCircleTone;
+  /** 지름(px). 좌측 제목 옆은 28, 하단 스텝퍼는 21을 쓴다. */
+  size: number;
+  className?: string;
+}
+
+const TONE_CLASS: Record<StepCircleTone, string> = {
+  current: "bg-foreground text-background",
+  done: "bg-success text-background",
+  idle: "bg-secondary text-muted-foreground/70",
+};
+
+/**
+ * 단계 번호를 담는 원.
+ * ⚠️ `leading-none`이 핵심이다 — 줄높이를 주면 숫자가 원 안에서 아래로 밀려 가운데가 안 맞는다.
+ */
+export function StepCircle({ children, tone, size, className }: StepCircleProps) {
+  return (
+    <span
+      style={{ width: size, height: size }}
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center rounded-full leading-none tabular-nums",
+        TONE_CLASS[tone],
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/features/onboarding/components/step-heading.tsx
+++ b/src/features/onboarding/components/step-heading.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from "react";
+
+import type { OnboardingStep } from "../types";
+import { StepCircle } from "./step-circle";
+
+interface StepHeadingProps {
+  step: OnboardingStep;
+  title: string;
+  children: ReactNode;
+}
+
+/** 좌측 상단 — 단계 번호 · 구분선 · 제목 · 설명. 온보딩 3단계가 같은 형태를 쓴다. */
+export function StepHeading({ step, title, children }: StepHeadingProps) {
+  return (
+    <>
+      <div className="flex items-center gap-[10.5px]">
+        <StepCircle tone="current" size={28} className="text-[13px]">
+          {step}
+        </StepCircle>
+        <span className="bg-border h-px flex-1" aria-hidden />
+      </div>
+
+      <div>
+        <h1 className="text-xl leading-[25px] font-semibold tracking-[-0.4px]">{title}</h1>
+        <p className="text-muted-foreground pt-[7px] text-[13px] leading-[21px]">{children}</p>
+      </div>
+    </>
+  );
+}

--- a/src/features/onboarding/components/step-hint-list.tsx
+++ b/src/features/onboarding/components/step-hint-list.tsx
@@ -1,0 +1,13 @@
+/** 좌측 설명의 점 목록. 온보딩 각 단계가 같은 형태로 쓴다. */
+export function StepHintList({ items }: { items: readonly string[] }) {
+  return (
+    <ul className="flex flex-col gap-[7px]">
+      {items.map((item) => (
+        <li key={item} className="text-muted-foreground flex gap-[7px] text-xs leading-[19px]">
+          <span className="bg-foreground mt-[7px] size-[3.5px] shrink-0 rounded-full" aria-hidden />
+          {item}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/features/onboarding/drag-ghost.ts
+++ b/src/features/onboarding/drag-ghost.ts
@@ -1,0 +1,21 @@
+/**
+ * 드래그 중 커서를 따라다니는 미리보기를 만든다.
+ *
+ * ⚠️ 행 요소를 그대로 넘기면(`setDragImage(row)`) 행 폭이 수백 px이라
+ *    커서 옆으로 거대한 잔상이 뻗는다. 이름만 담은 **작은 조각**을 따로 만들어 쓴다.
+ */
+export function setCompactDragImage(event: React.DragEvent, label: string) {
+  const ghost = document.createElement("div");
+  ghost.textContent = label;
+  ghost.className =
+    "bg-card text-foreground border-border pointer-events-none rounded-md border px-2.5 py-1 text-[13px] leading-none shadow-sm";
+  // 화면 밖에 두고 스냅샷만 찍게 한다
+  ghost.style.position = "fixed";
+  ghost.style.top = "-1000px";
+  ghost.style.left = "-1000px";
+
+  document.body.appendChild(ghost);
+  event.dataTransfer.setDragImage(ghost, 14, 14);
+  // 스냅샷을 뜬 뒤에 지운다 — 즉시 지우면 미리보기가 비어 보인다
+  requestAnimationFrame(() => ghost.remove());
+}

--- a/src/features/onboarding/mock/positions.ts
+++ b/src/features/onboarding/mock/positions.ts
@@ -1,0 +1,14 @@
+import { ROLE } from "@/constants/domain";
+
+import type { Position } from "../types";
+
+/**
+ * ⚠️ 목 데이터 — BE 연동 전. 온보딩 진입 시 보여줄 기본 예시 직급이다.
+ * Owner·Admin은 기업 승인 때 시스템이 계정을 발급하므로 여기에 없다.
+ */
+export const INITIAL_POSITIONS: Position[] = [
+  { id: "lead", name: "팀장", role: ROLE.LEADER },
+  { id: "gwajang", name: "과장", role: ROLE.MEMBER },
+  { id: "daeri", name: "대리", role: ROLE.MEMBER },
+  { id: "staff", name: "사원", role: ROLE.MEMBER },
+];

--- a/src/features/onboarding/positions.test.ts
+++ b/src/features/onboarding/positions.test.ts
@@ -1,0 +1,108 @@
+import { ROLE } from "@/constants/domain";
+
+import {
+  changePositionRole,
+  createPosition,
+  movePosition,
+  nextAvailablePositionName,
+  removePosition,
+  renamePosition,
+  shiftPosition,
+} from "./positions";
+import type { Position } from "./types";
+
+const makeList = (): Position[] => [
+  { id: "lead", name: "팀장", role: ROLE.LEADER },
+  { id: "gwajang", name: "과장", role: ROLE.MEMBER },
+  { id: "daeri", name: "대리", role: ROLE.MEMBER },
+  { id: "staff", name: "사원", role: ROLE.MEMBER },
+];
+
+const names = (positions: Position[]) => positions.map((position) => position.name);
+const roleOf = (positions: Position[], id: string) =>
+  positions.find((position) => position.id === id)?.role;
+
+describe("createPosition", () => {
+  it("이름과 권한을 그대로 쓴다", () => {
+    const position = createPosition("차장", ROLE.MEMBER);
+    expect(position.name).toBe("차장");
+    expect(position.role).toBe(ROLE.MEMBER);
+    expect(position.id).toEqual(expect.any(String));
+  });
+});
+
+describe("nextAvailablePositionName", () => {
+  it("겹치지 않으면 그대로 쓴다", () => {
+    expect(nextAvailablePositionName(makeList(), "차장")).toBe("차장");
+  });
+
+  it("겹치면 2부터 번호를 붙인다", () => {
+    expect(nextAvailablePositionName(makeList(), "사원")).toBe("사원 2");
+  });
+
+  it("이미 쓰인 번호는 건너뛴다", () => {
+    const list = [...makeList(), createPosition("사원 2", ROLE.MEMBER)];
+    expect(nextAvailablePositionName(list, "사원")).toBe("사원 3");
+  });
+});
+
+describe("renamePosition / changePositionRole / removePosition", () => {
+  it("이름만 바꾸고 권한은 그대로 둔다", () => {
+    const next = renamePosition(makeList(), "staff", "주임");
+    expect(names(next)).toEqual(["팀장", "과장", "대리", "주임"]);
+    expect(roleOf(next, "staff")).toBe(ROLE.MEMBER);
+  });
+
+  it("권한만 바꾼다", () => {
+    expect(roleOf(changePositionRole(makeList(), "staff", ROLE.LEADER), "staff")).toBe(ROLE.LEADER);
+  });
+
+  it("지우면 그 줄만 사라진다", () => {
+    expect(names(removePosition(makeList(), "gwajang"))).toEqual(["팀장", "대리", "사원"]);
+  });
+
+  it("원본을 바꾸지 않는다", () => {
+    const original = makeList();
+    removePosition(original, "lead");
+    renamePosition(original, "lead", "실장");
+    expect(names(original)).toEqual(["팀장", "과장", "대리", "사원"]);
+  });
+});
+
+describe("shiftPosition", () => {
+  it("한 칸 위로 옮긴다", () => {
+    expect(names(shiftPosition(makeList(), "daeri", -1))).toEqual(["팀장", "대리", "과장", "사원"]);
+  });
+
+  it("맨 끝에서 더 나가면 그대로 둔다", () => {
+    const list = makeList();
+    expect(shiftPosition(list, "lead", -1)).toEqual(list);
+    expect(shiftPosition(list, "staff", 1)).toEqual(list);
+  });
+});
+
+describe("movePosition", () => {
+  it("대상 앞/뒤로 옮긴다", () => {
+    expect(names(movePosition(makeList(), "staff", "lead", "before"))).toEqual([
+      "사원",
+      "팀장",
+      "과장",
+      "대리",
+    ]);
+    expect(names(movePosition(makeList(), "lead", "staff", "after"))).toEqual([
+      "과장",
+      "대리",
+      "사원",
+      "팀장",
+    ]);
+  });
+
+  it("자기 자신으로는 옮기지 않는다", () => {
+    const list = makeList();
+    expect(movePosition(list, "lead", "lead", "before")).toEqual(list);
+  });
+
+  it("옮겨도 개수는 그대로다", () => {
+    expect(movePosition(makeList(), "staff", "lead", "before")).toHaveLength(4);
+  });
+});

--- a/src/features/onboarding/positions.ts
+++ b/src/features/onboarding/positions.ts
@@ -1,0 +1,70 @@
+import type { AssignableRole, Position } from "./types";
+
+/** 직급 목록 조작 — 전부 순수 함수다(원본을 바꾸지 않는다). */
+
+export function createPosition(name: string, role: AssignableRole): Position {
+  return { id: crypto.randomUUID(), name, role };
+}
+
+/** 이름이 겹치지 않게 뒤에 번호를 붙인다 — `새 직급` → `새 직급 2`. */
+export function nextAvailablePositionName(positions: Position[], base: string): string {
+  const taken = new Set(positions.map((position) => position.name));
+  if (!taken.has(base)) return base;
+
+  let index = 2;
+  while (taken.has(`${base} ${index}`)) index += 1;
+  return `${base} ${index}`;
+}
+
+export function renamePosition(positions: Position[], id: string, name: string): Position[] {
+  return positions.map((position) => (position.id === id ? { ...position, name } : position));
+}
+
+export function changePositionRole(
+  positions: Position[],
+  id: string,
+  role: AssignableRole,
+): Position[] {
+  return positions.map((position) => (position.id === id ? { ...position, role } : position));
+}
+
+export function removePosition(positions: Position[], id: string): Position[] {
+  return positions.filter((position) => position.id !== id);
+}
+
+/** 드래그 이동 — 대상의 앞/뒤로 옮긴다. 직급은 서열이라 순서 자체가 의미를 가진다. */
+export function movePosition(
+  positions: Position[],
+  draggedId: string,
+  targetId: string,
+  position: "before" | "after",
+): Position[] {
+  if (draggedId === targetId) return positions;
+
+  const from = positions.findIndex((item) => item.id === draggedId);
+  const hasTarget = positions.some((item) => item.id === targetId);
+  if (from === -1 || !hasTarget) return positions;
+
+  const next = [...positions];
+  const [moved] = next.splice(from, 1);
+  if (!moved) return positions;
+
+  const targetIndex = next.findIndex((item) => item.id === targetId);
+  next.splice(position === "before" ? targetIndex : targetIndex + 1, 0, moved);
+  return next;
+}
+
+/** 키보드용 — 한 칸 위/아래로 옮긴다. */
+export function shiftPosition(positions: Position[], id: string, offset: 1 | -1): Position[] {
+  const from = positions.findIndex((item) => item.id === id);
+  if (from === -1) return positions;
+
+  const to = from + offset;
+  if (to < 0 || to >= positions.length) return positions;
+
+  const next = [...positions];
+  const [moved] = next.splice(from, 1);
+  if (!moved) return positions;
+  next.splice(to, 0, moved);
+  return next;
+}

--- a/src/features/onboarding/server.ts
+++ b/src/features/onboarding/server.ts
@@ -3,7 +3,8 @@ import "server-only";
 import { isMock } from "@/mocks/config";
 
 import { INITIAL_DEPARTMENTS } from "./mock/departments";
-import type { DepartmentNode } from "./types";
+import { INITIAL_POSITIONS } from "./mock/positions";
+import type { DepartmentNode, Position } from "./types";
 
 /**
  * 부서 트리 조회 — **격리막**(CLAUDE.md).
@@ -15,4 +16,12 @@ export async function getDepartments(): Promise<DepartmentNode[]> {
 
   // ⚠️ 미구현 — API 스펙 확정 후 BFF 경로(`ep.departments()`)로 fetch하고 매퍼로 UI 계약에 맞춘다.
   throw new Error("부서 조회 API가 아직 연결되지 않았습니다.");
+}
+
+/** 직급 목록 조회 — 격리막. 연동 시 이 함수와 매퍼만 고친다. */
+export async function getPositions(): Promise<Position[]> {
+  if (isMock) return INITIAL_POSITIONS;
+
+  // ⚠️ 미구현 — API 스펙 확정 후 BFF 경로로 fetch하고 매퍼로 UI 계약에 맞춘다.
+  throw new Error("직급 조회 API가 아직 연결되지 않았습니다.");
 }

--- a/src/features/onboarding/types.ts
+++ b/src/features/onboarding/types.ts
@@ -1,3 +1,5 @@
+import { ASSIGNABLE_ROLES, ROLE } from "@/constants/domain";
+
 /** 부서 트리 노드. 부서는 3계층까지 쓴다(CONVENTIONS §6). */
 export interface DepartmentNode {
   id: string;
@@ -33,3 +35,27 @@ export const ONBOARDING_STEP_LABEL: Record<OnboardingStep, string> = {
 };
 
 export const ONBOARDING_TOTAL_STEPS = 3;
+
+/* ───────── 2단계 · 직급 체계 ───────── */
+
+/**
+ * 직급 한 줄. **직급명과 권한은 분리된다** — 이름은 회사마다 다르게 쓰고,
+ * 권한은 이름과 무관하게 직접 고른다(Owner·Admin·Leader·Member).
+ */
+export interface Position {
+  id: string;
+  name: string;
+  role: AssignableRole;
+}
+
+/** 기업이 고를 수 있는 역할. `SYSTEM`은 서비스 운영자라 제외된다. */
+export type AssignableRole = (typeof ASSIGNABLE_ROLES)[number];
+
+/**
+ * 기업 승인 때 **시스템이 발급하는 계정.**
+ * 직급 매핑 대상이 아니라, 전체 권한 구조를 보여주려고 미리보기에 고정으로 띄운다.
+ */
+export const SYSTEM_ISSUED_POSITIONS = [
+  { name: "대표", role: ROLE.OWNER },
+  { name: "관리자", role: ROLE.ADMIN },
+] as const satisfies readonly { name: string; role: AssignableRole }[];

--- a/src/features/onboarding/use-department-drag.ts
+++ b/src/features/onboarding/use-department-drag.ts
@@ -1,7 +1,8 @@
 "use client";
 
-import { type RefObject, useState } from "react";
+import { useState } from "react";
 
+import { setCompactDragImage } from "./drag-ghost";
 import { MAX_DEPARTMENT_DEPTH } from "./types";
 
 /** 지금 끌고 있는 부서. 계층 제한을 판정하려면 하위 보유 여부가 필요하다. */
@@ -19,7 +20,8 @@ interface UseDepartmentDragParams {
   parentId: string | null;
   depth: number;
   hasChildren: boolean;
-  rowRef: RefObject<HTMLDivElement | null>;
+  /** 드래그 미리보기에 쓸 이름 */
+  nodeName: string;
   dragging: DraggingInfo | null;
   onDraggingChange: (info: DraggingInfo | null) => void;
   onMove: (draggedId: string, targetId: string, position: DropZone) => void;
@@ -34,7 +36,7 @@ export function useDepartmentDrag({
   parentId,
   depth,
   hasChildren,
-  rowRef,
+  nodeName,
   dragging,
   onDraggingChange,
   onMove,
@@ -71,8 +73,7 @@ export function useDepartmentDrag({
       onDragStart: (event: React.DragEvent) => {
         event.dataTransfer.setData("text/plain", nodeId);
         event.dataTransfer.effectAllowed = "move";
-        // 기본 미리보기는 손잡이 아이콘뿐이라 뭘 옮기는지 안 보인다 → 행 전체를 쓴다
-        if (rowRef.current) event.dataTransfer.setDragImage(rowRef.current, 12, 19);
+        setCompactDragImage(event, nodeName);
         onDraggingChange({ id: nodeId, parentId, hasChildren });
       },
       onDragEnd: () => {

--- a/src/features/onboarding/use-position-drag.ts
+++ b/src/features/onboarding/use-position-drag.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState } from "react";
+
+import { setCompactDragImage } from "./drag-ghost";
+
+/** 지금 끌고 있는 직급. 평면 목록이라 id만 있으면 된다. */
+export type DraggingPositionId = string | null;
+
+/** 놓는 자리 — 대상의 위/아래. 직급은 계층이 없어 "안에 넣기"가 없다. */
+export type PositionDropEdge = "before" | "after";
+
+interface UsePositionDragParams {
+  positionId: string;
+  /** 드래그 미리보기에 쓸 이름 */
+  positionName: string;
+  draggingId: DraggingPositionId;
+  onDraggingChange: (id: DraggingPositionId) => void;
+  onMove: (draggedId: string, targetId: string, edge: PositionDropEdge) => void;
+}
+
+/** 직급 한 줄의 드래그 처리 — 서열 순서 변경. */
+export function usePositionDrag({
+  positionId,
+  positionName,
+  draggingId,
+  onDraggingChange,
+  onMove,
+}: UsePositionDragParams) {
+  const [dropEdge, setDropEdge] = useState<PositionDropEdge | null>(null);
+
+  const isDragged = draggingId === positionId;
+  const canDrop = draggingId !== null && !isDragged;
+
+  return {
+    isDragged,
+    dropEdge,
+    /** 손잡이(grip)에 붙인다 */
+    handleProps: {
+      draggable: true,
+      onDragStart: (event: React.DragEvent) => {
+        event.dataTransfer.setData("text/plain", positionId);
+        event.dataTransfer.effectAllowed = "move";
+        setCompactDragImage(event, positionName);
+        onDraggingChange(positionId);
+      },
+      onDragEnd: () => {
+        onDraggingChange(null);
+        setDropEdge(null);
+      },
+    },
+    /** 행 전체에 붙인다 */
+    rowProps: {
+      onDragOver: (event: React.DragEvent) => {
+        if (!canDrop) return;
+        event.preventDefault();
+        event.dataTransfer.dropEffect = "move";
+        const { top, height } = event.currentTarget.getBoundingClientRect();
+        setDropEdge(event.clientY < top + height / 2 ? "before" : "after");
+      },
+      onDragLeave: () => setDropEdge(null),
+      onDrop: (event: React.DragEvent) => {
+        if (!canDrop || !dropEdge) return;
+        event.preventDefault();
+        onMove(event.dataTransfer.getData("text/plain"), positionId, dropEdge);
+        setDropEdge(null);
+        // 옮긴 행은 원래 자리에서 사라져 dragend가 오지 않는다 → 여기서 직접 끝낸다
+        onDraggingChange(null);
+      },
+    },
+  };
+}

--- a/src/features/onboarding/use-position-list.ts
+++ b/src/features/onboarding/use-position-list.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState } from "react";
+
+import { ROLE } from "@/constants/domain";
+
+import {
+  changePositionRole,
+  createPosition,
+  movePosition,
+  nextAvailablePositionName,
+  removePosition,
+  renamePosition,
+  shiftPosition,
+} from "./positions";
+import type { AssignableRole, Position } from "./types";
+
+/**
+ * 직급 목록 편집 상태.
+ * 목록 조작은 `positions.ts`의 순수 함수가 하고, 여기서는 **무엇을 언제 부를지**만 정한다.
+ */
+export function usePositionList(initial: Position[]) {
+  const [positions, setPositions] = useState(initial);
+  /** 이름을 편집 중인 직급 — 새로 만든 직급은 바로 편집 상태로 연다 */
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  const add = (name: string, role: AssignableRole) => {
+    const trimmed = name.trim();
+    if (!trimmed) return false;
+    setPositions((prev) => [
+      ...prev,
+      createPosition(nextAvailablePositionName(prev, trimmed), role),
+    ]);
+    return true;
+  };
+
+  return {
+    positions,
+    editingId,
+    setEditingId,
+    add,
+    rename: (id: string, name: string) => setPositions((prev) => renamePosition(prev, id, name)),
+    changeRole: (id: string, role: AssignableRole) =>
+      setPositions((prev) => changePositionRole(prev, id, role)),
+    remove: (id: string) => setPositions((prev) => removePosition(prev, id)),
+    move: (draggedId: string, targetId: string, position: "before" | "after") =>
+      setPositions((prev) => movePosition(prev, draggedId, targetId, position)),
+    shift: (id: string, offset: 1 | -1) => setPositions((prev) => shiftPosition(prev, id, offset)),
+    /** 새 직급의 기본 권한 — 가장 좁은 권한에서 시작해 필요한 만큼 올린다 */
+    defaultRole: ROLE.MEMBER as AssignableRole,
+  };
+}


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가
- [x] design — UI/UX 변경
- [x] refactor — 리팩토링
- [x] test — 테스트 코드

---

## 🗂 작업 영역

- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독

---

## 🙋 관련 역할

- [x] OWNER (대표)

---

## 📝 작업 내용

**무엇을** — 온보딩 2단계 **직급 체계** 화면(`/onboarding/2`)을 만들고, 1·2단계가 공유하는 조각을 정리했습니다.

**핵심 — 직급명과 권한은 분리됩니다.** 직급명은 회사마다 다르게 쓰고(팀장·과장·대리…), 권한은 그와 무관하게 고릅니다.

**드롭다운에 Leader·Member만 있는 이유**

`Owner`·`Admin`은 기업당 1명이고, **기업 승인 때 시스템이 두 계정을 발급해 대표 메일로 보냅니다.**
여러 사원이 같은 직급을 쓰므로 직급에 매핑하면 인원이 늘어나 규칙이 깨집니다. 그래서 직급 매핑 대상에서 뺐습니다.
한 사람에게 두 권한이 필요하면 계정을 따로 씁니다 — 예를 들어 인사팀장은 Admin 계정과 Leader 계정을 각각 갖습니다.

**되는 것**

- 직급 추가 / 이름 변경(더블클릭) / 삭제 / 권한 변경
- 드래그로 서열 순서 변경 — **평소엔 순서 번호, 마우스를 올리면 그 자리가 손잡이**로 바뀝니다(칸을 따로 쓰지 않습니다)
- 좌측 미리보기 — 위 두 줄(대표·관리자)은 발급 계정이라 고정, 아래는 표와 같은 상태를 봅니다
- 직급을 아무리 추가해도 카드 크기가 그대로고 안에서만 스크롤됩니다

**같이 정리한 것 (1단계에도 반영)**

- `StepCircle` · `StepHeading` · `StepHintList`로 공용 조각 분리 → 1단계 중복 제거
- **원 안 숫자·버튼 글자가 아래로 밀리던 문제** — `leading-5`가 원인이라 `leading-none`으로 교체
- **드래그 미리보기가 거대하던 문제** — 행 전체를 미리보기로 쓰던 걸 이름만 담은 작은 조각으로 교체
- 스텝퍼에 완료 표시 추가(지나온 단계가 초록 체크)
- 미리보기의 하위 부서가 너무 흐려서 대비 상향

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [ ] 🔐 권한 2축 — ⚠️ **미적용.** 라우트 가드는 `middleware.ts`가 생긴 뒤에 붙입니다(범위 밖)
- [ ] 🧬 zod — API 스펙 미확정이라 스키마 없음. `server.ts`에 자리만 잡아둠
- [x] 🕵️ **정직성** — 목 데이터 · 저장 미구현을 주석에 명시. 새로고침하면 사라집니다
- [x] 🎨 **디자인 토큰** — 생 hex 0건. 역할 배지 색을 `globals.css`에 토큰으로 정의(라이트/다크)

**품질**

- [x] ⚡ 최적화 — 서버 컴포넌트 기본, `'use client'`는 상호작용 컴포넌트만
- [x] ♿ **a11y** — `label htmlFor` · 아이콘 버튼 `aria-label` · `aria-current="step"` · **DnD 키보드 대체 경로**(`Alt`+↑↓)
- [x] ♻️ 재사용 확인 — `components/ui`의 Input · Select · Skeleton 사용, 온보딩 공용 조각 분리
- [x] 🧪 **loading / error / empty** 3상태 전부
- [ ] 브라우저 전용 API — 해당 없음

---

## 🔗 연관 이슈

Closes #16

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- ⚠️ **`globals.css`에 역할 배지 색 토큰 8개를 추가했습니다**(`--role-owner` 등). 공유 셸·디자인 시스템 영역이라 봐주세요. 다크 값도 함께 정의했습니다.
- ⚠️ **저장이 안 됩니다.** `actions.ts`(Server Action)는 API 스펙 확정 후 별도 이슈입니다.
- ⚠️ **`/onboarding/3`이 없어 "다음" 버튼이 404입니다.** 사원 초대 화면은 시안 확정 후 별도 이슈입니다.
- ⚠️ **"기업 승인 시 시스템이 Owner·Admin 계정을 발급" 은 아직 `DECISIONS.md`에 없습니다.** 이 화면 설계의 전제라 문서화가 필요합니다 — 별도 PR로 올릴까요?
- 시안의 주 버튼이 먹색인데 토큰 액센트는 파랑(`#3B82F6`)입니다. 1단계와 동일하게 시안을 따랐습니다.
- 드래그는 **실제 마우스로** 확인 부탁드립니다. 자동 테스트로는 감각까지 검증되지 않습니다.

---

## 📝 추가 메모

-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 온보딩 2단계에서 직급과 권한을 설정할 수 있습니다.
  * 직급 추가, 이름 및 권한 수정, 삭제와 순서 변경을 지원합니다.
  * 드래그 앤 드롭과 키보드로 직급 순서를 조정할 수 있습니다.
  * 직급별 권한 안내와 미리보기, 역할별 색상 배지를 제공합니다.
  * 온보딩 단계 표시, 로딩 화면 및 오류 발생 시 다시 시도 기능을 추가했습니다.

* **개선**
  * 온보딩 안내 문구와 부서 미리보기의 가독성 및 시각적 구성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
