### PR TITLE
[FEAT] 시스템 관리자 대시보드 구현 #34

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "next-themes": "^0.4.6",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "recharts": "^3.10.1",
         "server-only": "^0.0.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0",
@@ -2802,6 +2803,32 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -2855,6 +2882,18 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -3413,6 +3452,69 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -3555,6 +3657,12 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/validate-npm-package-name": {
@@ -5521,6 +5629,127 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -5645,6 +5874,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/dedent": {
@@ -6198,6 +6433,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
+      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks",
+        "tests/types"
+      ]
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -6667,6 +6913,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
@@ -7644,6 +7896,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "11.1.15",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.15.tgz",
+      "integrity": "sha512-VrNANlmnWQnh5COXIIOQXM9oOJw7naGKlBT74ZOOR6lpVXc3gFEu9FJLDFcpCJ2j+NWr8TIwtWD//T6ZX6TKiQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -7733,6 +7995,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ip-address": {
@@ -11601,7 +11872,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-is-18": {
@@ -11620,6 +11890,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/recast": {
       "version": "0.23.12",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.12.tgz",
@@ -11637,6 +11930,36 @@
         "node": ">= 4"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.10.1.tgz",
+      "integrity": "sha512-QXFrvt6IVcw7eeZCoyXTwkIJAX3Dv1nyVhMicXJ47GsGDDpcN8z6o644DibE9XjpBTThtsomLKnTV6lc+cVFUA==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^11.1.8",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.2.0",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -11649,6 +11972,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -13102,7 +13440,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
@@ -13747,6 +14084,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "next-themes": "^0.4.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "recharts": "^3.10.1",
     "server-only": "^0.0.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",

--- a/src/app/(system)/layout.tsx
+++ b/src/app/(system)/layout.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from "react";
+
+import { SystemSidebar } from "@/features/system/components/system-sidebar";
+import { SYSTEM_NAV } from "@/features/system/nav";
+
+/**
+ * SYSTEM(서비스 운영자) 화면이 공유하는 셸 — 사이드바는 여기 한 번만 그린다.
+ * `(shell)` 레이아웃과 같은 구조지만, SYSTEM은 로그인 뒤 화면과 완전히 다른
+ * 별도 운영 도구라 셸도 따로 둔다(CLAUDE.md §라우트 그룹: `(system)`은 별도 그룹).
+ *
+ * ⚠️ 지금은 목업(더미) 단계다 — 로그인이 붙기 전까지 계정 정보는 고정값이다.
+ */
+export default function SystemLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="bg-background flex h-dvh overflow-hidden">
+      <SystemSidebar sections={SYSTEM_NAV} account={{ email: "admin@getz.kr" }} />
+      <div className="bg-dot-grid flex min-w-0 flex-1 flex-col overflow-hidden">{children}</div>
+    </div>
+  );
+}

--- a/src/app/(system)/system/error.tsx
+++ b/src/app/(system)/system/error.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { RotateCw } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+/** 대시보드를 불러오지 못했을 때. 조용히 빈 화면을 보여주지 않는다(CLAUDE.md: 정직성). */
+export default function Error({ reset }: { reset: () => void }) {
+  return (
+    <main className="flex min-h-0 flex-1 flex-col items-center justify-center gap-4 px-6 text-center">
+      <div className="flex flex-col gap-2">
+        <h1 className="text-lg font-semibold tracking-tight">대시보드를 불러오지 못했어요</h1>
+        <p className="text-muted-foreground text-[13px] leading-[21px]">
+          잠시 후 다시 시도해 주세요. 계속 안 되면 담당자에게 알려주세요.
+        </p>
+      </div>
+      <Button type="button" onClick={reset}>
+        <RotateCw />
+        다시 시도
+      </Button>
+    </main>
+  );
+}

--- a/src/app/(system)/system/layout.tsx
+++ b/src/app/(system)/system/layout.tsx
@@ -1,0 +1,14 @@
+import { LayoutDashboard } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { PageHeader } from "@/features/shell/components/page-header";
+
+/** 대시보드 상단바 — 사이드바에서 바로 닿는 화면이라 `backTo`는 두지 않는다. */
+export default function SystemDashboardLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <PageHeader title="대시보드" icon={LayoutDashboard} />
+      {children}
+    </>
+  );
+}

--- a/src/app/(system)/system/loading.tsx
+++ b/src/app/(system)/system/loading.tsx
@@ -1,0 +1,23 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+/** 대시보드를 불러오는 동안. 실제 화면과 같은 골격이라 레이아웃이 흔들리지 않는다. */
+export default function Loading() {
+  return (
+    <main className="min-h-0 flex-1 overflow-y-auto p-8">
+      <div className="mx-auto flex max-w-[1440px] flex-col gap-6">
+        <div className="grid grid-cols-4 gap-4">
+          {Array.from({ length: 4 }, (_, index) => (
+            <Skeleton key={index} className="h-[104px] rounded-xl" />
+          ))}
+        </div>
+
+        <div className="flex gap-4">
+          <Skeleton className="h-[360px] flex-1 rounded-xl" />
+          <Skeleton className="h-[360px] w-[300px] shrink-0 rounded-xl" />
+        </div>
+
+        <Skeleton className="h-[320px] rounded-xl" />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(system)/system/page.tsx
+++ b/src/app/(system)/system/page.tsx
@@ -1,0 +1,55 @@
+import type { Metadata } from "next";
+
+import { PlanDistributionCard } from "@/features/system/components/plan-distribution-card";
+import { RecentCompaniesTable } from "@/features/system/components/recent-companies-table";
+import { SignupChartCard } from "@/features/system/components/signup-chart-card";
+import { StatCard } from "@/features/system/components/stat-card";
+import { formatCompactKrw } from "@/features/system/format";
+import { getDashboardOverview } from "@/features/system/server";
+
+export const metadata: Metadata = {
+  title: "대시보드",
+};
+
+export default async function SystemDashboardPage() {
+  const { summary, monthlySignups, planDistribution, recentCompanies } =
+    await getDashboardOverview();
+
+  return (
+    <main className="min-h-0 flex-1 overflow-y-auto p-8">
+      <div className="mx-auto flex max-w-[1440px] flex-col gap-6">
+        <div className="grid grid-cols-4 gap-4">
+          <StatCard
+            label="가입 기업 수"
+            value={`${summary.companyCount}`}
+            meta={`이번 달 +${summary.companyCountDeltaThisMonth}`}
+          />
+          <StatCard
+            label="활성 사용자"
+            value={`${summary.activeUserCount}`}
+            meta={`전월 대비 +${summary.activeUserDeltaPercent}%`}
+          />
+          <StatCard
+            label="MRR"
+            value={formatCompactKrw(summary.mrr)}
+            meta={`Team ${summary.teamPlanCompanyCount}개사`}
+            isHighlighted
+          />
+          <StatCard
+            label="승인 대기"
+            value={`${summary.pendingApprovalCount}건`}
+            meta="기업 가입 신청"
+            isHighlighted
+          />
+        </div>
+
+        <div className="flex gap-4">
+          <SignupChartCard data={monthlySignups} />
+          <PlanDistributionCard data={planDistribution} />
+        </div>
+
+        <RecentCompaniesTable companies={recentCompanies} />
+      </div>
+    </main>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -120,6 +120,10 @@
   --status-todo: #a8a29e;
   --status-progress: #22c55e;
   --status-done: #8b5cf6;
+  /* 차트 카테고리 색 — UI 시맨틱(액센트 블루)과 분리된 별도 채널.
+     data-viz 접근성 검증(CVD ΔE·명도·대비) 통과한 조합이다. */
+  --chart-1: #eb6834;
+  --chart-2: #2a78d6;
 }
 
 .dark {
@@ -173,6 +177,8 @@
   --status-todo: #8a827d;
   --status-progress: #22c55e;
   --status-done: #a78bfa;
+  --chart-1: #d95926;
+  --chart-2: #3987e5;
 }
 
 @layer utilities {

--- a/src/constants/domain.ts
+++ b/src/constants/domain.ts
@@ -191,6 +191,12 @@ export const POSITION_ROLES = [ROLE.LEADER, ROLE.MEMBER] as const;
 export const PLAN = { FREE: "FREE", TEAM: "TEAM" } as const;
 export type Plan = (typeof PLAN)[keyof typeof PLAN];
 
+/** 요금제명은 영문을 그대로 쓴다(역할 워딩과 같은 이유). */
+export const PLAN_LABEL: Record<Plan, string> = {
+  FREE: "Free",
+  TEAM: "Team",
+};
+
 export const PAYMENT_STATUS = {
   PAID: "PAID",
   UNPAID: "UNPAID",

--- a/src/features/shell/components/role-sidebar.tsx
+++ b/src/features/shell/components/role-sidebar.tsx
@@ -28,8 +28,11 @@ import { cn } from "@/lib/utils";
 
 import type { NavIconName, NavItem, NavSection } from "../nav";
 
-/** 이름 → 아이콘. 구성 파일은 서버에서 읽히므로 실제 컴포넌트는 여기서 붙인다. */
-const NAV_ICON: Record<NavIconName, LucideIcon> = {
+/**
+ * 이름 → 아이콘. 구성 파일은 서버에서 읽히므로 실제 컴포넌트는 여기서 붙인다.
+ * OWNER_NAV가 쓰는 이름만 채운다 — `Partial`이라 나머지(SYSTEM 전용 등)는 없어도 된다.
+ */
+const NAV_ICON: Partial<Record<NavIconName, LucideIcon>> = {
   dashboard: LayoutDashboard,
   project: Folder,
   search: Search,
@@ -119,7 +122,7 @@ export function RoleSidebar({ sections, user }: RoleSidebarProps) {
 }
 
 function SidebarItem({ item, isCurrent }: { item: NavItem; isCurrent: boolean }) {
-  const Icon = NAV_ICON[item.icon];
+  const Icon = NAV_ICON[item.icon] ?? LayoutDashboard;
   const inner = (
     <>
       <Icon className="size-[14px] shrink-0" aria-hidden />

--- a/src/features/shell/nav.ts
+++ b/src/features/shell/nav.ts
@@ -19,7 +19,10 @@ export type NavIconName =
   | "members"
   | "billing"
   | "storage"
-  | "setting";
+  | "setting"
+  | "approval"
+  | "company"
+  | "monitor";
 
 export interface NavItem {
   href: string;

--- a/src/features/system/components/plan-distribution-card.tsx
+++ b/src/features/system/components/plan-distribution-card.tsx
@@ -1,0 +1,38 @@
+import { PLAN, PLAN_LABEL } from "@/constants/domain";
+
+import type { PlanDistributionSlice } from "../types";
+import { PlanDonutChartLoader } from "./plan-donut-chart-loader";
+
+/** 도넛 조각과 같은 색이다(`plan-donut-chart.tsx`의 `SLICE_COLOR`). */
+const LEGEND_DOT_CLASS = {
+  [PLAN.TEAM]: "bg-chart-1",
+  [PLAN.FREE]: "bg-chart-2",
+} as const;
+
+/** "플랜 분포" 카드 — 도넛차트(클라이언트) + 범례(서버). */
+export function PlanDistributionCard({ data }: { data: PlanDistributionSlice[] }) {
+  return (
+    <section className="border-border bg-card w-[300px] shrink-0 rounded-xl border p-6">
+      <h2 className="text-foreground text-base font-semibold">플랜 분포</h2>
+
+      <div className="mt-4">
+        <PlanDonutChartLoader data={data} />
+      </div>
+
+      <ul className="mt-4 flex flex-col gap-2">
+        {data.map((slice) => (
+          <li key={slice.plan} className="flex items-center justify-between text-sm">
+            <span className="flex items-center gap-2">
+              <span
+                className={`size-2 shrink-0 rounded-full ${LEGEND_DOT_CLASS[slice.plan]}`}
+                aria-hidden
+              />
+              <span className="text-foreground">{PLAN_LABEL[slice.plan]}</span>
+            </span>
+            <span className="text-muted-foreground tabular-nums">{slice.companyCount}개사</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/features/system/components/plan-donut-chart-loader.tsx
+++ b/src/features/system/components/plan-donut-chart-loader.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+import { Skeleton } from "@/components/ui/skeleton";
+
+import type { PlanDistributionSlice } from "../types";
+
+/** `signup-chart-loader.tsx`와 같은 이유로 분리한 로더 — `recharts` 코드는 여기서만 불러온다. */
+const PlanDonutChart = dynamic(() => import("./plan-donut-chart").then((m) => m.PlanDonutChart), {
+  ssr: false,
+  loading: () => <Skeleton className="mx-auto size-[144px] rounded-full" />,
+});
+
+export function PlanDonutChartLoader({ data }: { data: PlanDistributionSlice[] }) {
+  return <PlanDonutChart data={data} />;
+}

--- a/src/features/system/components/plan-donut-chart.tsx
+++ b/src/features/system/components/plan-donut-chart.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
+
+import { type Plan, PLAN_LABEL } from "@/constants/domain";
+
+import type { PlanDistributionSlice } from "../types";
+
+/** 차트 카테고리 색과 맞춘다(globals.css `--chart-1`·`--chart-2`) — Team이 먼저, Free가 다음. */
+const SLICE_COLOR: Record<Plan, string> = {
+  TEAM: "var(--chart-1)",
+  FREE: "var(--chart-2)",
+};
+
+interface PlanDonutChartProps {
+  data: PlanDistributionSlice[];
+}
+
+/** 플랜 분포 도넛차트. 조각 이름·범례는 카드(`PlanDistributionCard`)가 따로 그린다. */
+export function PlanDonutChart({ data }: PlanDonutChartProps) {
+  return (
+    <ResponsiveContainer width="100%" height={160}>
+      <PieChart>
+        <Pie
+          data={data}
+          dataKey="companyCount"
+          nameKey="plan"
+          innerRadius={48}
+          outerRadius={72}
+          paddingAngle={2}
+          stroke="var(--card)"
+          strokeWidth={2}
+        >
+          {data.map((slice) => (
+            <Cell key={slice.plan} fill={SLICE_COLOR[slice.plan]} />
+          ))}
+        </Pie>
+        <Tooltip
+          contentStyle={{
+            background: "var(--popover)",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius-md)",
+            color: "var(--popover-foreground)",
+            fontSize: 12,
+          }}
+          formatter={(value, name) => [`${value}개사`, PLAN_LABEL[name as Plan]]}
+        />
+      </PieChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/features/system/components/recent-companies-table.tsx
+++ b/src/features/system/components/recent-companies-table.tsx
@@ -1,0 +1,59 @@
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { PLAN, PLAN_LABEL } from "@/constants/domain";
+
+import type { RecentCompany } from "../types";
+
+/** "최근 가입 기업" 표. 비어있으면 안내 문구로 대체한다(CLAUDE.md §정직성 · loading/error/empty). */
+export function RecentCompaniesTable({ companies }: { companies: RecentCompany[] }) {
+  if (companies.length === 0) {
+    return (
+      <section className="border-border bg-card rounded-xl border p-6">
+        <h2 className="text-foreground text-base font-semibold">최근 가입 기업</h2>
+        <p className="text-muted-foreground mt-8 text-center text-sm">아직 가입한 기업이 없어요</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="border-border bg-card overflow-hidden rounded-xl border">
+      <h2 className="text-foreground px-6 pt-6 pb-4 text-base font-semibold">최근 가입 기업</h2>
+
+      <Table>
+        <TableHeader>
+          <TableRow className="hover:bg-transparent">
+            <TableHead className="pl-6">기업명</TableHead>
+            <TableHead>플랜</TableHead>
+            <TableHead>구성원</TableHead>
+            <TableHead className="pr-6">가입일</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {companies.map((company) => (
+            <TableRow key={company.id}>
+              <TableCell className="text-foreground pl-6">{company.name}</TableCell>
+              <TableCell>
+                <Badge variant={company.plan === PLAN.TEAM ? "default" : "secondary"}>
+                  {PLAN_LABEL[company.plan]}
+                </Badge>
+              </TableCell>
+              <TableCell className="text-muted-foreground tabular-nums">
+                {company.memberCount}명
+              </TableCell>
+              <TableCell className="text-muted-foreground pr-6 tabular-nums">
+                {company.joinedAt}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </section>
+  );
+}

--- a/src/features/system/components/signup-chart-card.tsx
+++ b/src/features/system/components/signup-chart-card.tsx
@@ -1,0 +1,14 @@
+import type { MonthlySignup } from "../types";
+import { SignupChartLoader } from "./signup-chart-loader";
+
+/** "월별 신규 가입 기업" 카드. 차트만 클라이언트고 카드 틀은 서버에서 그린다. */
+export function SignupChartCard({ data }: { data: MonthlySignup[] }) {
+  return (
+    <section className="border-border bg-card flex-1 rounded-xl border p-6">
+      <h2 className="text-foreground text-base font-semibold">월별 신규 가입 기업</h2>
+      <div className="mt-4">
+        <SignupChartLoader data={data} />
+      </div>
+    </section>
+  );
+}

--- a/src/features/system/components/signup-chart-loader.tsx
+++ b/src/features/system/components/signup-chart-loader.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+import { Skeleton } from "@/components/ui/skeleton";
+
+import type { MonthlySignup } from "../types";
+
+/**
+ * `recharts`는 무겁다 — 대시보드 첫 로드 번들에서 뺀다(CLAUDE.md §최적화).
+ * `ssr: false`는 클라이언트 컴포넌트 안에서만 쓸 수 있어 이 로더가 따로 있다 —
+ * 서버 컴포넌트(카드 쪽)에서 바로 `dynamic(..., { ssr: false })`를 부르면 빌드가 깨진다.
+ */
+const SignupChart = dynamic(() => import("./signup-chart").then((m) => m.SignupChart), {
+  ssr: false,
+  loading: () => <Skeleton className="h-[280px] w-full" />,
+});
+
+export function SignupChartLoader({ data }: { data: MonthlySignup[] }) {
+  return <SignupChart data={data} />;
+}

--- a/src/features/system/components/signup-chart.tsx
+++ b/src/features/system/components/signup-chart.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+
+import type { MonthlySignup } from "../types";
+
+interface SignupChartProps {
+  data: MonthlySignup[];
+}
+
+/** 월별 신규 가입 기업 막대그래프. 단일 계열이라 범례는 두지 않는다. */
+export function SignupChart({ data }: SignupChartProps) {
+  return (
+    <ResponsiveContainer width="100%" height={280}>
+      <BarChart data={data} margin={{ top: 8, right: 8, left: -16, bottom: 0 }}>
+        <CartesianGrid vertical={false} stroke="var(--border)" />
+        <XAxis
+          dataKey="month"
+          tickLine={false}
+          axisLine={false}
+          tick={{ fill: "var(--muted-foreground)", fontSize: 12 }}
+        />
+        <YAxis
+          tickLine={false}
+          axisLine={false}
+          tick={{ fill: "var(--muted-foreground)", fontSize: 12 }}
+        />
+        <Tooltip
+          cursor={{ fill: "var(--muted)" }}
+          contentStyle={{
+            background: "var(--popover)",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius-md)",
+            color: "var(--popover-foreground)",
+            fontSize: 12,
+          }}
+          formatter={(value) => [`${value}개사`, "신규 가입"]}
+        />
+        <Bar dataKey="count" fill="var(--chart-1)" radius={[4, 4, 0, 0]} maxBarSize={32} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/features/system/components/stat-card.tsx
+++ b/src/features/system/components/stat-card.tsx
@@ -1,0 +1,27 @@
+import { cn } from "@/lib/utils";
+
+interface StatCardProps {
+  label: string;
+  value: string;
+  meta: string;
+  /** 눈에 띄어야 할 수치 — 차트와 같은 강조색을 써서 한 화면 안에서 시선을 통일한다 */
+  isHighlighted?: boolean;
+}
+
+/** 대시보드 상단 통계 한 칸. */
+export function StatCard({ label, value, meta, isHighlighted }: StatCardProps) {
+  return (
+    <div className="border-border bg-card flex flex-col gap-2 rounded-xl border p-5">
+      <p className="text-muted-foreground text-[13px] leading-[18px]">{label}</p>
+      <p
+        className={cn(
+          "text-2xl leading-8 font-semibold tabular-nums",
+          isHighlighted ? "text-chart-1" : "text-foreground",
+        )}
+      >
+        {value}
+      </p>
+      <p className="text-muted-foreground/70 text-xs leading-4">{meta}</p>
+    </div>
+  );
+}

--- a/src/features/system/components/system-sidebar.tsx
+++ b/src/features/system/components/system-sidebar.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import {
+  Activity,
+  Bell,
+  Building2,
+  ClipboardCheck,
+  CreditCard,
+  LayoutDashboard,
+  type LucideIcon,
+} from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { toast } from "sonner";
+
+import { ZLogo } from "@/components/icons/z-logo";
+import type { NavIconName, NavItem, NavSection } from "@/features/shell/nav";
+import { cn } from "@/lib/utils";
+
+/**
+ * 이름 → 아이콘. 구성 파일은 서버에서 읽히므로 실제 컴포넌트는 여기서 붙인다.
+ * SYSTEM_NAV가 쓰는 이름만 채운다 — `Partial`이라 나머지는 fallback 아이콘으로 대체된다.
+ */
+const NAV_ICON: Partial<Record<NavIconName, LucideIcon>> = {
+  dashboard: LayoutDashboard,
+  approval: ClipboardCheck,
+  company: Building2,
+  billing: CreditCard,
+  monitor: Activity,
+  notice: Bell,
+};
+
+interface SystemSidebarProps {
+  sections: NavSection[];
+  /** 하단 계정 줄 */
+  account: { email: string };
+}
+
+/**
+ * SYSTEM(서비스 운영자) 전용 사이드바.
+ *
+ * ⚠️ `RoleSidebar`와 구조는 비슷하지만 별도 컴포넌트다 — 헤더 표기("Z 운영자")와
+ *    하단 계정 줄(역할 배지 없이 이메일만)이 달라서 그대로 재사용하면 SYSTEM 분기가
+ *    RoleSidebar 안에 섞여 들어간다.
+ */
+export function SystemSidebar({ sections, account }: SystemSidebarProps) {
+  const pathname = usePathname();
+
+  return (
+    <aside className="border-border bg-background flex w-[220px] shrink-0 flex-col border-r">
+      <div className="flex h-[64px] shrink-0 items-center gap-2 px-[18px]">
+        <Link
+          href="/system"
+          aria-label="Z 운영자 홈으로"
+          className="focus-visible:ring-ring flex items-center gap-2 rounded transition-opacity hover:opacity-70 focus-visible:ring-2 focus-visible:outline-none"
+        >
+          <ZLogo className="text-foreground size-[22px]" title="Z" />
+          <span className="text-foreground text-sm leading-none font-semibold">운영자</span>
+        </Link>
+      </div>
+
+      <nav className="flex-1 overflow-y-auto p-[7px]">
+        {sections.map((section, index) => (
+          <div key={section.title ?? "primary"} className={index > 0 ? "pt-2.5" : undefined}>
+            {section.title && (
+              <p className="text-muted-foreground/80 px-[10.5px] pb-[5.25px] text-[11px] leading-4 tracking-[0.275px]">
+                {section.title}
+              </p>
+            )}
+
+            <ul className="flex flex-col gap-[1.75px]">
+              {section.items.map((item) => (
+                <li key={item.href}>
+                  <SidebarItem item={item} isCurrent={pathname.startsWith(item.href)} />
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </nav>
+
+      <div className="border-border flex h-[49px] shrink-0 items-center gap-[7px] border-t px-[17.5px]">
+        <span className="bg-role-owner flex size-[21px] shrink-0 items-center justify-center rounded-full text-[10px] leading-none text-white">
+          운
+        </span>
+        <div className="min-w-0 flex-1">
+          <p className="text-foreground truncate text-xs leading-[15px]">운영자 계정</p>
+          <p className="text-muted-foreground truncate text-[11px] leading-[14px]">
+            {account.email}
+          </p>
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+function SidebarItem({ item, isCurrent }: { item: NavItem; isCurrent: boolean }) {
+  const Icon = NAV_ICON[item.icon] ?? LayoutDashboard;
+  const inner = (
+    <>
+      <Icon className="size-[14px] shrink-0" aria-hidden />
+      <span className="min-w-0 flex-1 translate-y-px truncate text-[13px] leading-5">
+        {item.label}
+      </span>
+    </>
+  );
+
+  const shape = "flex h-[34px] items-center gap-[8.75px] rounded-md px-[10.5px] transition-colors";
+
+  // ⚠️ 아직 없는 화면은 링크로 두지 않는다 — 누르면 404가 뜬다(CLAUDE.md §정직성).
+  if (!item.isReady) {
+    return (
+      <button
+        type="button"
+        aria-disabled
+        onClick={() => toast(`${item.label} 화면은 아직 만드는 중이에요`)}
+        className={cn(
+          shape,
+          "text-muted-foreground hover:bg-foreground/5 hover:text-foreground focus-visible:ring-ring w-full text-left focus-visible:ring-2 focus-visible:outline-none",
+        )}
+      >
+        {inner}
+      </button>
+    );
+  }
+
+  return (
+    <Link
+      href={item.href}
+      aria-current={isCurrent ? "page" : undefined}
+      className={cn(
+        shape,
+        "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none",
+        isCurrent
+          ? "bg-foreground text-background"
+          : "text-muted-foreground hover:bg-foreground/5 hover:text-foreground",
+      )}
+    >
+      {inner}
+    </Link>
+  );
+}

--- a/src/features/system/format.test.ts
+++ b/src/features/system/format.test.ts
@@ -1,0 +1,23 @@
+import { formatCompactKrw } from "./format";
+
+describe("금액 축약 표기", () => {
+  it("백만 단위는 M로 줄인다", () => {
+    expect(formatCompactKrw(8_400_000)).toBe("₩8.4M");
+  });
+
+  it("소수점이 0이면 떼어낸다", () => {
+    expect(formatCompactKrw(8_000_000)).toBe("₩8M");
+  });
+
+  it("억 단위는 억으로 줄인다", () => {
+    expect(formatCompactKrw(120_000_000)).toBe("₩1.2억");
+  });
+
+  it("천 단위는 K로 줄인다", () => {
+    expect(formatCompactKrw(8_400)).toBe("₩8.4K");
+  });
+
+  it("천 미만은 그대로 자릿점만 붙인다", () => {
+    expect(formatCompactKrw(0)).toBe("₩0");
+  });
+});

--- a/src/features/system/format.ts
+++ b/src/features/system/format.ts
@@ -1,0 +1,13 @@
+/**
+ * 큰 금액을 축약 표기한다 — `8400000` → `₩8.4M`.
+ * ⚠️ 소수점이 `.0`이면 떼어낸다 — `₩8.0M`처럼 어색한 꼬리를 남기지 않는다.
+ */
+export function formatCompactKrw(amount: number): string {
+  const scale = (value: number, divisor: number, unit: string) =>
+    `₩${(value / divisor).toFixed(1).replace(/\.0$/, "")}${unit}`;
+
+  if (amount >= 100_000_000) return scale(amount, 100_000_000, "억");
+  if (amount >= 1_000_000) return scale(amount, 1_000_000, "M");
+  if (amount >= 1_000) return scale(amount, 1_000, "K");
+  return `₩${amount.toLocaleString("ko-KR")}`;
+}

--- a/src/features/system/mock/dashboard.ts
+++ b/src/features/system/mock/dashboard.ts
@@ -1,0 +1,36 @@
+import { PLAN } from "@/constants/domain";
+
+import type { DashboardOverview } from "../types";
+
+/** ⚠️ 목 데이터 — BE 연동 전. SYSTEM 대시보드 진입 시 보여줄 예시 값이다. */
+export const MOCK_DASHBOARD_OVERVIEW: DashboardOverview = {
+  summary: {
+    companyCount: 62,
+    companyCountDeltaThisMonth: 8,
+    activeUserCount: 841,
+    activeUserDeltaPercent: 12,
+    mrr: 8_400_000,
+    teamPlanCompanyCount: 38,
+    pendingApprovalCount: 3,
+  },
+  monthlySignups: [
+    { month: "2월", count: 3 },
+    { month: "3월", count: 5 },
+    { month: "4월", count: 7 },
+    { month: "5월", count: 8 },
+    { month: "6월", count: 10 },
+    { month: "7월", count: 8 },
+  ],
+  planDistribution: [
+    { plan: PLAN.TEAM, companyCount: 38 },
+    { plan: PLAN.FREE, companyCount: 24 },
+  ],
+  recentCompanies: [
+    { id: "1", name: "(주)테크스타트", plan: PLAN.TEAM, memberCount: 12, joinedAt: "2025-07-22" },
+    { id: "2", name: "그린로직스", plan: PLAN.FREE, memberCount: 4, joinedAt: "2025-07-21" },
+    { id: "3", name: "(주)레이어원", plan: PLAN.TEAM, memberCount: 27, joinedAt: "2025-07-19" },
+    { id: "4", name: "모멘텀랩", plan: PLAN.TEAM, memberCount: 8, joinedAt: "2025-07-17" },
+    { id: "5", name: "엔드포인트", plan: PLAN.FREE, memberCount: 3, joinedAt: "2025-07-15" },
+    { id: "6", name: "(주)블루스톤", plan: PLAN.TEAM, memberCount: 14, joinedAt: "2025-07-13" },
+  ],
+};

--- a/src/features/system/nav.ts
+++ b/src/features/system/nav.ts
@@ -1,0 +1,21 @@
+import type { NavSection } from "@/features/shell/nav";
+
+/**
+ * SYSTEM(서비스 운영자) 사이드바 구성.
+ *
+ * ⚠️ 지금은 대시보드만 실제 화면이다 — 나머지는 `isReady` 없이 둬서
+ *    눌러도 "준비 중" 안내만 뜨게 한다(CLAUDE.md §정직성).
+ */
+export const SYSTEM_NAV: NavSection[] = [
+  {
+    title: "운영 메뉴",
+    items: [
+      { href: "/system", label: "대시보드", icon: "dashboard", isReady: true },
+      { href: "/system/approval", label: "기업 승인", icon: "approval" },
+      { href: "/system/companies", label: "기업 관리", icon: "company" },
+      { href: "/system/billing", label: "구독·매출", icon: "billing" },
+      { href: "/system/monitoring", label: "시스템 모니터링", icon: "monitor" },
+      { href: "/system/notice", label: "공지", icon: "notice" },
+    ],
+  },
+];

--- a/src/features/system/server.ts
+++ b/src/features/system/server.ts
@@ -1,0 +1,18 @@
+import "server-only";
+
+import { isMock } from "@/mocks/config";
+
+import { MOCK_DASHBOARD_OVERVIEW } from "./mock/dashboard";
+import type { DashboardOverview } from "./types";
+
+/**
+ * SYSTEM 대시보드 조회 — **격리막**(CLAUDE.md).
+ * 컴포넌트는 `DashboardOverview`(UI 계약)만 알고, 목/실서버 분기는 여기서 끝낸다.
+ * 연동할 때 고칠 곳은 이 파일과 매퍼뿐이고 컴포넌트는 건드리지 않는다.
+ */
+export async function getDashboardOverview(): Promise<DashboardOverview> {
+  if (isMock) return MOCK_DASHBOARD_OVERVIEW;
+
+  // ⚠️ 미구현 — API 스펙 확정 후 `ep.systemDashboard()`로 fetch하고 매퍼로 UI 계약에 맞춘다.
+  throw new Error("대시보드 조회 API가 아직 연결되지 않았습니다.");
+}

--- a/src/features/system/types.ts
+++ b/src/features/system/types.ts
@@ -1,0 +1,46 @@
+import type { Plan } from "@/constants/domain";
+
+/** 대시보드 상단 통계 4종. */
+export interface DashboardSummary {
+  companyCount: number;
+  /** 이번 달 신규 가입 기업 수 */
+  companyCountDeltaThisMonth: number;
+  activeUserCount: number;
+  /** 전월 대비 증감률(%) */
+  activeUserDeltaPercent: number;
+  /** 월 반복 매출(원) */
+  mrr: number;
+  teamPlanCompanyCount: number;
+  pendingApprovalCount: number;
+}
+
+/** 월별 신규 가입 기업 수 — 막대그래프 한 칸. */
+export interface MonthlySignup {
+  /** 화면에 그대로 나가는 월 라벨("2월" 등) */
+  month: string;
+  count: number;
+}
+
+/** 플랜별 기업 수 — 도넛차트 한 조각. */
+export interface PlanDistributionSlice {
+  plan: Plan;
+  companyCount: number;
+}
+
+/** 최근 가입 기업 한 행. */
+export interface RecentCompany {
+  id: string;
+  name: string;
+  plan: Plan;
+  memberCount: number;
+  /** "YYYY-MM-DD" — 관리자 화면 표기라 일반 화면의 "8월 5일(화)" 형식을 따르지 않는다 */
+  joinedAt: string;
+}
+
+/** 대시보드 화면 하나가 필요로 하는 데이터 전부 — 격리막의 UI 계약. */
+export interface DashboardOverview {
+  summary: DashboardSummary;
+  monthlySignups: MonthlySignup[];
+  planDistribution: PlanDistributionSlice[];
+  recentCompanies: RecentCompany[];
+}

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -43,4 +43,7 @@ export const ep = {
   notificationStream: () => "/api/notifications/stream",
   notices: () => "/api/notices",
   subscription: () => "/api/subscription",
+
+  /* 시스템 운영자 */
+  systemDashboard: () => "/api/system/dashboard",
 } as const;


### PR DESCRIPTION
## 📋 PR 타입
- [x] feat — 새로운 기능 추가

## 🗂 작업 영역
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독

## 🙋 관련 역할
- [x] SYSTEM (서비스 운영자 — 확장, 데모 제외)

## 📝 작업 내용
- `/system` 대시보드 화면 구현 — 통계 4종, 월별 가입 막대그래프, 플랜 분포 도넛차트, 최근 가입 기업 표
- SYSTEM 전용 사이드바·셸 레이아웃 추가, 미구현 메뉴는 준비 중 토스트로 안내
- recharts 차트는 `next/dynamic(ssr:false)`로 코드 분할(네트워크 탭에서 별도 청크 확인함)
- 데이터는 격리막 구조(`types.ts`/`mock/`/`server.ts`)로 목 우선 진행

## ✅ 작업 체크리스트
**기본**
- [x] 브랜치 명명 규칙 준수, base `develop`(1단계 머지 후 새로 판 브랜치)
- [x] 커밋 컨벤션 준수
- [x] `Closes #` 기입
- [x] 불필요한 console·주석 코드 없음
- [x] 민감 정보 없음

**Z 필수**
- [ ] 권한 2축 검사 — 로그인·서버 검사 붙기 전이라 화면만 있음(추후 SYSTEM 역할 서버 재검사 필요, 코드에 주석 표시)
- [x] zod — 해당 없음(ERD 미확정, 목 데이터 직접 타입으로 관리 — 실 연동 시 매퍼에서 `safeParse` 추가 예정)
- [x] 정직성 — 목 데이터·미구현 메뉴 모두 주석/토스트로 명시
- [x] 디자인 토큰 — 하드코딩 없이 전부 토큰(1단계에서 추가한 차트 토큰 포함)

**품질**
- [x] 최적화 — recharts `next/dynamic(ssr:false)` 분리
- [x] a11y — 표는 `Table`, 배지는 `Badge`, 미구현 메뉴는 `aria-disabled`+안내
- [x] 재사용 확인 — `PageHeader`, `ui/table`, `ui/badge`, `ui/skeleton` 재사용
- [x] loading/error/empty 3상태 — 스켈레톤·재시도 화면·표 빈 상태 문구 모두 있음
- [ ] 브라우저 전용 API — 해당 없음

## 🔗 연관 이슈
Closes #34

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트
- 데이터 레이어가 실제 BE 연동 시 `server.ts`·매퍼만 고치면 되는 구조인지
- 차트 두 개가 실제로 별도 청크로 분리되는지(devtools 네트워크 탭)
- 아직 SYSTEM 서버 재검사가 없다는 점 — 로그인 붙는 다음 단계에서 처리 예정임을 인지하고 리뷰

## 📝 추가 메모
⚠️ 지금은 로그인이 없어 SYSTEM 역할 서버 재검사가 빠져있다 — CLAUDE.md §권한 원칙대로,
로그인·세션이 붙는 별도 작업에서 `assertPermission` 재검사를 추가해야 한다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 시스템 운영자용 대시보드를 추가했습니다.
  * 회사·사용자 요약 통계, 월별 가입 현황, 요금제 분포 차트, 최근 기업 목록을 제공합니다.
  * 운영자용 사이드바와 대시보드 공통 레이아웃을 제공합니다.
  * 로딩 스켈레톤과 오류 발생 시 재시도 기능을 추가했습니다.

* **개선**
  * 메뉴 아이콘과 차트 색상 테마를 확장했습니다.
  * 금액을 원화 단위로 간결하게 표시하는 기능을 추가했습니다.

* **테스트**
  * 원화 금액 축약 표시 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
