### PR TITLE
[FIX] 기업 승인 목록 표 컬럼 폭 미고정으로 페이지 전환 시 열 밀림 #55

### DIFF
--- a/src/app/(system)/system/companies/error.tsx
+++ b/src/app/(system)/system/companies/error.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { ScreenError } from "@/components/common/screen-error";
+
+export default function Error({ reset }: { reset: () => void }) {
+  return <ScreenError title="기업 목록을 불러오지 못했어요" reset={reset} />;
+}

--- a/src/app/(system)/system/companies/layout.tsx
+++ b/src/app/(system)/system/companies/layout.tsx
@@ -1,0 +1,13 @@
+import { Building2 } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { PageHeader } from "@/features/shell/components/page-header";
+
+export default function SystemCompaniesLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <PageHeader title="기업 관리" icon={Building2} />
+      {children}
+    </>
+  );
+}

--- a/src/app/(system)/system/companies/loading.tsx
+++ b/src/app/(system)/system/companies/loading.tsx
@@ -1,0 +1,17 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <main className="min-h-0 flex-1 overflow-y-auto p-8">
+      <div className="mx-auto flex max-w-[1440px] flex-col gap-4">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-8 w-[280px] rounded-lg" />
+          <Skeleton className="h-8 w-[110px] rounded-lg" />
+          <Skeleton className="h-8 w-[100px] rounded-lg" />
+        </div>
+        <Skeleton className="h-[561px] rounded-xl" />
+        <Skeleton className="mx-auto h-8 w-64 rounded-md" />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(system)/system/companies/page.tsx
+++ b/src/app/(system)/system/companies/page.tsx
@@ -1,0 +1,86 @@
+import type { Metadata } from "next";
+import { Suspense } from "react";
+
+import { Pagination } from "@/components/common/pagination";
+import type { CompanySize, CompanyStatus } from "@/constants/domain";
+import { CompanyDetailSheet } from "@/features/system/components/company-detail-sheet";
+import { CompanyFilterBar } from "@/features/system/components/company-filter-bar";
+import { CompanyTable } from "@/features/system/components/company-table";
+import { getManagedCompanies, getManagedCompanyById } from "@/features/system/server";
+
+export const metadata: Metadata = {
+  title: "기업 관리",
+};
+
+const PAGE_SIZE = 10;
+const BASE_PATH = "/system/companies";
+
+interface SystemCompaniesPageProps {
+  searchParams: Promise<{
+    page?: string;
+    id?: string;
+    q?: string;
+    size?: string;
+    status?: string;
+  }>;
+}
+
+function buildHref(
+  page: number,
+  query: { q?: string; size?: string; status?: string },
+  id?: string,
+): string {
+  const params = new URLSearchParams();
+  if (query.q) params.set("q", query.q);
+  if (query.size) params.set("size", query.size);
+  if (query.status) params.set("status", query.status);
+  if (page > 1) params.set("page", String(page));
+  if (id) params.set("id", id);
+  const qs = params.toString();
+  return qs ? `${BASE_PATH}?${qs}` : BASE_PATH;
+}
+
+export default async function SystemCompaniesPage({ searchParams }: SystemCompaniesPageProps) {
+  const params = await searchParams;
+  const page = Math.max(1, Number(params.page) || 1);
+  const query = { q: params.q, size: params.size, status: params.status };
+
+  const [{ items, totalPages }, selected] = await Promise.all([
+    getManagedCompanies(
+      {
+        keyword: params.q,
+        size: params.size as CompanySize | undefined,
+        status: params.status as CompanyStatus | undefined,
+      },
+      page,
+      PAGE_SIZE,
+    ),
+    params.id ? getManagedCompanyById(params.id) : Promise.resolve(null),
+  ]);
+
+  const currentPath = buildHref(page, query);
+
+  return (
+    <main className="min-h-0 flex-1 overflow-y-auto p-8">
+      <div className="mx-auto flex max-w-[1440px] flex-col gap-4">
+        <Suspense>
+          <CompanyFilterBar />
+        </Suspense>
+
+        <CompanyTable
+          companies={items}
+          buildDetailHref={(id) => buildHref(page, query, id)}
+          pageSize={PAGE_SIZE}
+        />
+
+        <Pagination
+          page={page}
+          totalPages={totalPages}
+          buildHref={(target) => buildHref(target, query)}
+        />
+      </div>
+
+      <CompanyDetailSheet company={selected} closeHref={currentPath} currentPath={currentPath} />
+    </main>
+  );
+}

--- a/src/constants/domain.ts
+++ b/src/constants/domain.ts
@@ -218,6 +218,12 @@ export const COMPANY_STATUS = {
 } as const;
 export type CompanyStatus = (typeof COMPANY_STATUS)[keyof typeof COMPANY_STATUS];
 
+export const COMPANY_STATUS_LABEL: Record<CompanyStatus, string> = {
+  ACTIVE: "활성",
+  SUSPENDED: "정지",
+  UNPAID: "미납",
+};
+
 /** 기업 가입 신청서의 직원 규모 구간. */
 export const COMPANY_SIZE = {
   MICRO: "MICRO",

--- a/src/features/system/actions.ts
+++ b/src/features/system/actions.ts
@@ -1,10 +1,13 @@
 "use server";
 
+import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
+import { COMPANY_STATUS } from "@/constants/domain";
 import { isMock } from "@/mocks/config";
 
 import { removeMockPendingApproval } from "./mock/approvals";
+import { setMockCompanyStatus } from "./mock/companies";
 
 /**
  * 기업 승인 화면의 **변경 창구** — 격리막(CLAUDE.md §Mock 격리막).
@@ -37,4 +40,36 @@ export async function rejectCompanyAction(formData: FormData): Promise<void> {
   }
 
   redirect(redirectTo);
+}
+
+/**
+ * "기업 관리" 상세 패널의 정지·정지 해제 — 격리막(CLAUDE.md §Mock 격리막).
+ * ⚠️ `redirect` 없이 **같은 화면에 머문다** — 승인/반려와 달리 상세를 계속 보는 흐름이라
+ *    `revalidatePath`로 목록·상세를 새로고침한다(CLAUDE.md §핵심 4원칙 ②).
+ */
+export async function suspendCompanyAction(formData: FormData): Promise<void> {
+  const id = String(formData.get("companyId") ?? "");
+  const path = String(formData.get("path") ?? "/system/companies");
+
+  if (isMock) {
+    setMockCompanyStatus(id, COMPANY_STATUS.SUSPENDED);
+  } else {
+    // ⚠️ 미구현 — API 스펙 확정 후 BFF 경로로 정지 요청을 보낸다.
+    throw new Error("기업 정지 API가 아직 연결되지 않았습니다.");
+  }
+
+  revalidatePath(path);
+}
+
+export async function unsuspendCompanyAction(formData: FormData): Promise<void> {
+  const id = String(formData.get("companyId") ?? "");
+  const path = String(formData.get("path") ?? "/system/companies");
+
+  if (isMock) {
+    setMockCompanyStatus(id, COMPANY_STATUS.ACTIVE);
+  } else {
+    throw new Error("기업 정지 해제 API가 아직 연결되지 않았습니다.");
+  }
+
+  revalidatePath(path);
 }

--- a/src/features/system/components/approval-table.tsx
+++ b/src/features/system/components/approval-table.tsx
@@ -28,6 +28,20 @@ const HEADER_HEIGHT_CLASS = "h-[41px]";
 const HEADER_HEIGHT_PX = 41;
 
 /**
+ * 컬럼 폭 — **%로 고정**한다(합 100). 픽셀 고정이면 화면 폭이 다른 환경에서 비율이 깨진다.
+ * `table-fixed` + `colgroup`과 짝을 이뤄야 실제로 적용된다 — 없으면 브라우저가 셀 내용(회사명·
+ * 이메일 길이)을 보고 폭을 다시 계산해 버려, 페이지를 넘길 때마다 회사명 길이에 따라 옆 컬럼이
+ * 밀리는 덜컥거림이 생긴다(`company-table.tsx`에서 같은 문제를 같은 방식으로 고쳤다).
+ */
+const COLUMN_WIDTH = {
+  name: "28%",
+  representative: "16%",
+  email: "28%",
+  size: "14%",
+  appliedAt: "14%",
+} as const;
+
+/**
  * 승인 대기 기업 표.
  *
  * ⚠️ 행 어디를 눌러도 상세로 들어간다 — 그렇다고 `tr`에 `onClick`을 달지 않는다.
@@ -55,7 +69,15 @@ export function ApprovalTable({ companies, buildDetailHref, pageSize }: Approval
 
   return (
     <div className="border-border bg-card overflow-hidden rounded-xl border">
-      <Table>
+      <Table className="table-fixed">
+        {/* 각 컬럼 폭을 %로 고정 — 회사명 길이가 페이지마다 달라져도 다른 컬럼이 밀리지 않는다(위 COLUMN_WIDTH 참고) */}
+        <colgroup>
+          <col style={{ width: COLUMN_WIDTH.name }} />
+          <col style={{ width: COLUMN_WIDTH.representative }} />
+          <col style={{ width: COLUMN_WIDTH.email }} />
+          <col style={{ width: COLUMN_WIDTH.size }} />
+          <col style={{ width: COLUMN_WIDTH.appliedAt }} />
+        </colgroup>
         <TableHeader>
           <TableRow className={cn(HEADER_HEIGHT_CLASS, "hover:bg-transparent")}>
             <TableHead className="pl-6">회사명</TableHead>
@@ -69,17 +91,28 @@ export function ApprovalTable({ companies, buildDetailHref, pageSize }: Approval
           {companies.map((company) => (
             // relative — stretched link(아래 after:absolute)가 이 행 기준으로 덮인다
             <TableRow key={company.id} className={cn(ROW_HEIGHT_CLASS, "relative")}>
-              <TableCell className="pl-6">
+              <TableCell className="max-w-0 pl-6">
                 <Link
                   href={buildDetailHref(company.id)}
-                  className="text-foreground focus-visible:ring-ring inline-flex items-center gap-2 rounded after:absolute after:inset-0 hover:underline focus-visible:ring-2 focus-visible:outline-none"
+                  className="text-foreground focus-visible:ring-ring flex items-center gap-2 rounded after:absolute after:inset-0 hover:underline focus-visible:ring-2 focus-visible:outline-none"
                 >
-                  {company.companyName}
-                  <Badge variant="secondary">승인 대기</Badge>
+                  <span className="truncate" title={company.companyName}>
+                    {company.companyName}
+                  </span>
+                  <Badge variant="secondary" className="shrink-0">
+                    승인 대기
+                  </Badge>
                 </Link>
               </TableCell>
-              <TableCell className="text-muted-foreground">{company.representativeName}</TableCell>
-              <TableCell className="text-muted-foreground">{company.contactEmail}</TableCell>
+              <TableCell className="text-muted-foreground max-w-0 truncate">
+                {company.representativeName}
+              </TableCell>
+              <TableCell
+                className="text-muted-foreground max-w-0 truncate"
+                title={company.contactEmail}
+              >
+                {company.contactEmail}
+              </TableCell>
               <TableCell className="text-muted-foreground">
                 {COMPANY_SIZE_LABEL[company.size]}
               </TableCell>

--- a/src/features/system/components/company-detail-sheet.tsx
+++ b/src/features/system/components/company-detail-sheet.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useFormStatus } from "react-dom";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Sheet, SheetContent, SheetFooter, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { COMPANY_SIZE_LABEL, COMPANY_STATUS, COMPANY_STATUS_LABEL, PLAN } from "@/constants/domain";
+
+import { suspendCompanyAction, unsuspendCompanyAction } from "../actions";
+import type { ManagedCompany } from "../types";
+
+interface CompanyDetailSheetProps {
+  company: ManagedCompany | null;
+  /** 닫히면 돌아갈 곳 — 지금 보던 페이지 그대로(쿼리의 `id`만 없어진 형태) */
+  closeHref: string;
+  /** Server Action이 끝난 뒤 새로고침할 경로 — `revalidatePath`에 넘긴다 */
+  currentPath: string;
+}
+
+/**
+ * "기업 관리" 행을 누르면 뜨는 상세 패널.
+ *
+ * ⚠️ 승인 화면(`approval-detail-sheet.tsx`)과 달리 **끝나도 화면을 안 떠난다** —
+ *    정지는 그 자리에서 상태만 바꾸는 조작이라 `redirect` 대신 `revalidatePath`를 쓴다.
+ * ⚠️ `company`가 `null`이어도 항상 렌더링한다 — Sheet가 닫히는 애니메이션 동안
+ *    내용이 먼저 사라지면 어색하다. 열림 여부는 `open` prop 하나로만 정한다.
+ */
+export function CompanyDetailSheet({ company, closeHref, currentPath }: CompanyDetailSheetProps) {
+  const router = useRouter();
+  const isSuspended = company?.status === COMPANY_STATUS.SUSPENDED;
+
+  return (
+    <Sheet
+      open={company !== null}
+      onOpenChange={(open) => {
+        if (!open) router.push(closeHref);
+      }}
+    >
+      <SheetContent>
+        {company && (
+          <>
+            <SheetHeader>
+              <SheetTitle>{company.name}</SheetTitle>
+            </SheetHeader>
+
+            <div className="flex flex-1 flex-col gap-4 overflow-y-auto px-4">
+              <Field label="기업 코드" value={company.code} />
+              <Field label="규모" value={COMPANY_SIZE_LABEL[company.size]} />
+              <Field label="플랜" value={company.plan === PLAN.TEAM ? "Team" : "Free"} />
+              <Field label="가입일" value={company.joinedAt} />
+              <Field label="구성원 수" value={`${company.memberCount}명`} />
+              <Field label="이번 달 회의" value={`${company.meetingCountThisMonth}회`} />
+
+              <div className="flex flex-col gap-0.5">
+                <p className="text-muted-foreground text-xs leading-4">상태</p>
+                <Badge variant={isSuspended ? "destructive" : "default"} className="w-fit">
+                  {COMPANY_STATUS_LABEL[company.status]}
+                </Badge>
+              </div>
+
+              <Field label="오너 이메일" value={company.ownerEmail} />
+            </div>
+
+            <SheetFooter>
+              <form
+                action={isSuspended ? unsuspendCompanyAction : suspendCompanyAction}
+                className="w-full"
+              >
+                <input type="hidden" name="companyId" value={company.id} />
+                <input type="hidden" name="path" value={currentPath} />
+                <SubmitButton isSuspended={isSuspended} />
+              </form>
+            </SheetFooter>
+          </>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function Field({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <p className="text-muted-foreground text-xs leading-4">{label}</p>
+      <p className="text-foreground text-sm leading-5">{value}</p>
+    </div>
+  );
+}
+
+function SubmitButton({ isSuspended }: { isSuspended: boolean }) {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button
+      type="submit"
+      variant={isSuspended ? "default" : "destructive"}
+      disabled={pending}
+      className="w-full"
+    >
+      {pending ? "처리 중…" : isSuspended ? "정지 해제" : "정지"}
+    </Button>
+  );
+}

--- a/src/features/system/components/company-filter-bar.tsx
+++ b/src/features/system/components/company-filter-bar.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { Search } from "lucide-react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
+
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  COMPANY_SIZE,
+  COMPANY_SIZE_LABEL,
+  COMPANY_STATUS,
+  COMPANY_STATUS_LABEL,
+} from "@/constants/domain";
+
+const SIZE_OPTIONS = Object.values(COMPANY_SIZE);
+const STATUS_OPTIONS = Object.values(COMPANY_STATUS);
+
+/** 필터 셀렉트의 "전체" 값 — 빈 문자열은 URLSearchParams가 지워버려 구분이 안 된다 */
+const ALL = "ALL";
+
+/**
+ * 기업명·코드 검색 + 규모·상태 필터.
+ *
+ * ⚠️ 검색·필터 결과는 **URL 쿼리로 표현한다** — 서버 컴포넌트(페이지)가 그 쿼리를 읽어
+ *    목록을 좁힌다(CLAUDE.md §핵심 4원칙 ①: 조회는 Server Component). 그래서 이 바는
+ *    입력만 받고 실제 필터링은 하지 않는다 — 목록 필터링 로직이 두 곳에 흩어지지 않는다.
+ * ⚠️ 필터가 바뀌면 **1페이지로 되돌린다** — 3페이지를 보다가 검색하면 빈 화면을 만날 수 있다.
+ */
+export function CompanyFilterBar() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [keyword, setKeyword] = useState(searchParams.get("q") ?? "");
+
+  const pushWith = (updates: Record<string, string>) => {
+    const params = new URLSearchParams(searchParams.toString());
+    for (const [key, value] of Object.entries(updates)) {
+      if (!value || value === ALL) params.delete(key);
+      else params.set(key, value);
+    }
+    params.delete("page");
+    router.push(`/system/companies?${params.toString()}`);
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <div className="relative w-full max-w-[280px]">
+        <Search
+          className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2"
+          aria-hidden
+        />
+        <Input
+          value={keyword}
+          onChange={(event) => setKeyword(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") pushWith({ q: keyword });
+          }}
+          onBlur={() => pushWith({ q: keyword })}
+          placeholder="기업명 또는 코드 검색"
+          aria-label="기업명 또는 코드 검색"
+          className="pl-8"
+        />
+      </div>
+
+      <Select
+        value={searchParams.get("size") ?? ALL}
+        onValueChange={(value) => pushWith({ size: value ?? ALL })}
+      >
+        <SelectTrigger aria-label="규모 필터" className="w-[110px]">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={ALL}>전체 규모</SelectItem>
+          {SIZE_OPTIONS.map((size) => (
+            <SelectItem key={size} value={size}>
+              {COMPANY_SIZE_LABEL[size]}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Select
+        value={searchParams.get("status") ?? ALL}
+        onValueChange={(value) => pushWith({ status: value ?? ALL })}
+      >
+        <SelectTrigger aria-label="상태 필터" className="w-[100px]">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={ALL}>전체 상태</SelectItem>
+          {STATUS_OPTIONS.map((status) => (
+            <SelectItem key={status} value={status}>
+              {COMPANY_STATUS_LABEL[status]}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/src/features/system/components/company-table.tsx
+++ b/src/features/system/components/company-table.tsx
@@ -1,0 +1,152 @@
+import Link from "next/link";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { COMPANY_SIZE_LABEL, COMPANY_STATUS_LABEL, PLAN } from "@/constants/domain";
+import { cn } from "@/lib/utils";
+
+import type { ManagedCompany } from "../types";
+
+interface CompanyTableProps {
+  companies: ManagedCompany[];
+  buildDetailHref: (id: string) => string;
+  /** 한 페이지 행 수 — 마지막 페이지처럼 행이 모자라도 이 개수만큼 높이를 잡아둔다 */
+  pageSize: number;
+}
+
+/** 행 하나의 높이 — `py-4`가 아니라 고정 클래스로 못박아 내용에 따라 늘어나지 않게 한다. */
+const ROW_HEIGHT_CLASS = "h-13"; // 52px
+const ROW_HEIGHT_PX = 52;
+const HEADER_HEIGHT_CLASS = "h-[41px]";
+const HEADER_HEIGHT_PX = 41;
+
+const STATUS_BADGE_VARIANT: Record<
+  ManagedCompany["status"],
+  "default" | "secondary" | "destructive"
+> = {
+  ACTIVE: "default",
+  SUSPENDED: "destructive",
+  UNPAID: "secondary",
+};
+
+/**
+ * 컬럼 폭 — **%로 고정**한다(합 100). 픽셀 고정이면 화면 폭이 다른 환경(다른 PC·해상도)에서
+ * 비율이 깨진다. `table-fixed` + `colgroup`과 짝을 이뤄야 실제로 적용된다 — `table-fixed` 없이는
+ * 브라우저가 내용 길이를 보고 폭을 다시 계산해 버려 이 값이 무시된다.
+ */
+const COLUMN_WIDTH = {
+  name: "24%",
+  code: "20%",
+  size: "12%",
+  plan: "10%",
+  members: "12%",
+  meetings: "12%",
+  status: "10%",
+} as const;
+
+/**
+ * 기업 관리 표.
+ *
+ * ⚠️ 행 어디를 눌러도 상세로 들어간다 — `tr`에 `onClick`을 달지 않고 "stretched link"
+ *    방식을 쓴다(CLAUDE.md §a11y: 클릭은 button/a). `approval-table.tsx`와 같은 패턴이다.
+ * ⚠️ **행 개수를 페이지마다 똑같이 맞춘다** — 부족한 만큼 보이지 않는 채움 행으로 채워
+ *    페이지 전환 시 목록 높이가 들썩이지 않게 한다(`approval-table.tsx`에서 겪은 문제,
+ *    같은 해법을 재사용한다).
+ */
+export function CompanyTable({ companies, buildDetailHref, pageSize }: CompanyTableProps) {
+  if (companies.length === 0) {
+    return (
+      <div
+        className="border-border bg-card flex flex-col items-center justify-center rounded-xl border p-10 text-center"
+        style={{ height: HEADER_HEIGHT_PX + pageSize * ROW_HEIGHT_PX }}
+      >
+        <p className="text-muted-foreground text-sm">조건에 맞는 기업이 없어요</p>
+      </div>
+    );
+  }
+
+  const fillerCount = Math.max(0, pageSize - companies.length);
+
+  return (
+    <div className="border-border bg-card overflow-hidden rounded-xl border">
+      <Table className="table-fixed">
+        {/* 각 컬럼 폭을 %로 고정 — 기업명이 길어져도 다른 컬럼이 밀리지 않는다(위 COLUMN_WIDTH 참고) */}
+        <colgroup>
+          <col style={{ width: COLUMN_WIDTH.name }} />
+          <col style={{ width: COLUMN_WIDTH.code }} />
+          <col style={{ width: COLUMN_WIDTH.size }} />
+          <col style={{ width: COLUMN_WIDTH.plan }} />
+          <col style={{ width: COLUMN_WIDTH.members }} />
+          <col style={{ width: COLUMN_WIDTH.meetings }} />
+          <col style={{ width: COLUMN_WIDTH.status }} />
+        </colgroup>
+        <TableHeader>
+          <TableRow className={cn(HEADER_HEIGHT_CLASS, "hover:bg-transparent")}>
+            <TableHead className="pl-6">기업명</TableHead>
+            <TableHead>기업 코드</TableHead>
+            <TableHead>규모</TableHead>
+            <TableHead>플랜</TableHead>
+            <TableHead>구성원</TableHead>
+            <TableHead>이번달 회의</TableHead>
+            <TableHead className="pr-6">상태</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {companies.map((company) => (
+            // relative — stretched link(아래 after:absolute)가 이 행 기준으로 덮인다
+            <TableRow key={company.id} className={cn(ROW_HEIGHT_CLASS, "relative")}>
+              <TableCell className="max-w-0 pl-6">
+                <Link
+                  href={buildDetailHref(company.id)}
+                  className="text-foreground focus-visible:ring-ring block truncate rounded after:absolute after:inset-0 hover:underline focus-visible:ring-2 focus-visible:outline-none"
+                  title={company.name}
+                >
+                  {company.name}
+                </Link>
+              </TableCell>
+              <TableCell className="text-muted-foreground max-w-0 truncate" title={company.code}>
+                {company.code}
+              </TableCell>
+              <TableCell className="text-muted-foreground">
+                {COMPANY_SIZE_LABEL[company.size]}
+              </TableCell>
+              <TableCell>
+                <Badge variant={company.plan === PLAN.TEAM ? "default" : "secondary"}>
+                  {company.plan === PLAN.TEAM ? "Team" : "Free"}
+                </Badge>
+              </TableCell>
+              <TableCell className="text-muted-foreground tabular-nums">
+                {company.memberCount}명
+              </TableCell>
+              <TableCell className="text-muted-foreground tabular-nums">
+                {company.meetingCountThisMonth}회
+              </TableCell>
+              <TableCell className="pr-6">
+                <Badge variant={STATUS_BADGE_VARIANT[company.status]}>
+                  {COMPANY_STATUS_LABEL[company.status]}
+                </Badge>
+              </TableCell>
+            </TableRow>
+          ))}
+          {/* 채움 행 — 보더 없이, 스크린리더에서도 안 읽힌다. 목적은 오직 <tr> 개수를 맞추는 것뿐 */}
+          {Array.from({ length: fillerCount }, (_, index) => (
+            <TableRow
+              key={`filler-${index}`}
+              aria-hidden
+              className={cn(ROW_HEIGHT_CLASS, "border-transparent hover:bg-transparent")}
+            >
+              <TableCell className="pl-6" colSpan={7} />
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/features/system/mock/companies.ts
+++ b/src/features/system/mock/companies.ts
@@ -1,0 +1,192 @@
+import { COMPANY_SIZE, COMPANY_STATUS, PLAN } from "@/constants/domain";
+
+import type { ManagedCompany } from "../types";
+
+/** ⚠️ 목 데이터 — BE 연동 전. 검색·필터·페이지네이션을 눈으로 확인할 수 있도록 넉넉히 둔다. */
+const BASE_COMPANIES: ManagedCompany[] = [
+  {
+    id: "1",
+    name: "(주)테크스타트",
+    code: "TECHSTART-2025",
+    size: COMPANY_SIZE.MEDIUM,
+    plan: PLAN.TEAM,
+    memberCount: 12,
+    meetingCountThisMonth: 47,
+    status: COMPANY_STATUS.ACTIVE,
+    joinedAt: "2025-01-14",
+    ownerEmail: "ceo@techstart.kr",
+  },
+  {
+    id: "2",
+    name: "그린로직스",
+    code: "GREENLOGICS-25",
+    size: COMPANY_SIZE.SMALL,
+    plan: PLAN.FREE,
+    memberCount: 4,
+    meetingCountThisMonth: 8,
+    status: COMPANY_STATUS.ACTIVE,
+    joinedAt: "2025-02-02",
+    ownerEmail: "hello@greenlogics.kr",
+  },
+  {
+    id: "3",
+    name: "(주)레이어원",
+    code: "LAYERONE-2025",
+    size: COMPANY_SIZE.MEDIUM,
+    plan: PLAN.TEAM,
+    memberCount: 27,
+    meetingCountThisMonth: 83,
+    status: COMPANY_STATUS.ACTIVE,
+    joinedAt: "2025-04-22",
+    ownerEmail: "ceo@techstart.kr",
+  },
+  {
+    id: "4",
+    name: "모멘텀랩",
+    code: "MOMENTUM-2025",
+    size: COMPANY_SIZE.SMALL,
+    plan: PLAN.TEAM,
+    memberCount: 8,
+    meetingCountThisMonth: 19,
+    status: COMPANY_STATUS.UNPAID,
+    joinedAt: "2025-03-11",
+    ownerEmail: "biz@momentumlab.kr",
+  },
+  {
+    id: "5",
+    name: "엔드포인트",
+    code: "ENDPOINT-2025",
+    size: COMPANY_SIZE.MICRO,
+    plan: PLAN.FREE,
+    memberCount: 3,
+    meetingCountThisMonth: 2,
+    status: COMPANY_STATUS.ACTIVE,
+    joinedAt: "2025-05-30",
+    ownerEmail: "admin@endpoint.dev",
+  },
+  {
+    id: "6",
+    name: "(주)블루스톤",
+    code: "BLUESTONE-2025",
+    size: COMPANY_SIZE.MEDIUM,
+    plan: PLAN.TEAM,
+    memberCount: 14,
+    meetingCountThisMonth: 31,
+    status: COMPANY_STATUS.SUSPENDED,
+    joinedAt: "2025-06-15",
+    ownerEmail: "ceo@techstart.kr",
+  },
+];
+
+/** 검색·페이지네이션이 실제로 넘어가는지 보이도록 이름만 바꿔 62개까지 늘린다. */
+const EXTRA_COMPANY_NAMES = [
+  "노드포지",
+  "(주)그레이스케일",
+  "블루밍웍스",
+  "(주)코어스퀘어",
+  "머스트텍",
+  "(주)비컨랩스",
+  "라이트하우스랩",
+  "클리어웍스",
+  "(주)파인애플스튜디오",
+  "솔로몬AI",
+  "리얼타임랩스",
+  "(주)브릿지파트너스",
+  "픽셀그로브",
+  "(주)스트림웍스",
+  "웨이브포인트",
+  "(주)크리스탈넷",
+  "오비트랩스",
+  "(주)메이플시스템즈",
+  "다이나모웍스",
+  "(주)실버라인",
+  "그래비티랩",
+  "(주)넥서스포지",
+  "브릿지스톤테크",
+  "(주)폴라리스랩",
+  "코발트웍스",
+  "(주)에메랄드시스템",
+  "선라이즈랩스",
+  "(주)베이스캠프",
+  "인피니티그룹",
+  "(주)스텔라웍스",
+  "포워드랩",
+  "(주)하모니시스템",
+  "블랙포레스트",
+  "(주)골든게이트랩",
+  "카이트웍스",
+  "(주)리버사이드",
+  "문라이트랩스",
+  "(주)선다이얼",
+  "패스파인더",
+  "(주)오로라시스템",
+  "리플렉트랩",
+  "(주)헤리티지웍스",
+  "스파클랩스",
+  "(주)트윈피크스",
+  "제니스랩",
+  "(주)벡터포인트",
+  "글로우웍스",
+  "(주)크레센트",
+  "아이콘랩스",
+  "(주)파노라마",
+  "브릴리언스랩",
+  "(주)에코시스템",
+  "노바크래프트",
+  "(주)스카이라인",
+  "루미나웍스",
+  "(주)프론티어랩",
+] as const;
+
+const SIZES = [COMPANY_SIZE.MICRO, COMPANY_SIZE.SMALL, COMPANY_SIZE.MEDIUM, COMPANY_SIZE.LARGE];
+const PLANS = [PLAN.FREE, PLAN.TEAM];
+const STATUSES = [
+  COMPANY_STATUS.ACTIVE,
+  COMPANY_STATUS.ACTIVE,
+  COMPANY_STATUS.ACTIVE,
+  COMPANY_STATUS.SUSPENDED,
+  COMPANY_STATUS.UNPAID,
+];
+
+const EXTRA_COMPANIES: ManagedCompany[] = EXTRA_COMPANY_NAMES.map((name, index) => {
+  const seed = index + 1;
+  const size = SIZES[seed % SIZES.length]!;
+  const plan = PLANS[seed % PLANS.length]!;
+  const status = STATUSES[seed % STATUSES.length]!;
+  const slug = name.replace(/[()·]/g, "").slice(0, 6).toUpperCase();
+
+  return {
+    id: `${BASE_COMPANIES.length + seed}`,
+    name,
+    code: `${slug}-${2020 + (seed % 6)}`,
+    size,
+    plan,
+    memberCount: plan === PLAN.FREE ? (seed % 5) + 1 : (seed % 40) + 5,
+    meetingCountThisMonth: (seed * 3) % 90,
+    status,
+    joinedAt: `2025-${String((seed % 12) + 1).padStart(2, "0")}-${String((seed % 27) + 1).padStart(2, "0")}`,
+    ownerEmail: `owner${seed}@${slug.toLowerCase()}.kr`,
+  };
+});
+
+let mockCompanies: ManagedCompany[] = [...BASE_COMPANIES, ...EXTRA_COMPANIES];
+
+export function listMockCompanies(): ManagedCompany[] {
+  return mockCompanies;
+}
+
+export function findMockCompany(id: string): ManagedCompany | null {
+  return mockCompanies.find((company) => company.id === id) ?? null;
+}
+
+/** 정지·정지 해제 — 실제 DB 흉내라 배열 안 항목을 직접 바꾼다. */
+export function setMockCompanyStatus(
+  id: string,
+  status: ManagedCompany["status"],
+): ManagedCompany | null {
+  const company = findMockCompany(id);
+  if (!company) return null;
+
+  mockCompanies = mockCompanies.map((item) => (item.id === id ? { ...item, status } : item));
+  return { ...company, status };
+}

--- a/src/features/system/nav.ts
+++ b/src/features/system/nav.ts
@@ -3,7 +3,7 @@ import type { NavSection } from "@/features/shell/nav";
 /**
  * SYSTEM(서비스 운영자) 사이드바 구성.
  *
- * ⚠️ 대시보드·기업 승인만 실제 화면이다 — 나머지는 `isReady` 없이 둬서
+ * ⚠️ 대시보드·기업 승인·기업 관리만 실제 화면이다 — 나머지는 `isReady` 없이 둬서
  *    눌러도 "준비 중" 안내만 뜨게 한다(CLAUDE.md §정직성).
  */
 export const SYSTEM_NAV: NavSection[] = [
@@ -12,7 +12,7 @@ export const SYSTEM_NAV: NavSection[] = [
     items: [
       { href: "/system", label: "대시보드", icon: "dashboard", isReady: true },
       { href: "/system/approval", label: "기업 승인", icon: "approval", isReady: true },
-      { href: "/system/companies", label: "기업 관리", icon: "company" },
+      { href: "/system/companies", label: "기업 관리", icon: "company", isReady: true },
       { href: "/system/billing", label: "구독·매출", icon: "billing" },
       { href: "/system/monitoring", label: "시스템 모니터링", icon: "monitor" },
       { href: "/system/notice", label: "공지", icon: "notice" },

--- a/src/features/system/server.ts
+++ b/src/features/system/server.ts
@@ -1,11 +1,13 @@
 import "server-only";
 
+import type { CompanySize, CompanyStatus } from "@/constants/domain";
 import { paginate, type PaginatedResult } from "@/lib/paginate";
 import { isMock } from "@/mocks/config";
 
 import { findMockPendingApproval, listMockPendingApprovals } from "./mock/approvals";
+import { findMockCompany, listMockCompanies, setMockCompanyStatus } from "./mock/companies";
 import { MOCK_DASHBOARD_OVERVIEW } from "./mock/dashboard";
-import type { DashboardOverview, PendingCompanyApproval } from "./types";
+import type { DashboardOverview, ManagedCompany, PendingCompanyApproval } from "./types";
 
 /**
  * SYSTEM 대시보드 조회 — **격리막**(CLAUDE.md).
@@ -37,4 +39,62 @@ export async function getPendingApprovalById(id: string): Promise<PendingCompany
   if (isMock) return findMockPendingApproval(id);
 
   throw new Error("기업 승인 상세 API가 아직 연결되지 않았습니다.");
+}
+
+/** "기업 관리" 목록 검색 조건 — 전부 선택값이라 없으면 전체를 대상으로 한다. */
+export interface CompanyListFilter {
+  /** 기업명 또는 코드 부분 일치(대소문자 무시) */
+  keyword?: string;
+  size?: CompanySize;
+  status?: CompanyStatus;
+}
+
+function matchesFilter(company: ManagedCompany, filter: CompanyListFilter): boolean {
+  if (filter.size && company.size !== filter.size) return false;
+  if (filter.status && company.status !== filter.status) return false;
+
+  if (filter.keyword) {
+    const keyword = filter.keyword.trim().toLowerCase();
+    if (keyword) {
+      const matchesName = company.name.toLowerCase().includes(keyword);
+      const matchesCode = company.code.toLowerCase().includes(keyword);
+      if (!matchesName && !matchesCode) return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * 기업 관리 목록 — 검색·필터 후 페이지 단위로 잘라 돌려준다.
+ * ⚠️ 검색·필터는 서버에서 계산한다 — 목록이 무한히 늘어날 수 있어(CLAUDE.md §성능) 클라이언트로
+ *    전체를 내려보내고 거르면 안 된다. 지금은 목 배열을 거르지만 자리(함수 시그니처)는 실서버와 같다.
+ */
+export async function getManagedCompanies(
+  filter: CompanyListFilter,
+  page: number,
+  pageSize: number,
+): Promise<PaginatedResult<ManagedCompany>> {
+  if (isMock) {
+    const filtered = listMockCompanies().filter((company) => matchesFilter(company, filter));
+    return paginate(filtered, page, pageSize);
+  }
+
+  // ⚠️ 미구현 — API 스펙 확정 후 `ep.systemDashboard()`류 경로로 fetch하고 매퍼로 맞춘다.
+  throw new Error("기업 관리 목록 API가 아직 연결되지 않았습니다.");
+}
+
+export async function getManagedCompanyById(id: string): Promise<ManagedCompany | null> {
+  if (isMock) return findMockCompany(id);
+
+  throw new Error("기업 상세 API가 아직 연결되지 않았습니다.");
+}
+
+export async function setCompanyStatus(
+  id: string,
+  status: CompanyStatus,
+): Promise<ManagedCompany | null> {
+  if (isMock) return setMockCompanyStatus(id, status);
+
+  throw new Error("기업 상태 변경 API가 아직 연결되지 않았습니다.");
 }

--- a/src/features/system/types.ts
+++ b/src/features/system/types.ts
@@ -1,4 +1,4 @@
-import type { CompanySize, Plan } from "@/constants/domain";
+import type { CompanySize, CompanyStatus, Plan } from "@/constants/domain";
 
 /** 대시보드 상단 통계 4종. */
 export interface DashboardSummary {
@@ -55,4 +55,21 @@ export interface PendingCompanyApproval {
   size: CompanySize;
   /** "YYYY-MM-DD" */
   appliedAt: string;
+}
+
+/** "기업 관리" 목록·상세가 함께 쓰는 한 기업. */
+export interface ManagedCompany {
+  id: string;
+  name: string;
+  /** 화면에 그대로 나가는 식별 코드(가입 승인 시 발급) — 검색 대상이기도 하다 */
+  code: string;
+  size: CompanySize;
+  plan: Plan;
+  memberCount: number;
+  /** 이번 달 회의 횟수 */
+  meetingCountThisMonth: number;
+  status: CompanyStatus;
+  /** "YYYY-MM-DD" */
+  joinedAt: string;
+  ownerEmail: string;
 }


### PR DESCRIPTION
## 📋 PR 타입
- [x] fix — 버그 수정
- [x] design — UI/UX 변경

## 🗂 작업 영역
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독

## 🙋 관련 역할
- [x] SYSTEM (서비스 운영자 — 확장, 데모 제외)

## 📝 작업 내용
- `ApprovalTable`에 `colgroup` + `table-fixed`를 추가해 컬럼 폭을 `%`로 고정(회사명 28% · 대표자 16% · 이메일 28% · 규모 14% · 신청일 14%)
- 회사명·이메일 셀에 `truncate` + `title` 툴팁 처리 — 폭이 고정되며 긴 텍스트가 셀을 넘치지 않게 함
- 회사명 셀의 "승인 대기" 뱃지에 `shrink-0` 추가 — 이름이 길어 `truncate`가 걸려도 뱃지 자체는 안 눌리게 함
- 기업 관리(`company-table.tsx`)에서 같은 문제를 같은 방식으로 이미 해결한 바 있어 그 패턴을 그대로 재사용

## ✅ 작업 체크리스트
**기본**
- [x] 브랜치 명명 규칙 준수, base `develop`
- [x] 커밋 컨벤션 준수
- [x] `Closes #` 기입
- [x] 불필요한 console·주석 코드 없음
- [x] 민감 정보 없음

**Z 필수**
- [ ] 권한 2축 검사 — 해당 없음(순수 레이아웃 수정)
- [ ] zod — 해당 없음
- [ ] 정직성 — 해당 없음
- [x] 디자인 토큰 — 색상 변경 없음, 기존 토큰 그대로 유지

**품질**
- [ ] 최적화 — 해당 없음
- [x] a11y — `truncate`된 텍스트에 `title` 툴팁으로 전체 값 확인 가능
- [x] 재사용 확인 — 새 컴포넌트 추가 없이 기존 `ApprovalTable` 내부만 수정
- [ ] loading/error/empty — 해당 없음(기존 유지)
- [ ] 브라우저 전용 API — 해당 없음

## 🔗 연관 이슈
Closes #55 

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트
- 컬럼 폭 비율(28/16/28/14/14)이 실제 데이터 길이(회사명·이메일)에 적당한지
- `truncate` 적용 후에도 "승인 대기" 뱃지가 잘리지 않는지

## 📝 추가 메모
⚠️ 요청에 따라 이번 PR은 단순 디자인 수정으로 판단해 타입체크·브라우저 확인을 생략함 — 필요 시 리뷰어가 로컬에서 페이지 전환하며 육안 확인 요망.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 시스템에 기업 관리 화면을 추가했습니다.
  * 기업명·코드, 규모, 상태로 기업을 검색하고 필터링할 수 있습니다.
  * 기업 목록의 페이지네이션과 상세 정보 확인을 지원합니다.
  * 기업 상태를 정지하거나 다시 활성화할 수 있습니다.
  * 로딩 및 목록 조회 실패 화면을 제공합니다.

* **개선 사항**
  * 기업 목록 표의 가독성과 반응형 표시를 개선했습니다.
  * 시스템 사이드바에서 기업 관리 메뉴를 사용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
