### PR TITLE
[FEAT] 미납 기업 안내 발송 모달 #63

### DIFF
--- a/src/app/(system)/system/billing/error.tsx
+++ b/src/app/(system)/system/billing/error.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { ScreenError } from "@/components/common/screen-error";
+
+export default function Error({ reset }: { reset: () => void }) {
+  return <ScreenError title="구독·매출 정보를 불러오지 못했어요" reset={reset} />;
+}

--- a/src/app/(system)/system/billing/layout.tsx
+++ b/src/app/(system)/system/billing/layout.tsx
@@ -1,0 +1,13 @@
+import { CreditCard } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { PageHeader } from "@/features/shell/components/page-header";
+
+export default function SystemBillingLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <PageHeader title="구독·매출 관리" icon={CreditCard} />
+      {children}
+    </>
+  );
+}

--- a/src/app/(system)/system/billing/loading.tsx
+++ b/src/app/(system)/system/billing/loading.tsx
@@ -1,0 +1,17 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <main className="min-h-0 flex-1 overflow-y-auto p-8">
+      <div className="mx-auto flex max-w-[1440px] flex-col gap-4">
+        <div className="grid grid-cols-4 gap-4">
+          {Array.from({ length: 4 }, (_, index) => (
+            <Skeleton key={index} className="h-[104px] rounded-xl" />
+          ))}
+        </div>
+        <Skeleton className="h-[360px] rounded-xl" />
+        <Skeleton className="h-[313px] rounded-xl" />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(system)/system/billing/page.tsx
+++ b/src/app/(system)/system/billing/page.tsx
@@ -1,0 +1,58 @@
+import { ArrowRight } from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { MrrChartCard } from "@/features/system/components/mrr-chart-card";
+import { StatCard } from "@/features/system/components/stat-card";
+import { SubscriptionTable } from "@/features/system/components/subscription-table";
+import { formatCompactKrw } from "@/features/system/format";
+import { getBillingOverview } from "@/features/system/server";
+
+export const metadata: Metadata = {
+  title: "구독·매출 관리",
+};
+
+export default async function SystemBillingPage() {
+  const { summary, monthlyMrr, subscriptions } = await getBillingOverview();
+
+  return (
+    <main className="min-h-0 flex-1 overflow-y-auto p-8">
+      <div className="mx-auto flex max-w-[1440px] flex-col gap-6">
+        <div className="grid grid-cols-4 gap-4">
+          <StatCard
+            label="이번 달 MRR"
+            value={formatCompactKrw(summary.mrr)}
+            meta={`전월 대비 +${summary.mrrDeltaPercent}%`}
+            isHighlighted
+          />
+          <StatCard
+            label="결제 완료"
+            value={`${summary.paidCount}건`}
+            meta={formatCompactKrw(summary.paidAmount)}
+          />
+          <StatCard
+            label="미납"
+            value={`${summary.unpaidCount}건`}
+            meta="안내 발송 필요"
+            isHighlighted
+          />
+          <StatCard label="해지" value={`${summary.canceledCountThisMonth}건`} meta="이번 달" />
+        </div>
+
+        <MrrChartCard data={monthlyMrr} />
+
+        <div className="flex flex-col gap-3">
+          <SubscriptionTable subscriptions={subscriptions} />
+
+          <Link
+            href="/system/companies"
+            className="text-muted-foreground hover:text-foreground focus-visible:ring-ring inline-flex items-center gap-1 self-end rounded text-sm transition-colors focus-visible:ring-2 focus-visible:outline-none"
+          >
+            전체 기업 목록 보기
+            <ArrowRight className="size-3.5" aria-hidden />
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/features/system/actions.ts
+++ b/src/features/system/actions.ts
@@ -7,7 +7,7 @@ import { COMPANY_STATUS } from "@/constants/domain";
 import { isMock } from "@/mocks/config";
 
 import { removeMockPendingApproval } from "./mock/approvals";
-import { setMockCompanyStatus } from "./mock/companies";
+import { findMockCompany, setMockCompanyStatus } from "./mock/companies";
 
 /**
  * 기업 승인 화면의 **변경 창구** — 격리막(CLAUDE.md §Mock 격리막).
@@ -72,4 +72,26 @@ export async function unsuspendCompanyAction(formData: FormData): Promise<void> 
   }
 
   revalidatePath(path);
+}
+
+/**
+ * "구독·매출" 미납 안내 발송 — 격리막(CLAUDE.md §Mock 격리막).
+ *
+ * ⚠️ **폼이 아니라 직접 호출한다.** 확인 Dialog에서 "예"를 누른 뒤 그 자리에서 toast로
+ *    결과를 보여줘야 해서(CLAUDE.md §토스트: 변경 결과 피드백) `redirect`도 `revalidatePath`도
+ *    필요 없다 — 화면·데이터 어느 것도 안 바뀌고 그냥 메일 한 통을 보내는 조작이다.
+ * ⚠️ 지금은 목이라 **실제로 메일이 나가지 않는다** — 성공만 흉내 낸다(§정직성).
+ */
+export async function sendUnpaidNoticeAction(
+  companyId: string,
+): Promise<{ success: boolean; ownerEmail?: string }> {
+  if (!isMock) {
+    // ⚠️ 미구현 — API 스펙 확정 후 BFF 경로로 메일 발송 요청을 보낸다.
+    throw new Error("안내 발송 API가 아직 연결되지 않았습니다.");
+  }
+
+  const company = findMockCompany(companyId);
+  if (!company) return { success: false };
+
+  return { success: true, ownerEmail: company.ownerEmail };
 }

--- a/src/features/system/components/mrr-chart-card.tsx
+++ b/src/features/system/components/mrr-chart-card.tsx
@@ -1,0 +1,14 @@
+import type { MonthlyMrr } from "../types";
+import { MrrChartLoader } from "./mrr-chart-loader";
+
+/** "월별 MRR 추이" 카드. 차트만 클라이언트고 카드 틀은 서버에서 그린다(`signup-chart-card.tsx`와 같은 구성). */
+export function MrrChartCard({ data }: { data: MonthlyMrr[] }) {
+  return (
+    <section className="border-border bg-card rounded-xl border p-6">
+      <h2 className="text-foreground text-base font-semibold">월별 MRR 추이</h2>
+      <div className="mt-4">
+        <MrrChartLoader data={data} />
+      </div>
+    </section>
+  );
+}

--- a/src/features/system/components/mrr-chart-loader.tsx
+++ b/src/features/system/components/mrr-chart-loader.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+import { Skeleton } from "@/components/ui/skeleton";
+
+import type { MonthlyMrr } from "../types";
+
+/**
+ * `recharts`는 무겁다 — 첫 로드 번들에서 뺀다(CLAUDE.md §최적화).
+ * `ssr: false`는 클라이언트 컴포넌트 안에서만 쓸 수 있어 이 로더가 따로 있다(`signup-chart-loader.tsx`와 같은 이유).
+ */
+const MrrChart = dynamic(() => import("./mrr-chart").then((m) => m.MrrChart), {
+  ssr: false,
+  loading: () => <Skeleton className="h-[280px] w-full" />,
+});
+
+export function MrrChartLoader({ data }: { data: MonthlyMrr[] }) {
+  return <MrrChart data={data} />;
+}

--- a/src/features/system/components/mrr-chart.tsx
+++ b/src/features/system/components/mrr-chart.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+
+import { formatCompactKrw } from "../format";
+import type { MonthlyMrr } from "../types";
+
+interface MrrChartProps {
+  data: MonthlyMrr[];
+}
+
+/** 월별 MRR 추이 막대그래프. 단일 계열이라 범례는 두지 않는다(`signup-chart.tsx`와 같은 구성). */
+export function MrrChart({ data }: MrrChartProps) {
+  return (
+    <ResponsiveContainer width="100%" height={280}>
+      <BarChart data={data} margin={{ top: 8, right: 8, left: -16, bottom: 0 }}>
+        <CartesianGrid vertical={false} stroke="var(--border)" />
+        <XAxis
+          dataKey="month"
+          tickLine={false}
+          axisLine={false}
+          tick={{ fill: "var(--muted-foreground)", fontSize: 12 }}
+        />
+        <YAxis
+          tickLine={false}
+          axisLine={false}
+          tick={{ fill: "var(--muted-foreground)", fontSize: 12 }}
+          tickFormatter={(value: number) => formatCompactKrw(value)}
+        />
+        <Tooltip
+          cursor={{ fill: "var(--muted)" }}
+          contentStyle={{
+            background: "var(--popover)",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius-md)",
+            color: "var(--popover-foreground)",
+            fontSize: 12,
+          }}
+          formatter={(value) => [formatCompactKrw(Number(value)), "MRR"]}
+        />
+        <Bar dataKey="amount" fill="var(--chart-1)" radius={[4, 4, 0, 0]} maxBarSize={32} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/features/system/components/notice-mail-dialog.tsx
+++ b/src/features/system/components/notice-mail-dialog.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useTransition } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+import { sendUnpaidNoticeAction } from "../actions";
+
+interface NoticeMailDialogProps {
+  /** 발송 대상. `null`이면 닫힌 상태다(`department-delete-dialog.tsx`와 같은 패턴). */
+  target: { companyId: string; companyName: string; ownerEmail: string } | null;
+  onClose: () => void;
+}
+
+/**
+ * 미납 기업 담당자에게 안내 메일을 보낼지 묻는 확인창.
+ *
+ * ⚠️ **파괴적 조작은 토스트가 아니라 Dialog로 확인받는다**(CLAUDE.md §토스트: 확인은 Dialog).
+ *    메일 발송 자체는 되돌릴 수 없는 일이라 예/아니오로 한 번 더 확인한다.
+ * ⚠️ 목이라 **실제로 메일이 나가지 않는다** — 성공 흉내만 낸다. 조용히 되는 척하지 않도록
+ *    발송 완료 토스트 문구에도 이 사실을 남긴다(§정직성).
+ */
+export function NoticeMailDialog({ target, onClose }: NoticeMailDialogProps) {
+  const [isPending, startTransition] = useTransition();
+
+  const handleConfirm = () => {
+    if (!target) return;
+
+    startTransition(async () => {
+      const result = await sendUnpaidNoticeAction(target.companyId);
+
+      if (result.success) {
+        toast(`${target.companyName} 담당자에게 안내 메일을 발송했어요`);
+      } else {
+        toast(`${target.companyName} 정보를 찾을 수 없어 발송하지 못했어요`);
+      }
+
+      onClose();
+    });
+  };
+
+  return (
+    <Dialog open={target !== null} onOpenChange={onClose}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>안내 메일을 보낼까요?</DialogTitle>
+          <DialogDescription>
+            {target?.companyName} 담당자({target?.ownerEmail})에게 안내 이메일을 발송하시겠습니까?
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={onClose} disabled={isPending}>
+            아니오
+          </Button>
+          <Button type="button" onClick={handleConfirm} disabled={isPending}>
+            {isPending ? "발송 중…" : "예"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/system/components/subscription-table.tsx
+++ b/src/features/system/components/subscription-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { toast } from "sonner";
+import { useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -17,6 +17,7 @@ import { cn } from "@/lib/utils";
 
 import { formatWon } from "../format";
 import type { SubscriptionRecord } from "../types";
+import { NoticeMailDialog } from "./notice-mail-dialog";
 
 interface SubscriptionTableProps {
   subscriptions: SubscriptionRecord[];
@@ -50,10 +51,16 @@ const COLUMN_WIDTH = {
  * 구독·매출 목록 — 항상 5건(미납 우선 + 최신 가입순)만 보여준다(서버에서 이미 잘라 넘겨준다).
  *
  * ⚠️ "안내 발송" 버튼은 **미납 상태에서만** 뜬다 — 완료·해지 건에는 보낼 안내가 없다.
- * ⚠️ 지금은 버튼만 있고 실제 발송(확인 모달 · Server Action · 완료 토스트)은 다음 단계에서 붙는다.
- *    안 되는 걸 되는 척하지 않는다(CLAUDE.md §정직성) — 눌러도 준비 중 안내만 뜬다.
+ * ⚠️ 버튼을 누르면 바로 보내지 않고 **확인 Dialog**를 먼저 띄운다 — 메일 발송은 되돌릴 수
+ *    없는 조작이라 토스트만으로 확인받지 않는다(CLAUDE.md §토스트: 파괴적 작업은 Dialog).
  */
 export function SubscriptionTable({ subscriptions }: SubscriptionTableProps) {
+  const [noticeTarget, setNoticeTarget] = useState<{
+    companyId: string;
+    companyName: string;
+    ownerEmail: string;
+  } | null>(null);
+
   if (subscriptions.length === 0) {
     return (
       <div className="border-border bg-card flex items-center justify-center rounded-xl border p-10 text-center">
@@ -117,7 +124,13 @@ export function SubscriptionTable({ subscriptions }: SubscriptionTableProps) {
                     type="button"
                     variant="secondary"
                     size="sm"
-                    onClick={() => toast("안내 발송 기능은 아직 준비 중이에요")}
+                    onClick={() =>
+                      setNoticeTarget({
+                        companyId: subscription.companyId,
+                        companyName: subscription.companyName,
+                        ownerEmail: subscription.ownerEmail,
+                      })
+                    }
                   >
                     안내 발송
                   </Button>
@@ -127,6 +140,8 @@ export function SubscriptionTable({ subscriptions }: SubscriptionTableProps) {
           ))}
         </TableBody>
       </Table>
+
+      <NoticeMailDialog target={noticeTarget} onClose={() => setNoticeTarget(null)} />
     </div>
   );
 }

--- a/src/features/system/components/subscription-table.tsx
+++ b/src/features/system/components/subscription-table.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { PAYMENT_STATUS, PAYMENT_STATUS_LABEL, PLAN } from "@/constants/domain";
+import { cn } from "@/lib/utils";
+
+import { formatWon } from "../format";
+import type { SubscriptionRecord } from "../types";
+
+interface SubscriptionTableProps {
+  subscriptions: SubscriptionRecord[];
+}
+
+/** 행 하나의 높이 — 고정 클래스로 못박아 내용에 따라 늘어나지 않게 한다(`company-table.tsx`와 같은 이유). */
+const ROW_HEIGHT_CLASS = "h-13"; // 52px
+const HEADER_HEIGHT_CLASS = "h-[41px]";
+
+const STATUS_BADGE_VARIANT: Record<SubscriptionRecord["paymentStatus"], "default" | "secondary"> = {
+  PAID: "default",
+  UNPAID: "secondary",
+  CANCELED: "secondary",
+};
+
+/**
+ * 컬럼 폭 — **%로 고정**한다(합 100). `table-fixed` + `colgroup`과 짝을 이뤄야 실제로 적용된다 —
+ * 기업 관리·기업 승인 표에서 겪은 "페이지 전환 시 열 밀림"과 같은 문제를 처음부터 막는다.
+ */
+const COLUMN_WIDTH = {
+  company: "26%",
+  plan: "12%",
+  members: "10%",
+  amount: "16%",
+  billingDate: "14%",
+  status: "10%",
+  action: "12%",
+} as const;
+
+/**
+ * 구독·매출 목록 — 항상 5건(미납 우선 + 최신 가입순)만 보여준다(서버에서 이미 잘라 넘겨준다).
+ *
+ * ⚠️ "안내 발송" 버튼은 **미납 상태에서만** 뜬다 — 완료·해지 건에는 보낼 안내가 없다.
+ * ⚠️ 지금은 버튼만 있고 실제 발송(확인 모달 · Server Action · 완료 토스트)은 다음 단계에서 붙는다.
+ *    안 되는 걸 되는 척하지 않는다(CLAUDE.md §정직성) — 눌러도 준비 중 안내만 뜬다.
+ */
+export function SubscriptionTable({ subscriptions }: SubscriptionTableProps) {
+  if (subscriptions.length === 0) {
+    return (
+      <div className="border-border bg-card flex items-center justify-center rounded-xl border p-10 text-center">
+        <p className="text-muted-foreground text-sm">구독 중인 기업이 없어요</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-border bg-card overflow-hidden rounded-xl border">
+      <Table className="table-fixed">
+        {/* 각 컬럼 폭을 %로 고정 — 기업명 길이가 달라져도 다른 컬럼이 밀리지 않는다(위 COLUMN_WIDTH 참고) */}
+        <colgroup>
+          <col style={{ width: COLUMN_WIDTH.company }} />
+          <col style={{ width: COLUMN_WIDTH.plan }} />
+          <col style={{ width: COLUMN_WIDTH.members }} />
+          <col style={{ width: COLUMN_WIDTH.amount }} />
+          <col style={{ width: COLUMN_WIDTH.billingDate }} />
+          <col style={{ width: COLUMN_WIDTH.status }} />
+          <col style={{ width: COLUMN_WIDTH.action }} />
+        </colgroup>
+        <TableHeader>
+          <TableRow className={cn(HEADER_HEIGHT_CLASS, "hover:bg-transparent")}>
+            <TableHead className="pl-6">기업명</TableHead>
+            <TableHead>플랜</TableHead>
+            <TableHead>인원</TableHead>
+            <TableHead>금액</TableHead>
+            <TableHead>결제일</TableHead>
+            <TableHead>상태</TableHead>
+            <TableHead className="pr-6">액션</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {subscriptions.map((subscription) => (
+            <TableRow key={subscription.companyId} className={ROW_HEIGHT_CLASS}>
+              <TableCell className="max-w-0 truncate pl-6" title={subscription.companyName}>
+                {subscription.companyName}
+              </TableCell>
+              <TableCell>
+                <Badge variant={subscription.plan === PLAN.TEAM ? "default" : "secondary"}>
+                  {subscription.plan === PLAN.TEAM ? "Team" : "Free"}
+                </Badge>
+              </TableCell>
+              <TableCell className="text-muted-foreground tabular-nums">
+                {subscription.memberCount}명
+              </TableCell>
+              <TableCell className="text-muted-foreground tabular-nums">
+                {formatWon(subscription.amount)}
+              </TableCell>
+              <TableCell className="text-muted-foreground tabular-nums">
+                {subscription.billingDate ?? "–"}
+              </TableCell>
+              <TableCell>
+                <Badge variant={STATUS_BADGE_VARIANT[subscription.paymentStatus]}>
+                  {PAYMENT_STATUS_LABEL[subscription.paymentStatus]}
+                </Badge>
+              </TableCell>
+              <TableCell className="pr-6">
+                {subscription.paymentStatus === PAYMENT_STATUS.UNPAID && (
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => toast("안내 발송 기능은 아직 준비 중이에요")}
+                  >
+                    안내 발송
+                  </Button>
+                )}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/features/system/format.ts
+++ b/src/features/system/format.ts
@@ -11,3 +11,8 @@ export function formatCompactKrw(amount: number): string {
   if (amount >= 1_000) return scale(amount, 1_000, "K");
   return `₩${amount.toLocaleString("ko-KR")}`;
 }
+
+/** 금액 표기 — `₩118,800`. 자릿점은 로케일에 맡기지 않는다(서버·클라이언트가 갈릴 수 있다). */
+export function formatWon(amount: number): string {
+  return `₩${amount.toLocaleString("ko-KR")}`;
+}

--- a/src/features/system/mock/billing.ts
+++ b/src/features/system/mock/billing.ts
@@ -1,0 +1,63 @@
+import { COMPANY_STATUS, PAYMENT_STATUS, PLAN } from "@/constants/domain";
+
+import type { BillingOverview, ManagedCompany, SubscriptionRecord } from "../types";
+import { listMockCompanies } from "./companies";
+
+/** Team 플랜 1인당 월 단가 — `features/billing/plans.ts`의 시안값과 맞춘다(₩9,900). */
+const TEAM_UNIT_PRICE = 9_900;
+
+/** 화면에 보여줄 구독 목록 수 — 화면 명세: 미납 우선, 모자라면 최신 가입순으로 채운다. */
+const SUBSCRIPTION_DISPLAY_COUNT = 5;
+
+/** ⚠️ 목 데이터 — BE 연동 전. SYSTEM 구독·매출 진입 시 보여줄 예시 값이다. */
+export const MOCK_BILLING_OVERVIEW: BillingOverview = {
+  summary: {
+    mrr: 8_400_000,
+    mrrDeltaPercent: 11.8,
+    paidCount: 37,
+    paidAmount: 8_400_000,
+    unpaidCount: 1,
+    canceledCountThisMonth: 2,
+  },
+  monthlyMrr: [
+    { month: "2월", amount: 4_200_000 },
+    { month: "3월", amount: 5_100_000 },
+    { month: "4월", amount: 6_300_000 },
+    { month: "5월", amount: 7_000_000 },
+    { month: "6월", amount: 7_600_000 },
+    { month: "7월", amount: 8_400_000 },
+  ],
+  subscriptions: buildMockSubscriptions(),
+};
+
+/**
+ * 구독 목록 = 기업 관리 목 데이터에서 파생한다 — 두 화면이 같은 기업을 다르게 보여줄 뿐이라
+ * 별도 배열을 또 손으로 채우면 언젠가 서로 어긋난다(CLAUDE.md §도메인 상수: 값 목록은 한 곳에서).
+ * ⚠️ 화면 명세: **항상 5건만** — 미납 기업을 먼저 채우고, 모자라면 `joinedAt` 최신순으로 채운다.
+ */
+function buildMockSubscriptions(): SubscriptionRecord[] {
+  const toRecord = (company: ManagedCompany): SubscriptionRecord => ({
+    companyId: company.id,
+    companyName: company.name,
+    plan: company.plan,
+    memberCount: company.memberCount,
+    amount: company.plan === PLAN.TEAM ? company.memberCount * TEAM_UNIT_PRICE : 0,
+    billingDate: company.plan === PLAN.TEAM ? "2025-07-01" : null,
+    paymentStatus:
+      company.status === COMPANY_STATUS.SUSPENDED
+        ? PAYMENT_STATUS.CANCELED
+        : company.status === COMPANY_STATUS.UNPAID
+          ? PAYMENT_STATUS.UNPAID
+          : PAYMENT_STATUS.PAID,
+    ownerEmail: company.ownerEmail,
+    joinedAt: company.joinedAt,
+  });
+
+  const companies = listMockCompanies();
+  const unpaid = companies.filter((company) => company.status === COMPANY_STATUS.UNPAID);
+  const rest = companies
+    .filter((company) => company.status !== COMPANY_STATUS.UNPAID)
+    .sort((a, b) => b.joinedAt.localeCompare(a.joinedAt));
+
+  return [...unpaid, ...rest].slice(0, SUBSCRIPTION_DISPLAY_COUNT).map(toRecord);
+}

--- a/src/features/system/nav.ts
+++ b/src/features/system/nav.ts
@@ -3,7 +3,7 @@ import type { NavSection } from "@/features/shell/nav";
 /**
  * SYSTEM(서비스 운영자) 사이드바 구성.
  *
- * ⚠️ 대시보드·기업 승인·기업 관리만 실제 화면이다 — 나머지는 `isReady` 없이 둬서
+ * ⚠️ 대시보드·기업 승인·기업 관리·구독 매출만 실제 화면이다 — 나머지는 `isReady` 없이 둬서
  *    눌러도 "준비 중" 안내만 뜨게 한다(CLAUDE.md §정직성).
  */
 export const SYSTEM_NAV: NavSection[] = [
@@ -13,7 +13,7 @@ export const SYSTEM_NAV: NavSection[] = [
       { href: "/system", label: "대시보드", icon: "dashboard", isReady: true },
       { href: "/system/approval", label: "기업 승인", icon: "approval", isReady: true },
       { href: "/system/companies", label: "기업 관리", icon: "company", isReady: true },
-      { href: "/system/billing", label: "구독·매출", icon: "billing" },
+      { href: "/system/billing", label: "구독·매출", icon: "billing", isReady: true },
       { href: "/system/monitoring", label: "시스템 모니터링", icon: "monitor" },
       { href: "/system/notice", label: "공지", icon: "notice" },
     ],

--- a/src/features/system/server.ts
+++ b/src/features/system/server.ts
@@ -5,9 +5,15 @@ import { paginate, type PaginatedResult } from "@/lib/paginate";
 import { isMock } from "@/mocks/config";
 
 import { findMockPendingApproval, listMockPendingApprovals } from "./mock/approvals";
+import { MOCK_BILLING_OVERVIEW } from "./mock/billing";
 import { findMockCompany, listMockCompanies, setMockCompanyStatus } from "./mock/companies";
 import { MOCK_DASHBOARD_OVERVIEW } from "./mock/dashboard";
-import type { DashboardOverview, ManagedCompany, PendingCompanyApproval } from "./types";
+import type {
+  BillingOverview,
+  DashboardOverview,
+  ManagedCompany,
+  PendingCompanyApproval,
+} from "./types";
 
 /**
  * SYSTEM 대시보드 조회 — **격리막**(CLAUDE.md).
@@ -97,4 +103,15 @@ export async function setCompanyStatus(
   if (isMock) return setMockCompanyStatus(id, status);
 
   throw new Error("기업 상태 변경 API가 아직 연결되지 않았습니다.");
+}
+
+/**
+ * SYSTEM 구독·매출 조회 — **격리막**(CLAUDE.md).
+ * ⚠️ 이 화면은 프로젝트 기간 내내 목으로 남을 가능성이 크다(팀 합의) — 그래도 격리막은 유지한다.
+ */
+export async function getBillingOverview(): Promise<BillingOverview> {
+  if (isMock) return MOCK_BILLING_OVERVIEW;
+
+  // ⚠️ 미구현 — API 스펙 확정 후 `ep.systemDashboard()`류 경로로 fetch하고 매퍼로 UI 계약에 맞춘다.
+  throw new Error("구독·매출 조회 API가 아직 연결되지 않았습니다.");
 }

--- a/src/features/system/types.ts
+++ b/src/features/system/types.ts
@@ -1,4 +1,4 @@
-import type { CompanySize, CompanyStatus, Plan } from "@/constants/domain";
+import type { CompanySize, CompanyStatus, PaymentStatus, Plan } from "@/constants/domain";
 
 /** 대시보드 상단 통계 4종. */
 export interface DashboardSummary {
@@ -72,4 +72,51 @@ export interface ManagedCompany {
   /** "YYYY-MM-DD" */
   joinedAt: string;
   ownerEmail: string;
+}
+
+/** 구독·매출 상단 통계 4종. */
+export interface BillingSummary {
+  /** 이번 달 월 반복 매출(원) */
+  mrr: number;
+  /** 전월 대비 증감률(%) */
+  mrrDeltaPercent: number;
+  /** 결제 완료 건수 */
+  paidCount: number;
+  /** 결제 완료 건 합계(원) — 통계 카드의 보조 문구용 */
+  paidAmount: number;
+  unpaidCount: number;
+  /** 이번 달 해지 건수 */
+  canceledCountThisMonth: number;
+}
+
+/** 월별 MRR 추이 — 막대그래프 한 칸. */
+export interface MonthlyMrr {
+  /** 화면에 그대로 나가는 월 라벨("2월" 등) */
+  month: string;
+  amount: number;
+}
+
+/** 구독·매출 목록 한 행. */
+export interface SubscriptionRecord {
+  companyId: string;
+  companyName: string;
+  plan: Plan;
+  memberCount: number;
+  /** 이번 결제 금액(원) — Free 플랜은 0 */
+  amount: number;
+  /** "YYYY-MM-DD" | null — Free 플랜은 결제일이 없다 */
+  billingDate: string | null;
+  paymentStatus: PaymentStatus;
+  /** 미납 기업에 안내 메일을 보낼 대상 — 승인 시 발급된 오너 이메일과 같다 */
+  ownerEmail: string;
+  /** 정렬 기준(최신 가입순 보충 표시용) — 화면에는 안 나간다 */
+  joinedAt: string;
+}
+
+/** 구독·매출 화면 하나가 필요로 하는 데이터 전부 — 격리막의 UI 계약. */
+export interface BillingOverview {
+  summary: BillingSummary;
+  monthlyMrr: MonthlyMrr[];
+  /** 항상 5건 — 미납 우선, 모자라면 최신 가입순으로 채운다(화면 명세) */
+  subscriptions: SubscriptionRecord[];
 }


### PR DESCRIPTION
## 📋 PR 타입
- [x] feat — 새로운 기능 추가

## 🗂 작업 영역
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독

## 🙋 관련 역할
- [x] SYSTEM (서비스 운영자 — 확장, 데모 제외)

## 📝 작업 내용
- `NoticeMailDialog` 컴포넌트 추가 — 미납 기업 안내 발송 확인 모달(예/아니오), `useTransition`으로 대기 상태 표시
- `sendUnpaidNoticeAction` Server Action 추가 — `redirect`/`revalidatePath` 없이 결과만 반환하는
  방식(화면·데이터 변경 없는 순수 발송 조작이라 기존 승인/정지 액션과 흐름이 다름)
- `SubscriptionTable`의 "안내 발송" 버튼이 이전 단계의 "준비 중" 토스트 대신 실제로 모달을 열도록 연결
- 완료 시 공용 `sonner` toast로 결과 안내(성공/기업 정보 없음 두 갈래)

## ✅ 작업 체크리스트
**기본**
- [x] 브랜치 명명 규칙 준수, base `develop`
- [x] 커밋 컨벤션 준수
- [x] `Closes #` 기입
- [x] 불필요한 console·주석 코드 없음
- [x] 민감 정보 없음

**Z 필수**
- [ ] 권한 2축 검사 — 로그인 전이라 화면만 있음(추후 서버 재검사 필요)
- [x] zod — 해당 없음(ERD 미확정, 목 데이터 직접 타입 관리)
- [x] 정직성 — 실제 메일 미발송·성공 흉내임을 주석에 명시
- [x] 디자인 토큰 — 하드코딩 없음, 기존 `Dialog`/`Button` 토큰 그대로 사용

**품질**
- [ ] 최적화 — 해당 없음(무거운 라이브러리 없음)
- [x] a11y — `Dialog` 컴포넌트 재사용(포커스 트랩·`role="dialog"` 내장), 버튼 처리 중 비활성화
- [x] 재사용 확인 — `department-delete-dialog.tsx`와 동일한 "controlled by nullable target" 패턴 재사용
- [ ] loading/error/empty — 해당 없음(모달 자체는 기존 화면의 부분 기능)
- [ ] 브라우저 전용 API — 해당 없음

## 🔗 연관 이슈
Closes #63

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트
- Server Action이 `redirect`/`revalidatePath` 없이 결과 객체만 반환하는 방식이 이 조작(메일 발송)의
  성격에 맞는 선택인지
- 모달이 열려있는 동안 다른 행의 "안내 발송"을 눌러도 안전한지(상태가 `noticeTarget` 하나로만 관리됨)

## 📝 추가 메모
⚠️ 지금은 목이라 실제로 메일이 발송되지 않는다 — API 연동 시 `sendUnpaidNoticeAction`만 고치면
컴포넌트는 안 건드린다(격리막).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 구독·매출 관리 화면을 추가했습니다.
  * MRR, 결제 완료, 미납, 해지 현황과 월별 MRR 차트를 제공합니다.
  * 구독 목록에서 플랜, 결제 상태, 금액, 결제일을 확인할 수 있습니다.
  * 미납 기업에 안내 메일을 발송할 수 있습니다.
  * 로딩 상태와 오류 복구 화면을 제공합니다.
  * 시스템 사이드바에서 구독·매출 관리 메뉴를 이용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
