### PR TITLE
[FEAT] 구독·매출 관리 화면 #61

### DIFF
--- a/src/app/(system)/system/billing/error.tsx
+++ b/src/app/(system)/system/billing/error.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { ScreenError } from "@/components/common/screen-error";
+
+export default function Error({ reset }: { reset: () => void }) {
+  return <ScreenError title="구독·매출 정보를 불러오지 못했어요" reset={reset} />;
+}

--- a/src/app/(system)/system/billing/layout.tsx
+++ b/src/app/(system)/system/billing/layout.tsx
@@ -1,0 +1,13 @@
+import { CreditCard } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { PageHeader } from "@/features/shell/components/page-header";
+
+export default function SystemBillingLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <PageHeader title="구독·매출 관리" icon={CreditCard} />
+      {children}
+    </>
+  );
+}

--- a/src/app/(system)/system/billing/loading.tsx
+++ b/src/app/(system)/system/billing/loading.tsx
@@ -1,0 +1,17 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <main className="min-h-0 flex-1 overflow-y-auto p-8">
+      <div className="mx-auto flex max-w-[1440px] flex-col gap-4">
+        <div className="grid grid-cols-4 gap-4">
+          {Array.from({ length: 4 }, (_, index) => (
+            <Skeleton key={index} className="h-[104px] rounded-xl" />
+          ))}
+        </div>
+        <Skeleton className="h-[360px] rounded-xl" />
+        <Skeleton className="h-[313px] rounded-xl" />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(system)/system/billing/page.tsx
+++ b/src/app/(system)/system/billing/page.tsx
@@ -1,0 +1,58 @@
+import { ArrowRight } from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { MrrChartCard } from "@/features/system/components/mrr-chart-card";
+import { StatCard } from "@/features/system/components/stat-card";
+import { SubscriptionTable } from "@/features/system/components/subscription-table";
+import { formatCompactKrw } from "@/features/system/format";
+import { getBillingOverview } from "@/features/system/server";
+
+export const metadata: Metadata = {
+  title: "구독·매출 관리",
+};
+
+export default async function SystemBillingPage() {
+  const { summary, monthlyMrr, subscriptions } = await getBillingOverview();
+
+  return (
+    <main className="min-h-0 flex-1 overflow-y-auto p-8">
+      <div className="mx-auto flex max-w-[1440px] flex-col gap-6">
+        <div className="grid grid-cols-4 gap-4">
+          <StatCard
+            label="이번 달 MRR"
+            value={formatCompactKrw(summary.mrr)}
+            meta={`전월 대비 +${summary.mrrDeltaPercent}%`}
+            isHighlighted
+          />
+          <StatCard
+            label="결제 완료"
+            value={`${summary.paidCount}건`}
+            meta={formatCompactKrw(summary.paidAmount)}
+          />
+          <StatCard
+            label="미납"
+            value={`${summary.unpaidCount}건`}
+            meta="안내 발송 필요"
+            isHighlighted
+          />
+          <StatCard label="해지" value={`${summary.canceledCountThisMonth}건`} meta="이번 달" />
+        </div>
+
+        <MrrChartCard data={monthlyMrr} />
+
+        <div className="flex flex-col gap-3">
+          <SubscriptionTable subscriptions={subscriptions} />
+
+          <Link
+            href="/system/companies"
+            className="text-muted-foreground hover:text-foreground focus-visible:ring-ring inline-flex items-center gap-1 self-end rounded text-sm transition-colors focus-visible:ring-2 focus-visible:outline-none"
+          >
+            전체 기업 목록 보기
+            <ArrowRight className="size-3.5" aria-hidden />
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/features/system/components/mrr-chart-card.tsx
+++ b/src/features/system/components/mrr-chart-card.tsx
@@ -1,0 +1,14 @@
+import type { MonthlyMrr } from "../types";
+import { MrrChartLoader } from "./mrr-chart-loader";
+
+/** "월별 MRR 추이" 카드. 차트만 클라이언트고 카드 틀은 서버에서 그린다(`signup-chart-card.tsx`와 같은 구성). */
+export function MrrChartCard({ data }: { data: MonthlyMrr[] }) {
+  return (
+    <section className="border-border bg-card rounded-xl border p-6">
+      <h2 className="text-foreground text-base font-semibold">월별 MRR 추이</h2>
+      <div className="mt-4">
+        <MrrChartLoader data={data} />
+      </div>
+    </section>
+  );
+}

--- a/src/features/system/components/mrr-chart-loader.tsx
+++ b/src/features/system/components/mrr-chart-loader.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+import { Skeleton } from "@/components/ui/skeleton";
+
+import type { MonthlyMrr } from "../types";
+
+/**
+ * `recharts`는 무겁다 — 첫 로드 번들에서 뺀다(CLAUDE.md §최적화).
+ * `ssr: false`는 클라이언트 컴포넌트 안에서만 쓸 수 있어 이 로더가 따로 있다(`signup-chart-loader.tsx`와 같은 이유).
+ */
+const MrrChart = dynamic(() => import("./mrr-chart").then((m) => m.MrrChart), {
+  ssr: false,
+  loading: () => <Skeleton className="h-[280px] w-full" />,
+});
+
+export function MrrChartLoader({ data }: { data: MonthlyMrr[] }) {
+  return <MrrChart data={data} />;
+}

--- a/src/features/system/components/mrr-chart.tsx
+++ b/src/features/system/components/mrr-chart.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+
+import { formatCompactKrw } from "../format";
+import type { MonthlyMrr } from "../types";
+
+interface MrrChartProps {
+  data: MonthlyMrr[];
+}
+
+/** 월별 MRR 추이 막대그래프. 단일 계열이라 범례는 두지 않는다(`signup-chart.tsx`와 같은 구성). */
+export function MrrChart({ data }: MrrChartProps) {
+  return (
+    <ResponsiveContainer width="100%" height={280}>
+      <BarChart data={data} margin={{ top: 8, right: 8, left: -16, bottom: 0 }}>
+        <CartesianGrid vertical={false} stroke="var(--border)" />
+        <XAxis
+          dataKey="month"
+          tickLine={false}
+          axisLine={false}
+          tick={{ fill: "var(--muted-foreground)", fontSize: 12 }}
+        />
+        <YAxis
+          tickLine={false}
+          axisLine={false}
+          tick={{ fill: "var(--muted-foreground)", fontSize: 12 }}
+          tickFormatter={(value: number) => formatCompactKrw(value)}
+        />
+        <Tooltip
+          cursor={{ fill: "var(--muted)" }}
+          contentStyle={{
+            background: "var(--popover)",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius-md)",
+            color: "var(--popover-foreground)",
+            fontSize: 12,
+          }}
+          formatter={(value) => [formatCompactKrw(Number(value)), "MRR"]}
+        />
+        <Bar dataKey="amount" fill="var(--chart-1)" radius={[4, 4, 0, 0]} maxBarSize={32} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/features/system/components/subscription-table.tsx
+++ b/src/features/system/components/subscription-table.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { PAYMENT_STATUS, PAYMENT_STATUS_LABEL, PLAN } from "@/constants/domain";
+import { cn } from "@/lib/utils";
+
+import { formatWon } from "../format";
+import type { SubscriptionRecord } from "../types";
+
+interface SubscriptionTableProps {
+  subscriptions: SubscriptionRecord[];
+}
+
+/** 행 하나의 높이 — 고정 클래스로 못박아 내용에 따라 늘어나지 않게 한다(`company-table.tsx`와 같은 이유). */
+const ROW_HEIGHT_CLASS = "h-13"; // 52px
+const HEADER_HEIGHT_CLASS = "h-[41px]";
+
+const STATUS_BADGE_VARIANT: Record<SubscriptionRecord["paymentStatus"], "default" | "secondary"> = {
+  PAID: "default",
+  UNPAID: "secondary",
+  CANCELED: "secondary",
+};
+
+/**
+ * 컬럼 폭 — **%로 고정**한다(합 100). `table-fixed` + `colgroup`과 짝을 이뤄야 실제로 적용된다 —
+ * 기업 관리·기업 승인 표에서 겪은 "페이지 전환 시 열 밀림"과 같은 문제를 처음부터 막는다.
+ */
+const COLUMN_WIDTH = {
+  company: "26%",
+  plan: "12%",
+  members: "10%",
+  amount: "16%",
+  billingDate: "14%",
+  status: "10%",
+  action: "12%",
+} as const;
+
+/**
+ * 구독·매출 목록 — 항상 5건(미납 우선 + 최신 가입순)만 보여준다(서버에서 이미 잘라 넘겨준다).
+ *
+ * ⚠️ "안내 발송" 버튼은 **미납 상태에서만** 뜬다 — 완료·해지 건에는 보낼 안내가 없다.
+ * ⚠️ 지금은 버튼만 있고 실제 발송(확인 모달 · Server Action · 완료 토스트)은 다음 단계에서 붙는다.
+ *    안 되는 걸 되는 척하지 않는다(CLAUDE.md §정직성) — 눌러도 준비 중 안내만 뜬다.
+ */
+export function SubscriptionTable({ subscriptions }: SubscriptionTableProps) {
+  if (subscriptions.length === 0) {
+    return (
+      <div className="border-border bg-card flex items-center justify-center rounded-xl border p-10 text-center">
+        <p className="text-muted-foreground text-sm">구독 중인 기업이 없어요</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-border bg-card overflow-hidden rounded-xl border">
+      <Table className="table-fixed">
+        {/* 각 컬럼 폭을 %로 고정 — 기업명 길이가 달라져도 다른 컬럼이 밀리지 않는다(위 COLUMN_WIDTH 참고) */}
+        <colgroup>
+          <col style={{ width: COLUMN_WIDTH.company }} />
+          <col style={{ width: COLUMN_WIDTH.plan }} />
+          <col style={{ width: COLUMN_WIDTH.members }} />
+          <col style={{ width: COLUMN_WIDTH.amount }} />
+          <col style={{ width: COLUMN_WIDTH.billingDate }} />
+          <col style={{ width: COLUMN_WIDTH.status }} />
+          <col style={{ width: COLUMN_WIDTH.action }} />
+        </colgroup>
+        <TableHeader>
+          <TableRow className={cn(HEADER_HEIGHT_CLASS, "hover:bg-transparent")}>
+            <TableHead className="pl-6">기업명</TableHead>
+            <TableHead>플랜</TableHead>
+            <TableHead>인원</TableHead>
+            <TableHead>금액</TableHead>
+            <TableHead>결제일</TableHead>
+            <TableHead>상태</TableHead>
+            <TableHead className="pr-6">액션</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {subscriptions.map((subscription) => (
+            <TableRow key={subscription.companyId} className={ROW_HEIGHT_CLASS}>
+              <TableCell className="max-w-0 truncate pl-6" title={subscription.companyName}>
+                {subscription.companyName}
+              </TableCell>
+              <TableCell>
+                <Badge variant={subscription.plan === PLAN.TEAM ? "default" : "secondary"}>
+                  {subscription.plan === PLAN.TEAM ? "Team" : "Free"}
+                </Badge>
+              </TableCell>
+              <TableCell className="text-muted-foreground tabular-nums">
+                {subscription.memberCount}명
+              </TableCell>
+              <TableCell className="text-muted-foreground tabular-nums">
+                {formatWon(subscription.amount)}
+              </TableCell>
+              <TableCell className="text-muted-foreground tabular-nums">
+                {subscription.billingDate ?? "–"}
+              </TableCell>
+              <TableCell>
+                <Badge variant={STATUS_BADGE_VARIANT[subscription.paymentStatus]}>
+                  {PAYMENT_STATUS_LABEL[subscription.paymentStatus]}
+                </Badge>
+              </TableCell>
+              <TableCell className="pr-6">
+                {subscription.paymentStatus === PAYMENT_STATUS.UNPAID && (
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => toast("안내 발송 기능은 아직 준비 중이에요")}
+                  >
+                    안내 발송
+                  </Button>
+                )}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/features/system/format.ts
+++ b/src/features/system/format.ts
@@ -11,3 +11,8 @@ export function formatCompactKrw(amount: number): string {
   if (amount >= 1_000) return scale(amount, 1_000, "K");
   return `₩${amount.toLocaleString("ko-KR")}`;
 }
+
+/** 금액 표기 — `₩118,800`. 자릿점은 로케일에 맡기지 않는다(서버·클라이언트가 갈릴 수 있다). */
+export function formatWon(amount: number): string {
+  return `₩${amount.toLocaleString("ko-KR")}`;
+}

--- a/src/features/system/mock/billing.ts
+++ b/src/features/system/mock/billing.ts
@@ -1,0 +1,63 @@
+import { COMPANY_STATUS, PAYMENT_STATUS, PLAN } from "@/constants/domain";
+
+import type { BillingOverview, ManagedCompany, SubscriptionRecord } from "../types";
+import { listMockCompanies } from "./companies";
+
+/** Team 플랜 1인당 월 단가 — `features/billing/plans.ts`의 시안값과 맞춘다(₩9,900). */
+const TEAM_UNIT_PRICE = 9_900;
+
+/** 화면에 보여줄 구독 목록 수 — 화면 명세: 미납 우선, 모자라면 최신 가입순으로 채운다. */
+const SUBSCRIPTION_DISPLAY_COUNT = 5;
+
+/** ⚠️ 목 데이터 — BE 연동 전. SYSTEM 구독·매출 진입 시 보여줄 예시 값이다. */
+export const MOCK_BILLING_OVERVIEW: BillingOverview = {
+  summary: {
+    mrr: 8_400_000,
+    mrrDeltaPercent: 11.8,
+    paidCount: 37,
+    paidAmount: 8_400_000,
+    unpaidCount: 1,
+    canceledCountThisMonth: 2,
+  },
+  monthlyMrr: [
+    { month: "2월", amount: 4_200_000 },
+    { month: "3월", amount: 5_100_000 },
+    { month: "4월", amount: 6_300_000 },
+    { month: "5월", amount: 7_000_000 },
+    { month: "6월", amount: 7_600_000 },
+    { month: "7월", amount: 8_400_000 },
+  ],
+  subscriptions: buildMockSubscriptions(),
+};
+
+/**
+ * 구독 목록 = 기업 관리 목 데이터에서 파생한다 — 두 화면이 같은 기업을 다르게 보여줄 뿐이라
+ * 별도 배열을 또 손으로 채우면 언젠가 서로 어긋난다(CLAUDE.md §도메인 상수: 값 목록은 한 곳에서).
+ * ⚠️ 화면 명세: **항상 5건만** — 미납 기업을 먼저 채우고, 모자라면 `joinedAt` 최신순으로 채운다.
+ */
+function buildMockSubscriptions(): SubscriptionRecord[] {
+  const toRecord = (company: ManagedCompany): SubscriptionRecord => ({
+    companyId: company.id,
+    companyName: company.name,
+    plan: company.plan,
+    memberCount: company.memberCount,
+    amount: company.plan === PLAN.TEAM ? company.memberCount * TEAM_UNIT_PRICE : 0,
+    billingDate: company.plan === PLAN.TEAM ? "2025-07-01" : null,
+    paymentStatus:
+      company.status === COMPANY_STATUS.SUSPENDED
+        ? PAYMENT_STATUS.CANCELED
+        : company.status === COMPANY_STATUS.UNPAID
+          ? PAYMENT_STATUS.UNPAID
+          : PAYMENT_STATUS.PAID,
+    ownerEmail: company.ownerEmail,
+    joinedAt: company.joinedAt,
+  });
+
+  const companies = listMockCompanies();
+  const unpaid = companies.filter((company) => company.status === COMPANY_STATUS.UNPAID);
+  const rest = companies
+    .filter((company) => company.status !== COMPANY_STATUS.UNPAID)
+    .sort((a, b) => b.joinedAt.localeCompare(a.joinedAt));
+
+  return [...unpaid, ...rest].slice(0, SUBSCRIPTION_DISPLAY_COUNT).map(toRecord);
+}

--- a/src/features/system/nav.ts
+++ b/src/features/system/nav.ts
@@ -3,7 +3,7 @@ import type { NavSection } from "@/features/shell/nav";
 /**
  * SYSTEM(서비스 운영자) 사이드바 구성.
  *
- * ⚠️ 대시보드·기업 승인·기업 관리만 실제 화면이다 — 나머지는 `isReady` 없이 둬서
+ * ⚠️ 대시보드·기업 승인·기업 관리·구독 매출만 실제 화면이다 — 나머지는 `isReady` 없이 둬서
  *    눌러도 "준비 중" 안내만 뜨게 한다(CLAUDE.md §정직성).
  */
 export const SYSTEM_NAV: NavSection[] = [
@@ -13,7 +13,7 @@ export const SYSTEM_NAV: NavSection[] = [
       { href: "/system", label: "대시보드", icon: "dashboard", isReady: true },
       { href: "/system/approval", label: "기업 승인", icon: "approval", isReady: true },
       { href: "/system/companies", label: "기업 관리", icon: "company", isReady: true },
-      { href: "/system/billing", label: "구독·매출", icon: "billing" },
+      { href: "/system/billing", label: "구독·매출", icon: "billing", isReady: true },
       { href: "/system/monitoring", label: "시스템 모니터링", icon: "monitor" },
       { href: "/system/notice", label: "공지", icon: "notice" },
     ],

--- a/src/features/system/server.ts
+++ b/src/features/system/server.ts
@@ -5,9 +5,15 @@ import { paginate, type PaginatedResult } from "@/lib/paginate";
 import { isMock } from "@/mocks/config";
 
 import { findMockPendingApproval, listMockPendingApprovals } from "./mock/approvals";
+import { MOCK_BILLING_OVERVIEW } from "./mock/billing";
 import { findMockCompany, listMockCompanies, setMockCompanyStatus } from "./mock/companies";
 import { MOCK_DASHBOARD_OVERVIEW } from "./mock/dashboard";
-import type { DashboardOverview, ManagedCompany, PendingCompanyApproval } from "./types";
+import type {
+  BillingOverview,
+  DashboardOverview,
+  ManagedCompany,
+  PendingCompanyApproval,
+} from "./types";
 
 /**
  * SYSTEM 대시보드 조회 — **격리막**(CLAUDE.md).
@@ -97,4 +103,15 @@ export async function setCompanyStatus(
   if (isMock) return setMockCompanyStatus(id, status);
 
   throw new Error("기업 상태 변경 API가 아직 연결되지 않았습니다.");
+}
+
+/**
+ * SYSTEM 구독·매출 조회 — **격리막**(CLAUDE.md).
+ * ⚠️ 이 화면은 프로젝트 기간 내내 목으로 남을 가능성이 크다(팀 합의) — 그래도 격리막은 유지한다.
+ */
+export async function getBillingOverview(): Promise<BillingOverview> {
+  if (isMock) return MOCK_BILLING_OVERVIEW;
+
+  // ⚠️ 미구현 — API 스펙 확정 후 `ep.systemDashboard()`류 경로로 fetch하고 매퍼로 UI 계약에 맞춘다.
+  throw new Error("구독·매출 조회 API가 아직 연결되지 않았습니다.");
 }

--- a/src/features/system/types.ts
+++ b/src/features/system/types.ts
@@ -1,4 +1,4 @@
-import type { CompanySize, CompanyStatus, Plan } from "@/constants/domain";
+import type { CompanySize, CompanyStatus, PaymentStatus, Plan } from "@/constants/domain";
 
 /** 대시보드 상단 통계 4종. */
 export interface DashboardSummary {
@@ -72,4 +72,51 @@ export interface ManagedCompany {
   /** "YYYY-MM-DD" */
   joinedAt: string;
   ownerEmail: string;
+}
+
+/** 구독·매출 상단 통계 4종. */
+export interface BillingSummary {
+  /** 이번 달 월 반복 매출(원) */
+  mrr: number;
+  /** 전월 대비 증감률(%) */
+  mrrDeltaPercent: number;
+  /** 결제 완료 건수 */
+  paidCount: number;
+  /** 결제 완료 건 합계(원) — 통계 카드의 보조 문구용 */
+  paidAmount: number;
+  unpaidCount: number;
+  /** 이번 달 해지 건수 */
+  canceledCountThisMonth: number;
+}
+
+/** 월별 MRR 추이 — 막대그래프 한 칸. */
+export interface MonthlyMrr {
+  /** 화면에 그대로 나가는 월 라벨("2월" 등) */
+  month: string;
+  amount: number;
+}
+
+/** 구독·매출 목록 한 행. */
+export interface SubscriptionRecord {
+  companyId: string;
+  companyName: string;
+  plan: Plan;
+  memberCount: number;
+  /** 이번 결제 금액(원) — Free 플랜은 0 */
+  amount: number;
+  /** "YYYY-MM-DD" | null — Free 플랜은 결제일이 없다 */
+  billingDate: string | null;
+  paymentStatus: PaymentStatus;
+  /** 미납 기업에 안내 메일을 보낼 대상 — 승인 시 발급된 오너 이메일과 같다 */
+  ownerEmail: string;
+  /** 정렬 기준(최신 가입순 보충 표시용) — 화면에는 안 나간다 */
+  joinedAt: string;
+}
+
+/** 구독·매출 화면 하나가 필요로 하는 데이터 전부 — 격리막의 UI 계약. */
+export interface BillingOverview {
+  summary: BillingSummary;
+  monthlyMrr: MonthlyMrr[];
+  /** 항상 5건 — 미납 우선, 모자라면 최신 가입순으로 채운다(화면 명세) */
+  subscriptions: SubscriptionRecord[];
 }


### PR DESCRIPTION
## 📋 PR 타입
- [x] feat — 새로운 기능 추가

## 🗂 작업 영역
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독

## 🙋 관련 역할
- [x] SYSTEM (서비스 운영자 — 확장, 데모 제외)

## 📝 작업 내용
- `/system/billing` 구독·매출 관리 화면 구현 — 통계 4종, 월별 MRR 막대그래프, 구독 목록 표
- recharts는 `next/dynamic(ssr:false)`로 분리(대시보드 화면과 동일한 3단 분리: chart/loader/card)
- 구독 목록은 항상 5건 — 미납 우선 + 최신 가입순 채움, `mock/companies.ts`에서 파생시켜 데이터 소스 단일화
- 표 컬럼 폭을 `colgroup` + `table-fixed`로 `%` 고정 — 기업 관리·기업 승인 화면에서 겪은 "페이지 전환 시 열 밀림"을 처음부터 방지
- "안내 발송" 버튼은 미납 행에만 노출되지만 지금은 클릭 시 준비 중 토스트만 — 실제 발송 로직은 다음 PR

## ✅ 작업 체크리스트
**기본**
- [x] 브랜치 명명 규칙 준수, base `develop`
- [x] 커밋 컨벤션 준수
- [x] `Closes #` 기입
- [x] 불필요한 console·주석 코드 없음
- [x] 민감 정보 없음

**Z 필수**
- [ ] 권한 2축 검사 — 로그인 전이라 화면만 있음(추후 서버 재검사 필요)
- [x] zod — 해당 없음(ERD 미확정, 목 데이터 직접 타입 관리)
- [x] 정직성 — 목 데이터 주석으로 명시, "안내 발송" 버튼은 준비 중 안내로 미구현임을 알림
- [x] 디자인 토큰 — 하드코딩 없음

**품질**
- [x] 최적화 — recharts `next/dynamic(ssr:false)` 분리
- [x] a11y — 링크는 `Link`, 버튼은 `Button` 재사용, 표는 `Table` 재사용
- [x] 재사용 확인 — `StatCard`, `formatCompactKrw`, `Pagination` 불필요(5건 고정이라 페이지네이션 없음), 차트 분리 패턴 그대로 재사용
- [x] loading/error/empty 3상태
- [ ] 브라우저 전용 API — 해당 없음

## 🔗 연관 이슈
Closes #61 

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트
- 구독 목록 "미납 우선 + 최신순 채움" 로직이 5건을 정확히 채우는지(`buildMockSubscriptions` 함수)
- 표 컬럼 폭 비율이 실제 데이터(기업명·금액 등) 길이에 적당한지
- "안내 발송" 버튼이 미납 행에만 정확히 노출되는지

## 📝 추가 메모
⚠️ "안내 발송" 버튼은 이번 PR에서는 준비 중 토스트만 뜬다 — 확인 모달(예/아니오)과 실제 발송
Server Action은 다음 단계 PR에서 이어붙일 예정이다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 구독·매출 관리 화면이 추가되어 MRR, 결제 완료, 미납, 해지 현황을 한눈에 확인할 수 있습니다.
  * 월별 MRR 차트와 구독 목록에서 기업명, 플랜, 금액, 결제 상태를 확인할 수 있습니다.
  * 미납 항목에는 안내 발송 버튼이 제공됩니다.
  * 화면 로딩 상태와 데이터 조회 오류 안내를 지원합니다.
  * 시스템 사이드바에서 구독·매출 관리 화면으로 바로 이동할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
