### PR TITLE
[FEAT] 온보딩 완료 화면 #22

### DIFF
--- a/src/app/(onboarding)/onboarding/done/page.tsx
+++ b/src/app/(onboarding)/onboarding/done/page.tsx
@@ -1,40 +1,11 @@
-import { Check } from "lucide-react";
 import type { Metadata } from "next";
 
-import { ZLogo } from "@/components/icons/z-logo";
-import { StepCircle } from "@/features/onboarding/components/step-circle";
+import { OnboardingDone } from "@/features/onboarding/components/onboarding-done";
 
 export const metadata: Metadata = {
   title: "초기 설정 완료 — Z",
 };
 
-/**
- * ⚠️ **임시 화면** — 3단계의 [완료]·[나중에 하기]가 갈 곳이 필요해서 최소한만 둔다.
- *    완료 화면 시안이 나오면 이 파일을 통째로 교체한다.
- *    대시보드(`/owner`)가 아직 없어서 이동 버튼도 두지 않았다(정직성: 안 되는 걸 되는 척하지 않는다).
- */
 export default function OnboardingDonePage() {
-  return (
-    <main className="bg-background flex min-h-dvh flex-col items-center justify-center gap-6 bg-[radial-gradient(var(--border)_1px,transparent_1px)] [background-size:18px_18px] px-6 text-center">
-      <ZLogo className="text-foreground size-6" title="Z" />
-
-      <StepCircle tone="done" size={44}>
-        <Check className="size-5" />
-      </StepCircle>
-
-      <div className="flex flex-col gap-2">
-        <h1 className="text-xl leading-[25px] font-semibold tracking-[-0.4px]">
-          초기 설정을 마쳤어요
-        </h1>
-        <p className="text-muted-foreground max-w-[420px] text-[13px] leading-[21px]">
-          부서·직급 체계와 초대 목록을 담아 뒀어요. ⚠️ 초대 메일은 아직 나가지 않습니다 — 서버 연동
-          후에 실제로 발송됩니다.
-        </p>
-      </div>
-
-      <p className="text-muted-foreground/60 border-border rounded-md border border-dashed px-3 py-2 text-[11px] leading-4">
-        완료 화면과 대시보드는 아직 만드는 중이에요 — 디자인 확정 후 이어집니다
-      </p>
-    </main>
-  );
+  return <OnboardingDone />;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -175,6 +175,70 @@
   --status-done: #a78bfa;
 }
 
+@layer utilities {
+  /*
+   * 살랑이는 움직임 — 완료 표시처럼 "여기 다 됐다"를 눈으로 잡아둘 때만 쓴다.
+   * ⚠️ 모션 규칙(100/150/250ms)은 상태 전환용이다. 이건 계속 도는 장식이라 느리게 간다.
+   */
+  @keyframes float {
+    0%,
+    100% {
+      transform: translateY(0);
+    }
+    50% {
+      transform: translateY(-6px);
+    }
+  }
+
+  .animate-float {
+    animation: float 3s ease-in-out infinite;
+  }
+
+  /* 빈 원이 먹색으로 차오른다 — 완료 화면에 들어온 순간 한 번만 */
+  @keyframes fill-in {
+    from {
+      transform: scale(0);
+    }
+    to {
+      transform: scale(1);
+    }
+  }
+
+  .animate-fill-in {
+    animation: fill-in 450ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+
+  /* 차오른 뒤에 표시가 얹힌다 */
+  @keyframes mark-in {
+    from {
+      opacity: 0;
+      transform: scale(0.4);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+
+  .animate-mark-in {
+    animation: mark-in 320ms cubic-bezier(0.16, 1, 0.3, 1) 260ms both;
+  }
+
+  /*
+   * 움직임을 줄여달라고 한 사람에게는 멈춘 그림을 준다.
+   * ⚠️ `both`로 잡아둔 시작 상태(scale 0·투명)가 남으면 안 보인다 — 끝 상태를 직접 준다.
+   */
+  @media (prefers-reduced-motion: reduce) {
+    .animate-float,
+    .animate-fill-in,
+    .animate-mark-in {
+      animation: none;
+      opacity: 1;
+      transform: none;
+    }
+  }
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/src/features/onboarding/components/check-mark.tsx
+++ b/src/features/onboarding/components/check-mark.tsx
@@ -1,0 +1,29 @@
+import { Check } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+interface CheckMarkProps {
+  /** 한 변(px). 설명 목록은 14, 요약 줄은 16, 완료 배지 안은 13을 쓴다. */
+  size?: number;
+  /** 작게 쓸 때는 굵게 — 안 그러면 흐리게 보인다 */
+  strokeWidth?: number;
+  className?: string;
+}
+
+/**
+ * 다 됐다는 표시 — 테두리 없이 **먹색 체크만**.
+ *
+ * 온보딩 좌측 설명·완료 요약·완료 배지가 전부 이걸 쓴다. 한 군데만 다른 모양이면
+ * 그 줄만 덜 만든 것처럼 보인다.
+ * ⚠️ 초록을 쓰지 않는다(CLAUDE.md §디자인 토큰: 색으로 알리는 건 에러뿐).
+ */
+export function CheckMark({ size = 16, strokeWidth = 2.5, className }: CheckMarkProps) {
+  return (
+    <Check
+      style={{ width: size, height: size }}
+      strokeWidth={strokeWidth}
+      className={cn("text-foreground shrink-0", className)}
+      aria-hidden
+    />
+  );
+}

--- a/src/features/onboarding/components/department-setup.tsx
+++ b/src/features/onboarding/components/department-setup.tsx
@@ -62,11 +62,15 @@ export function DepartmentSetup({
   return (
     <div className="flex flex-col gap-[21px]">
       {/* 높이를 여기서 한 번만 정한다 — 좌우 두 칸이 같은 높이를 나눠 쓴다 */}
-      <div className="flex flex-col gap-7 lg:h-[560px] lg:flex-row">
+      {/*
+        ⚠️ 높이를 560px로 못박으면 낮은 화면(노트북 150% 배율 등)에서 아래가 잘린다.
+           **세로가 충분할 때만** 고정한다 — 좁으면 내용 높이 그대로 두고 페이지가 스크롤되게 한다.
+      */}
+      <div className="flex flex-col gap-7 lg:flex-row [@media(min-height:820px)]:lg:h-[560px]">
         <DepartmentIntro departments={tree.departments} />
 
         {/* 높이 고정 — 부서를 아무리 추가해도 카드 크기는 그대로고 안에서만 스크롤된다 */}
-        <section className="border-border bg-card flex h-[440px] flex-1 flex-col overflow-hidden rounded-xl border shadow-sm lg:h-full">
+        <section className="border-border bg-card flex h-[440px] flex-1 flex-col overflow-hidden rounded-xl border shadow-sm [@media(min-height:820px)]:lg:h-full">
           <header className="border-border bg-muted flex h-12 shrink-0 items-center justify-between border-b px-4">
             <h2 className="flex items-center gap-2 text-[13px] leading-5">
               <span className="bg-foreground size-2 rounded-full" aria-hidden />

--- a/src/features/onboarding/components/done-summary.tsx
+++ b/src/features/onboarding/components/done-summary.tsx
@@ -11,8 +11,6 @@ export interface SummaryRow {
   label: string;
   /** 오른쪽에 붙는 결과. 숫자가 들어가므로 `tabular-nums`로 자리를 맞춘다. */
   value: string;
-  /** 아직 안 끝난 일이면 이유를 적는다(발송 대기 등) */
-  note?: string;
 }
 
 interface DoneSummaryProps {
@@ -42,13 +40,9 @@ export function DoneSummary({
         roleCount > 0 ? `부서 ${departmentCount} · 역할 ${roleCount}` : `부서 ${departmentCount}`,
     },
     { icon: Users, label: "직급 체계", value: `직급 ${positionCount}` },
-    {
-      icon: Mail,
-      label: "사원 초대",
-      value: inviteCount > 0 ? `${inviteCount}명` : "없음",
-      // ⚠️ 실제 발송은 미구현이다 — 보냈다고 적지 않는다(CLAUDE.md §정직성)
-      note: inviteCount > 0 ? "발송 대기" : undefined,
-    },
+    // ⚠️ 여기서 "발송"이라고 적지 않는다 — 실제 메일은 아직 안 나간다(CLAUDE.md §정직성).
+    //    이 화면은 "정한 것"을 요약할 뿐이고, 발송 안내는 3단계 화면이 이미 한다.
+    { icon: Mail, label: "사원 초대", value: inviteCount > 0 ? `${inviteCount}명` : "없음" },
   ];
 
   return (
@@ -75,11 +69,6 @@ export function DoneSummary({
           <span className="flex-1" aria-hidden />
 
           <dd className="flex items-center gap-2">
-            {row.note && (
-              <span className="text-muted-foreground/60 border-border rounded border border-dashed px-1.5 py-0.5 text-[11px] leading-4">
-                {row.note}
-              </span>
-            )}
             <span className="text-muted-foreground text-[13px] leading-5 tabular-nums">
               {row.value}
             </span>

--- a/src/features/onboarding/components/done-summary.tsx
+++ b/src/features/onboarding/components/done-summary.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import type { LucideIcon } from "lucide-react";
+import { FolderOpen, Mail, Users } from "lucide-react";
+
+import { CheckMark } from "./check-mark";
+
+/** 요약 한 줄 — 무엇을, 얼마나 정했는지. */
+export interface SummaryRow {
+  icon: LucideIcon;
+  label: string;
+  /** 오른쪽에 붙는 결과. 숫자가 들어가므로 `tabular-nums`로 자리를 맞춘다. */
+  value: string;
+  /** 아직 안 끝난 일이면 이유를 적는다(발송 대기 등) */
+  note?: string;
+}
+
+interface DoneSummaryProps {
+  departmentCount: number;
+  roleCount: number;
+  positionCount: number;
+  inviteCount: number;
+}
+
+/**
+ * 온보딩에서 정한 것 세 줄.
+ *
+ * ⚠️ 초록 체크를 줄마다 붙이지 않는다 — 색으로 알리는 건 에러뿐이다(CLAUDE.md §디자인 토큰).
+ *    다 됐다는 건 이 화면에 왔다는 사실과 위쪽 큰 표시가 이미 말한다.
+ */
+export function DoneSummary({
+  departmentCount,
+  roleCount,
+  positionCount,
+  inviteCount,
+}: DoneSummaryProps) {
+  const rows: SummaryRow[] = [
+    {
+      icon: FolderOpen,
+      label: "부서 체계",
+      value:
+        roleCount > 0 ? `부서 ${departmentCount} · 역할 ${roleCount}` : `부서 ${departmentCount}`,
+    },
+    { icon: Users, label: "직급 체계", value: `직급 ${positionCount}` },
+    {
+      icon: Mail,
+      label: "사원 초대",
+      value: inviteCount > 0 ? `${inviteCount}명` : "없음",
+      // ⚠️ 실제 발송은 미구현이다 — 보냈다고 적지 않는다(CLAUDE.md §정직성)
+      note: inviteCount > 0 ? "발송 대기" : undefined,
+    },
+  ];
+
+  return (
+    <dl className="border-border bg-card w-full overflow-hidden rounded-lg border">
+      {rows.map((row, index) => (
+        <div
+          key={row.label}
+          className={
+            index > 0
+              ? "border-border flex items-center gap-2.5 border-t px-4 py-3"
+              : "flex items-center gap-2.5 px-4 py-3"
+          }
+        >
+          {/*
+            ⚠️ 상자 기준으로는 이미 정중앙이다(둘 다 20px 줄 안에서 가운데).
+               그래도 처져 보여 1px 올린다 — 눈으로 맞춘 값이라 계산 근거는 없다.
+          */}
+          <row.icon
+            className="text-muted-foreground/60 size-4 shrink-0 -translate-y-px"
+            aria-hidden
+          />
+          <dt className="text-[13px] leading-5">{row.label}</dt>
+
+          <span className="flex-1" aria-hidden />
+
+          <dd className="flex items-center gap-2">
+            {row.note && (
+              <span className="text-muted-foreground/60 border-border rounded border border-dashed px-1.5 py-0.5 text-[11px] leading-4">
+                {row.note}
+              </span>
+            )}
+            <span className="text-muted-foreground text-[13px] leading-5 tabular-nums">
+              {row.value}
+            </span>
+            <CheckMark size={16} className="-translate-y-px" />
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/src/features/onboarding/components/invite-setup.tsx
+++ b/src/features/onboarding/components/invite-setup.tsx
@@ -100,7 +100,11 @@ export function InviteSetup({ departments, positions }: InviteSetupProps) {
   return (
     <div className="flex flex-col gap-[21px]">
       {/* 높이를 여기서 한 번만 정한다 — 좌우 두 칸이 같은 높이를 나눠 쓴다(2단계와 동일) */}
-      <div className="flex flex-col gap-7 lg:h-[560px] lg:flex-row">
+      {/*
+        ⚠️ 높이를 560px로 못박으면 낮은 화면(노트북 150% 배율 등)에서 아래가 잘린다.
+           **세로가 충분할 때만** 고정한다 — 좁으면 내용 높이 그대로 두고 페이지가 스크롤되게 한다.
+      */}
+      <div className="flex flex-col gap-7 lg:flex-row [@media(min-height:820px)]:lg:h-[560px]">
         <InviteIntro
           invites={[...list.sent, ...list.sendable]}
           departments={departmentOptions}
@@ -109,7 +113,7 @@ export function InviteSetup({ departments, positions }: InviteSetupProps) {
         />
 
         {/* 높이 고정 — 줄을 아무리 추가해도 카드 크기는 그대로고 안에서만 스크롤된다 */}
-        <section className="border-border bg-card flex h-[440px] flex-1 flex-col overflow-hidden rounded-xl border shadow-sm lg:h-full">
+        <section className="border-border bg-card flex h-[440px] flex-1 flex-col overflow-hidden rounded-xl border shadow-sm [@media(min-height:820px)]:lg:h-full">
           <header className="border-border bg-muted flex h-12 shrink-0 items-center border-b px-4">
             <h2 className="flex items-center gap-2 text-[13px] leading-5">
               <span className="bg-foreground size-2 rounded-full" aria-hidden />

--- a/src/features/onboarding/components/onboarding-done.tsx
+++ b/src/features/onboarding/components/onboarding-done.tsx
@@ -9,7 +9,6 @@ import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 import { loadDraft } from "../draft";
-import { countDepartments } from "../tree";
 import { type DepartmentNode, type Invite, ONBOARDING_STEP, type Position } from "../types";
 import { CheckMark } from "./check-mark";
 import { DoneSummary } from "./done-summary";
@@ -30,8 +29,12 @@ function countOf(
 ): DoneCounts {
   return {
     departmentCount: departments.length,
-    // 역할은 부서 아래 한 겹뿐이다 — 전체에서 부서를 빼면 역할 수다
-    roleCount: countDepartments(departments) - departments.length,
+    /**
+     * 역할 = 부서의 **직속 자식**만.
+     * ⚠️ `전체 - 부서`로 빼지 않는다 — 어쩌다 3계층이 들어오면 손자까지 역할로 세어 숫자가 부풀어 오른다.
+     *    타입(`DepartmentNode.children`)은 재귀라 깊이를 막아주지 않는다.
+     */
+    roleCount: departments.reduce((sum, department) => sum + department.children.length, 0),
     positionCount: positions.length,
     inviteCount: invites.filter((invite) => invite.isSent).length,
   };

--- a/src/features/onboarding/components/onboarding-done.tsx
+++ b/src/features/onboarding/components/onboarding-done.tsx
@@ -9,6 +9,7 @@ import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 import { loadDraft } from "../draft";
+import { isValidEmail } from "../invites";
 import { type DepartmentNode, type Invite, ONBOARDING_STEP, type Position } from "../types";
 import { CheckMark } from "./check-mark";
 import { DoneSummary } from "./done-summary";
@@ -36,7 +37,13 @@ function countOf(
      */
     roleCount: departments.reduce((sum, department) => sum + department.children.length, 0),
     positionCount: positions.length,
-    inviteCount: invites.filter((invite) => invite.isSent).length,
+    /**
+     * 초대 = **주소를 제대로 적어둔 줄** 전부.
+     * ⚠️ `isSent`로 거르지 않는다 — [완료]는 발송을 부르지 않아서, 3단계에서 주소만 적고
+     *    바로 넘어오면 전부 `isSent=false`다. 그걸 거르면 적어둔 게 있는데도 "없음"이 뜬다.
+     *    어차피 실제 발송은 미구현이라 이 줄들은 다 "발송 대기"다.
+     */
+    inviteCount: invites.filter((invite) => isValidEmail(invite.email)).length,
   };
 }
 

--- a/src/features/onboarding/components/onboarding-done.tsx
+++ b/src/features/onboarding/components/onboarding-done.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { ChevronRight } from "lucide-react";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { ZLogo } from "@/components/icons/z-logo";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+import { loadDraft } from "../draft";
+import { countDepartments } from "../tree";
+import { type DepartmentNode, type Invite, ONBOARDING_STEP, type Position } from "../types";
+import { CheckMark } from "./check-mark";
+import { DoneSummary } from "./done-summary";
+import { OnboardingShell } from "./onboarding-shell";
+
+/** 보관함에서 읽어낸 결과. 아직 못 읽었으면 `null`이다. */
+interface DoneCounts {
+  departmentCount: number;
+  roleCount: number;
+  positionCount: number;
+  inviteCount: number;
+}
+
+function countOf(
+  departments: DepartmentNode[],
+  positions: Position[],
+  invites: Invite[],
+): DoneCounts {
+  return {
+    departmentCount: departments.length,
+    // 역할은 부서 아래 한 겹뿐이다 — 전체에서 부서를 빼면 역할 수다
+    roleCount: countDepartments(departments) - departments.length,
+    positionCount: positions.length,
+    inviteCount: invites.filter((invite) => invite.isSent).length,
+  };
+}
+
+/**
+ * 온보딩 완료 화면.
+ *
+ * ⚠️ **서버 저장이 아직 없다.** 여기 숫자는 브라우저 보관함(`draft.ts`)에서 읽는다 —
+ *    커밋 API가 붙으면 그 응답으로 바꾸고 보관함은 지운다(`clearDraft`).
+ */
+export function OnboardingDone() {
+  const [counts, setCounts] = useState<DoneCounts | null>(null);
+
+  useEffect(() => {
+    const draft = loadDraft();
+    // sessionStorage는 첫 렌더 뒤에야 읽을 수 있다
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setCounts(countOf(draft.departments ?? [], draft.positions ?? [], draft.invites ?? []));
+  }, []);
+
+  return (
+    <OnboardingShell step={ONBOARDING_STEP.INVITE} isDone>
+      <div className="mx-auto flex w-full max-w-[420px] flex-col items-center gap-6">
+        {/*
+          빈 원에서 시작해 먹색이 차오르고, 그 위에 **Z 로고**가 얹힌다.
+          체크는 작은 배지로 옆에 붙어 살랑인다.
+          ⚠️ 배지는 초록이 아니라 카드색 바탕에 먹색이다 — 색으로 알리는 건 에러뿐(CLAUDE.md §디자인 토큰).
+        */}
+        <span className="relative" aria-hidden>
+          <span className="border-border relative flex size-[68px] items-center justify-center rounded-full border">
+            <span className="bg-foreground animate-fill-in absolute inset-0 rounded-full" />
+            <ZLogo className="text-background animate-mark-in relative size-7" />
+          </span>
+
+          {/*
+            배지는 **테두리 있는 원**이다. 검은 원 위에 걸쳐 있어서, 테두리가 없으면
+            흰 바탕만 남아 원이 파먹힌 것처럼 보인다.
+          */}
+          <span className="animate-mark-in absolute -top-0.5 -right-0.5">
+            <span className="bg-card border-foreground animate-float flex size-5 items-center justify-center rounded-full border">
+              <CheckMark size={11} strokeWidth={3} />
+            </span>
+          </span>
+        </span>
+
+        <div className="flex flex-col items-center gap-2 text-center">
+          <h1 className="text-xl leading-[26px] font-semibold tracking-[-0.4px]">준비됐어요</h1>
+          <p className="text-muted-foreground text-[13px] leading-[21px] text-balance break-keep">
+            부서·직급 체계와 초대 목록을 정했어요. 이대로 회의를 시작할 수 있습니다.
+          </p>
+        </div>
+
+        {counts ? (
+          <DoneSummary {...counts} />
+        ) : (
+          // 보관함을 읽기 전 — 높이를 미리 잡아 화면이 들썩이지 않게 한다
+          <div className="border-border bg-card h-[141px] w-full animate-pulse rounded-lg border" />
+        )}
+
+        <div className="flex w-full flex-col items-center gap-2.5">
+          <Link
+            href="/pricing"
+            className={cn(
+              buttonVariants(),
+              "bg-foreground text-background hover:bg-foreground/90 h-[38px] w-full gap-1.5 rounded-md text-[13px] leading-none",
+            )}
+          >
+            <span className="leading-none">플랜 선택하기</span>
+            <ChevronRight className="size-3.5" />
+          </Link>
+
+          {/* 결제를 강요하지 않는다 — 그냥 시작해도 되는 길을 같이 보여준다 */}
+          <Link
+            href="/owner"
+            className="text-muted-foreground hover:text-foreground focus-visible:ring-ring rounded px-2 py-1 text-xs leading-[18px] transition-colors focus-visible:ring-2 focus-visible:outline-none"
+          >
+            건너뛰기 — 기본 Free 플랜으로 시작
+          </Link>
+        </div>
+
+        {/* ⚠️ 두 화면 다 아직 없다. 눌리게는 두되 뭐가 없는지 숨기지 않는다(§정직성) */}
+        <p className="text-muted-foreground/60 text-center text-[11px] leading-4 break-keep">
+          요금제·대시보드 화면은 다음 작업이에요 — 지금 누르면 빈 화면입니다.
+        </p>
+      </div>
+    </OnboardingShell>
+  );
+}

--- a/src/features/onboarding/components/onboarding-done.tsx
+++ b/src/features/onboarding/components/onboarding-done.tsx
@@ -102,31 +102,17 @@ export function OnboardingDone() {
           <div className="border-border bg-card h-[141px] w-full animate-pulse rounded-lg border" />
         )}
 
-        <div className="flex w-full flex-col items-center gap-2.5">
-          <Link
-            href="/pricing"
-            className={cn(
-              buttonVariants(),
-              "bg-foreground text-background hover:bg-foreground/90 h-[38px] w-full gap-1.5 rounded-md text-[13px] leading-none",
-            )}
-          >
-            <span className="leading-none">플랜 선택하기</span>
-            <ChevronRight className="size-3.5" />
-          </Link>
-
-          {/* 결제를 강요하지 않는다 — 그냥 시작해도 되는 길을 같이 보여준다 */}
-          <Link
-            href="/owner"
-            className="text-muted-foreground hover:text-foreground focus-visible:ring-ring rounded px-2 py-1 text-xs leading-[18px] transition-colors focus-visible:ring-2 focus-visible:outline-none"
-          >
-            건너뛰기 — 기본 Free 플랜으로 시작
-          </Link>
-        </div>
-
-        {/* ⚠️ 두 화면 다 아직 없다. 눌리게는 두되 뭐가 없는지 숨기지 않는다(§정직성) */}
-        <p className="text-muted-foreground/60 text-center text-[11px] leading-4 break-keep">
-          요금제·대시보드 화면은 다음 작업이에요 — 지금 누르면 빈 화면입니다.
-        </p>
+        {/* 갈 곳은 하나다 — Free/Team 중 무엇을 쓸지는 요금제 화면에서 고른다 */}
+        <Link
+          href="/pricing"
+          className={cn(
+            buttonVariants(),
+            "bg-foreground text-background hover:bg-foreground/90 h-[38px] w-full gap-1.5 rounded-md text-[13px] leading-none",
+          )}
+        >
+          <span className="leading-none">플랜 선택하기</span>
+          <ChevronRight className="size-3.5" />
+        </Link>
       </div>
     </OnboardingShell>
   );

--- a/src/features/onboarding/components/onboarding-shell.tsx
+++ b/src/features/onboarding/components/onboarding-shell.tsx
@@ -44,13 +44,14 @@ export function OnboardingShell({ step, isDone = false, children }: OnboardingSh
         )}
       </header>
 
-      {/* 세로 가운데 정렬 — 콘텐츠가 화면 위쪽에만 몰리지 않게 한다 */}
       {/*
         ⚠️ `overflow-hidden`이 아니라 `overflow-y-auto`다. 화면이 낮으면 내용이 안 들어가는데,
            숨겨버리면 [다음] 버튼에 아예 닿을 수 없다. 평소에는 넘치지 않아 스크롤바가 안 보인다.
+        ⚠️ 가운데 정렬을 `justify-center`로 하지 않는다 — 내용이 넘치면 **위쪽이 스크롤 시작점 밖으로**
+           밀려나 아예 닿을 수 없다. `m-auto`는 자리가 남을 때만 가운데로 밀고, 넘치면 0이 된다.
       */}
-      <main className="flex min-h-0 flex-1 flex-col justify-center overflow-y-auto px-[21px] py-6 lg:py-10">
-        <div className="mx-auto w-full max-w-[1160px]">{children}</div>
+      <main className="flex min-h-0 flex-1 flex-col overflow-y-auto px-[21px] py-6 lg:py-10">
+        <div className="m-auto w-full max-w-[1160px]">{children}</div>
       </main>
 
       <footer className="border-border bg-background/90 flex h-16 shrink-0 items-center justify-center border-t px-[21px]">

--- a/src/features/onboarding/components/onboarding-shell.tsx
+++ b/src/features/onboarding/components/onboarding-shell.tsx
@@ -14,29 +14,42 @@ const STEPS = Object.keys(ONBOARDING_STEP_LABEL).map(Number) as OnboardingStep[]
 
 interface OnboardingShellProps {
   step: OnboardingStep;
+  /**
+   * 마지막 완료 화면인가.
+   * 헤더의 단계 표기가 "완료"로 바뀌고, 스텝퍼는 전부 지나온 모양이 된다.
+   * 도움말은 숨긴다 — 더 할 일이 없는 화면이라 알려줄 것도 없다.
+   */
+  isDone?: boolean;
   children: ReactNode;
 }
 
-/** 온보딩 3단계가 공유하는 헤더·스텝퍼 프레임. */
-export function OnboardingShell({ step, children }: OnboardingShellProps) {
+/** 온보딩 3단계와 완료 화면이 공유하는 헤더·스텝퍼 프레임. */
+export function OnboardingShell({ step, isDone = false, children }: OnboardingShellProps) {
   // 도움말은 화면 위에 떠 있는 패널이다 — 본문 레이아웃은 건드리지 않는다
   const [isGuideOpen, setIsGuideOpen] = useState(false);
 
   return (
     // 배경 점 그리드 — 토큰(--border)을 그대로 써서 다크에서도 따라온다.
-    // ⚠️ 화면 높이에 딱 맞춰 고정한다(h-dvh + overflow-hidden) — 페이지가 스크롤되거나
+    // ⚠️ 화면 높이에 맞춘다 — 평소엔 페이지가 스크롤되거나
     //    끝에서 튕기지 않는다. 움직임은 카드 안쪽 목록에서만 일어난다.
     <div className="bg-background flex h-dvh flex-col overflow-hidden overscroll-none bg-[radial-gradient(var(--border)_1px,transparent_1px)] [background-size:18px_18px]">
       <header className="border-border bg-background/90 flex h-[52px] shrink-0 items-center gap-[7px] border-b px-[21px] backdrop-blur">
         <ZLogo className="text-foreground size-[18px]" title="Z" />
-        <span className="text-muted-foreground/70 ml-auto text-xs leading-[18px] tabular-nums">
-          단계 <span className="text-foreground">{step}</span> / {ONBOARDING_TOTAL_STEPS}
-        </span>
+        {isDone ? (
+          <span className="text-foreground ml-auto text-xs leading-[18px]">완료</span>
+        ) : (
+          <span className="text-muted-foreground/70 ml-auto text-xs leading-[18px] tabular-nums">
+            단계 <span className="text-foreground">{step}</span> / {ONBOARDING_TOTAL_STEPS}
+          </span>
+        )}
       </header>
 
       {/* 세로 가운데 정렬 — 콘텐츠가 화면 위쪽에만 몰리지 않게 한다 */}
-      {/* 세로 가운데 정렬 — 콘텐츠가 화면 위쪽에만 몰리지 않게 한다 */}
-      <main className="flex min-h-0 flex-1 flex-col justify-center overflow-hidden px-[21px] py-10">
+      {/*
+        ⚠️ `overflow-hidden`이 아니라 `overflow-y-auto`다. 화면이 낮으면 내용이 안 들어가는데,
+           숨겨버리면 [다음] 버튼에 아예 닿을 수 없다. 평소에는 넘치지 않아 스크롤바가 안 보인다.
+      */}
+      <main className="flex min-h-0 flex-1 flex-col justify-center overflow-y-auto px-[21px] py-6 lg:py-10">
         <div className="mx-auto w-full max-w-[1160px]">{children}</div>
       </main>
 
@@ -44,30 +57,44 @@ export function OnboardingShell({ step, children }: OnboardingShellProps) {
         <ol className="flex flex-wrap items-center">
           {STEPS.map((value) => (
             <li key={value} className="flex items-center">
-              <StepperItem label={ONBOARDING_STEP_LABEL[value]} step={value} current={step} />
+              <StepperItem
+                label={ONBOARDING_STEP_LABEL[value]}
+                step={value}
+                // 완료 화면에서는 마지막 단계까지 전부 지나온 것으로 본다
+                current={isDone ? ONBOARDING_TOTAL_STEPS + 1 : step}
+              />
               {/* 지나온 구간은 선도 진하게 이어진다 */}
               <span
                 className={cn(
                   "mx-[14px] h-px w-[35px]",
-                  value < step ? "bg-foreground" : "bg-border",
+                  isDone || value < step ? "bg-foreground" : "bg-border",
                 )}
                 aria-hidden
               />
             </li>
           ))}
           <li className="flex items-center gap-[7px] pl-[14px]">
-            <StepCircle tone="idle" size={28}>
+            <StepCircle tone={isDone ? "current" : "idle"} size={28}>
               <Check className="size-3" />
             </StepCircle>
-            <span className="text-muted-foreground/70 text-xs leading-[18px]">완료</span>
+            <span
+              className={cn(
+                "text-xs leading-[18px]",
+                isDone ? "text-foreground" : "text-muted-foreground/70",
+              )}
+            >
+              완료
+            </span>
           </li>
         </ol>
       </footer>
-      <OnboardingGuide
-        step={step}
-        isOpen={isGuideOpen}
-        onToggle={() => setIsGuideOpen((prev) => !prev)}
-      />
+      {!isDone && (
+        <OnboardingGuide
+          step={step}
+          isOpen={isGuideOpen}
+          onToggle={() => setIsGuideOpen((prev) => !prev)}
+        />
+      )}
     </div>
   );
 }
@@ -79,7 +106,8 @@ function StepperItem({
 }: {
   label: string;
   step: OnboardingStep;
-  current: OnboardingStep;
+  /** 완료 화면에서는 마지막 단계보다 큰 값이 들어온다 */
+  current: number;
 }) {
   const isDone = step < current;
   const isCurrent = step === current;

--- a/src/features/onboarding/components/position-setup.tsx
+++ b/src/features/onboarding/components/position-setup.tsx
@@ -58,11 +58,15 @@ export function PositionSetup({ initialPositions }: { initialPositions: Position
   return (
     <div className="flex flex-col gap-[21px]">
       {/* 높이를 여기서 한 번만 정한다 — 좌우 두 칸이 같은 높이를 나눠 쓴다 */}
-      <div className="flex flex-col gap-7 lg:h-[560px] lg:flex-row">
+      {/*
+        ⚠️ 높이를 560px로 못박으면 낮은 화면(노트북 150% 배율 등)에서 아래가 잘린다.
+           **세로가 충분할 때만** 고정한다 — 좁으면 내용 높이 그대로 두고 페이지가 스크롤되게 한다.
+      */}
+      <div className="flex flex-col gap-7 lg:flex-row [@media(min-height:820px)]:lg:h-[560px]">
         <PositionIntro positions={list.positions} />
 
         {/* 높이 고정 — 직급을 아무리 추가해도 카드 크기는 그대로고 안에서만 스크롤된다 */}
-        <section className="border-border bg-card flex h-[440px] flex-1 flex-col overflow-hidden rounded-xl border shadow-sm lg:h-full">
+        <section className="border-border bg-card flex h-[440px] flex-1 flex-col overflow-hidden rounded-xl border shadow-sm [@media(min-height:820px)]:lg:h-full">
           <header className="border-border bg-muted flex h-12 shrink-0 items-center border-b px-4">
             <h2 className="flex items-center gap-2 text-[13px] leading-5">
               <span className="bg-foreground size-2 rounded-full" aria-hidden />

--- a/src/features/onboarding/components/step-hint-list.tsx
+++ b/src/features/onboarding/components/step-hint-list.tsx
@@ -1,10 +1,15 @@
-/** 좌측 설명의 점 목록. 온보딩 각 단계가 같은 형태로 쓴다. */
+import { CheckMark } from "./check-mark";
+
+/**
+ * 좌측 설명 목록. 온보딩 각 단계가 같은 형태로 쓴다.
+ * 표시는 완료 화면과 같은 `CheckMark`다 — 화면끼리 모양이 이어진다.
+ */
 export function StepHintList({ items }: { items: readonly string[] }) {
   return (
     <ul className="flex flex-col gap-[7px]">
       {items.map((item) => (
         <li key={item} className="text-muted-foreground flex gap-[7px] text-xs leading-[19px]">
-          <span className="bg-foreground mt-[7px] size-[3.5px] shrink-0 rounded-full" aria-hidden />
+          <CheckMark size={14} className="mt-[3px]" />
           {item}
         </li>
       ))}

--- a/src/features/onboarding/draft.test.ts
+++ b/src/features/onboarding/draft.test.ts
@@ -67,3 +67,46 @@ describe("임시 보관함 복원", () => {
     expect(loadDraft().departments).toBeUndefined();
   });
 });
+
+describe("2계층을 넘는 부서 트리는 되살리지 않는다", () => {
+  beforeEach(() => window.sessionStorage.clear());
+
+  it("부서 > 역할 두 겹은 통과한다", () => {
+    put({
+      departments: [
+        { id: "d1", name: "개발팀", children: [{ id: "r1", name: "프론트엔드", children: [] }] },
+      ],
+    });
+    expect(loadDraft().departments).toHaveLength(1);
+  });
+
+  // ⚠️ 화면은 2계층만 만들지만 sessionStorage는 손으로 고칠 수 있다.
+  //    3계층이 들어오면 트리도, 완료 화면의 역할 수도 어긋난다.
+  // ⚠️ 부서가 **여러 개**여야 잡히는 버그가 있었다 — 배열 인덱스가 깊이로 새어
+  //    두 번째 부서부터 3계층 취급을 받았다. 한 개짜리 테스트로는 안 잡힌다.
+  it("부서가 여러 개여도 전부 되살린다", () => {
+    put({
+      departments: [
+        { id: "d1", name: "개발팀", children: [{ id: "r1", name: "프론트엔드", children: [] }] },
+        { id: "d2", name: "디자인팀", children: [] },
+        { id: "d3", name: "경영지원", children: [{ id: "r2", name: "인사", children: [] }] },
+      ],
+    });
+    expect(loadDraft().departments).toHaveLength(3);
+  });
+
+  it("역할 밑에 또 하위가 있으면 버린다", () => {
+    put({
+      departments: [
+        {
+          id: "d1",
+          name: "개발팀",
+          children: [
+            { id: "r1", name: "프론트엔드", children: [{ id: "x", name: "더깊이", children: [] }] },
+          ],
+        },
+      ],
+    });
+    expect(loadDraft().departments).toBeUndefined();
+  });
+});

--- a/src/features/onboarding/draft.ts
+++ b/src/features/onboarding/draft.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import type { DepartmentNode, Invite, Position } from "./types";
+import { MAX_DEPARTMENT_DEPTH } from "./types";
 
 /**
  * 온보딩 임시 보관함 — **BE 연동 전까지만 쓰는 코드다.**
@@ -31,15 +32,17 @@ export interface OnboardingDraft {
  * ⚠️ `JSON.parse` 결과를 그냥 단언하면 **깨진 값이 그대로 화면까지 간다.** 스키마가 바뀐 뒤
  *    남아 있던 값이나 손으로 고친 값이 들어오면 `.map()`에서 터진다. 통과 못 한 항목은 버린다.
  */
-function isDepartmentNode(value: unknown): value is DepartmentNode {
+function isDepartmentNode(value: unknown, depth = 0): value is DepartmentNode {
   if (typeof value !== "object" || value === null) return false;
   const node = value as Record<string, unknown>;
-  return (
-    typeof node.id === "string" &&
-    typeof node.name === "string" &&
-    Array.isArray(node.children) &&
-    node.children.every(isDepartmentNode)
-  );
+  if (typeof node.id !== "string" || typeof node.name !== "string") return false;
+  if (!Array.isArray(node.children)) return false;
+
+  // ⚠️ 깊이도 본다 — 화면은 2계층(부서 > 역할)만 만들지만 타입은 재귀라 막아주지 않는다.
+  //    3계층이 들어오면 트리도 요약 숫자도 어긋난다.
+  if (node.children.length > 0 && depth + 1 >= MAX_DEPARTMENT_DEPTH) return false;
+
+  return node.children.every((child) => isDepartmentNode(child, depth + 1));
 }
 
 function isPosition(value: unknown): value is Position {
@@ -65,10 +68,16 @@ function isInvite(value: unknown): value is Invite {
   );
 }
 
-/** 배열이고 모든 항목이 통과할 때만 되살린다. 하나라도 깨졌으면 그 항목만 없는 셈 친다. */
+/**
+ * 배열이고 모든 항목이 통과할 때만 되살린다. 하나라도 깨졌으면 그 목록은 없는 셈 친다.
+ *
+ * ⚠️ `value.every(guard)`로 넘기지 않는다 — `every`는 콜백에 **(항목, 인덱스, 배열)** 을 준다.
+ *    `isDepartmentNode(node, depth)`처럼 둘째 인자를 받는 가드에 인덱스가 깊이로 새어 들어가,
+ *    두 번째 항목부터 엉뚱하게 걸러진다. 항목 하나만 넘긴다.
+ */
 function pick<T>(value: unknown, guard: (item: unknown) => item is T): T[] | undefined {
   if (!Array.isArray(value)) return undefined;
-  return value.every(guard) ? value : undefined;
+  return value.every((item) => guard(item)) ? value : undefined;
 }
 
 function parseDraft(value: unknown): OnboardingDraft {


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가
- [x] design — UI/UX 변경
- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독

---

## 🙋 관련 역할

- [x] OWNER (대표)

---

## 📝 작업 내용

- **온보딩 완료 화면**(`/onboarding/done`) — 3단계를 마친 뒤 도착하는 화면. 1~3단계와 **같은 셸**을 씁니다(헤더·점 그리드·스텝퍼). `OnboardingShell`에 `isDone`을 더해, 헤더 단계 표기가 `완료`로 바뀌고 스텝퍼는 전부 지나온 모양이 됩니다. 도움말은 숨깁니다.
- **완료 표시** — 빈 원에서 시작해 먹색이 차오르고 Z 로고가 얹힌 뒤, 작은 배지만 계속 살랑입니다. `prefers-reduced-motion`이면 멈춘 그림을 줍니다.
- **요약 카드** — 부서·역할 / 직급 / 초대 수. 값만 담백하게 보여줍니다.
- **`[플랜 선택하기]` 하나** — 다음 걸음은 요금제 화면입니다.
- **완료 표시를 `CheckMark` 하나로 통일** — 좌측 설명 목록의 점도 같은 체크로 바꿨습니다.

> **화면에서 뺀 것**
> 처음엔 `발송 대기` 배지, `건너뛰기 — 기본 Free 플랜으로 시작`, `요금제·대시보드는 다음 작업이에요` 안내를 넣었다가 **전부 뺐습니다.**
> - `발송 대기` — 어차피 모든 초대가 대기 상태라 줄마다 붙일 이유가 없습니다. 이 화면은 "정한 것"을 요약할 뿐이고, 발송 안내는 3단계 화면이 이미 합니다.
> - `건너뛰기` — Free/Team 선택은 **요금제 화면**이 합니다. 여기서 또 고르게 하면 선택지가 두 군데로 갈립니다.
> - `다음 작업이에요` 안내 — 요금제 화면(#25)을 만들었으니 사실이 아니게 됐습니다.

### 함께 고친 것 — 낮은 화면 잘림

노트북 배율 150% 같은 환경에서 **[다음] 버튼과 좌측 미리보기가 잘리고 스크롤도 막혔습니다.** 카드 높이가 `lg:h-[560px]` 고정인데 셸이 `h-dvh + overflow-hidden`이었습니다.

- 560px 고정은 **세로 820px 이상일 때만** 겁니다. 좁으면 내용 높이 그대로 둡니다.
- `main`을 `overflow-y-auto`로. 가운데 정렬은 `justify-center` 대신 자식의 `m-auto`로 바꿨습니다 — 넘칠 때 `justify-center`는 위쪽을 스크롤 시작점 밖으로 밀어냅니다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 (`feature/onboarding-done#22`, base `develop`)
- [x] 커밋 컨벤션 · `Closes #` 기입 · `console` 없음 · 민감 정보 없음

**Z 필수**

- [x] 🔐 권한 2축 — ⚠️ **해당 없음.** OWNER 전용 흐름이고 서버 변경이 없습니다.
- [ ] 🧬 zod — ⚠️ **미적용.** 커밋 API가 없어 매퍼가 없습니다.
- [x] 🕵️ 정직성 — 실제 발송은 미구현입니다. 서버 저장이 없어 1~3단계 값을 `sessionStorage`(`draft.ts`)에 임시로 물려 뒀습니다.
- [x] 🎨 디자인 토큰 · 다크 값 정의됨
- [x] ⚡ 최적화 · ♿ a11y · ♻️ 재사용(`CheckMark` 신설) · 🧪 3상태

---

## 🔗 연관 이슈

Closes #22

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- **초록을 안 쓴 선택** — 시안은 줄마다 초록 체크였는데, "색으로 알리는 건 에러뿐"에 따라 전부 먹색으로 갔습니다.
- **높이 미디어쿼리(`min-height:820px`)** — 임의 기준값입니다.

---

## 📝 추가 메모

- `typecheck` · `lint` · `test`(99) · `build` 통과.
- 1280×660, 1280×520에서 버튼까지 닿는 것을 확인했습니다.
