### PR TITLE
[REFACTOR] 완료 표식(Z 마크) 공용 컴포넌트로 분리 #40

### DIFF
--- a/src/components/common/z-done-mark.tsx
+++ b/src/components/common/z-done-mark.tsx
@@ -9,6 +9,8 @@ import { ZLogo } from "@/components/icons/z-logo";
  * ⚠️ 배지는 **테두리 있는 원**이다. 검은 원 위에 걸쳐 있어서, 테두리가 없으면 바탕만 남아
  *    원이 파먹힌 것처럼 보인다.
  * ⚠️ 온보딩 완료·기업 등록 완료가 같은 표식을 쓴다 — 끝났다는 신호는 화면마다 다르면 안 된다.
+ * ⚠️ 배지·체크·로고 크기를 **전부 `size`에서 계산한다.** 배지만 고정 px로 두면 지름을 키우거나
+ *    줄였을 때 비율이 깨져 다른 그림이 된다.
  */
 interface ZDoneMarkProps {
   /** 원 지름(px). 로고와 배지는 여기에 맞춰 따라간다 */
@@ -16,6 +18,11 @@ interface ZDoneMarkProps {
 }
 
 export function ZDoneMark({ size = 68 }: ZDoneMarkProps) {
+  // 기본값(68)에서 로고 28px · 배지 20px · 체크 11px이 나오는 비율이다
+  const logoSize = size * 0.41;
+  const badgeSize = size * 0.29;
+  const checkSize = Math.round(badgeSize * 0.55);
+
   return (
     <span className="relative" aria-hidden>
       <span
@@ -24,14 +31,18 @@ export function ZDoneMark({ size = 68 }: ZDoneMarkProps) {
       >
         <span className="bg-foreground animate-fill-in absolute inset-0 rounded-full" />
         <ZLogo
-          style={{ width: size * 0.41, height: size * 0.41 }}
+          style={{ width: logoSize, height: logoSize }}
           className="text-background animate-mark-in relative"
         />
       </span>
 
-      <span className="animate-mark-in absolute -top-0.5 -right-0.5">
-        <span className="bg-card border-foreground animate-float flex size-5 items-center justify-center rounded-full border">
-          <CheckMark size={11} strokeWidth={3} />
+      {/* 원 테두리에 살짝 걸치게 — 지름의 3%만 밖으로 뺀다 */}
+      <span className="animate-mark-in absolute" style={{ top: -size * 0.03, right: -size * 0.03 }}>
+        <span
+          style={{ width: badgeSize, height: badgeSize }}
+          className="bg-card border-foreground animate-float flex items-center justify-center rounded-full border"
+        >
+          <CheckMark size={checkSize} strokeWidth={3} />
         </span>
       </span>
     </span>

--- a/src/components/common/z-done-mark.tsx
+++ b/src/components/common/z-done-mark.tsx
@@ -1,0 +1,39 @@
+import { CheckMark } from "@/components/common/check-mark";
+import { ZLogo } from "@/components/icons/z-logo";
+
+/**
+ * 다 됐다는 표식 — 빈 원에서 시작해 먹색이 차오르고 그 위에 **Z 로고**가 얹힌다.
+ * 체크는 작은 배지로 옆에 붙어 살랑인다.
+ *
+ * ⚠️ 배지는 초록이 아니라 카드색 바탕에 먹색이다 — 색으로 알리는 건 에러뿐(§디자인 토큰).
+ * ⚠️ 배지는 **테두리 있는 원**이다. 검은 원 위에 걸쳐 있어서, 테두리가 없으면 바탕만 남아
+ *    원이 파먹힌 것처럼 보인다.
+ * ⚠️ 온보딩 완료·기업 등록 완료가 같은 표식을 쓴다 — 끝났다는 신호는 화면마다 다르면 안 된다.
+ */
+interface ZDoneMarkProps {
+  /** 원 지름(px). 로고와 배지는 여기에 맞춰 따라간다 */
+  size?: number;
+}
+
+export function ZDoneMark({ size = 68 }: ZDoneMarkProps) {
+  return (
+    <span className="relative" aria-hidden>
+      <span
+        style={{ width: size, height: size }}
+        className="border-border relative flex items-center justify-center rounded-full border"
+      >
+        <span className="bg-foreground animate-fill-in absolute inset-0 rounded-full" />
+        <ZLogo
+          style={{ width: size * 0.41, height: size * 0.41 }}
+          className="text-background animate-mark-in relative"
+        />
+      </span>
+
+      <span className="animate-mark-in absolute -top-0.5 -right-0.5">
+        <span className="bg-card border-foreground animate-float flex size-5 items-center justify-center rounded-full border">
+          <CheckMark size={11} strokeWidth={3} />
+        </span>
+      </span>
+    </span>
+  );
+}

--- a/src/features/onboarding/components/onboarding-done.tsx
+++ b/src/features/onboarding/components/onboarding-done.tsx
@@ -4,8 +4,7 @@ import { ChevronRight } from "lucide-react";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
-import { CheckMark } from "@/components/common/check-mark";
-import { ZLogo } from "@/components/icons/z-logo";
+import { ZDoneMark } from "@/components/common/z-done-mark";
 import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -66,27 +65,7 @@ export function OnboardingDone() {
   return (
     <OnboardingShell step={ONBOARDING_STEP.INVITE} isDone>
       <div className="mx-auto flex w-full max-w-[420px] flex-col items-center gap-6">
-        {/*
-          빈 원에서 시작해 먹색이 차오르고, 그 위에 **Z 로고**가 얹힌다.
-          체크는 작은 배지로 옆에 붙어 살랑인다.
-          ⚠️ 배지는 초록이 아니라 카드색 바탕에 먹색이다 — 색으로 알리는 건 에러뿐(CLAUDE.md §디자인 토큰).
-        */}
-        <span className="relative" aria-hidden>
-          <span className="border-border relative flex size-[68px] items-center justify-center rounded-full border">
-            <span className="bg-foreground animate-fill-in absolute inset-0 rounded-full" />
-            <ZLogo className="text-background animate-mark-in relative size-7" />
-          </span>
-
-          {/*
-            배지는 **테두리 있는 원**이다. 검은 원 위에 걸쳐 있어서, 테두리가 없으면
-            흰 바탕만 남아 원이 파먹힌 것처럼 보인다.
-          */}
-          <span className="animate-mark-in absolute -top-0.5 -right-0.5">
-            <span className="bg-card border-foreground animate-float flex size-5 items-center justify-center rounded-full border">
-              <CheckMark size={11} strokeWidth={3} />
-            </span>
-          </span>
-        </span>
+        <ZDoneMark />
 
         <div className="flex flex-col items-center gap-2 text-center">
           <h1 className="text-xl leading-[26px] font-semibold tracking-[-0.4px]">준비됐어요</h1>


### PR DESCRIPTION
## 📋 PR 타입

- [x] refactor — 리팩토링

---

## 🗂 작업 영역

- [x] 공유 셸 · 디자인 시스템
- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

- 온보딩 완료 화면의 **완료 표식**(먹색 원이 차오르고 Z 로고가 얹히며 체크 배지가 붙는 것)을 `components/common/z-done-mark.tsx`로 분리했다.
- 온보딩 완료 화면은 이 컴포넌트를 쓰도록 교체했다. **겉모습·애니메이션은 그대로다** — 마크업을 그대로 옮기고 원 지름만 `size`로 받는다.
- 왜 지금 빼는가: 기업 등록 신청 완료 화면(#38)에도 같은 표식이 필요한데, 마크업이 온보딩 컴포넌트 안에 30줄 박혀 있어 복붙 말고는 방법이 없었다. **끝났다는 신호는 화면마다 다르면 안 된다.**

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`refactor/common-done-mark#40`, base `develop`)
- [x] 커밋 컨벤션 준수 (`refactor: 완료 표식을 공용 컴포넌트로 분리 #40`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [x] 🔐 권한 2축 — **해당 없음.** 표시 전용 컴포넌트다
- [x] 🧬 zod — **해당 없음.** 다루는 데이터가 없다
- [x] 🕵️ 정직성 — 동작 변화 없음. 목·폴백 없음
- [x] 🎨 디자인 토큰 사용 — 배지는 초록이 아니라 카드색 바탕에 먹색이다(색으로 알리는 건 에러뿐)

**품질**

- [x] ⚡ 무거운 것 없음 · SVG는 `currentColor`
- [x] ♿ a11y — 장식이라 `aria-hidden`. 뜻은 옆의 제목이 말한다
- [x] ♻️ 재사용 확인 — 기존 `CheckMark`·`ZLogo`를 그대로 조합한다
- [x] 🧪 `loading` / `error` / `empty` — 해당 없음(순수 표시 컴포넌트)
- [x] 브라우저 전용 API 미사용

---

## 🔗 연관 이슈

Closes #40

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- **겉모습이 바뀌면 안 되는 순수 리팩터다.** `/onboarding/done`을 열어 표식이 이전과 같은지 봐 주세요.
- 지름을 키우면 로고와 체크 배지가 따라 커지도록 `size` 하나만 받는다.

---

## 📝 추가 메모

`ZDoneMark`를 두 번째로 쓰는 곳은 기업 등록 신청 완료 화면(#38)이다. 이 PR이 먼저 머지돼야 그쪽이 빌드된다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 완료 상태를 나타내는 새로운 표시 아이콘을 추가했습니다.
  * 테두리 원, Z 로고, 체크 배지와 애니메이션을 결합해 완료 상태를 더욱 명확하게 표현합니다.

* **개선**
  * 온보딩 완료 화면의 완료 표시를 새로운 아이콘으로 통일했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
