### PR TITLE
[FEAT] 기업 가입 승인 페이지 구현 #49

### DIFF
--- a/src/app/(system)/system/approval/error.tsx
+++ b/src/app/(system)/system/approval/error.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { ScreenError } from "@/components/common/screen-error";
+
+export default function Error({ reset }: { reset: () => void }) {
+  return <ScreenError title="기업 승인 목록을 불러오지 못했어요" reset={reset} />;
+}

--- a/src/app/(system)/system/approval/layout.tsx
+++ b/src/app/(system)/system/approval/layout.tsx
@@ -1,0 +1,13 @@
+import { ClipboardCheck } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { PageHeader } from "@/features/shell/components/page-header";
+
+export default function SystemApprovalLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <PageHeader title="기업 가입 승인" icon={ClipboardCheck} />
+      {children}
+    </>
+  );
+}

--- a/src/app/(system)/system/approval/loading.tsx
+++ b/src/app/(system)/system/approval/loading.tsx
@@ -1,0 +1,12 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <main className="min-h-0 flex-1 overflow-y-auto p-8">
+      <div className="mx-auto flex max-w-[1440px] flex-col gap-4">
+        <Skeleton className="h-[360px] rounded-xl" />
+        <Skeleton className="mx-auto h-8 w-64 rounded-md" />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(system)/system/approval/page.tsx
+++ b/src/app/(system)/system/approval/page.tsx
@@ -1,0 +1,45 @@
+import type { Metadata } from "next";
+
+import { Pagination } from "@/components/common/pagination";
+import { ApprovalDetailSheet } from "@/features/system/components/approval-detail-sheet";
+import { ApprovalTable } from "@/features/system/components/approval-table";
+import { getPendingApprovalById, getPendingApprovals } from "@/features/system/server";
+
+export const metadata: Metadata = {
+  title: "기업 가입 승인",
+};
+
+const PAGE_SIZE = 10;
+
+interface SystemApprovalPageProps {
+  searchParams: Promise<{ page?: string; id?: string }>;
+}
+
+function buildHref(page: number, id?: string): string {
+  const query = new URLSearchParams();
+  if (page > 1) query.set("page", String(page));
+  if (id) query.set("id", id);
+  const qs = query.toString();
+  return qs ? `/system/approval?${qs}` : "/system/approval";
+}
+
+export default async function SystemApprovalPage({ searchParams }: SystemApprovalPageProps) {
+  const params = await searchParams;
+  const page = Math.max(1, Number(params.page) || 1);
+
+  const [{ items, totalPages }, selected] = await Promise.all([
+    getPendingApprovals(page, PAGE_SIZE),
+    params.id ? getPendingApprovalById(params.id) : Promise.resolve(null),
+  ]);
+
+  return (
+    <main className="min-h-0 flex-1 overflow-y-auto p-8">
+      <div className="mx-auto flex max-w-[1440px] flex-col gap-4">
+        <ApprovalTable companies={items} buildDetailHref={(id) => buildHref(page, id)} />
+        <Pagination page={page} totalPages={totalPages} buildHref={(target) => buildHref(target)} />
+      </div>
+
+      <ApprovalDetailSheet company={selected} closeHref={buildHref(page)} />
+    </main>
+  );
+}

--- a/src/components/common/pagination.tsx
+++ b/src/components/common/pagination.tsx
@@ -1,0 +1,92 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import Link from "next/link";
+
+import { getPaginationRange } from "@/lib/paginate";
+import { cn } from "@/lib/utils";
+
+interface PaginationProps {
+  page: number;
+  totalPages: number;
+  /** 페이지 번호 → 그 페이지의 href. 목록 화면마다 유지해야 할 다른 쿼리(검색어 등)가 다르다 */
+  buildHref: (page: number) => string;
+}
+
+const ITEM_CLASS =
+  "focus-visible:ring-ring flex size-8 items-center justify-center rounded-md text-sm transition-colors focus-visible:ring-2 focus-visible:outline-none";
+
+/**
+ * 목록 하단 페이지네이션 — 순수 서버 컴포넌트다(`Link` 이동만 하므로 클라이언트 JS가 없다).
+ * ⚠️ 기업·회의·액션처럼 무한히 늘어날 수 있는 목록은 이 컴포넌트를 쓴다(CLAUDE.md §성능).
+ */
+export function Pagination({ page, totalPages, buildHref }: PaginationProps) {
+  if (totalPages <= 1) return null;
+
+  const range = getPaginationRange(page, totalPages);
+
+  return (
+    <nav aria-label="페이지" className="flex items-center justify-center gap-1">
+      <PageLink
+        href={buildHref(Math.max(1, page - 1))}
+        disabled={page === 1}
+        aria-label="이전 페이지"
+      >
+        <ChevronLeft className="size-4" aria-hidden />
+      </PageLink>
+
+      {range.map((entry, index) =>
+        entry === "ellipsis" ? (
+          <span
+            key={`ellipsis-${index}`}
+            aria-hidden
+            className="text-muted-foreground flex size-8 items-center justify-center text-sm"
+          >
+            …
+          </span>
+        ) : (
+          <PageLink
+            key={entry}
+            href={buildHref(entry)}
+            aria-current={entry === page ? "page" : undefined}
+            className={
+              entry === page
+                ? "bg-foreground text-background"
+                : "text-muted-foreground hover:bg-foreground/5 hover:text-foreground"
+            }
+          >
+            <span className="tabular-nums">{entry}</span>
+          </PageLink>
+        ),
+      )}
+
+      <PageLink
+        href={buildHref(Math.min(totalPages, page + 1))}
+        disabled={page === totalPages}
+        aria-label="다음 페이지"
+      >
+        <ChevronRight className="size-4" aria-hidden />
+      </PageLink>
+    </nav>
+  );
+}
+
+function PageLink({
+  href,
+  disabled,
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof Link> & { disabled?: boolean }) {
+  if (disabled) {
+    return (
+      <span className={cn(ITEM_CLASS, "text-muted-foreground/40", className)} aria-disabled>
+        {children}
+      </span>
+    );
+  }
+
+  return (
+    <Link href={href} className={cn(ITEM_CLASS, className)} {...props}>
+      {children}
+    </Link>
+  );
+}

--- a/src/constants/domain.ts
+++ b/src/constants/domain.ts
@@ -217,3 +217,19 @@ export const COMPANY_STATUS = {
   UNPAID: "UNPAID",
 } as const;
 export type CompanyStatus = (typeof COMPANY_STATUS)[keyof typeof COMPANY_STATUS];
+
+/** 기업 가입 신청서의 직원 규모 구간. */
+export const COMPANY_SIZE = {
+  MICRO: "MICRO",
+  SMALL: "SMALL",
+  MEDIUM: "MEDIUM",
+  LARGE: "LARGE",
+} as const;
+export type CompanySize = (typeof COMPANY_SIZE)[keyof typeof COMPANY_SIZE];
+
+export const COMPANY_SIZE_LABEL: Record<CompanySize, string> = {
+  MICRO: "5명 이하",
+  SMALL: "6~20명",
+  MEDIUM: "21~100명",
+  LARGE: "101명 이상",
+};

--- a/src/features/system/actions.ts
+++ b/src/features/system/actions.ts
@@ -1,0 +1,40 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+import { isMock } from "@/mocks/config";
+
+import { removeMockPendingApproval } from "./mock/approvals";
+
+/**
+ * 기업 승인 화면의 **변경 창구** — 격리막(CLAUDE.md §Mock 격리막).
+ * ⚠️ 지금은 목뿐이다 — 승인·반려 둘 다 대기 목록에서 지우기만 한다(실제 기업 코드 발급·메일
+ *    발송·"기업 관리" 반영은 API가 붙어야 의미가 있다).
+ */
+export async function approveCompanyAction(formData: FormData): Promise<void> {
+  const id = String(formData.get("companyId") ?? "");
+  const redirectTo = String(formData.get("redirectTo") ?? "/system/approval");
+
+  if (isMock) {
+    removeMockPendingApproval(id);
+  } else {
+    // ⚠️ 미구현 — API 스펙 확정 후 BFF 경로로 승인 요청을 보낸다.
+    throw new Error("기업 승인 API가 아직 연결되지 않았습니다.");
+  }
+
+  // ⚠️ `redirect`는 내부적으로 예외를 던진다 — try/catch 밖에 둔다(CLAUDE.md §렌더링·데이터)
+  redirect(redirectTo);
+}
+
+export async function rejectCompanyAction(formData: FormData): Promise<void> {
+  const id = String(formData.get("companyId") ?? "");
+  const redirectTo = String(formData.get("redirectTo") ?? "/system/approval");
+
+  if (isMock) {
+    removeMockPendingApproval(id);
+  } else {
+    throw new Error("기업 반려 API가 아직 연결되지 않았습니다.");
+  }
+
+  redirect(redirectTo);
+}

--- a/src/features/system/components/approval-detail-sheet.tsx
+++ b/src/features/system/components/approval-detail-sheet.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useFormStatus } from "react-dom";
+
+import { Button } from "@/components/ui/button";
+import { Sheet, SheetContent, SheetFooter, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { COMPANY_SIZE_LABEL } from "@/constants/domain";
+
+import { approveCompanyAction, rejectCompanyAction } from "../actions";
+import type { PendingCompanyApproval } from "../types";
+
+interface ApprovalDetailSheetProps {
+  company: PendingCompanyApproval | null;
+  /** 닫히면 돌아갈 곳 — 지금 보던 페이지 그대로(쿼리의 `id`만 없어진 형태) */
+  closeHref: string;
+}
+
+/**
+ * "기업 승인" 행을 누르면 뜨는 상세 패널.
+ * ⚠️ `company`가 `null`이어도 항상 렌더링한다 — Sheet가 닫히는 애니메이션 동안
+ *    내용이 먼저 사라지면 어색하다. 열림 여부는 `open` prop 하나로만 정한다.
+ */
+export function ApprovalDetailSheet({ company, closeHref }: ApprovalDetailSheetProps) {
+  const router = useRouter();
+
+  return (
+    <Sheet
+      open={company !== null}
+      onOpenChange={(open) => {
+        if (!open) router.push(closeHref);
+      }}
+    >
+      <SheetContent>
+        {company && (
+          <>
+            <SheetHeader>
+              <SheetTitle>신청 상세</SheetTitle>
+            </SheetHeader>
+
+            <div className="flex flex-1 flex-col gap-4 overflow-y-auto px-4">
+              <Field label="회사명" value={company.companyName} />
+              <Field label="사업자등록번호" value={company.businessRegistrationNumber} />
+              <Field label="대표자" value={company.representativeName} />
+              <Field label="담당자 이메일" value={company.contactEmail} />
+              <Field label="직원 규모" value={COMPANY_SIZE_LABEL[company.size]} />
+              <Field label="신청일" value={company.appliedAt} />
+
+              <p className="text-muted-foreground bg-muted rounded-md p-3 text-xs leading-[18px]">
+                승인 시 기업 코드가 자동 발급되고 담당자 이메일로 발송됩니다.
+              </p>
+            </div>
+
+            <SheetFooter className="flex-row">
+              <form action={rejectCompanyAction} className="flex-1">
+                <input type="hidden" name="companyId" value={company.id} />
+                <input type="hidden" name="redirectTo" value={closeHref} />
+                <SubmitButton variant="destructive" label="반려" pendingLabel="반려 중…" />
+              </form>
+              <form action={approveCompanyAction} className="flex-1">
+                <input type="hidden" name="companyId" value={company.id} />
+                <input type="hidden" name="redirectTo" value={closeHref} />
+                <SubmitButton variant="default" label="승인" pendingLabel="승인 중…" />
+              </form>
+            </SheetFooter>
+          </>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function Field({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <p className="text-muted-foreground text-xs leading-4">{label}</p>
+      <p className="text-foreground text-sm leading-5">{value}</p>
+    </div>
+  );
+}
+
+function SubmitButton({
+  variant,
+  label,
+  pendingLabel,
+}: {
+  variant: "default" | "destructive";
+  label: string;
+  pendingLabel: string;
+}) {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button type="submit" variant={variant} disabled={pending} className="w-full">
+      {pending ? pendingLabel : label}
+    </Button>
+  );
+}

--- a/src/features/system/components/approval-table.tsx
+++ b/src/features/system/components/approval-table.tsx
@@ -1,0 +1,79 @@
+import Link from "next/link";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { COMPANY_SIZE_LABEL } from "@/constants/domain";
+
+import type { PendingCompanyApproval } from "../types";
+
+interface ApprovalTableProps {
+  companies: PendingCompanyApproval[];
+  buildDetailHref: (id: string) => string;
+}
+
+/**
+ * 승인 대기 기업 표.
+ *
+ * ⚠️ 행 어디를 눌러도 상세로 들어간다 — 그렇다고 `tr`에 `onClick`을 달지 않는다.
+ *    그러면 키보드·스크린리더로는 못 누른다(CLAUDE.md §a11y: 클릭은 button/a).
+ *    대신 회사명 링크를 **행 전체 크기로 늘리는 "stretched link" 방식**을 쓴다 —
+ *    포커스 가능한 진짜 `<a>`는 하나뿐이고, 그 히트 영역만 CSS로 행 전체를 덮는다.
+ */
+export function ApprovalTable({ companies, buildDetailHref }: ApprovalTableProps) {
+  if (companies.length === 0) {
+    return (
+      <div className="border-border bg-card rounded-xl border p-10 text-center">
+        <p className="text-muted-foreground text-sm">승인 대기 중인 기업이 없어요</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-border bg-card overflow-hidden rounded-xl border">
+      <Table>
+        <TableHeader>
+          <TableRow className="hover:bg-transparent">
+            <TableHead className="pl-6">회사명</TableHead>
+            <TableHead>대표자</TableHead>
+            <TableHead>담당자 이메일</TableHead>
+            <TableHead>규모</TableHead>
+            <TableHead className="pr-6">신청일</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {companies.map((company) => (
+            // relative — stretched link(아래 after:absolute)가 이 행 기준으로 덮인다
+            <TableRow key={company.id} className="relative">
+              <TableCell className="py-4 pl-6">
+                <Link
+                  href={buildDetailHref(company.id)}
+                  className="text-foreground focus-visible:ring-ring inline-flex items-center gap-2 rounded after:absolute after:inset-0 hover:underline focus-visible:ring-2 focus-visible:outline-none"
+                >
+                  {company.companyName}
+                  <Badge variant="secondary">승인 대기</Badge>
+                </Link>
+              </TableCell>
+              <TableCell className="text-muted-foreground py-4">
+                {company.representativeName}
+              </TableCell>
+              <TableCell className="text-muted-foreground py-4">{company.contactEmail}</TableCell>
+              <TableCell className="text-muted-foreground py-4">
+                {COMPANY_SIZE_LABEL[company.size]}
+              </TableCell>
+              <TableCell className="text-muted-foreground py-4 pr-6 tabular-nums">
+                {company.appliedAt}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/features/system/mock/approvals.ts
+++ b/src/features/system/mock/approvals.ts
@@ -1,0 +1,140 @@
+import { COMPANY_SIZE } from "@/constants/domain";
+
+import type { PendingCompanyApproval } from "../types";
+
+/**
+ * ⚠️ 목 데이터 — BE 연동 전. **서버 프로세스 메모리에만 있다**(재시작하면 초기값으로 되돌아간다).
+ * 승인·반려 Server Action이 이 배열을 직접 지운다 — 실제 DB 흉내다.
+ */
+let mockPendingApprovals: PendingCompanyApproval[] = [
+  {
+    id: "1",
+    companyName: "(주)넥스트웨이브",
+    businessRegistrationNumber: "123-45-67890",
+    representativeName: "이지훈",
+    contactEmail: "contact@nextwave.kr",
+    size: COMPANY_SIZE.MEDIUM,
+    appliedAt: "2025-07-28",
+  },
+  {
+    id: "2",
+    companyName: "솔로몬AI",
+    businessRegistrationNumber: "234-56-78901",
+    representativeName: "박서현",
+    contactEmail: "admin@solomonai.io",
+    size: COMPANY_SIZE.SMALL,
+    appliedAt: "2025-07-27",
+  },
+  {
+    id: "3",
+    companyName: "리얼타임랩스",
+    businessRegistrationNumber: "345-67-89012",
+    representativeName: "김도현",
+    contactEmail: "ceo@realtlabs.kr",
+    size: COMPANY_SIZE.MICRO,
+    appliedAt: "2025-07-26",
+  },
+  {
+    id: "4",
+    companyName: "(주)브릿지파트너스",
+    businessRegistrationNumber: "456-78-90123",
+    representativeName: "정유나",
+    contactEmail: "hello@bridgeptn.com",
+    size: COMPANY_SIZE.LARGE,
+    appliedAt: "2025-07-25",
+  },
+  {
+    id: "5",
+    companyName: "클리어웍스",
+    businessRegistrationNumber: "567-89-01234",
+    representativeName: "한승우",
+    contactEmail: "team@clearworks.kr",
+    size: COMPANY_SIZE.SMALL,
+    appliedAt: "2025-07-24",
+  },
+  {
+    id: "6",
+    companyName: "(주)파인애플스튜디오",
+    businessRegistrationNumber: "678-90-12345",
+    representativeName: "오세연",
+    contactEmail: "info@pineapplestudio.kr",
+    size: COMPANY_SIZE.MEDIUM,
+    appliedAt: "2025-07-23",
+  },
+  {
+    id: "7",
+    companyName: "노드포지",
+    businessRegistrationNumber: "789-01-23456",
+    representativeName: "최민재",
+    contactEmail: "contact@nodeforge.dev",
+    size: COMPANY_SIZE.MICRO,
+    appliedAt: "2025-07-22",
+  },
+  {
+    id: "8",
+    companyName: "(주)그레이스케일",
+    businessRegistrationNumber: "890-12-34567",
+    representativeName: "송지원",
+    contactEmail: "admin@grayscale.kr",
+    size: COMPANY_SIZE.SMALL,
+    appliedAt: "2025-07-21",
+  },
+  {
+    id: "9",
+    companyName: "블루밍웍스",
+    businessRegistrationNumber: "901-23-45678",
+    representativeName: "장하은",
+    contactEmail: "hi@bloomingworks.io",
+    size: COMPANY_SIZE.MICRO,
+    appliedAt: "2025-07-20",
+  },
+  {
+    id: "10",
+    companyName: "(주)코어스퀘어",
+    businessRegistrationNumber: "012-34-56789",
+    representativeName: "윤태호",
+    contactEmail: "biz@coresquare.co.kr",
+    size: COMPANY_SIZE.MEDIUM,
+    appliedAt: "2025-07-19",
+  },
+  {
+    id: "11",
+    companyName: "머스트텍",
+    businessRegistrationNumber: "111-22-33445",
+    representativeName: "임소율",
+    contactEmail: "contact@musttech.kr",
+    size: COMPANY_SIZE.SMALL,
+    appliedAt: "2025-07-18",
+  },
+  {
+    id: "12",
+    companyName: "(주)비컨랩스",
+    businessRegistrationNumber: "222-33-44556",
+    representativeName: "배준영",
+    contactEmail: "hello@beaconlabs.kr",
+    size: COMPANY_SIZE.LARGE,
+    appliedAt: "2025-07-17",
+  },
+  {
+    id: "13",
+    companyName: "라이트하우스랩",
+    businessRegistrationNumber: "333-44-55667",
+    representativeName: "구예린",
+    contactEmail: "team@lighthouselab.io",
+    size: COMPANY_SIZE.MICRO,
+    appliedAt: "2025-07-16",
+  },
+];
+
+export function listMockPendingApprovals(): PendingCompanyApproval[] {
+  return mockPendingApprovals;
+}
+
+export function findMockPendingApproval(id: string): PendingCompanyApproval | null {
+  return mockPendingApprovals.find((company) => company.id === id) ?? null;
+}
+
+/** 승인·반려 둘 다 대기 목록에서 지운다 — "기업 관리"·"반려 이력" 화면은 아직 없다. */
+export function removeMockPendingApproval(id: string): void {
+  mockPendingApprovals = mockPendingApprovals.filter((company) => company.id !== id);
+}

--- a/src/features/system/nav.ts
+++ b/src/features/system/nav.ts
@@ -3,7 +3,7 @@ import type { NavSection } from "@/features/shell/nav";
 /**
  * SYSTEM(서비스 운영자) 사이드바 구성.
  *
- * ⚠️ 지금은 대시보드만 실제 화면이다 — 나머지는 `isReady` 없이 둬서
+ * ⚠️ 대시보드·기업 승인만 실제 화면이다 — 나머지는 `isReady` 없이 둬서
  *    눌러도 "준비 중" 안내만 뜨게 한다(CLAUDE.md §정직성).
  */
 export const SYSTEM_NAV: NavSection[] = [
@@ -11,7 +11,7 @@ export const SYSTEM_NAV: NavSection[] = [
     title: "운영 메뉴",
     items: [
       { href: "/system", label: "대시보드", icon: "dashboard", isReady: true },
-      { href: "/system/approval", label: "기업 승인", icon: "approval" },
+      { href: "/system/approval", label: "기업 승인", icon: "approval", isReady: true },
       { href: "/system/companies", label: "기업 관리", icon: "company" },
       { href: "/system/billing", label: "구독·매출", icon: "billing" },
       { href: "/system/monitoring", label: "시스템 모니터링", icon: "monitor" },

--- a/src/features/system/server.ts
+++ b/src/features/system/server.ts
@@ -1,9 +1,11 @@
 import "server-only";
 
+import { paginate, type PaginatedResult } from "@/lib/paginate";
 import { isMock } from "@/mocks/config";
 
+import { findMockPendingApproval, listMockPendingApprovals } from "./mock/approvals";
 import { MOCK_DASHBOARD_OVERVIEW } from "./mock/dashboard";
-import type { DashboardOverview } from "./types";
+import type { DashboardOverview, PendingCompanyApproval } from "./types";
 
 /**
  * SYSTEM 대시보드 조회 — **격리막**(CLAUDE.md).
@@ -15,4 +17,24 @@ export async function getDashboardOverview(): Promise<DashboardOverview> {
 
   // ⚠️ 미구현 — API 스펙 확정 후 `ep.systemDashboard()`로 fetch하고 매퍼로 UI 계약에 맞춘다.
   throw new Error("대시보드 조회 API가 아직 연결되지 않았습니다.");
+}
+
+/**
+ * 승인 대기 기업 목록 — 페이지 단위로 잘라 돌려준다.
+ * ⚠️ 이 화면은 프로젝트 기간 내내 목으로 남을 가능성이 크다(팀 합의) — 그래도 격리막은 유지한다.
+ */
+export async function getPendingApprovals(
+  page: number,
+  pageSize: number,
+): Promise<PaginatedResult<PendingCompanyApproval>> {
+  if (isMock) return paginate(listMockPendingApprovals(), page, pageSize);
+
+  // ⚠️ 미구현 — API 스펙 확정 후 `ep.systemDashboard()`류 경로로 fetch하고 매퍼로 맞춘다.
+  throw new Error("기업 승인 목록 API가 아직 연결되지 않았습니다.");
+}
+
+export async function getPendingApprovalById(id: string): Promise<PendingCompanyApproval | null> {
+  if (isMock) return findMockPendingApproval(id);
+
+  throw new Error("기업 승인 상세 API가 아직 연결되지 않았습니다.");
 }

--- a/src/features/system/types.ts
+++ b/src/features/system/types.ts
@@ -1,4 +1,4 @@
-import type { Plan } from "@/constants/domain";
+import type { CompanySize, Plan } from "@/constants/domain";
 
 /** 대시보드 상단 통계 4종. */
 export interface DashboardSummary {
@@ -43,4 +43,16 @@ export interface DashboardOverview {
   monthlySignups: MonthlySignup[];
   planDistribution: PlanDistributionSlice[];
   recentCompanies: RecentCompany[];
+}
+
+/** 기업 가입 승인 대기 신청서 한 건. */
+export interface PendingCompanyApproval {
+  id: string;
+  companyName: string;
+  businessRegistrationNumber: string;
+  representativeName: string;
+  contactEmail: string;
+  size: CompanySize;
+  /** "YYYY-MM-DD" */
+  appliedAt: string;
 }

--- a/src/lib/paginate.test.ts
+++ b/src/lib/paginate.test.ts
@@ -1,0 +1,52 @@
+import { getPaginationRange, paginate } from "./paginate";
+
+describe("배열 페이지 자르기", () => {
+  const items = Array.from({ length: 23 }, (_, index) => index + 1);
+
+  it("페이지 크기만큼 잘라낸다", () => {
+    const result = paginate(items, 1, 5);
+    expect(result.items).toEqual([1, 2, 3, 4, 5]);
+    expect(result.totalCount).toBe(23);
+    expect(result.totalPages).toBe(5);
+  });
+
+  it("마지막 페이지는 남은 만큼만 담는다", () => {
+    const result = paginate(items, 5, 5);
+    expect(result.items).toEqual([21, 22, 23]);
+  });
+
+  it("범위를 넘는 페이지 요청은 마지막 페이지로 당긴다", () => {
+    const result = paginate(items, 999, 5);
+    expect(result.page).toBe(5);
+    expect(result.items).toEqual([21, 22, 23]);
+  });
+
+  it("0 이하 페이지 요청은 1페이지로 당긴다 — 빈 화면이 뜨면 안 된다", () => {
+    expect(paginate(items, 0, 5).page).toBe(1);
+    expect(paginate(items, -3, 5).page).toBe(1);
+  });
+
+  it("빈 배열이어도 최소 1페이지다", () => {
+    const result = paginate([], 1, 5);
+    expect(result.totalPages).toBe(1);
+    expect(result.items).toEqual([]);
+  });
+});
+
+describe("페이지 번호 축약 목록", () => {
+  it("페이지가 적으면 생략 없이 전부 보여준다", () => {
+    expect(getPaginationRange(1, 5)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("현재 페이지가 앞쪽이면 뒤만 생략한다", () => {
+    expect(getPaginationRange(2, 20)).toEqual([1, 2, 3, 4, 5, "ellipsis", 20]);
+  });
+
+  it("현재 페이지가 뒤쪽이면 앞만 생략한다", () => {
+    expect(getPaginationRange(19, 20)).toEqual([1, "ellipsis", 16, 17, 18, 19, 20]);
+  });
+
+  it("현재 페이지가 가운데면 양쪽 다 생략한다", () => {
+    expect(getPaginationRange(10, 20)).toEqual([1, "ellipsis", 9, 10, 11, "ellipsis", 20]);
+  });
+});

--- a/src/lib/paginate.ts
+++ b/src/lib/paginate.ts
@@ -1,0 +1,64 @@
+/** 페이지 하나로 잘라낸 결과. */
+export interface PaginatedResult<T> {
+  items: T[];
+  /** 범위를 벗어난 요청은 안으로 당겨진 값이다 — 호출한 쪽 페이지 번호와 다를 수 있다 */
+  page: number;
+  totalPages: number;
+  totalCount: number;
+}
+
+/**
+ * 배열을 페이지 단위로 자른다.
+ * ⚠️ `page`가 범위를 벗어나면(0 이하·마지막 페이지 초과) **안으로 당긴다** — 빈 화면 대신
+ *    가장 가까운 유효 페이지를 보여준다.
+ */
+export function paginate<T>(items: T[], page: number, pageSize: number): PaginatedResult<T> {
+  const totalCount = items.length;
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+  const safePage = Math.min(Math.max(page, 1), totalPages);
+  const start = (safePage - 1) * pageSize;
+
+  return { items: items.slice(start, start + pageSize), page: safePage, totalPages, totalCount };
+}
+
+const ELLIPSIS = "ellipsis";
+
+/**
+ * 페이지 번호 목록을 **생략 있는 축약형**으로 계산한다 — 항상 첫·끝 페이지를 보여주고,
+ * 현재 페이지 좌우 1칸만 펼친 뒤 나머지는 "…"로 접는다.
+ * ⚠️ 기업 수가 무한히 늘어날 수 있어 페이지가 수백 개가 될 수 있다 — 전부 나열하면 못 쓴다.
+ */
+export function getPaginationRange(page: number, totalPages: number): (number | typeof ELLIPSIS)[] {
+  const SIBLING_COUNT = 1;
+  const totalVisible = SIBLING_COUNT * 2 + 5; // 첫·끝·현재·양옆 + 생략 자리 둘
+
+  if (totalPages <= totalVisible) {
+    return Array.from({ length: totalPages }, (_, index) => index + 1);
+  }
+
+  const leftSibling = Math.max(page - SIBLING_COUNT, 1);
+  const rightSibling = Math.min(page + SIBLING_COUNT, totalPages);
+
+  const showLeftEllipsis = leftSibling > 2;
+  const showRightEllipsis = rightSibling < totalPages - 1;
+
+  if (!showLeftEllipsis && showRightEllipsis) {
+    const leftRange = Array.from({ length: 3 + SIBLING_COUNT * 2 }, (_, index) => index + 1);
+    return [...leftRange, ELLIPSIS, totalPages];
+  }
+
+  if (showLeftEllipsis && !showRightEllipsis) {
+    const rightCount = 3 + SIBLING_COUNT * 2;
+    const rightRange = Array.from(
+      { length: rightCount },
+      (_, index) => totalPages - rightCount + 1 + index,
+    );
+    return [1, ELLIPSIS, ...rightRange];
+  }
+
+  const middleRange = Array.from(
+    { length: rightSibling - leftSibling + 1 },
+    (_, index) => leftSibling + index,
+  );
+  return [1, ELLIPSIS, ...middleRange, ELLIPSIS, totalPages];
+}


### PR DESCRIPTION
## 📋 PR 타입
- [x] feat — 새로운 기능 추가

## 🗂 작업 영역
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독

## 🙋 관련 역할
- [x] SYSTEM (서비스 운영자 — 확장, 데모 제외)

## 📝 작업 내용
- `/system/approval` 승인 대기 기업 목록 + 페이지네이션 + 상세 Sheet(승인/반려) 구현
- 페이지네이션은 순수 서버 컴포넌트(`components/common/pagination.tsx`) + 축약 계산 로직(`lib/paginate.ts`, 테스트 포함)
- 승인/반려는 Server Action(`features/system/actions.ts`)이 mock 배열을 직접 지움 — 실제 DB 흉내
- 표 행은 stretched-link 패턴으로 어디를 눌러도 상세로 진입, 키보드·스크린리더 접근 유지

## ✅ 작업 체크리스트
**기본**
- [x] 브랜치 명명 규칙 준수, base `develop`
- [x] 커밋 컨벤션 준수
- [x] `Closes #` 기입
- [x] 불필요한 console·주석 코드 없음
- [x] 민감 정보 없음

**Z 필수**
- [ ] 권한 2축 검사 — 로그인 전이라 화면만 있음(추후 서버 재검사 필요)
- [x] zod — 해당 없음(목 데이터 직접 타입 관리)
- [x] 정직성 — mock 데이터 명시, 목으로 계속 유지될 화면임을 주석에 표시
- [x] 디자인 토큰 — 하드코딩 없음

**품질**
- [ ] 최적화 — 해당 없음(recharts 아님)
- [x] a11y — `tr onClick` 대신 stretched-link, 표는 `Table` 컴포넌트, 페이지네이션은 `nav`+`aria-current`
- [x] 재사용 확인 — `ui/table`, `ui/badge`, `ui/sheet`, `ui/button` 재사용
- [x] loading/error/empty 3상태
- [ ] 브라우저 전용 API — 해당 없음

## 🔗 연관 이슈
Closes #49 

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트
- 페이지네이션 축약 로직(`getPaginationRange`)이 페이지 수가 많을 때도 정확한지(테스트로 커버)
- 승인/반려 Server Action이 실제로 mock 목록에서 제거되는지

## 📝 추가 메모
⚠️ 목으로 계속 유지될 화면이지만, `server.ts`/매퍼 격리막 구조는 그대로 유지했다 — 나중에 방침이 바뀌어도 컴포넌트는 안 건드린다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 기업 가입 승인 페이지를 추가했습니다.
  - 승인 대기 기업 목록, 상세 정보, 신청일·규모·대표자 정보를 확인할 수 있습니다.
  - 기업을 승인하거나 반려할 수 있습니다.
  - 페이지 이동과 상세 패널을 지원합니다.
  - 시스템 메뉴에서 기업 가입 승인 화면으로 이동할 수 있습니다.

- **개선 사항**
  - 데이터 로딩 중 안내 화면과 오류 발생 시 재시도 기능을 제공합니다.
  - 승인 목록이 없을 때 빈 상태를 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
