### PR TITLE
[DOCS] CLAUDE.md 라우트 그룹 트리 상세화 #78

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,20 +25,35 @@
 
 ## 라우트 그룹
 
-```
 app/
-├─ (public)/     /  /login  /register  /pricing  /invite/[token]
-├─ (onboarding)/ /onboarding/*                     ← OWNER 초기설정
-├─ (role)/       /owner  /manage  /team  /my       ← 역할 전용 대시보드·관리
-├─ (app)/        /app/*                            ← 공용 워크벤치(권한 차등, ADMIN 제외)
-└─ (system)/     /system/*                         ← 목업(더미), 향후 개선
-```
+├─ (public)/     /  /login  /register  /pricing  /invite/[token]
+│                                                  ← 로그인 전. 기업 코드는 여기서만.
+├─ (onboarding)/ /onboarding/*                     ← OWNER 초기설정 (부서·직급/권한·사원초대)
+│
+├─ (role)/       ← 같은 셸(사이드바 220px), 네비 항목만 역할/권한별로 다름
+│   ├─ /owner        OWNER 전용 : 대시보드 · /owner/setting(기업설정)
+│   │                            · /owner/leader-handovers(팀장급 오프보딩 인수인계, :no_entry:OWNER 전용)
+│   ├─ /manage       OWNER ‖ is_admin : /manage/members(+/:id) · /manage/new(계정발급)
+│   │                            · /manage/rooms · /manage/billing · /manage/storage
+│   ├─ /team         LEADER 전용(본인 부서 스코프) : 대시보드 · /team/members(+/:id)
+│   │                            · /team/action · /team/handover(+/:id)
+│   └─ /my           MEMBER 대시보드
+│
+├─ (app)/        /app/*   ← 공용 워크벤치(로그인 전원, 컴포넌트 레벨 권한 차등)
+│                 projects(+/new·/:tag·/:tag/team/:teamId) · actions/:id · my/actions
+│                 · meeting(+/:id·/:id/capture·/:id/review) · rooms · board · calendar
+│                 · notice(+/:id·/new·/:id/edit) · people · me · search · handover
+│
+└─ (system)/     /system/*                          ← 목업(더미), 향후 개선
 
-- **기업 코드를 URL에 붙이지 않는다.** 기업 식별은 세션(httpOnly 쿠키의 `companyId`)이 한다 — 주소창 값은 사용자가 고칠 수 있어 어차피 서버가 세션과 대조해야 한다. 기업 코드는 **로그인 전 화면**(`/login`·`/register`·`/invite`)에만 등장.
-- `(role)` 하위 4개는 **같은 셸(사이드바 220px)** 을 쓰고 네비 항목만 역할별로 달라진다 → 레이아웃 1개 + 역할별 네비 구성.
-- `/owner`와 `/manage`는 **사원관리 권한이 사실상 동일** → 화면을 복붙하지 말고 **공용 컴포넌트 + 권한 prop**으로.
-- `/app/*`은 공용 화면에서 권한만 다르다 → 라우트를 나누지 말고 **컴포넌트 레벨 가드**.
-- ⛔ **팀 명세에 없는 화면·기능은 만들지 않는다.** 화면 안 항목 배치도 명세 순서를 따른다.
+- **기업 코드는 URL에 안 붙인다.** 기업 식별은 세션 쿠키(`companyId`). 코드는 로그인 전 화면(`/login`·`/register`·`/invite`)에만.
+- `(role)` 4개는 **같은 셸(사이드바 220px)**, 네비만 역할별 → 레이아웃 1개 + 역할별 네비.
+- :star: **ADMIN은 역할 아닌 플래그(`is_admin`).** 전용 대시보드 없이 base role 대시보드 사용, `/manage/*` 메뉴만 추가. 가드 = `role==="owner" || is_admin`. 관리 기능은 `/manage`로 단일화(중복 금지). 관리자 권한 부여 토글도 admin 조작 가능.
+- :no_entry: 단 **`/owner/leader-handovers`(팀장 오프보딩 인수인계)는 OWNER 전용**(위계상 admin 불가). 팀장 휴직은 여기 말고 `/manage/members/:id`에서 승인.
+- `/app/*`은 라우트 분리 대신 **컴포넌트 레벨 가드**. (`/app/my/actions`=OWNER 접근 불가 / `/app/projects/new`·기획 편집=OWNER만 / `/app/handover`=OWNER 제외)
+- 진입 스코프만 다르고 데이터 같으면 라우트는 나누되 **상세 컴포넌트 재사용** (`/team/action` vs `/app/projects/:tag/team/:teamId`).
+- 회의 생성 진입점 없음 → `/app/rooms` 예약 = 회의 개설.
+- :no_entry: **명세에 없는 화면·기능은 안 만든다.** 화면 내 항목 순서도 명세 따름.
 
 ## 폴더·네이밍
 


### PR DESCRIPTION
## 📋 PR 타입

> 해당하는 타입을 선택해 주세요 (복수 선택 가능)

- [ ] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [x] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- CLAUDE.md "라우트 그룹" 섹션을 코드블록에서 **트리 형태로 확장**, 그룹별 하위 경로·권한 조건을 함께 명시
- `(role)`을 `/owner`·`/manage`·`/team`·`/my`로 펼치고, **ADMIN은 역할 아닌 플래그(`is_admin`)**·가드 규칙·`/manage` 단일화 명문화
- `/owner/leader-handovers` OWNER 전용(admin 불가), 팀장 휴직 승인 경로 구분 등 권한 2축 관련 서술 보강
- 왜: 화면 목록이 확정된 상태를 문서에 반영해, 문서만 보고도 화면-권한 매핑을 대조할 수 있게 하기 위함

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`docs/md-route#{이슈번호}`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거 (해당 없음)
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 해당 없음(문서). 단 서술된 권한 규칙이 실제 가드와 일치하는지는 리뷰 포인트 참고
- [ ] 🧬 **zod** — 해당 없음
- [ ] 🕵️ **정직성** — 해당 없음
- [ ] 🎨 디자인 토큰 사용 — 해당 없음

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [ ] ♿ a11y — 해당 없음
- [ ] ♻️ 재사용 확인 — 해당 없음
- [ ] 🧪 `loading` / `error` / `empty` 3상태 — 해당 없음
- [ ] 브라우저 전용 API — 해당 없음

---

## 🔗 연관 이슈

Closes #78 

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

- 문서에 새로 명시한 권한 규칙(`is_admin` 가드, `/owner/leader-handovers` OWNER 전용, `/app/my/actions` OWNER 불가 등)이 **실제 구현·팀 합의와 일치하는지** 확인 필요
- 새 규칙 도입이 아니라 기존 확정 사항의 문서화라는 전제가 맞는지

---

## 📝 추가 메모

단일 파일(CLAUDE.md) 문서 변경. 코드·테스트 변경 없음.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서**
  - 라우트 그룹별 경로와 화면 구성을 상세히 정리했습니다.
  - OWNER, ADMIN, LEADER, MEMBER별 대시보드 및 관리 기능 접근 범위를 명확히 했습니다.
  - 관리자 플래그와 역할별 예외 권한 규칙을 문서화했습니다.
  - 앱 화면의 컴포넌트 수준 접근 제어, 회의 생성 진입점, 라우트 간 컴포넌트 재사용 기준을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
