### PR TITLE
[DOCS] deploy 문서 변경 #80

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to EC2
 on:
   push:
     branches:
-      - main
+      - develop
 
 concurrency:
   group: production-ec2-deploy

--- a/src/features/system/actions.test.ts
+++ b/src/features/system/actions.test.ts
@@ -124,9 +124,32 @@ describe("공지 발행", () => {
     const result = await publishNoticeAction({
       title: "제목",
       content: "",
-      target: NOTICE_TARGET.TEAM,
+      target: NOTICE_TARGET.UNPAID,
     });
 
     expect(result).toEqual({ success: false });
+  });
+
+  // ⚠️ "특정 기업" 대상인데 고른 곳이 없으면 발송 대상이 없다 — 서버에서도 막는다.
+  it("특정 기업 대상인데 고른 기업이 없으면 막는다", async () => {
+    const result = await publishNoticeAction({
+      title: "제목",
+      content: "내용",
+      target: NOTICE_TARGET.SPECIFIC,
+      companyIds: [],
+    });
+
+    expect(result).toEqual({ success: false });
+  });
+
+  it("특정 기업을 골랐으면 발행 성공", async () => {
+    const result = await publishNoticeAction({
+      title: "제목",
+      content: "내용",
+      target: NOTICE_TARGET.SPECIFIC,
+      companyIds: ["1", "2"],
+    });
+
+    expect(result).toEqual({ success: true });
   });
 });

--- a/src/features/system/components/notice-compose-card.test.tsx
+++ b/src/features/system/components/notice-compose-card.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 
 import { NOTICE_TARGET } from "@/constants/domain";
 
+import type { NoticeTargetCompany } from "../types";
 import { NoticeComposeCard } from "./notice-compose-card";
 
 // 서버 액션은 격리막 너머다 — 여기선 카드의 발행 흐름만 본다(액션 자체는 actions.test.ts에서).
@@ -11,8 +12,13 @@ jest.mock("../actions", () => ({
   publishNoticeAction: (input: unknown) => publishNoticeAction(input),
 }));
 
+const COMPANIES: NoticeTargetCompany[] = [
+  { id: "1", name: "(주)테크스타트", code: "TECHSTART-2025" },
+  { id: "2", name: "그린로직스", code: "GREENLOGICS-25" },
+];
+
 function setup() {
-  return { user: userEvent.setup(), ...render(<NoticeComposeCard />) };
+  return { user: userEvent.setup(), ...render(<NoticeComposeCard companies={COMPANIES} />) };
 }
 
 beforeEach(() => publishNoticeAction.mockReset());
@@ -51,6 +57,8 @@ describe("NoticeComposeCard", () => {
       title: "점검 안내",
       content: "오늘 밤 점검이 있어요",
       target: NOTICE_TARGET.ALL,
+      // 전체 기업 대상이면 companyIds는 넘기지 않는다("특정 기업"일 때만 채운다)
+      companyIds: undefined,
     });
     expect(await screen.findByText("공지를 발행했어요")).toBeInTheDocument();
   });

--- a/src/features/system/server.test.ts
+++ b/src/features/system/server.test.ts
@@ -1,7 +1,7 @@
 // server.ts는 "server-only"를 import한다 — jest(기본 조건)에선 그 모듈이 던지므로 비운다.
 jest.mock("server-only", () => ({}));
 
-import { COMPANY_SIZE, COMPANY_STATUS } from "@/constants/domain";
+import { COMPANY_STATUS } from "@/constants/domain";
 
 import { MOCK_BILLING_OVERVIEW } from "./mock/billing";
 import { listMockCompanies } from "./mock/companies";
@@ -71,17 +71,20 @@ describe("기업 관리 목록 — 검색·필터·페이지네이션", () => {
     expect(result.items.every((company) => company.status === COMPANY_STATUS.ACTIVE)).toBe(true);
   });
 
-  it("규모·상태를 함께 걸면 둘 다 만족하는 것만 남는다", async () => {
+  it("검색어·상태를 함께 걸면 둘 다 만족하는 것만 남는다", async () => {
     const result = await getManagedCompanies(
-      { size: COMPANY_SIZE.MEDIUM, status: COMPANY_STATUS.ACTIVE },
+      { keyword: "테크", status: COMPANY_STATUS.ACTIVE },
       1,
       100,
     );
 
+    expect(result.items.length).toBeGreaterThan(0);
     expect(
       result.items.every(
         (company) =>
-          company.size === COMPANY_SIZE.MEDIUM && company.status === COMPANY_STATUS.ACTIVE,
+          (company.name.toLowerCase().includes("테크") ||
+            company.code.toLowerCase().includes("테크")) &&
+          company.status === COMPANY_STATUS.ACTIVE,
       ),
     ).toBe(true);
   });


### PR DESCRIPTION
## 📋 PR 타입

> 해당하는 타입을 선택해 주세요 (복수 선택 가능)

- [ ] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [x] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- deploy 기준을 main에서 develop으로 변경
-
-

---

## ✅ 작업 체크리스트

**기본**

- [ ] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [ ] 아래 `Closes #` 에 이슈 번호 기입
- [ ] 불필요한 `console` · 주석 처리된 코드 제거
- [ ] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**(회의 담당자 등), 그리고 **서버(Server Action/BFF)에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [ ] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시 (조용히 "되는 척" 금지)
- [ ] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그)
- [ ] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [ ] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인)
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음

---

## 🔗 연관 이슈

Closes #80

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

-

---

## 📝 추가 메모


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **배포**
  * 배포 자동화가 `develop` 브랜치의 변경 사항을 기준으로 실행되도록 변경되었습니다.

* **품질 개선**
  * 공지 발행 시 대상 기업 선택 및 빈 목록 검증이 강화되었습니다.
  * 기업 검색과 상태 필터 조합에 대한 검증이 개선되었습니다.
  * 전체 기업 대상 공지 발행 시 기업 선택 정보가 올바르게 처리되는지 확인합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->