### PR TITLE
[TEST] system 도메인 테스트 코드 작성 #76

### DIFF
--- a/src/features/system/actions.test.ts
+++ b/src/features/system/actions.test.ts
@@ -1,0 +1,132 @@
+// 서버 액션은 next 런타임 함수를 부른다 — jsdom엔 없으니 목으로 대체하고 호출만 검증한다.
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("next/navigation", () => ({ redirect: jest.fn() }));
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { COMPANY_STATUS, NOTICE_TARGET } from "@/constants/domain";
+
+import {
+  approveCompanyAction,
+  publishNoticeAction,
+  rejectCompanyAction,
+  retryPipelineAction,
+  sendUnpaidNoticeAction,
+  suspendCompanyAction,
+  unsuspendCompanyAction,
+} from "./actions";
+import { findMockPendingApproval } from "./mock/approvals";
+import { findMockCompany, setMockCompanyStatus } from "./mock/companies";
+
+const redirectMock = redirect as unknown as jest.Mock;
+const revalidatePathMock = revalidatePath as unknown as jest.Mock;
+
+const form = (entries: Record<string, string>) => {
+  const data = new FormData();
+  for (const [key, value] of Object.entries(entries)) data.append(key, value);
+  return data;
+};
+
+beforeEach(() => {
+  redirectMock.mockClear();
+  revalidatePathMock.mockClear();
+});
+
+describe("기업 승인·반려", () => {
+  // ⚠️ 목 배열을 실제로 지운다 — 테스트마다 다른 id를 써서 서로 간섭하지 않게 한다.
+  it("승인하면 대기 목록에서 빠지고 목록 화면으로 보낸다", async () => {
+    expect(findMockPendingApproval("2")).not.toBeNull();
+
+    await approveCompanyAction(form({ companyId: "2" }));
+
+    expect(findMockPendingApproval("2")).toBeNull();
+    expect(redirectMock).toHaveBeenCalledWith("/system/approval");
+  });
+
+  it("반려도 대기 목록에서 지운다", async () => {
+    expect(findMockPendingApproval("3")).not.toBeNull();
+
+    await rejectCompanyAction(form({ companyId: "3", redirectTo: "/system/approval?done=1" }));
+
+    expect(findMockPendingApproval("3")).toBeNull();
+    expect(redirectMock).toHaveBeenCalledWith("/system/approval?done=1");
+  });
+});
+
+describe("기업 정지·정지 해제", () => {
+  // 상세 화면에 머무는 흐름 — redirect 없이 revalidatePath로 새로고침한다.
+  afterEach(() => setMockCompanyStatus("2", COMPANY_STATUS.ACTIVE));
+
+  it("정지하면 상태가 SUSPENDED로 바뀌고 해당 경로를 재검증한다", async () => {
+    await suspendCompanyAction(form({ companyId: "2", path: "/system/companies/2" }));
+
+    expect(findMockCompany("2")?.status).toBe(COMPANY_STATUS.SUSPENDED);
+    expect(revalidatePathMock).toHaveBeenCalledWith("/system/companies/2");
+    expect(redirectMock).not.toHaveBeenCalled();
+  });
+
+  it("정지 해제하면 상태가 ACTIVE로 돌아온다", async () => {
+    setMockCompanyStatus("2", COMPANY_STATUS.SUSPENDED);
+
+    await unsuspendCompanyAction(form({ companyId: "2" }));
+
+    expect(findMockCompany("2")?.status).toBe(COMPANY_STATUS.ACTIVE);
+    expect(revalidatePathMock).toHaveBeenCalledWith("/system/companies");
+  });
+});
+
+describe("미납 안내 발송", () => {
+  it("있는 기업이면 오너 이메일과 함께 성공한다", async () => {
+    const result = await sendUnpaidNoticeAction("1");
+
+    expect(result).toEqual({ success: true, ownerEmail: findMockCompany("1")?.ownerEmail });
+  });
+
+  it("없는 기업이면 실패로 돌려준다", async () => {
+    expect(await sendUnpaidNoticeAction("존재하지-않음")).toEqual({ success: false });
+  });
+});
+
+describe("파이프라인 재처리", () => {
+  it("실패 목록에 있는 회의는 재처리 성공", async () => {
+    expect(await retryPipelineAction("MTG-2025-0721-03")).toEqual({ success: true });
+  });
+
+  it("실패 목록에 없는 회의는 성공하지 않는다", async () => {
+    expect(await retryPipelineAction("MTG-없음")).toEqual({ success: false });
+  });
+});
+
+describe("공지 발행", () => {
+  // ⚠️ 화면 가드는 UX일 뿐 — 서버에서도 빈 값을 한 번 더 막는다(CLAUDE.md §권한).
+  it("제목·내용이 차 있으면 발행 성공", async () => {
+    const result = await publishNoticeAction({
+      title: "점검 안내",
+      content: "내용",
+      target: NOTICE_TARGET.ALL,
+    });
+
+    expect(result).toEqual({ success: true });
+  });
+
+  it("제목이 공백뿐이면 막는다", async () => {
+    const result = await publishNoticeAction({
+      title: "   ",
+      content: "내용",
+      target: NOTICE_TARGET.ALL,
+    });
+
+    expect(result).toEqual({ success: false });
+  });
+
+  it("내용이 비면 막는다", async () => {
+    const result = await publishNoticeAction({
+      title: "제목",
+      content: "",
+      target: NOTICE_TARGET.TEAM,
+    });
+
+    expect(result).toEqual({ success: false });
+  });
+});

--- a/src/features/system/components/notice-compose-card.test.tsx
+++ b/src/features/system/components/notice-compose-card.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { NOTICE_TARGET } from "@/constants/domain";
+
+import { NoticeComposeCard } from "./notice-compose-card";
+
+// 서버 액션은 격리막 너머다 — 여기선 카드의 발행 흐름만 본다(액션 자체는 actions.test.ts에서).
+const publishNoticeAction = jest.fn();
+jest.mock("../actions", () => ({
+  publishNoticeAction: (input: unknown) => publishNoticeAction(input),
+}));
+
+function setup() {
+  return { user: userEvent.setup(), ...render(<NoticeComposeCard />) };
+}
+
+beforeEach(() => publishNoticeAction.mockReset());
+
+describe("NoticeComposeCard", () => {
+  const publishButton = () => screen.getByRole("button", { name: "발행" });
+
+  // ⚠️ 제목·내용이 다 차기 전엔 발행 버튼이 눌리지 않는다(클라이언트 가드).
+  it("제목·내용이 비면 발행 버튼이 잠겨 있다", () => {
+    setup();
+
+    expect(publishButton()).toBeDisabled();
+  });
+
+  it("제목만 적어도 아직 잠겨 있다", async () => {
+    const { user } = setup();
+
+    await user.type(screen.getByLabelText("제목"), "점검 안내");
+
+    expect(publishButton()).toBeDisabled();
+  });
+
+  it("제목·내용이 차면 발행할 수 있고, 발행하면 성공 안내가 뜬다", async () => {
+    publishNoticeAction.mockResolvedValue({ success: true });
+    const { user } = setup();
+
+    await user.type(screen.getByLabelText("제목"), "점검 안내");
+    await user.type(screen.getByLabelText("내용"), "오늘 밤 점검이 있어요");
+
+    const button = publishButton();
+    expect(button).toBeEnabled();
+
+    await user.click(button);
+
+    expect(publishNoticeAction).toHaveBeenCalledWith({
+      title: "점검 안내",
+      content: "오늘 밤 점검이 있어요",
+      target: NOTICE_TARGET.ALL,
+    });
+    expect(await screen.findByText("공지를 발행했어요")).toBeInTheDocument();
+  });
+
+  // 발행이 실패하면 성공 안내를 띄우지 않는다 — 조용히 성공한 척하지 않는다(§정직성).
+  it("발행이 실패하면 성공 안내를 띄우지 않는다", async () => {
+    publishNoticeAction.mockResolvedValue({ success: false });
+    const { user } = setup();
+
+    await user.type(screen.getByLabelText("제목"), "점검 안내");
+    await user.type(screen.getByLabelText("내용"), "내용");
+    await user.click(publishButton());
+
+    await waitFor(() => expect(publishNoticeAction).toHaveBeenCalled());
+    expect(screen.queryByText("공지를 발행했어요")).not.toBeInTheDocument();
+  });
+});

--- a/src/features/system/mock/billing.test.ts
+++ b/src/features/system/mock/billing.test.ts
@@ -1,0 +1,48 @@
+import { COMPANY_STATUS, PAYMENT_STATUS, PLAN } from "@/constants/domain";
+
+import { MOCK_BILLING_OVERVIEW } from "./billing";
+import { listMockCompanies } from "./companies";
+
+const { subscriptions, summary } = MOCK_BILLING_OVERVIEW;
+const unpaidCompanyCount = listMockCompanies().filter(
+  (company) => company.status === COMPANY_STATUS.UNPAID,
+).length;
+
+describe("구독 목록은 기업 관리 데이터에서 파생한다", () => {
+  // ⚠️ 화면 명세: 항상 5건만 보여준다.
+  it("항상 5건이다", () => {
+    expect(subscriptions).toHaveLength(5);
+  });
+
+  // ⚠️ 요약 카드("미납 N건")와 목록(미납 우선 채움)이 같은 소스를 세야 어긋나지 않는다.
+  it("요약의 미납 건수는 기업 목록의 미납 수와 같다", () => {
+    expect(summary.unpaidCount).toBe(unpaidCompanyCount);
+  });
+
+  // ⚠️ 미납을 먼저 채우고 모자라면 최신 가입순으로 보충한다.
+  it("미납 기업이 목록 맨 앞에 온다", () => {
+    const leading = subscriptions.slice(0, Math.min(unpaidCompanyCount, 5));
+
+    expect(leading.every((record) => record.paymentStatus === PAYMENT_STATUS.UNPAID)).toBe(true);
+  });
+
+  it("미납으로 다 못 채우면 나머지는 최신 가입순으로 붙는다", () => {
+    const rest = subscriptions.slice(unpaidCompanyCount);
+
+    for (let i = 1; i < rest.length; i++) {
+      expect(rest[i - 1]!.joinedAt.localeCompare(rest[i]!.joinedAt)).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("Team 플랜은 인원×단가로 금액이 잡히고 Free는 0원·결제일 없음", () => {
+    for (const record of subscriptions) {
+      if (record.plan === PLAN.FREE) {
+        expect(record.amount).toBe(0);
+        expect(record.billingDate).toBeNull();
+      } else {
+        expect(record.amount).toBe(record.memberCount * 9_900);
+        expect(record.billingDate).not.toBeNull();
+      }
+    }
+  });
+});

--- a/src/features/system/server.test.ts
+++ b/src/features/system/server.test.ts
@@ -1,0 +1,134 @@
+// server.ts는 "server-only"를 import한다 — jest(기본 조건)에선 그 모듈이 던지므로 비운다.
+jest.mock("server-only", () => ({}));
+
+import { COMPANY_SIZE, COMPANY_STATUS } from "@/constants/domain";
+
+import { MOCK_BILLING_OVERVIEW } from "./mock/billing";
+import { listMockCompanies } from "./mock/companies";
+import { MOCK_DASHBOARD_OVERVIEW } from "./mock/dashboard";
+import { MOCK_MONITORING_OVERVIEW } from "./mock/monitoring";
+import { MOCK_NOTICE_HISTORY } from "./mock/notices";
+import {
+  getBillingOverview,
+  getDashboardOverview,
+  getManagedCompanies,
+  getManagedCompanyById,
+  getMonitoringOverview,
+  getNoticeHistory,
+  getPendingApprovalById,
+  getPendingApprovals,
+} from "./server";
+
+const TOTAL_COMPANIES = listMockCompanies().length;
+
+describe("기업 관리 목록 — 검색·필터·페이지네이션", () => {
+  it("조건이 없으면 전체를 페이지 단위로 자른다", async () => {
+    const result = await getManagedCompanies({}, 1, 10);
+
+    expect(result.totalCount).toBe(TOTAL_COMPANIES);
+    expect(result.items).toHaveLength(10);
+    expect(result.page).toBe(1);
+    expect(result.totalPages).toBe(Math.ceil(TOTAL_COMPANIES / 10));
+  });
+
+  // ⚠️ 범위를 벗어난 페이지는 빈 화면 대신 마지막 페이지로 당긴다(lib/paginate 규칙).
+  it("범위를 벗어난 페이지는 마지막 페이지로 당긴다", async () => {
+    const result = await getManagedCompanies({}, 999, 10);
+
+    const lastPage = Math.ceil(TOTAL_COMPANIES / 10);
+    expect(result.page).toBe(lastPage);
+    expect(result.items.length).toBeGreaterThan(0);
+  });
+
+  it("기업명 부분 일치로 걸러낸다", async () => {
+    const result = await getManagedCompanies({ keyword: "테크스타트" }, 1, 20);
+
+    expect(result.totalCount).toBeGreaterThan(0);
+    for (const company of result.items) {
+      const hit =
+        company.name.includes("테크스타트") || company.code.toLowerCase().includes("테크스타트");
+      expect(hit).toBe(true);
+    }
+  });
+
+  // ⚠️ 검색은 대소문자를 무시한다 — 코드(GREENLOGICS-25)를 소문자로 쳐도 잡혀야 한다.
+  it("코드 검색은 대소문자를 가리지 않는다", async () => {
+    const result = await getManagedCompanies({ keyword: "greenlogics" }, 1, 20);
+
+    expect(result.items.some((company) => company.name === "그린로직스")).toBe(true);
+  });
+
+  it("공백만 있는 검색어는 필터로 치지 않는다", async () => {
+    const result = await getManagedCompanies({ keyword: "   " }, 1, 10);
+
+    expect(result.totalCount).toBe(TOTAL_COMPANIES);
+  });
+
+  it("상태 필터는 그 상태만 남긴다", async () => {
+    const result = await getManagedCompanies({ status: COMPANY_STATUS.ACTIVE }, 1, 100);
+
+    expect(result.items.length).toBeGreaterThan(0);
+    expect(result.items.every((company) => company.status === COMPANY_STATUS.ACTIVE)).toBe(true);
+  });
+
+  it("규모·상태를 함께 걸면 둘 다 만족하는 것만 남는다", async () => {
+    const result = await getManagedCompanies(
+      { size: COMPANY_SIZE.MEDIUM, status: COMPANY_STATUS.ACTIVE },
+      1,
+      100,
+    );
+
+    expect(
+      result.items.every(
+        (company) =>
+          company.size === COMPANY_SIZE.MEDIUM && company.status === COMPANY_STATUS.ACTIVE,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("기업 상세 조회", () => {
+  it("있는 id는 그 기업을 돌려준다", async () => {
+    const company = await getManagedCompanyById("1");
+
+    expect(company?.name).toBe("(주)테크스타트");
+  });
+
+  it("없는 id는 null이다", async () => {
+    expect(await getManagedCompanyById("존재하지-않음")).toBeNull();
+  });
+});
+
+describe("기업 승인 대기 목록", () => {
+  it("페이지 단위로 자른다", async () => {
+    const result = await getPendingApprovals(1, 5);
+
+    expect(result.items).toHaveLength(5);
+    expect(result.page).toBe(1);
+    expect(result.totalCount).toBeGreaterThan(5);
+  });
+
+  it("있는 id는 그 신청서를, 없는 id는 null을 돌려준다", async () => {
+    expect((await getPendingApprovalById("1"))?.companyName).toBe("(주)넥스트웨이브");
+    expect(await getPendingApprovalById("존재하지-않음")).toBeNull();
+  });
+});
+
+// 격리막 통과 — 목 모드에선 UI 계약 객체를 그대로 넘긴다(server.ts는 분기만 한다).
+describe("목 모드 조회는 목 데이터를 그대로 넘긴다", () => {
+  it("대시보드", async () => {
+    expect(await getDashboardOverview()).toBe(MOCK_DASHBOARD_OVERVIEW);
+  });
+
+  it("구독·매출", async () => {
+    expect(await getBillingOverview()).toBe(MOCK_BILLING_OVERVIEW);
+  });
+
+  it("시스템 모니터링", async () => {
+    expect(await getMonitoringOverview()).toBe(MOCK_MONITORING_OVERVIEW);
+  });
+
+  it("공지 발행 이력", async () => {
+    expect(await getNoticeHistory()).toBe(MOCK_NOTICE_HISTORY);
+  });
+});


### PR DESCRIPTION
## 📋 PR 타입

> 해당하는 타입을 선택해 주세요 (복수 선택 가능)

- [ ] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [x] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [x] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- `features/system`에 테스트 40개(5 suites) 추가 — onboarding 스타일(순수 로직 + 핵심 컴포넌트 RTL)
- `server.test.ts`: 키워드 부분일치·대소문자 무시, 규모+상태 복합 필터, 범위 밖 페이지 당김, 격리막 목 통과
- `actions.test.ts`: 승인·반려 목록 제거+redirect, 정지/해제 상태변경+revalidatePath, 공지 **서버측 빈값 가드**
- `mock/billing.test.ts`: 구독 파생(항상 5건·미납 우선·요약 미납수=목록 소스 일치·Team 금액=인원×단가)
- `notice-compose-card.test.tsx`: 채우기 전 발행 잠금, 성공 안내, 실패 시 성공한 척 안 함(정직성)

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 테스트 대상 액션이 서버측 검증(공지 빈값 가드)을 갖는지 확인
- [ ] 🧬 **zod** — 해당 없음(테스트만 추가, 스키마 변경 없음)
- [x] 🕵️ **정직성** — 목/미구현 분기는 격리막 목 경로로만 검증, 발송 실패 시 성공 안내 안 뜸을 테스트로 고정
- [ ] 🎨 디자인 토큰 사용 — 해당 없음

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [x] ♿ a11y — 컴포넌트 테스트가 `getByRole`·`getByLabelText`로 접근성 트리에 의존
- [x] ♻️ 재사용 확인 — 기존 `format.test.ts`·onboarding 테스트 패턴 재사용
- [ ] 🧪 `loading` / `error` / `empty` 3상태 — 해당 없음(로직·상호작용 테스트)
- [ ] 브라우저 전용 API(STT · 녹음) 사용 — 해당 없음

---

## 🔗 연관 이슈

Closes #76

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

- 목 전역 상태 간섭 차단: 액션 테스트는 서로 다른 id + `afterEach` 복원 → 전체 219 tests 동시 실행에서 누수 없음
- `server-only`/`next/cache`/`next/navigation` 목 대체 방식이 적절한지
- 62개·미납 건수를 하드코딩 대신 `listMockCompanies()`에서 계산 → 목 변경에 안 깨지는지

---

## 📝 추가 메모

- `npx jest src/features/system` → **5 passed / 40 tests**
- `npx jest` (전체) → **19 suites / 219 tests** 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 기업 승인·반려, 정지·해제, 미납 안내, 파이프라인 재처리 및 공지 발행의 성공·실패와 입력 검증을 추가로 확인합니다.
  * 공지 작성 화면의 입력 조건, 발행 성공·실패 안내 및 전달 값을 검증합니다.
  * 결제 목록의 미납 우선 정렬, 가입일순 정렬, 플랜별 금액과 결제일 규칙을 검증합니다.
  * 기업 검색·필터·페이지네이션, 상세 조회와 대시보드 관련 데이터 조회 동작을 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
