### PR TITLE
[FEAT] 이용약관·개인정보처리방침 모달 #39

### DIFF
--- a/src/app/(public)/privacy/page.tsx
+++ b/src/app/(public)/privacy/page.tsx
@@ -1,98 +1,15 @@
-import { Archive, Database, Handshake, KeyRound, Target } from "lucide-react";
 import type { Metadata } from "next";
 
-import { DocPage, DocSection } from "@/features/landing/components/doc-page";
+import { DocPage } from "@/features/landing/components/doc-page";
+import { PrivacyContent } from "@/features/legal/privacy-content";
 
 export const metadata: Metadata = { title: "개인정보처리방침 — Z" };
 
-/** ⚠️ 실제 수집 항목은 ERD·API 확정 후 다시 맞춘다. */
-const COLLECTED = [
-  {
-    kind: "계정 정보",
-    items: "이름 · 회사 이메일 · 부서 · 직급",
-    when: "관리자가 계정을 발급할 때",
-  },
-  {
-    kind: "이용 기록",
-    items: "회의 녹음 · 자막 · 액션 · 인수인계 문서",
-    when: "서비스를 쓰는 동안",
-  },
-  {
-    kind: "결제 기록",
-    items: "플랜 · 결제 일시 · 금액 (카드번호 제외)",
-    when: "유료 플랜을 결제할 때",
-  },
-] as const;
-
+/** ⚠️ 본문은 `features/legal`에 있다 — 모달도 같은 글을 쓴다. */
 export default function PrivacyPage() {
   return (
     <DocPage title="개인정보처리방침" description="어떤 정보를 왜 다루는지 적어 둡니다.">
-      <DocSection title="1. 다루는 정보" icon={Database}>
-        <div className="border-border overflow-x-auto rounded-lg border">
-          <table className="w-full min-w-[480px] border-collapse text-left">
-            <thead>
-              <tr className="border-border bg-secondary border-b">
-                <th scope="col" className="px-4 py-2.5 text-[12px] leading-[18px] font-medium">
-                  구분
-                </th>
-                <th scope="col" className="px-4 py-2.5 text-[12px] leading-[18px] font-medium">
-                  항목
-                </th>
-                <th scope="col" className="px-4 py-2.5 text-[12px] leading-[18px] font-medium">
-                  언제
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {COLLECTED.map((row) => (
-                <tr key={row.kind} className="border-border border-t first:border-t-0">
-                  <th
-                    scope="row"
-                    className="px-4 py-2.5 text-[13px] leading-5 font-normal whitespace-nowrap"
-                  >
-                    {row.kind}
-                  </th>
-                  <td className="text-muted-foreground px-4 py-2.5 text-[13px] leading-5 break-keep">
-                    {row.items}
-                  </td>
-                  <td className="text-muted-foreground px-4 py-2.5 text-[13px] leading-5 break-keep">
-                    {row.when}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </DocSection>
-
-      <DocSection title="2. 쓰는 목적" icon={Target}>
-        <p>
-          회의 기록을 정리해 담당자에게 할 일을 전달하고, 인수인계 문서를 구성하기 위해 씁니다. 그
-          밖의 목적으로 쓰지 않으며, 광고에 활용하지 않습니다.
-        </p>
-      </DocSection>
-
-      <DocSection title="3. 처리 위탁" icon={Handshake}>
-        <p>
-          결제는 Toss Payments에 위탁합니다. 카드 정보는{" "}
-          <strong className="text-foreground">Z가 받지 않으며</strong>, 카드번호는 우리 서버에
-          저장되지 않습니다. 서버는 AWS에서 운영합니다.
-        </p>
-      </DocSection>
-
-      <DocSection title="4. 보관과 파기" icon={Archive}>
-        <p>
-          기록은 회사가 구독을 유지하는 동안 보관됩니다. 회사가 프로젝트를 삭제하면 그에 속한 녹음도
-          함께 삭제되고, 탈퇴한 조직의 데이터는 관련 법령이 정한 기간이 지나면 파기합니다.
-        </p>
-      </DocSection>
-
-      <DocSection title="5. 이용자의 권리" icon={KeyRound}>
-        <p>
-          자신의 정보 열람·정정·삭제는 회사의 관리자를 통해 요청할 수 있습니다. 회의 기록처럼 회사에
-          귀속되는 자료는 회사의 정책에 따릅니다.
-        </p>
-      </DocSection>
+      <PrivacyContent />
     </DocPage>
   );
 }

--- a/src/app/(public)/terms/page.tsx
+++ b/src/app/(public)/terms/page.tsx
@@ -1,93 +1,15 @@
-import {
-  BadgeCheck,
-  BookText,
-  CreditCard,
-  FileText,
-  Mail,
-  RefreshCw,
-  ShieldAlert,
-  UserCog,
-  Wrench,
-} from "lucide-react";
 import type { Metadata } from "next";
 
-import { DocPage, DocSection } from "@/features/landing/components/doc-page";
+import { DocPage } from "@/features/landing/components/doc-page";
+import { TermsContent } from "@/features/legal/terms-content";
 
 export const metadata: Metadata = { title: "이용약관 — Z" };
 
-/**
- * ⚠️ **법무 확정본이 아니다.** 서비스를 열기 전에 검토받은 본문으로 교체한다.
- *    (화면에 경고 띠를 두지 않는 건 팀 결정이다 — 문서 자체가 완성된 모양으로 보여야 한다.)
- */
+/** ⚠️ 본문은 `features/legal`에 있다 — 모달도 같은 글을 쓴다. */
 export default function TermsPage() {
   return (
     <DocPage title="이용약관" description="Z를 쓰실 때 적용되는 약속입니다.">
-      <DocSection title="1. 용어" icon={BookText}>
-        <p>
-          “회사 계정”은 Z에 가입해 조직을 만든 주체를, “구성원”은 그 조직이 발급한 계정을 쓰는
-          사람을 말합니다. “기록”은 회의 녹음·자막·요약·액션·인수인계 문서를 통틀어 말합니다.
-        </p>
-      </DocSection>
-
-      <DocSection title="2. 서비스 소개" icon={BadgeCheck}>
-        <p>
-          Z는 회의 내용을 기록하고, 결정과 할 일을 담당자에게 배정하는 사내 협업 도구입니다. 회사가
-          계정을 발급하며, 한 계정은 하나의 회사에 속합니다.
-        </p>
-      </DocSection>
-
-      <DocSection title="3. 계정과 이용자의 의무" icon={UserCog}>
-        <p>
-          계정은 회사의 관리자가 발급합니다. 발급받은 계정 정보를 다른 사람과 공유할 수 없고,
-          비밀번호를 잃어버린 경우 관리자에게 재발급을 요청해 주세요.
-        </p>
-        <p>
-          법령이나 공서양속에 어긋나는 자료를 올리거나, 다른 회사·구성원의 데이터에 접근을 시도하는
-          행위는 금지됩니다. 위반이 확인되면 회사와 협의해 이용을 제한할 수 있습니다.
-        </p>
-      </DocSection>
-
-      <DocSection title="4. 회의 기록과 권리" icon={FileText}>
-        <p>
-          회의 녹음과 자막은 회의를 개설한 사람이 시작합니다. 기록은 회사에 귀속되며, 담당자가
-          바뀌어도 회사 안에 남습니다. 회의에 참여하는 모든 분께 기록이 남는다는 사실을 미리 알려
-          주세요.
-        </p>
-        <p>Z 서비스 자체(화면·상표·코드)에 대한 권리는 Z에 있습니다.</p>
-      </DocSection>
-
-      <DocSection title="5. 구독과 결제" icon={CreditCard}>
-        <p>
-          유료 플랜은 구성원 수를 기준으로 매월 또는 매년 청구됩니다. 언제든지 해지할 수 있고,
-          해지하면 다음 결제부터 청구되지 않습니다. 이미 결제한 기간은 기간 만료일까지 쓸 수
-          있습니다.
-        </p>
-      </DocSection>
-
-      <DocSection title="6. 서비스 변경과 중단" icon={Wrench}>
-        <p>
-          점검·장애·불가항력으로 서비스가 일시 중단될 수 있습니다. 계획된 점검은 미리 공지하고,
-          서비스를 접게 되는 경우 기록을 내려받을 수 있는 기간을 안내합니다.
-        </p>
-      </DocSection>
-
-      <DocSection title="7. 책임의 한계" icon={ShieldAlert}>
-        <p>
-          Z는 기록을 안전하게 보관하기 위해 노력하지만, 회사·구성원 사이의 분쟁이나 기록의 내용
-          자체에 대해서는 책임지지 않습니다. 무료 플랜은 있는 그대로 제공됩니다.
-        </p>
-      </DocSection>
-
-      <DocSection title="8. 약관의 변경" icon={RefreshCw}>
-        <p>
-          약관이 바뀌면 적용 7일 전에 화면으로 알립니다. 이용자에게 불리한 변경은 30일 전에
-          알립니다.
-        </p>
-      </DocSection>
-
-      <DocSection title="9. 문의" icon={Mail}>
-        <p>약관에 관한 문의는 회사의 관리자를 통해 전달해 주세요.</p>
-      </DocSection>
+      <TermsContent />
     </DocPage>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -213,6 +213,19 @@
 
 @layer utilities {
   /*
+   * 스크롤바를 감춘다 — 모달 안처럼 **틀이 이미 경계를 말해 주는** 자리에서만 쓴다.
+   * ⚠️ 스크롤 자체는 살아 있다. 막대만 지우는 것이라 휠·트랙패드·키보드 모두 그대로 동작한다.
+   */
+  .scrollbar-hidden {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+
+  .scrollbar-hidden::-webkit-scrollbar {
+    display: none;
+  }
+
+  /*
    * 랜딩 밝은 스킨 — 띠·흐름 섹션이 쓰는 `--landing-dark-*`는 이름과 달리
    * **밴드(띠) 표면 토큰**이다. 검정 무대 기준값(흰 글자·흰 5% 바탕)을 그대로 두면
    * 밝은 바탕에서 글자와 알약이 통째로 사라진다 — 여기서 밝은 값으로 뒤집는다.

--- a/src/features/landing/components/doc-page.tsx
+++ b/src/features/landing/components/doc-page.tsx
@@ -116,16 +116,20 @@ export function DocSection({
       {/* 왼쪽 모서리에서 번지는 빛 — 링만 돌면 안쪽이 비어 보인다 */}
       <span
         aria-hidden
-        className="from-landing-accent/[0.09] via-landing-violet/[0.05] pointer-events-none absolute inset-0 bg-gradient-to-r to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+        className="from-landing-accent/[0.05] pointer-events-none absolute inset-0 bg-gradient-to-r via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100"
       />
 
+      {/*
+        ⚠️ 아이콘을 2.5px 끌어올려 맞춘다. `items-center`는 **글자 상자**를 맞추는데,
+           16px 한글은 그 상자 안에서 위쪽에 앉아 아이콘이 상대적으로 내려가 보인다.
+      */}
       <h2 className="relative flex items-center gap-2.5 text-[16px] leading-6 font-semibold tracking-[-0.2px] break-keep">
         {/* 절 표시 — 아이콘이 있으면 아이콘, 없으면 점 */}
         {Icon ? (
           /* ⚠️ 상자를 두르지 않는다 — "1. 용어"처럼 번호가 붙은 제목 옆에 사각 배지까지 오면
              표식이 둘이라 어수선하다. 아이콘 하나로 충분하다 */
           <Icon
-            className="text-foreground/70 size-[18px] shrink-0 transition-transform duration-300 group-hover:scale-110"
+            className="text-foreground/70 mt-[-2.5px] size-[18px] shrink-0 transition-transform duration-300 group-hover:scale-110"
             aria-hidden
           />
         ) : (
@@ -134,8 +138,7 @@ export function DocSection({
             className="bg-foreground ring-foreground/15 size-[6px] shrink-0 rounded-full ring-0 transition-all duration-300 group-hover:ring-4"
           />
         )}
-        {/* 한글 글자가 상자 안에서 위쪽에 앉아 아이콘보다 떠 보인다 — 1px 내려 맞춘다 */}
-        <span className="translate-y-px">{title}</span>
+        <span>{title}</span>
       </h2>
       <div className="text-muted-foreground relative flex flex-col gap-3 pt-3 pl-[15px] text-[14px] leading-[24px] break-keep">
         {children}

--- a/src/features/legal/legal-dialog.tsx
+++ b/src/features/legal/legal-dialog.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { type ReactNode, useState } from "react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+import { PrivacyContent } from "./privacy-content";
+import { TermsContent } from "./terms-content";
+
+/**
+ * 약관·개인정보를 **모달로** 보여준다.
+ *
+ * ⚠️ 링크로 페이지를 열면 입력하던 폼이 통째로 날아간다 — 로그인·등록 화면에서는 치명적이다.
+ *    읽고 닫으면 하던 자리로 돌아오도록 모달로 띄운다.
+ * ⚠️ 페이지(`/terms`·`/privacy`)도 그대로 둔다. 주소를 공유하거나 북마크할 수 있어야 하고,
+ *    약관은 법적으로도 따로 가리킬 수 있어야 한다.
+ * ⚠️ 본문이 길다 — 모달 안에서만 스크롤한다(`overflow-y-auto`). 페이지가 같이 밀리면 안 된다.
+ */
+const DOCS = {
+  terms: { title: "이용약관", description: "Z를 쓰실 때 적용되는 약속이에요." },
+  privacy: { title: "개인정보처리방침", description: "어떤 정보를 왜 다루는지 적어 뒀어요." },
+} as const;
+
+interface LegalDialogProps {
+  doc: keyof typeof DOCS;
+  /** 모달을 여는 글자 */
+  children: ReactNode;
+}
+
+export function LegalDialog({ doc, children }: LegalDialogProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [hasOverflow, setHasOverflow] = useState(false);
+  const meta = DOCS[doc];
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      {/* ⚠️ 이 Dialog는 `asChild`를 받지 않는다 — 트리거 자체에 스타일을 준다 */}
+      <DialogTrigger className="text-foreground focus-visible:ring-ring rounded font-semibold transition-opacity hover:opacity-70 focus-visible:ring-2 focus-visible:outline-hidden">
+        {children}
+      </DialogTrigger>
+
+      {/*
+        ⚠️ `gap-0` — DialogContent가 자체 `gap-4`를 갖고 있어 아래 `mt-*`와 겹쳐 두 배가 된다.
+           여백은 여기서 한 곳으로만 준다(공용 `SuccessDialog`와 같은 규칙).
+        ⚠️ 본문이 길다 — 머리는 고정하고 **본문만** 스크롤한다.
+        ⚠️ 높이를 `flex-1`로 잡지 않는다. 이 Dialog의 기본 레이아웃이 `grid`라
+           `flex-1`이 먹지 않아 내용이 잘린 채 스크롤도 안 됐다.
+           스크롤 상자에 **직접 `max-h`** 를 준다 — 짧은 글은 그만큼만, 긴 글은 스크롤된다.
+      */}
+      <DialogContent className="gap-0 p-8 sm:max-w-[640px]">
+        <DialogHeader className="items-center gap-2 text-center">
+          <DialogTitle className="text-xl leading-[26px] font-semibold tracking-[-0.4px]">
+            {meta.title}
+          </DialogTitle>
+          <DialogDescription className="text-center text-[13px] leading-[21px] break-keep">
+            {meta.description}
+          </DialogDescription>
+        </DialogHeader>
+
+        {/*
+          ⚠️ 바깥에 `overflow-hidden`을 걸지 않는다. 걸면 첫 카드의 위 테두리가 잘려 나간다 —
+             흐림 띠는 스크롤 상자 위에 얹히는 것이라 굳이 잘라낼 필요가 없다.
+          ⚠️ 안쪽은 `px-1`·`pt-4`만큼 물러선다. 첫 카드는 `first:mt-0`이라 위 여백이 없어,
+             상자에 딱 붙으면 둘째 카드보다 위가 좁아 잘린 것처럼 보인다.
+          ⚠️ 스크롤 막대는 감춘다 — 모달 틀이 이미 경계를 말해 준다.
+          ⚠️ 아래에 `pb-9`를 둔다. 흐림 띠(32px)가 마지막 줄을 덮어 **글이 잘린 것처럼** 보였다 —
+             띠 높이만큼 여백을 둬야 끝까지 읽힌다.
+        */}
+        <div className="relative -mx-1 mt-5">
+          <div
+            /*
+              ⚠️ 넘칠 때만 흐림 띠를 켠다 — 개인정보처리방침처럼 짧은 글에서는 스크롤이 없는데도
+                 위아래가 흐려져 잘린 것처럼 보인다. 실제 높이를 재서 판단한다.
+              ⚠️ `useEffect` 대신 **ref 콜백**에서 잰다. 효과에서 상태를 바꾸면 렌더가 한 번 더 돈다.
+            */
+            ref={(node) => {
+              if (node) setHasOverflow(node.scrollHeight > node.clientHeight + 1);
+            }}
+            className="scrollbar-hidden max-h-[min(60dvh,520px)] overflow-y-auto px-1 pt-4 pb-9"
+          >
+            {doc === "terms" ? <TermsContent /> : <PrivacyContent />}
+          </div>
+
+          {hasOverflow && (
+            <>
+              <span
+                aria-hidden
+                className="from-card pointer-events-none absolute inset-x-0 top-0 h-6 bg-gradient-to-b to-transparent"
+              />
+              <span
+                aria-hidden
+                className="from-card pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-t to-transparent"
+              />
+            </>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/legal/legal-dialog.tsx
+++ b/src/features/legal/legal-dialog.tsx
@@ -54,7 +54,14 @@ export function LegalDialog({ doc, children }: LegalDialogProps) {
            `flex-1`이 먹지 않아 내용이 잘린 채 스크롤도 안 됐다.
            스크롤 상자에 **직접 `max-h`** 를 준다 — 짧은 글은 그만큼만, 긴 글은 스크롤된다.
       */}
-      <DialogContent className="gap-0 p-8 sm:max-w-[640px]">
+      {/*
+        ⚠️ **모달 자체**를 화면보다 작게 묶는다. 본문에만 `max-h`를 주면 머리·안쪽 여백 높이가
+           그 위에 더해져, 세로가 짧은 화면에서 팝업이 화면 밖으로 삐져나간다 —
+           가운데 고정이라 닫기 버튼에도 못 닿는다.
+        ⚠️ 행을 `auto`(머리) + `minmax(0,1fr)`(본문)로 나눈다. `minmax(0,…)`이 있어야
+           본문이 내용 높이 밑으로 줄어들 수 있다(그래야 스크롤이 생긴다).
+      */}
+      <DialogContent className="grid max-h-[min(calc(100dvh-2rem),620px)] grid-rows-[auto_minmax(0,1fr)] gap-0 p-8 sm:max-w-[640px]">
         <DialogHeader className="items-center gap-2 text-center">
           <DialogTitle className="text-xl leading-[26px] font-semibold tracking-[-0.4px]">
             {meta.title}
@@ -73,17 +80,29 @@ export function LegalDialog({ doc, children }: LegalDialogProps) {
           ⚠️ 아래에 `pb-9`를 둔다. 흐림 띠(32px)가 마지막 줄을 덮어 **글이 잘린 것처럼** 보였다 —
              띠 높이만큼 여백을 둬야 끝까지 읽힌다.
         */}
-        <div className="relative -mx-1 mt-5">
+        <div className="relative -mx-1 mt-5 min-h-0">
           <div
             /*
+              ⚠️ 스크롤 상자에 **포커스가 가야 한다**(`tabIndex={0}`). 본문에 링크·버튼이 없어서,
+                 이게 없으면 키보드만 쓰는 사람은 긴 약관을 아예 내릴 수 없다.
               ⚠️ 넘칠 때만 흐림 띠를 켠다 — 개인정보처리방침처럼 짧은 글에서는 스크롤이 없는데도
                  위아래가 흐려져 잘린 것처럼 보인다. 실제 높이를 재서 판단한다.
               ⚠️ `useEffect` 대신 **ref 콜백**에서 잰다. 효과에서 상태를 바꾸면 렌더가 한 번 더 돈다.
+              ⚠️ 창 크기가 바뀌면 담기는 높이도 바뀐다 — `ResizeObserver`로 다시 잰다.
+                 한 번만 재면 넓혔을 때 띠가 남거나, 줄였을 때 안 뜬다.
             */
+            role="region"
+            aria-label={`${meta.title} 본문`}
+            tabIndex={0}
             ref={(node) => {
-              if (node) setHasOverflow(node.scrollHeight > node.clientHeight + 1);
+              if (!node) return;
+              const measure = () => setHasOverflow(node.scrollHeight > node.clientHeight + 1);
+              measure();
+              const observer = new ResizeObserver(measure);
+              observer.observe(node);
+              return () => observer.disconnect();
             }}
-            className="scrollbar-hidden max-h-[min(60dvh,520px)] overflow-y-auto px-1 pt-4 pb-9"
+            className="scrollbar-hidden focus-visible:ring-ring h-full overflow-y-auto px-1 pt-4 pb-9 focus-visible:ring-2 focus-visible:outline-hidden"
           >
             {doc === "terms" ? <TermsContent /> : <PrivacyContent />}
           </div>

--- a/src/features/legal/privacy-content.tsx
+++ b/src/features/legal/privacy-content.tsx
@@ -1,0 +1,100 @@
+import { Archive, Database, Handshake, KeyRound, Target } from "lucide-react";
+
+import { DocSection } from "@/features/landing/components/doc-page";
+
+/**
+ * 개인정보처리방침 본문.
+ *
+ * ⚠️ 페이지(`/privacy`)와 모달이 **같은 글**을 쓴다. 두 벌로 두면 한쪽만 고쳐져 어긋난다.
+ * ⚠️ 법무 검토 전 초안이다 — 출시 전 확정본으로 교체한다.
+ */
+const COLLECTED = [
+  {
+    kind: "계정 정보",
+    items: "이름 · 회사 이메일 · 부서 · 직급",
+    when: "관리자가 계정을 발급할 때",
+  },
+  {
+    kind: "이용 기록",
+    items: "회의 녹음 · 자막 · 액션 · 인수인계 문서",
+    when: "서비스를 쓰는 동안",
+  },
+  {
+    kind: "결제 기록",
+    items: "플랜 · 결제 일시 · 금액 (카드번호 제외)",
+    when: "유료 플랜을 결제할 때",
+  },
+] as const;
+
+export function PrivacyContent() {
+  return (
+    <>
+      <DocSection title="1. 다루는 정보" icon={Database}>
+        <div className="border-border overflow-x-auto rounded-lg border">
+          <table className="w-full min-w-[480px] border-collapse text-left">
+            <thead>
+              <tr className="border-border bg-secondary border-b">
+                <th scope="col" className="px-4 py-2.5 text-[12px] leading-[18px] font-medium">
+                  구분
+                </th>
+                <th scope="col" className="px-4 py-2.5 text-[12px] leading-[18px] font-medium">
+                  항목
+                </th>
+                <th scope="col" className="px-4 py-2.5 text-[12px] leading-[18px] font-medium">
+                  언제
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {COLLECTED.map((row) => (
+                <tr key={row.kind} className="border-border border-t first:border-t-0">
+                  <th
+                    scope="row"
+                    className="px-4 py-2.5 text-[13px] leading-5 font-normal whitespace-nowrap"
+                  >
+                    {row.kind}
+                  </th>
+                  <td className="text-muted-foreground px-4 py-2.5 text-[13px] leading-5 break-keep">
+                    {row.items}
+                  </td>
+                  <td className="text-muted-foreground px-4 py-2.5 text-[13px] leading-5 break-keep">
+                    {row.when}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </DocSection>
+
+      <DocSection title="2. 쓰는 목적" icon={Target}>
+        <p>
+          회의 기록을 정리해 담당자에게 할 일을 전달하고, 인수인계 문서를 구성하기 위해 씁니다. 그
+          밖의 목적으로 쓰지 않으며, 광고에 활용하지 않습니다.
+        </p>
+      </DocSection>
+
+      <DocSection title="3. 처리 위탁" icon={Handshake}>
+        <p>
+          결제는 Toss Payments에 위탁합니다. 카드 정보는{" "}
+          <strong className="text-foreground">Z가 받지 않으며</strong>, 카드번호는 우리 서버에
+          저장되지 않습니다. 서버는 AWS에서 운영합니다.
+        </p>
+      </DocSection>
+
+      <DocSection title="4. 보관과 파기" icon={Archive}>
+        <p>
+          기록은 회사가 구독을 유지하는 동안 보관됩니다. 회사가 프로젝트를 삭제하면 그에 속한 녹음도
+          함께 삭제되고, 탈퇴한 조직의 데이터는 관련 법령이 정한 기간이 지나면 파기합니다.
+        </p>
+      </DocSection>
+
+      <DocSection title="5. 이용자의 권리" icon={KeyRound}>
+        <p>
+          자신의 정보 열람·정정·삭제는 회사의 관리자를 통해 요청할 수 있습니다. 회의 기록처럼 회사에
+          귀속되는 자료는 회사의 정책에 따릅니다.
+        </p>
+      </DocSection>
+    </>
+  );
+}

--- a/src/features/legal/terms-content.tsx
+++ b/src/features/legal/terms-content.tsx
@@ -1,0 +1,92 @@
+import {
+  BadgeCheck,
+  BookText,
+  CreditCard,
+  FileText,
+  Mail,
+  RefreshCw,
+  ShieldAlert,
+  UserCog,
+  Wrench,
+} from "lucide-react";
+
+import { DocSection } from "@/features/landing/components/doc-page";
+
+/**
+ * 이용약관 본문.
+ *
+ * ⚠️ 페이지(`/terms`)와 모달이 **같은 글**을 쓴다. 두 벌로 두면 한쪽만 고쳐져 어긋난다.
+ * ⚠️ 법무 검토 전 초안이다 — 출시 전 확정본으로 교체한다.
+ */
+export function TermsContent() {
+  return (
+    <>
+      <DocSection title="1. 용어" icon={BookText}>
+        <p>
+          “회사 계정”은 Z에 가입해 조직을 만든 주체를, “구성원”은 그 조직이 발급한 계정을 쓰는
+          사람을 말합니다. “기록”은 회의 녹음·자막·요약·액션·인수인계 문서를 통틀어 말합니다.
+        </p>
+      </DocSection>
+
+      <DocSection title="2. 서비스 소개" icon={BadgeCheck}>
+        <p>
+          Z는 회의 내용을 기록하고, 결정과 할 일을 담당자에게 배정하는 사내 협업 도구입니다. 회사가
+          계정을 발급하며, 한 계정은 하나의 회사에 속합니다.
+        </p>
+      </DocSection>
+
+      <DocSection title="3. 계정과 이용자의 의무" icon={UserCog}>
+        <p>
+          계정은 회사의 관리자가 발급합니다. 발급받은 계정 정보를 다른 사람과 공유할 수 없고,
+          비밀번호를 잃어버린 경우 관리자에게 재발급을 요청해 주세요.
+        </p>
+        <p>
+          법령이나 공서양속에 어긋나는 자료를 올리거나, 다른 회사·구성원의 데이터에 접근을 시도하는
+          행위는 금지됩니다. 위반이 확인되면 회사와 협의해 이용을 제한할 수 있습니다.
+        </p>
+      </DocSection>
+
+      <DocSection title="4. 회의 기록과 권리" icon={FileText}>
+        <p>
+          회의 녹음과 자막은 회의를 개설한 사람이 시작합니다. 기록은 회사에 귀속되며, 담당자가
+          바뀌어도 회사 안에 남습니다. 회의에 참여하는 모든 분께 기록이 남는다는 사실을 미리 알려
+          주세요.
+        </p>
+        <p>Z 서비스 자체(화면·상표·코드)에 대한 권리는 Z에 있습니다.</p>
+      </DocSection>
+
+      <DocSection title="5. 구독과 결제" icon={CreditCard}>
+        <p>
+          유료 플랜은 구성원 수를 기준으로 매월 또는 매년 청구됩니다. 언제든지 해지할 수 있고,
+          해지하면 다음 결제부터 청구되지 않습니다. 이미 결제한 기간은 기간 만료일까지 쓸 수
+          있습니다.
+        </p>
+      </DocSection>
+
+      <DocSection title="6. 서비스 변경과 중단" icon={Wrench}>
+        <p>
+          점검·장애·불가항력으로 서비스가 일시 중단될 수 있습니다. 계획된 점검은 미리 공지하고,
+          서비스를 접게 되는 경우 기록을 내려받을 수 있는 기간을 안내합니다.
+        </p>
+      </DocSection>
+
+      <DocSection title="7. 책임의 한계" icon={ShieldAlert}>
+        <p>
+          Z는 기록을 안전하게 보관하기 위해 노력하지만, 회사·구성원 사이의 분쟁이나 기록의 내용
+          자체에 대해서는 책임지지 않습니다. 무료 플랜은 있는 그대로 제공됩니다.
+        </p>
+      </DocSection>
+
+      <DocSection title="8. 약관의 변경" icon={RefreshCw}>
+        <p>
+          약관이 바뀌면 적용 7일 전에 화면으로 알립니다. 이용자에게 불리한 변경은 30일 전에
+          알립니다.
+        </p>
+      </DocSection>
+
+      <DocSection title="9. 문의" icon={Mail}>
+        <p>약관에 관한 문의는 회사의 관리자를 통해 전달해 주세요.</p>
+      </DocSection>
+    </>
+  );
+}


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가
- [x] refactor — 리팩토링

---

## 🗂 작업 영역

- [x] 공유 셸 · 디자인 시스템
- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [x] 공통 (로그인 전 화면)

---

## 📝 작업 내용

- **약관·개인정보 본문을 공용 컴포넌트로 분리** (`features/legal/terms-content` · `privacy-content`) — 지금까지 두 문서가 각 페이지 안에 박혀 있어 다른 곳에서 재사용할 수 없었다.
- **`LegalDialog` 추가** — 계정 화면에서 약관을 **모달로** 연다. 링크로 페이지를 열면 입력하던 폼이 통째로 날아가는데, 로그인·등록 화면에서는 치명적이다. 읽고 닫으면 하던 자리로 돌아온다.
- `/terms`·`/privacy` 페이지는 **그대로 둔다.** 주소를 공유·북마크할 수 있어야 하고 약관은 법적으로도 따로 가리킬 수 있어야 한다. 이제 페이지와 모달이 같은 본문을 쓴다.
- **넘칠 때만** 위아래 흐림 띠를 켠다 — 개인정보처리방침처럼 짧은 글에서 스크롤이 없는데도 흐려지면 잘린 것처럼 보인다. 실제 높이를 재서 판단한다.
- `.scrollbar-hidden` 유틸 추가 — 모달 틀이 이미 경계를 말해 주므로 막대는 감춘다. **스크롤 자체는 살아 있다**(휠·트랙패드·키보드 그대로).
- 문서 섹션 제목의 아이콘을 한글 글자와 광학적으로 맞췄다(`doc-page`).

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/legal-dialog#39`, base `develop`)
- [x] 커밋 컨벤션 준수 (`feat: 약관·개인정보 모달과 본문 공용화 #39`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [x] 🔐 권한 2축 — **해당 없음.** 로그인 전 공개 문서다
- [x] 🧬 zod — **해당 없음.** 스키마로 다룰 데이터가 없다(정적 문서)
- [x] 🕵️ 정직성 — 약관 본문이 **법무 검토 전 초안**임을 이슈에 명시
- [x] 🎨 디자인 토큰 사용 (생 hex 없음) · 다크 값 정의됨

**품질**

- [x] ⚡ 시맨틱 태그 · 무거운 것 없음
- [x] ♿ a11y — `role="dialog"`(shadcn Dialog) · 트리거는 `button` · 포커스 트랩
- [x] ♻️ 재사용 확인 — 공용 `Dialog`를 그대로 쓰고 여백 규칙만 맞췄다
- [x] 🧪 `loading` / `error` / `empty` — 정적 문서라 3상태가 없다(불러오는 것도, 빌 것도 없음)
- [x] 브라우저 전용 API 미사용

---

## 🔗 연관 이슈

Closes #39

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- **모달 안 스크롤 높이**를 `flex-1`이 아니라 `max-h`로 직접 잡았다. shadcn `DialogContent`의 기본 레이아웃이 `grid`라 `flex-1`이 먹지 않아 내용이 잘린 채 스크롤도 안 됐다.
- 흐림 띠 판정을 `useEffect`가 아니라 **ref 콜백**에서 한다 — 효과에서 상태를 바꾸면 렌더가 한 번 더 돈다.

---

## 📝 추가 메모

`LegalDialog`는 이 PR에서 **아직 화면에 안 붙는다.** 쓰는 곳은 로그인·기업 등록 화면(#38)이고, 이 PR이 먼저 머지돼야 그쪽이 빌드된다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 이용약관 및 개인정보처리방침을 모달에서 확인할 수 있습니다.
  * 법률 문서 콘텐츠를 일관된 형식으로 제공합니다.
  * 스크롤바를 숨긴 상태에서도 문서 스크롤을 사용할 수 있습니다.

* **개선**
  * 문서 섹션의 호버 효과와 아이콘·제목 정렬을 개선했습니다.
  * 긴 문서 모달에서 스크롤 위치에 따라 흐림 효과를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
