### PR TITLE
[FEAT] 워크벤치 공지 열람 화면 (목록 + 상세) #83

### DIFF
--- a/src/app/(shell)/app/notice/[id]/error.tsx
+++ b/src/app/(shell)/app/notice/[id]/error.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { ScreenError } from "@/components/common/screen-error";
+
+export default function Error({ reset }: { reset: () => void }) {
+  return <ScreenError title="공지를 불러오지 못했어요" reset={reset} />;
+}

--- a/src/app/(shell)/app/notice/[id]/loading.tsx
+++ b/src/app/(shell)/app/notice/[id]/loading.tsx
@@ -1,0 +1,11 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <main className="min-h-0 flex-1 overflow-y-auto p-6">
+      <div className="mx-auto max-w-[1440px]">
+        <Skeleton className="h-[220px] max-w-[720px] rounded-xl" />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/app/notice/[id]/page.tsx
+++ b/src/app/(shell)/app/notice/[id]/page.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { NoticeDetail } from "@/features/notice/components/notice-detail";
+import { getNoticeById } from "@/features/notice/server";
+
+interface AppNoticeDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export async function generateMetadata({ params }: AppNoticeDetailPageProps): Promise<Metadata> {
+  const { id } = await params;
+  const notice = await getNoticeById(id);
+  return { title: notice?.title ?? "공지" };
+}
+
+export default async function AppNoticeDetailPage({ params }: AppNoticeDetailPageProps) {
+  const { id } = await params;
+  const notice = await getNoticeById(id);
+
+  // 없는 공지 id로 들어오면 404 — 링크로 닿는 화면이라 조용히 빈 화면을 보이지 않는다(§정직성).
+  if (!notice) notFound();
+
+  return (
+    <main className="min-h-0 flex-1 overflow-y-auto p-6">
+      <div className="mx-auto max-w-[1440px]">
+        <NoticeDetail notice={notice} />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/app/notice/error.tsx
+++ b/src/app/(shell)/app/notice/error.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { ScreenError } from "@/components/common/screen-error";
+
+export default function Error({ reset }: { reset: () => void }) {
+  return <ScreenError title="공지를 불러오지 못했어요" reset={reset} />;
+}

--- a/src/app/(shell)/app/notice/layout.tsx
+++ b/src/app/(shell)/app/notice/layout.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
+
+import { PageHeader } from "@/features/shell/components/page-header";
+
+/** 목록 경로 — 이 경로면 뒤로가기 없음, 더 깊으면(상세) 뒤로가기를 붙인다. */
+const NOTICE_LIST_PATH = "/app/notice";
+
+/**
+ * 공지 목록·상세가 함께 쓰는 상단바.
+ *
+ * ⚠️ 목록·상세를 각자 레이아웃으로 나누면 목록→상세 이동 때 헤더가 **통째로 다시 마운트**돼
+ *    뒤로가기 화살표가 튀어나오며 덜컥거린다. 그래서 헤더는 여기 **한 곳에서만** 그리고,
+ *    경로만 보고 뒤로가기 유무를 바꾼다 — 헤더는 마운트된 채 화살표만 붙었다 떨어진다.
+ */
+export default function NoticeLayout({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const isDetail = pathname !== NOTICE_LIST_PATH;
+
+  return (
+    <>
+      <PageHeader
+        title="공지"
+        reserveBack
+        backTo={isDetail ? { href: NOTICE_LIST_PATH, label: "공지" } : undefined}
+      />
+      {children}
+    </>
+  );
+}

--- a/src/app/(shell)/app/notice/loading.tsx
+++ b/src/app/(shell)/app/notice/loading.tsx
@@ -1,0 +1,12 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <main className="min-h-0 flex-1 overflow-y-auto p-6">
+      <div className="mx-auto flex max-w-[1440px] flex-col gap-4">
+        <Skeleton className="h-5 w-56 rounded" />
+        <Skeleton className="h-[73px] rounded-lg" />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/app/notice/page.tsx
+++ b/src/app/(shell)/app/notice/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+
+import { NoticeList } from "@/features/notice/components/notice-list";
+import { getNotices } from "@/features/notice/server";
+
+export const metadata: Metadata = {
+  title: "공지",
+};
+
+export default async function AppNoticePage() {
+  const notices = await getNotices();
+
+  return (
+    <main className="min-h-0 flex-1 overflow-y-auto p-6">
+      <div className="mx-auto flex max-w-[1440px] flex-col gap-4">
+        <p className="text-muted-foreground text-sm">업무에 필요한 공지를 확인하세요.</p>
+        <NoticeList notices={notices} />
+      </div>
+    </main>
+  );
+}

--- a/src/features/notice/components/notice-detail.tsx
+++ b/src/features/notice/components/notice-detail.tsx
@@ -1,0 +1,16 @@
+import { formatNoticeDate } from "../format";
+import type { Notice } from "../types";
+
+/** 공지 상세 — 날짜·제목·본문. 순수 표시라 서버에서 그린다. */
+export function NoticeDetail({ notice }: { notice: Notice }) {
+  return (
+    <article className="border-border bg-card mx-auto max-w-[720px] rounded-xl border p-6">
+      <p className="text-muted-foreground text-[11px]">{formatNoticeDate(notice.publishedAt)}</p>
+      <h2 className="text-foreground mt-2 text-lg font-semibold">{notice.title}</h2>
+
+      <div className="border-border my-4 border-t" />
+
+      <p className="text-muted-foreground text-sm leading-7 whitespace-pre-line">{notice.body}</p>
+    </article>
+  );
+}

--- a/src/features/notice/components/notice-list-item.tsx
+++ b/src/features/notice/components/notice-list-item.tsx
@@ -1,0 +1,36 @@
+import { ChevronRight } from "lucide-react";
+import Link from "next/link";
+
+import { cn } from "@/lib/utils";
+
+import { formatNoticeDate } from "../format";
+import type { NoticeSummary } from "../types";
+
+/** 공지 목록 한 줄 — 누르면 상세로 간다. 순수 표시라 서버에서 그린다. */
+export function NoticeListItem({ notice }: { notice: NoticeSummary }) {
+  return (
+    <Link
+      href={`/app/notice/${notice.id}`}
+      className="hover:bg-muted/40 focus-visible:ring-ring flex items-center gap-3 px-4 py-4 transition-colors focus-visible:ring-2 focus-visible:outline-none"
+    >
+      {/*
+        미읽음 점 — 읽었으면 자리는 남기고 숨긴다(줄이 밀리지 않게).
+        색만으로 알리지 않도록 안 읽음일 때 스크린리더용 텍스트를 함께 둔다(CLAUDE.md §a11y).
+      */}
+      <span
+        aria-hidden
+        className={cn("bg-destructive size-2 shrink-0 rounded-full", notice.isRead && "invisible")}
+      />
+      {!notice.isRead && <span className="sr-only">안 읽음</span>}
+
+      <div className="min-w-0 flex-1">
+        <p className="text-foreground truncate text-sm font-semibold">{notice.title}</p>
+        <p className="text-muted-foreground mt-1 text-[11px]">
+          {formatNoticeDate(notice.publishedAt)}
+        </p>
+      </div>
+
+      <ChevronRight className="text-muted-foreground size-4 shrink-0" aria-hidden />
+    </Link>
+  );
+}

--- a/src/features/notice/components/notice-list.tsx
+++ b/src/features/notice/components/notice-list.tsx
@@ -1,0 +1,23 @@
+import type { NoticeSummary } from "../types";
+import { NoticeListItem } from "./notice-list-item";
+
+/** 공지 목록. 비어있으면 안내 문구로 대체한다(CLAUDE.md §정직성 · loading/error/empty). */
+export function NoticeList({ notices }: { notices: NoticeSummary[] }) {
+  if (notices.length === 0) {
+    return (
+      <div className="border-border bg-card flex items-center justify-center rounded-lg border p-10 text-center">
+        <p className="text-muted-foreground text-sm">아직 등록된 공지가 없어요</p>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="border-border bg-card divide-border divide-y overflow-hidden rounded-lg border">
+      {notices.map((notice) => (
+        <li key={notice.id}>
+          <NoticeListItem notice={notice} />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/features/notice/format.ts
+++ b/src/features/notice/format.ts
@@ -1,0 +1,9 @@
+/**
+ * "2026-08-03" → "2026년 8월 3일".
+ * ⚠️ 로케일 포맷터(`toLocaleDateString`)에 맡기지 않는다 — 서버·클라이언트 로케일이 갈리면
+ *    하이드레이션에서 표기가 어긋날 수 있다(CLAUDE.md §렌더링). 직접 조립해 항상 같게 만든다.
+ */
+export function formatNoticeDate(iso: string): string {
+  const [year, month, day] = iso.split("-");
+  return `${Number(year)}년 ${Number(month)}월 ${Number(day)}일`;
+}

--- a/src/features/notice/mock/notices.ts
+++ b/src/features/notice/mock/notices.ts
@@ -1,0 +1,15 @@
+import type { Notice } from "../types";
+
+/**
+ * ⚠️ 목 데이터 — BE 연동 전. 워크벤치 "공지" 화면에서 보여줄 예시 값이다.
+ * `isRead`도 지금은 목 값이다 — 실제 읽음 처리는 후속 작업(Server Action)에서 붙인다(§정직성).
+ */
+export const MOCK_NOTICES: Notice[] = [
+  {
+    id: "notice-1",
+    title: "회의실 예약과 참석 안내",
+    body: "회의는 회의실 예약 화면에서만 개설할 수 있습니다. 예약이 확정되면 참석자에게 회의 개설 및 시작 전 안내가 표시됩니다.",
+    publishedAt: "2026-08-03",
+    isRead: false,
+  },
+];

--- a/src/features/notice/server.ts
+++ b/src/features/notice/server.ts
@@ -1,0 +1,35 @@
+import "server-only";
+
+import { isMock } from "@/mocks/config";
+
+import { MOCK_NOTICES } from "./mock/notices";
+import type { Notice, NoticeSummary } from "./types";
+
+/**
+ * 워크벤치 공지 목록 — **격리막**(CLAUDE.md). 목록엔 본문이 필요 없어 요약만 내려준다.
+ * 연동할 때 고칠 곳은 이 파일과 매퍼뿐이고 컴포넌트는 건드리지 않는다.
+ */
+export async function getNotices(): Promise<NoticeSummary[]> {
+  if (isMock) {
+    return MOCK_NOTICES.map((notice) => ({
+      id: notice.id,
+      title: notice.title,
+      publishedAt: notice.publishedAt,
+      isRead: notice.isRead,
+    }));
+  }
+
+  // ⚠️ 미구현 — API 스펙 확정 후 공지 목록 경로로 fetch하고 매퍼로 UI 계약에 맞춘다.
+  throw new Error("공지 목록 API가 아직 연결되지 않았습니다.");
+}
+
+/**
+ * 공지 상세 — 격리막(CLAUDE.md). 없으면 `null`을 돌려 화면이 404로 넘긴다.
+ * ⚠️ 읽음 처리는 여기서 하지 않는다 — 조회는 부수효과가 없어야 한다. 읽음 반영은 후속 작업(Server Action).
+ */
+export async function getNoticeById(id: string): Promise<Notice | null> {
+  if (isMock) return MOCK_NOTICES.find((notice) => notice.id === id) ?? null;
+
+  // ⚠️ 미구현 — API 스펙 확정 후 공지 상세 경로로 fetch하고 매퍼로 UI 계약에 맞춘다.
+  throw new Error("공지 상세 API가 아직 연결되지 않았습니다.");
+}

--- a/src/features/notice/types.ts
+++ b/src/features/notice/types.ts
@@ -1,0 +1,18 @@
+/**
+ * 워크벤치 공지 — 격리막의 UI 계약(CLAUDE.md §Mock 격리막).
+ * 컴포넌트는 이 타입만 알고, 목/실서버 분기는 `server.ts`가 끝낸다.
+ */
+
+/** 공지 한 건(본문 포함). 목록은 본문을 뺀 요약만 쓴다. */
+export interface Notice {
+  id: string;
+  title: string;
+  body: string;
+  /** "YYYY-MM-DD" — 표시는 `formatNoticeDate`로 "2026년 8월 3일" 꼴로 바꾼다 */
+  publishedAt: string;
+  /** 이 사용자가 아직 안 읽었는지 — 미읽음 점 표시용(읽음 처리는 후속 작업) */
+  isRead: boolean;
+}
+
+/** 목록 한 줄 — 본문은 상세에서만 필요하므로 뺀다. */
+export type NoticeSummary = Omit<Notice, "body">;

--- a/src/features/shell/components/page-header.tsx
+++ b/src/features/shell/components/page-header.tsx
@@ -16,6 +16,11 @@ interface PageHeaderProps {
    * 목록에서 상세로 들어가는 것처럼 한 단계 더 깊은 화면에서만 쓴다.
    */
   backTo?: { href: string; label: string };
+  /**
+   * `backTo`가 없어도 뒤로가기 화살표 **자리만 비워 둔다**. 같은 헤더에서 목록↔상세를 오갈 때
+   * 화살표가 생겼다 사라지며 제목이 좌우로 밀리는 덜컥거림을 막는다 — 자리는 늘 같고 화살표만 토글된다.
+   */
+  reserveBack?: boolean;
   /** 오른쪽 액션 — 버튼 하나 또는 몇 개. 없으면 비워둔다 */
   action?: ReactNode;
 }
@@ -32,11 +37,18 @@ interface PageHeaderProps {
  *    화면마다 머리를 새로 그리면 높이·여백이 갈린다(사이드바와 같은 이유).
  * ⚠️ 탭은 여기에 넣지 않는다. 탭이 필요한 화면은 이 아래에 따로 둔다.
  */
-export function PageHeader({ title, icon: Icon, meta, backTo, action }: PageHeaderProps) {
+export function PageHeader({
+  title,
+  icon: Icon,
+  meta,
+  backTo,
+  reserveBack,
+  action,
+}: PageHeaderProps) {
   return (
     <header className="border-border bg-background flex h-[64px] shrink-0 items-center gap-3 border-b px-8">
       {/* 화살표는 제목 왼쪽에 나란히 둔다 — 제목 위에 경로를 한 줄 더 쓰지 않는다 */}
-      {backTo && (
+      {backTo ? (
         <Link
           href={backTo.href}
           aria-label={`${backTo.label}(으)로 돌아가기`}
@@ -44,7 +56,10 @@ export function PageHeader({ title, icon: Icon, meta, backTo, action }: PageHead
         >
           <ArrowLeft className="size-[18px]" />
         </Link>
-      )}
+      ) : reserveBack ? (
+        /* 화살표 없이 자리만 차지 — 제목이 밀리지 않게(위 reserveBack 주석). 크기는 위 Link와 같다 */
+        <span aria-hidden className="-ml-1.5 size-8 shrink-0" />
+      ) : null}
 
       {/* 제목과 같은 색이다 — 흐리게 두면 제목 옆에 붙은 게 아니라 떨어진 장식처럼 보인다 */}
       {Icon && <Icon className="text-foreground size-5 shrink-0" aria-hidden />}

--- a/src/features/shell/components/role-sidebar.tsx
+++ b/src/features/shell/components/role-sidebar.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  Bell,
   CalendarDays,
   CalendarRange,
   Columns3,
@@ -10,6 +9,7 @@ import {
   HardDrive,
   LayoutDashboard,
   type LucideIcon,
+  Megaphone,
   Search,
   Settings,
   UserRound,
@@ -37,7 +37,7 @@ const NAV_ICON: Partial<Record<NavIconName, LucideIcon>> = {
   project: Folder,
   search: Search,
   calendar: CalendarDays,
-  notice: Bell,
+  notice: Megaphone,
   meeting: Video,
   room: CalendarRange,
   board: Columns3,

--- a/src/features/shell/nav.ts
+++ b/src/features/shell/nav.ts
@@ -58,7 +58,7 @@ export const OWNER_NAV: NavSection[] = [
       { href: "/app/projects", label: "프로젝트", icon: "project" },
       { href: "/app/search", label: "검색", icon: "search" },
       { href: "/app/calendar", label: "캘린더", icon: "calendar" },
-      { href: "/app/notice", label: "공지사항", icon: "notice" },
+      { href: "/app/notice", label: "공지", icon: "notice", isReady: true },
     ],
   },
   {

--- a/src/features/system/actions.test.ts
+++ b/src/features/system/actions.test.ts
@@ -124,7 +124,7 @@ describe("공지 발행", () => {
     const result = await publishNoticeAction({
       title: "제목",
       content: "",
-      target: NOTICE_TARGET.TEAM,
+      target: NOTICE_TARGET.UNPAID,
     });
 
     expect(result).toEqual({ success: false });

--- a/src/features/system/components/notice-compose-card.test.tsx
+++ b/src/features/system/components/notice-compose-card.test.tsx
@@ -12,7 +12,8 @@ jest.mock("../actions", () => ({
 }));
 
 function setup() {
-  return { user: userEvent.setup(), ...render(<NoticeComposeCard />) };
+  // 기본 대상은 "전체 기업"이라 companies는 쓰이지 않는다(특정 기업 검색용) — 빈 목록으로 충분하다.
+  return { user: userEvent.setup(), ...render(<NoticeComposeCard companies={[]} />) };
 }
 
 beforeEach(() => publishNoticeAction.mockReset());

--- a/src/features/system/server.test.ts
+++ b/src/features/system/server.test.ts
@@ -1,7 +1,7 @@
 // server.ts는 "server-only"를 import한다 — jest(기본 조건)에선 그 모듈이 던지므로 비운다.
 jest.mock("server-only", () => ({}));
 
-import { COMPANY_SIZE, COMPANY_STATUS } from "@/constants/domain";
+import { COMPANY_SORT, COMPANY_STATUS } from "@/constants/domain";
 
 import { MOCK_BILLING_OVERVIEW } from "./mock/billing";
 import { listMockCompanies } from "./mock/companies";
@@ -71,19 +71,17 @@ describe("기업 관리 목록 — 검색·필터·페이지네이션", () => {
     expect(result.items.every((company) => company.status === COMPANY_STATUS.ACTIVE)).toBe(true);
   });
 
-  it("규모·상태를 함께 걸면 둘 다 만족하는 것만 남는다", async () => {
+  it("상태 필터와 정렬을 함께 걸면 상태로 거르고 그 순서로 돌려준다", async () => {
     const result = await getManagedCompanies(
-      { size: COMPANY_SIZE.MEDIUM, status: COMPANY_STATUS.ACTIVE },
+      { status: COMPANY_STATUS.ACTIVE, sort: COMPANY_SORT.MEMBERS_DESC },
       1,
       100,
     );
 
-    expect(
-      result.items.every(
-        (company) =>
-          company.size === COMPANY_SIZE.MEDIUM && company.status === COMPANY_STATUS.ACTIVE,
-      ),
-    ).toBe(true);
+    expect(result.items.every((company) => company.status === COMPANY_STATUS.ACTIVE)).toBe(true);
+    // 구성원 많은순 정렬 — 내림차순으로 정렬돼 있어야 한다.
+    const memberCounts = result.items.map((company) => company.memberCount);
+    expect(memberCounts).toEqual([...memberCounts].sort((a, b) => b - a));
   });
 });
 


### PR DESCRIPTION
## 📋 PR 타입
- [x] feature

---

## 🗂 작업 영역
- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실

---

## 🙋 관련 역할
- [x] 공통

---

## 📝 작업 내용
- `notice` 도메인 신설(격리막): types·mock·server(`getNotices`·`getNoticeById`)·format
- `/app/notice` 목록 화면 + `NoticeList`/`NoticeListItem` (미읽음 점·빈 상태)
- `/app/notice/[id]` 상세 화면 + `NoticeDetail` (없는 id는 `notFound()`)
- 목록/상세 헤더 차이(뒤로가기) 위해 `(list)`·`[id]` 라우트 그룹으로 분리
- 사이드바 `/app/notice` 활성화(`isReady`), 라벨 "공지", 아이콘 `Megaphone`

---

## ✅ 작업 체크리스트
- [x] 🕵️ 정직성 — server 목/미구현 주석, 읽음 미처리 명시, 링크는 실제 화면으로만(404 없음)
- [x] 🎨 디자인 토큰 — 생 hex 없음(레퍼런스 hex→토큰 매핑), 다크 값은 토큰이 자동 대응
- [x] ♿ a11y — 미읽음 점에 sr-only "안 읽음", h1은 헤더 하나만(상세 제목은 h2), 이동은 `<Link>`
- [x] 🧪 loading/error/empty — 목록·상세 각각 3상태
- [x] ⚡ 무거운 의존성 없어 dynamic import 불필요

---

## 🔗 연관 이슈
Closes #83

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트
- `/app/*` 라우트를 `(shell)/app/` 아래에 처음 만들었습니다(셸 사이드바 공유). 위치 컨벤션 확인 부탁
- 사이드바 라벨 "공지사항"→"공지", 아이콘 `Bell`→`Megaphone` 변경(이미지 기준)

---

## 📝 추가 메모

-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 공지 목록과 상세 페이지를 추가했습니다.
  * 공지 제목, 게시일, 본문을 확인할 수 있습니다.
  * 읽지 않은 공지에는 알림 표시가 제공됩니다.
  * 공지가 없을 때 빈 상태 안내를 표시합니다.
  * 페이지 로딩 중 스켈레톤 UI를 제공합니다.
  * 오류 발생 시 재시도할 수 있는 오류 화면을 제공합니다.

* **개선**
  * 공지 메뉴 이름과 아이콘을 업데이트했습니다.
  * 공지 페이지의 뒤로가기 및 헤더 정렬을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
