### PR TITLE
[FEAT] 워크벤치 공지 작성·수정 + 읽음 처리 #85

### DIFF
--- a/src/app/(shell)/app/notice/[id]/edit/page.tsx
+++ b/src/app/(shell)/app/notice/[id]/edit/page.tsx
@@ -1,0 +1,41 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { updateNoticeAction } from "@/features/notice/actions";
+import { NoticeForm } from "@/features/notice/components/notice-form";
+import { getNoticeById } from "@/features/notice/server";
+import { getMockActor } from "@/lib/mock-actor";
+import { canManageNotice } from "@/lib/permission";
+
+export const metadata: Metadata = {
+  title: "공지 수정",
+};
+
+interface AppNoticeEditPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function AppNoticeEditPage({ params }: AppNoticeEditPageProps) {
+  // 권한 없는 사람은 화면 자체를 숨긴다(404) — 서버 재검사는 액션에서도 한 번 더(§권한).
+  if (!canManageNotice(getMockActor())) notFound();
+
+  const { id } = await params;
+  const notice = await getNoticeById(id);
+  if (!notice) notFound();
+
+  return (
+    <main className="min-h-0 flex-1 overflow-y-auto p-6">
+      <div className="mx-auto flex max-w-[720px] flex-col gap-4">
+        <h2 className="text-foreground text-base font-semibold">공지 수정</h2>
+        <div className="border-border bg-card rounded-xl border p-6">
+          <NoticeForm
+            action={updateNoticeAction}
+            notice={notice}
+            submitLabel="수정"
+            cancelHref={`/app/notice/${notice.id}`}
+          />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/app/notice/[id]/error.tsx
+++ b/src/app/(shell)/app/notice/[id]/error.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { ScreenError } from "@/components/common/screen-error";
+
+export default function Error({ reset }: { reset: () => void }) {
+  return <ScreenError title="공지를 불러오지 못했어요" reset={reset} />;
+}

--- a/src/app/(shell)/app/notice/[id]/loading.tsx
+++ b/src/app/(shell)/app/notice/[id]/loading.tsx
@@ -1,0 +1,11 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <main className="min-h-0 flex-1 overflow-y-auto p-6">
+      <div className="mx-auto max-w-[1440px]">
+        <Skeleton className="h-[220px] max-w-[720px] rounded-xl" />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/app/notice/[id]/page.tsx
+++ b/src/app/(shell)/app/notice/[id]/page.tsx
@@ -3,6 +3,8 @@ import { notFound } from "next/navigation";
 
 import { NoticeDetail } from "@/features/notice/components/notice-detail";
 import { getNoticeById } from "@/features/notice/server";
+import { getMockActor } from "@/lib/mock-actor";
+import { canManageNotice } from "@/lib/permission";
 
 interface AppNoticeDetailPageProps {
   params: Promise<{ id: string }>;
@@ -24,7 +26,7 @@ export default async function AppNoticeDetailPage({ params }: AppNoticeDetailPag
   return (
     <main className="min-h-0 flex-1 overflow-y-auto p-6">
       <div className="mx-auto max-w-[1440px]">
-        <NoticeDetail notice={notice} />
+        <NoticeDetail notice={notice} canManage={canManageNotice(getMockActor())} />
       </div>
     </main>
   );

--- a/src/app/(shell)/app/notice/[id]/page.tsx
+++ b/src/app/(shell)/app/notice/[id]/page.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { NoticeDetail } from "@/features/notice/components/notice-detail";
+import { getNoticeById } from "@/features/notice/server";
+
+interface AppNoticeDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export async function generateMetadata({ params }: AppNoticeDetailPageProps): Promise<Metadata> {
+  const { id } = await params;
+  const notice = await getNoticeById(id);
+  return { title: notice?.title ?? "공지" };
+}
+
+export default async function AppNoticeDetailPage({ params }: AppNoticeDetailPageProps) {
+  const { id } = await params;
+  const notice = await getNoticeById(id);
+
+  // 없는 공지 id로 들어오면 404 — 링크로 닿는 화면이라 조용히 빈 화면을 보이지 않는다(§정직성).
+  if (!notice) notFound();
+
+  return (
+    <main className="min-h-0 flex-1 overflow-y-auto p-6">
+      <div className="mx-auto max-w-[1440px]">
+        <NoticeDetail notice={notice} />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/app/notice/error.tsx
+++ b/src/app/(shell)/app/notice/error.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { ScreenError } from "@/components/common/screen-error";
+
+export default function Error({ reset }: { reset: () => void }) {
+  return <ScreenError title="공지를 불러오지 못했어요" reset={reset} />;
+}

--- a/src/app/(shell)/app/notice/layout.tsx
+++ b/src/app/(shell)/app/notice/layout.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
+
+import { PageHeader } from "@/features/shell/components/page-header";
+
+/** 목록 경로 — 이 경로면 뒤로가기 없음, 더 깊으면(상세) 뒤로가기를 붙인다. */
+const NOTICE_LIST_PATH = "/app/notice";
+
+/**
+ * 공지 목록·상세가 함께 쓰는 상단바.
+ *
+ * ⚠️ 목록·상세를 각자 레이아웃으로 나누면 목록→상세 이동 때 헤더가 **통째로 다시 마운트**돼
+ *    뒤로가기 화살표가 튀어나오며 덜컥거린다. 그래서 헤더는 여기 **한 곳에서만** 그리고,
+ *    경로만 보고 뒤로가기 유무를 바꾼다 — 헤더는 마운트된 채 화살표만 붙었다 떨어진다.
+ */
+export default function NoticeLayout({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const isDetail = pathname !== NOTICE_LIST_PATH;
+
+  return (
+    <>
+      <PageHeader
+        title="공지"
+        reserveBack
+        backTo={isDetail ? { href: NOTICE_LIST_PATH, label: "공지" } : undefined}
+      />
+      {children}
+    </>
+  );
+}

--- a/src/app/(shell)/app/notice/loading.tsx
+++ b/src/app/(shell)/app/notice/loading.tsx
@@ -1,0 +1,12 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <main className="min-h-0 flex-1 overflow-y-auto p-6">
+      <div className="mx-auto flex max-w-[1440px] flex-col gap-4">
+        <Skeleton className="h-5 w-56 rounded" />
+        <Skeleton className="h-[73px] rounded-lg" />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/app/notice/new/page.tsx
+++ b/src/app/(shell)/app/notice/new/page.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { createNoticeAction } from "@/features/notice/actions";
+import { NoticeForm } from "@/features/notice/components/notice-form";
+import { getMockActor } from "@/lib/mock-actor";
+import { canManageNotice } from "@/lib/permission";
+
+export const metadata: Metadata = {
+  title: "새 공지",
+};
+
+export default function AppNoticeNewPage() {
+  // 권한 없는 사람은 화면 자체를 숨긴다(404) — 서버 재검사는 액션에서도 한 번 더(§권한).
+  if (!canManageNotice(getMockActor())) notFound();
+
+  return (
+    <main className="min-h-0 flex-1 overflow-y-auto p-6">
+      <div className="mx-auto flex max-w-[720px] flex-col gap-4">
+        <h2 className="text-foreground text-base font-semibold">새 공지</h2>
+        <div className="border-border bg-card rounded-xl border p-6">
+          <NoticeForm action={createNoticeAction} submitLabel="발행" cancelHref="/app/notice" />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/app/notice/page.tsx
+++ b/src/app/(shell)/app/notice/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+
+import { NoticeList } from "@/features/notice/components/notice-list";
+import { getNotices } from "@/features/notice/server";
+
+export const metadata: Metadata = {
+  title: "공지",
+};
+
+export default async function AppNoticePage() {
+  const notices = await getNotices();
+
+  return (
+    <main className="min-h-0 flex-1 overflow-y-auto p-6">
+      <div className="mx-auto flex max-w-[1440px] flex-col gap-4">
+        <p className="text-muted-foreground text-sm">업무에 필요한 공지를 확인하세요.</p>
+        <NoticeList notices={notices} />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/app/notice/page.tsx
+++ b/src/app/(shell)/app/notice/page.tsx
@@ -7,6 +7,7 @@ import { NoticeList } from "@/features/notice/components/notice-list";
 import { getNotices } from "@/features/notice/server";
 import { getMockActor } from "@/lib/mock-actor";
 import { canManageNotice } from "@/lib/permission";
+import { cn } from "@/lib/utils";
 
 export const metadata: Metadata = {
   title: "공지",
@@ -25,7 +26,11 @@ export default async function AppNoticePage() {
           {canManage && (
             <Link
               href="/app/notice/new"
-              className={buttonVariants({ variant: "default", size: "sm" })}
+              // 시안의 주 버튼은 액센트(파랑)가 아니라 먹색이다 — `department-setup.tsx`와 같은 이유.
+              className={cn(
+                buttonVariants({ size: "sm" }),
+                "bg-foreground text-background hover:bg-foreground/90",
+              )}
             >
               <Plus aria-hidden />새 공지
             </Link>

--- a/src/app/(shell)/app/notice/page.tsx
+++ b/src/app/(shell)/app/notice/page.tsx
@@ -1,7 +1,12 @@
+import { Plus } from "lucide-react";
 import type { Metadata } from "next";
+import Link from "next/link";
 
+import { buttonVariants } from "@/components/ui/button";
 import { NoticeList } from "@/features/notice/components/notice-list";
 import { getNotices } from "@/features/notice/server";
+import { getMockActor } from "@/lib/mock-actor";
+import { canManageNotice } from "@/lib/permission";
 
 export const metadata: Metadata = {
   title: "공지",
@@ -9,11 +14,24 @@ export const metadata: Metadata = {
 
 export default async function AppNoticePage() {
   const notices = await getNotices();
+  // 작성 권한이 있을 때만 "새 공지"를 보인다 — 서버 재검사는 createNoticeAction이 다시 한다(§권한).
+  const canManage = canManageNotice(getMockActor());
 
   return (
     <main className="min-h-0 flex-1 overflow-y-auto p-6">
       <div className="mx-auto flex max-w-[1440px] flex-col gap-4">
-        <p className="text-muted-foreground text-sm">업무에 필요한 공지를 확인하세요.</p>
+        <div className="flex items-center justify-between gap-4">
+          <p className="text-muted-foreground text-sm">업무에 필요한 공지를 확인하세요.</p>
+          {canManage && (
+            <Link
+              href="/app/notice/new"
+              className={buttonVariants({ variant: "default", size: "sm" })}
+            >
+              <Plus aria-hidden />새 공지
+            </Link>
+          )}
+        </div>
+
         <NoticeList notices={notices} />
       </div>
     </main>

--- a/src/app/(shell)/layout.tsx
+++ b/src/app/(shell)/layout.tsx
@@ -1,8 +1,25 @@
 import type { ReactNode } from "react";
 
 import { ROLE } from "@/constants/domain";
+import { getUnreadNoticeCount } from "@/features/notice/server";
 import { RoleSidebar } from "@/features/shell/components/role-sidebar";
+import type { NavSection } from "@/features/shell/nav";
 import { OWNER_NAV } from "@/features/shell/nav";
+
+/**
+ * 공지 미읽음이 있으면 사이드바 "공지" 항목에 빨간 점을 끼워 넣는다.
+ * ⚠️ 정적 `OWNER_NAV`를 그대로 두고 **여기서 서버 상태(미읽음 수)만 얹는다** — 구성과 상태를
+ *    한 파일에 섞지 않는다. 읽음 처리(`markNoticeReadAction`)가 `revalidatePath`로 이 셸을 다시 그린다.
+ */
+function withNoticeDot(sections: NavSection[], hasUnread: boolean): NavSection[] {
+  if (!hasUnread) return sections;
+  return sections.map((section) => ({
+    ...section,
+    items: section.items.map((item) =>
+      item.href === "/app/notice" ? { ...item, dot: true } : item,
+    ),
+  }));
+}
 
 /**
  * 로그인 뒤 화면이 모두 쓰는 셸 — **사이드바는 여기 한 번만** 그린다.
@@ -13,10 +30,13 @@ import { OWNER_NAV } from "@/features/shell/nav";
  * ⚠️ 역할마다 **레이아웃이 아니라 `sections`만** 갈아 끼운다(CLAUDE.md §라우트 그룹).
  *    지금은 OWNER 구성뿐이다 — 로그인이 붙으면 세션의 역할로 고른다(지금 사용자는 목).
  */
-export default function ShellLayout({ children }: { children: ReactNode }) {
+export default async function ShellLayout({ children }: { children: ReactNode }) {
+  const unreadNoticeCount = await getUnreadNoticeCount();
+  const sections = withNoticeDot(OWNER_NAV, unreadNoticeCount > 0);
+
   return (
     <div className="bg-background flex h-dvh overflow-hidden">
-      <RoleSidebar sections={OWNER_NAV} user={{ name: "대표 계정", role: ROLE.OWNER }} />
+      <RoleSidebar sections={sections} user={{ name: "대표 계정", role: ROLE.OWNER }} />
 
       {/*
         상단바는 여기서 그리지 않는다 — 제목·액션이 도메인마다 달라서

--- a/src/features/notice/actions.ts
+++ b/src/features/notice/actions.ts
@@ -1,0 +1,98 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { getMockActor } from "@/lib/mock-actor";
+import { canManageNotice } from "@/lib/permission";
+import { isMock } from "@/mocks/config";
+
+import { addMockNotice, markMockNoticeRead, updateMockNotice } from "./mock/notices";
+import type { NoticeDraft, NoticeFormErrors } from "./types";
+import { validateNoticeDraft } from "./validate";
+
+const LIST_PATH = "/app/notice";
+
+/**
+ * 공지 읽음 처리 — 격리막(CLAUDE.md §Mock 격리막).
+ * ⚠️ 상세를 열면 그 화면의 잎사귀가 이 액션을 부른다(부수효과 없는 조회와 분리). 끝나면
+ *    `revalidatePath`로 목록 미읽음 점·사이드바 표시를 갱신한다.
+ * ⚠️ 지금은 목이라 **전역** 읽음이다 — 세션이 붙으면 "이 사용자" 기준으로 바뀐다(§정직성).
+ */
+export async function markNoticeReadAction(formData: FormData): Promise<void> {
+  if (!isMock) {
+    // ⚠️ 미구현 — API 스펙 확정 후 BFF 경로로 읽음 처리 요청을 보낸다.
+    throw new Error("공지 읽음 처리 API가 아직 연결되지 않았습니다.");
+  }
+
+  const id = String(formData.get("id") ?? "");
+  markMockNoticeRead(id);
+  // 목록 경로만 무효화한다 — 상세(현재 경로)는 건드리지 않아 재검증→재제출 루프가 안 생긴다.
+  revalidatePath(LIST_PATH);
+}
+
+/** 작성·수정 폼 결과 — `useActionState`가 그대로 들고 있는 모양. */
+export interface NoticeFormState {
+  errors: NoticeFormErrors;
+}
+
+function readDraft(formData: FormData): NoticeDraft {
+  return {
+    title: String(formData.get("title") ?? ""),
+    body: String(formData.get("body") ?? ""),
+  };
+}
+
+/**
+ * 공지 작성 — 격리막(CLAUDE.md §Mock 격리막).
+ * ⚠️ **권한을 서버에서 다시 본다** — 화면 숨김은 UX일 뿐 보안이 아니다(§권한). 지금은 목 actor다.
+ * ⚠️ 화면과 **같은 함수**(`validateNoticeDraft`)로 다시 검증한다 — 규칙이 두 벌이면 어긋난다.
+ */
+export async function createNoticeAction(
+  _prev: NoticeFormState,
+  formData: FormData,
+): Promise<NoticeFormState> {
+  if (!canManageNotice(getMockActor())) return { errors: { title: "공지를 작성할 권한이 없어요" } };
+
+  const draft = readDraft(formData);
+  const errors = validateNoticeDraft(draft);
+  if (Object.keys(errors).length > 0) return { errors };
+
+  if (!isMock) {
+    // ⚠️ 미구현 — API 스펙 확정 후 BFF 경로로 작성 요청을 보낸다.
+    throw new Error("공지 작성 API가 아직 연결되지 않았습니다.");
+  }
+
+  // "YYYY-MM-DD" — 발행일은 서버 기준으로 찍는다(목 데이터는 날짜를 만들지 않는다).
+  const publishedAt = new Date().toISOString().slice(0, 10);
+  addMockNotice(draft, publishedAt);
+
+  revalidatePath(LIST_PATH);
+  // ⚠️ `redirect`는 내부적으로 예외를 던진다 — try/catch 밖에 둔다(§렌더링·데이터)
+  redirect(LIST_PATH);
+}
+
+/** 공지 수정 — 작성과 같은 규칙. 끝나면 그 공지 상세로 돌아간다. */
+export async function updateNoticeAction(
+  _prev: NoticeFormState,
+  formData: FormData,
+): Promise<NoticeFormState> {
+  if (!canManageNotice(getMockActor())) return { errors: { title: "공지를 수정할 권한이 없어요" } };
+
+  const id = String(formData.get("id") ?? "");
+  const draft = readDraft(formData);
+  const errors = validateNoticeDraft(draft);
+  if (Object.keys(errors).length > 0) return { errors };
+
+  if (!isMock) {
+    // ⚠️ 미구현 — API 스펙 확정 후 BFF 경로로 수정 요청을 보낸다.
+    throw new Error("공지 수정 API가 아직 연결되지 않았습니다.");
+  }
+
+  const updated = updateMockNotice(id, draft);
+  if (!updated) return { errors: { title: "수정할 공지를 찾을 수 없어요" } };
+
+  revalidatePath(LIST_PATH);
+  revalidatePath(`${LIST_PATH}/${id}`);
+  redirect(`${LIST_PATH}/${id}`);
+}

--- a/src/features/notice/actions.ts
+++ b/src/features/notice/actions.ts
@@ -7,7 +7,12 @@ import { getMockActor } from "@/lib/mock-actor";
 import { canManageNotice } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
-import { addMockNotice, markMockNoticeRead, updateMockNotice } from "./mock/notices";
+import {
+  addMockNotice,
+  deleteMockNotice,
+  markMockNoticeRead,
+  updateMockNotice,
+} from "./mock/notices";
 import type { NoticeDraft, NoticeFormErrors } from "./types";
 import { validateNoticeDraft } from "./validate";
 
@@ -95,4 +100,27 @@ export async function updateNoticeAction(
   revalidatePath(LIST_PATH);
   revalidatePath(`${LIST_PATH}/${id}`);
   redirect(`${LIST_PATH}/${id}`);
+}
+
+/**
+ * 공지 삭제 — 격리막(CLAUDE.md §Mock 격리막).
+ * ⚠️ 되돌릴 수 없는 조작이라 화면(`NoticeDeleteButton`)에서 확인 Dialog를 먼저 띄운 뒤에만 이 폼이
+ *    제출된다(§토스트: 파괴적 작업은 Dialog). 여기서도 **권한을 다시 본다**(§권한: 서버 재검사).
+ */
+export async function deleteNoticeAction(formData: FormData): Promise<void> {
+  if (!canManageNotice(getMockActor())) {
+    throw new Error("공지를 삭제할 권한이 없어요");
+  }
+
+  if (!isMock) {
+    // ⚠️ 미구현 — API 스펙 확정 후 BFF 경로로 삭제 요청을 보낸다.
+    throw new Error("공지 삭제 API가 아직 연결되지 않았습니다.");
+  }
+
+  const id = String(formData.get("id") ?? "");
+  deleteMockNotice(id);
+
+  revalidatePath(LIST_PATH);
+  // ⚠️ `redirect`는 내부적으로 예외를 던진다 — try/catch 밖에 둔다(§렌더링·데이터)
+  redirect(LIST_PATH);
 }

--- a/src/features/notice/components/mark-notice-read.tsx
+++ b/src/features/notice/components/mark-notice-read.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import { markNoticeReadAction } from "../actions";
+
+/**
+ * 공지 상세를 열면 그 공지를 읽음 처리한다 — 화면엔 안 보이는 폼을 마운트 시 한 번 제출한다.
+ *
+ * ⚠️ **폼 제출로 부른다**(useEffect에서 액션을 직접 호출하지 않는다) — 직접 호출은 dev에서 액션이
+ *    RSC와 다른 모듈 인스턴스에서 돌아 목 변경이 목록 렌더에 안 보였다. 폼 액션 경로는 작성(create)과
+ *    같은 경로라 변경이 그대로 반영된다. 액션이 `revalidatePath`로 목록·사이드바를 갱신한다.
+ */
+export function MarkNoticeRead({ id }: { id: string }) {
+  const formRef = useRef<HTMLFormElement>(null);
+  const submitted = useRef(false);
+
+  useEffect(() => {
+    if (submitted.current) return;
+    submitted.current = true;
+    formRef.current?.requestSubmit();
+  }, []);
+
+  return (
+    <form ref={formRef} action={markNoticeReadAction} className="hidden" aria-hidden>
+      <input type="hidden" name="id" value={id} />
+    </form>
+  );
+}

--- a/src/features/notice/components/notice-delete-button.tsx
+++ b/src/features/notice/components/notice-delete-button.tsx
@@ -15,13 +15,18 @@ import {
 
 import { deleteNoticeAction } from "../actions";
 
+interface NoticeDeleteButtonProps {
+  id: string;
+  title: string;
+}
+
 /**
  * 공지 삭제 — 되돌릴 수 없는 조작이라 확인 Dialog를 먼저 띄운다(CLAUDE.md §토스트: 파괴적 작업은
  * 토스트가 아니라 Dialog로 확인). `department-delete-dialog.tsx`와 같은 패턴이다.
  * ⚠️ 확인을 누르면 **폼 액션**(`deleteNoticeAction`)이 실행되고, 성공하면 액션 안 `redirect`가
  *    목록으로 보낸다.
  */
-export function NoticeDeleteButton({ id, title }: { id: string; title: string }) {
+export function NoticeDeleteButton({ id, title }: NoticeDeleteButtonProps) {
   const [open, setOpen] = useState(false);
 
   return (

--- a/src/features/notice/components/notice-delete-button.tsx
+++ b/src/features/notice/components/notice-delete-button.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Trash2 } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+import { deleteNoticeAction } from "../actions";
+
+/**
+ * 공지 삭제 — 되돌릴 수 없는 조작이라 확인 Dialog를 먼저 띄운다(CLAUDE.md §토스트: 파괴적 작업은
+ * 토스트가 아니라 Dialog로 확인). `department-delete-dialog.tsx`와 같은 패턴이다.
+ * ⚠️ 확인을 누르면 **폼 액션**(`deleteNoticeAction`)이 실행되고, 성공하면 액션 안 `redirect`가
+ *    목록으로 보낸다.
+ */
+export function NoticeDeleteButton({ id, title }: { id: string; title: string }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="xs"
+        onClick={() => setOpen(true)}
+        className="border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive"
+      >
+        <Trash2 aria-hidden />
+        삭제
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>&lsquo;{title}&rsquo; 공지를 삭제할까요?</DialogTitle>
+            <DialogDescription>삭제하면 되돌릴 수 없어요.</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+              취소
+            </Button>
+            <form action={deleteNoticeAction}>
+              <input type="hidden" name="id" value={id} />
+              <Button type="submit" variant="destructive">
+                삭제
+              </Button>
+            </form>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/features/notice/components/notice-detail.tsx
+++ b/src/features/notice/components/notice-detail.tsx
@@ -1,11 +1,30 @@
+import Link from "next/link";
+
+import { buttonVariants } from "@/components/ui/button";
+
 import { formatNoticeDate } from "../format";
 import type { Notice } from "../types";
+import { MarkNoticeRead } from "./mark-notice-read";
 
-/** 공지 상세 — 날짜·제목·본문. 순수 표시라 서버에서 그린다. */
-export function NoticeDetail({ notice }: { notice: Notice }) {
+/** 공지 상세 — 날짜·제목·본문. 관리 권한이 있으면 수정으로 갈 수 있다. */
+export function NoticeDetail({ notice, canManage }: { notice: Notice; canManage: boolean }) {
   return (
     <article className="border-border bg-card mx-auto max-w-[720px] rounded-xl border p-6">
-      <p className="text-muted-foreground text-[11px]">{formatNoticeDate(notice.publishedAt)}</p>
+      {/* 열람하면 읽음 처리 — 화면엔 아무것도 안 그린다 */}
+      <MarkNoticeRead id={notice.id} />
+
+      <div className="flex items-start justify-between gap-3">
+        <p className="text-muted-foreground text-[11px]">{formatNoticeDate(notice.publishedAt)}</p>
+        {canManage && (
+          <Link
+            href={`/app/notice/${notice.id}/edit`}
+            className={buttonVariants({ variant: "outline", size: "xs" })}
+          >
+            수정
+          </Link>
+        )}
+      </div>
+
       <h2 className="text-foreground mt-2 text-lg font-semibold">{notice.title}</h2>
 
       <div className="border-border my-4 border-t" />

--- a/src/features/notice/components/notice-detail.tsx
+++ b/src/features/notice/components/notice-detail.tsx
@@ -1,0 +1,16 @@
+import { formatNoticeDate } from "../format";
+import type { Notice } from "../types";
+
+/** 공지 상세 — 날짜·제목·본문. 순수 표시라 서버에서 그린다. */
+export function NoticeDetail({ notice }: { notice: Notice }) {
+  return (
+    <article className="border-border bg-card mx-auto max-w-[720px] rounded-xl border p-6">
+      <p className="text-muted-foreground text-[11px]">{formatNoticeDate(notice.publishedAt)}</p>
+      <h2 className="text-foreground mt-2 text-lg font-semibold">{notice.title}</h2>
+
+      <div className="border-border my-4 border-t" />
+
+      <p className="text-muted-foreground text-sm leading-7 whitespace-pre-line">{notice.body}</p>
+    </article>
+  );
+}

--- a/src/features/notice/components/notice-detail.tsx
+++ b/src/features/notice/components/notice-detail.tsx
@@ -1,3 +1,4 @@
+import { Pencil } from "lucide-react";
 import Link from "next/link";
 
 import { buttonVariants } from "@/components/ui/button";
@@ -5,8 +6,9 @@ import { buttonVariants } from "@/components/ui/button";
 import { formatNoticeDate } from "../format";
 import type { Notice } from "../types";
 import { MarkNoticeRead } from "./mark-notice-read";
+import { NoticeDeleteButton } from "./notice-delete-button";
 
-/** 공지 상세 — 날짜·제목·본문. 관리 권한이 있으면 수정으로 갈 수 있다. */
+/** 공지 상세 — 날짜·제목·본문. 관리 권한이 있으면 수정·삭제로 갈 수 있다. */
 export function NoticeDetail({ notice, canManage }: { notice: Notice; canManage: boolean }) {
   return (
     <article className="border-border bg-card mx-auto max-w-[720px] rounded-xl border p-6">
@@ -16,12 +18,16 @@ export function NoticeDetail({ notice, canManage }: { notice: Notice; canManage:
       <div className="flex items-start justify-between gap-3">
         <p className="text-muted-foreground text-[11px]">{formatNoticeDate(notice.publishedAt)}</p>
         {canManage && (
-          <Link
-            href={`/app/notice/${notice.id}/edit`}
-            className={buttonVariants({ variant: "outline", size: "xs" })}
-          >
-            수정
-          </Link>
+          <div className="flex shrink-0 gap-2">
+            <Link
+              href={`/app/notice/${notice.id}/edit`}
+              className={buttonVariants({ variant: "outline", size: "xs" })}
+            >
+              <Pencil aria-hidden />
+              수정
+            </Link>
+            <NoticeDeleteButton id={notice.id} title={notice.title} />
+          </div>
         )}
       </div>
 

--- a/src/features/notice/components/notice-form.tsx
+++ b/src/features/notice/components/notice-form.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import Link from "next/link";
+import { useActionState } from "react";
+
+import { Button, buttonVariants } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+import type { NoticeFormState } from "../actions";
+import type { Notice } from "../types";
+
+interface NoticeFormProps {
+  /** 작성이면 `createNoticeAction`, 수정이면 `updateNoticeAction` */
+  action: (prev: NoticeFormState, formData: FormData) => Promise<NoticeFormState>;
+  /** 수정일 때만 — 기존 값 채우기 + id 전달 */
+  notice?: Notice;
+  submitLabel: string;
+  /** 취소 시 돌아갈 곳 */
+  cancelHref: string;
+}
+
+/**
+ * 공지 작성·수정 폼 — 작성/수정이 같은 폼을 쓴다(입력·검증이 같다).
+ *
+ * ⚠️ `useActionState`로 서버 액션과 묶는다 — 검증 오류는 서버가 돌려준 걸 칸 밑에 인라인으로 보인다
+ *    (토스트가 아니라 §토스트: 폼 검증 오류는 인라인). 성공하면 액션이 `redirect`로 화면을 옮긴다.
+ */
+export function NoticeForm({ action, notice, submitLabel, cancelHref }: NoticeFormProps) {
+  const [state, formAction, isPending] = useActionState(action, { errors: {} });
+
+  return (
+    <form action={formAction} className="flex flex-col gap-4">
+      {notice && <input type="hidden" name="id" value={notice.id} />}
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="notice-title">제목</Label>
+        <Input
+          id="notice-title"
+          name="title"
+          defaultValue={notice?.title}
+          placeholder="공지 제목"
+          aria-invalid={Boolean(state.errors.title)}
+        />
+        {state.errors.title && <p className="text-destructive text-xs">{state.errors.title}</p>}
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="notice-body">내용</Label>
+        <textarea
+          id="notice-body"
+          name="body"
+          rows={8}
+          defaultValue={notice?.body}
+          placeholder="공지 내용을 입력하세요"
+          aria-invalid={Boolean(state.errors.body)}
+          className="border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive dark:bg-input/30 min-h-[180px] w-full resize-none rounded-lg border bg-transparent px-2.5 py-2 text-sm transition-colors outline-none focus-visible:ring-3"
+        />
+        {state.errors.body && <p className="text-destructive text-xs">{state.errors.body}</p>}
+      </div>
+
+      <div className="flex justify-end gap-2">
+        <Link href={cancelHref} className={buttonVariants({ variant: "outline", size: "sm" })}>
+          취소
+        </Link>
+        <Button type="submit" size="sm" disabled={isPending}>
+          {isPending ? "저장 중…" : submitLabel}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/features/notice/components/notice-form.tsx
+++ b/src/features/notice/components/notice-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useActionState } from "react";
+import { useActionState, useState } from "react";
 
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -25,9 +25,14 @@ interface NoticeFormProps {
  *
  * ⚠️ `useActionState`로 서버 액션과 묶는다 — 검증 오류는 서버가 돌려준 걸 칸 밑에 인라인으로 보인다
  *    (토스트가 아니라 §토스트: 폼 검증 오류는 인라인). 성공하면 액션이 `redirect`로 화면을 옮긴다.
+ * ⚠️ 제목·내용 입력을 **직접 추적**한다 — 둘 다 채워지기 전엔 제출 버튼을 잠근다(빈 공지 발행 방지).
+ *    `name` 속성은 그대로 둬서 제어 컴포넌트여도 `FormData`엔 정상적으로 값이 실린다.
  */
 export function NoticeForm({ action, notice, submitLabel, cancelHref }: NoticeFormProps) {
   const [state, formAction, isPending] = useActionState(action, { errors: {} });
+  const [title, setTitle] = useState(notice?.title ?? "");
+  const [body, setBody] = useState(notice?.body ?? "");
+  const canSubmit = title.trim().length > 0 && body.trim().length > 0;
 
   return (
     <form action={formAction} className="flex flex-col gap-4">
@@ -38,7 +43,8 @@ export function NoticeForm({ action, notice, submitLabel, cancelHref }: NoticeFo
         <Input
           id="notice-title"
           name="title"
-          defaultValue={notice?.title}
+          value={title}
+          onChange={(event) => setTitle(event.target.value)}
           placeholder="공지 제목"
           aria-invalid={Boolean(state.errors.title)}
         />
@@ -51,7 +57,8 @@ export function NoticeForm({ action, notice, submitLabel, cancelHref }: NoticeFo
           id="notice-body"
           name="body"
           rows={8}
-          defaultValue={notice?.body}
+          value={body}
+          onChange={(event) => setBody(event.target.value)}
           placeholder="공지 내용을 입력하세요"
           aria-invalid={Boolean(state.errors.body)}
           className="border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive dark:bg-input/30 min-h-[180px] w-full resize-none rounded-lg border bg-transparent px-2.5 py-2 text-sm transition-colors outline-none focus-visible:ring-3"
@@ -63,7 +70,13 @@ export function NoticeForm({ action, notice, submitLabel, cancelHref }: NoticeFo
         <Link href={cancelHref} className={buttonVariants({ variant: "outline", size: "sm" })}>
           취소
         </Link>
-        <Button type="submit" size="sm" disabled={isPending}>
+        <Button
+          type="submit"
+          size="sm"
+          disabled={isPending || !canSubmit}
+          // 시안의 주 버튼은 액센트(파랑)가 아니라 먹색이다 — `department-setup.tsx`와 같은 이유.
+          className="bg-foreground text-background hover:bg-foreground/90"
+        >
           {isPending ? "저장 중…" : submitLabel}
         </Button>
       </div>

--- a/src/features/notice/components/notice-list-item.tsx
+++ b/src/features/notice/components/notice-list-item.tsx
@@ -1,0 +1,36 @@
+import { ChevronRight } from "lucide-react";
+import Link from "next/link";
+
+import { cn } from "@/lib/utils";
+
+import { formatNoticeDate } from "../format";
+import type { NoticeSummary } from "../types";
+
+/** 공지 목록 한 줄 — 누르면 상세로 간다. 순수 표시라 서버에서 그린다. */
+export function NoticeListItem({ notice }: { notice: NoticeSummary }) {
+  return (
+    <Link
+      href={`/app/notice/${notice.id}`}
+      className="hover:bg-muted/40 focus-visible:ring-ring flex items-center gap-3 px-4 py-4 transition-colors focus-visible:ring-2 focus-visible:outline-none"
+    >
+      {/*
+        미읽음 점 — 읽었으면 자리는 남기고 숨긴다(줄이 밀리지 않게).
+        색만으로 알리지 않도록 안 읽음일 때 스크린리더용 텍스트를 함께 둔다(CLAUDE.md §a11y).
+      */}
+      <span
+        aria-hidden
+        className={cn("bg-destructive size-2 shrink-0 rounded-full", notice.isRead && "invisible")}
+      />
+      {!notice.isRead && <span className="sr-only">안 읽음</span>}
+
+      <div className="min-w-0 flex-1">
+        <p className="text-foreground truncate text-sm font-semibold">{notice.title}</p>
+        <p className="text-muted-foreground mt-1 text-[11px]">
+          {formatNoticeDate(notice.publishedAt)}
+        </p>
+      </div>
+
+      <ChevronRight className="text-muted-foreground size-4 shrink-0" aria-hidden />
+    </Link>
+  );
+}

--- a/src/features/notice/components/notice-list.tsx
+++ b/src/features/notice/components/notice-list.tsx
@@ -1,0 +1,23 @@
+import type { NoticeSummary } from "../types";
+import { NoticeListItem } from "./notice-list-item";
+
+/** 공지 목록. 비어있으면 안내 문구로 대체한다(CLAUDE.md §정직성 · loading/error/empty). */
+export function NoticeList({ notices }: { notices: NoticeSummary[] }) {
+  if (notices.length === 0) {
+    return (
+      <div className="border-border bg-card flex items-center justify-center rounded-lg border p-10 text-center">
+        <p className="text-muted-foreground text-sm">아직 등록된 공지가 없어요</p>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="border-border bg-card divide-border divide-y overflow-hidden rounded-lg border">
+      {notices.map((notice) => (
+        <li key={notice.id}>
+          <NoticeListItem notice={notice} />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/features/notice/format.ts
+++ b/src/features/notice/format.ts
@@ -1,0 +1,9 @@
+/**
+ * "2026-08-03" → "2026년 8월 3일".
+ * ⚠️ 로케일 포맷터(`toLocaleDateString`)에 맡기지 않는다 — 서버·클라이언트 로케일이 갈리면
+ *    하이드레이션에서 표기가 어긋날 수 있다(CLAUDE.md §렌더링). 직접 조립해 항상 같게 만든다.
+ */
+export function formatNoticeDate(iso: string): string {
+  const [year, month, day] = iso.split("-");
+  return `${Number(year)}년 ${Number(month)}월 ${Number(day)}일`;
+}

--- a/src/features/notice/mock/notices.ts
+++ b/src/features/notice/mock/notices.ts
@@ -72,3 +72,10 @@ export function updateMockNotice(id: string, draft: NoticeDraft): Notice | null 
   store.notices = store.notices.map((item) => (item.id === id ? updated : item));
   return updated;
 }
+
+/** 삭제 — 있던 공지면 지우고 true, 이미 없으면 false(중복 삭제 요청도 조용히 넘어간다). */
+export function deleteMockNotice(id: string): boolean {
+  const existed = store.notices.some((notice) => notice.id === id);
+  store.notices = store.notices.filter((notice) => notice.id !== id);
+  return existed;
+}

--- a/src/features/notice/mock/notices.ts
+++ b/src/features/notice/mock/notices.ts
@@ -1,10 +1,20 @@
-import type { Notice } from "../types";
+import type { Notice, NoticeDraft } from "../types";
 
 /**
- * ⚠️ 목 데이터 — BE 연동 전. 워크벤치 "공지" 화면에서 보여줄 예시 값이다.
- * `isRead`도 지금은 목 값이다 — 실제 읽음 처리는 후속 작업(Server Action)에서 붙인다(§정직성).
+ * ⚠️ 목 데이터 — BE 연동 전. **서버 프로세스 메모리에만 있다**(재시작하면 초기값으로 되돌아간다).
+ * 작성·수정·읽음 Server Action이 이 배열을 직접 바꾼다 — 실제 DB 흉내다.
+ * ⚠️ `isRead`도 목 값이다 — 로그인(세션)이 없어 "이 사용자가 읽음"이 아니라 **전역**으로 흉내 낸다(§정직성).
+ *
+ * ⚠️ 상태를 `globalThis`에 매단다 — dev의 HMR(코드 저장 시 모듈 재평가)로 `let`이 초기화되면
+ *    방금 만든/읽은 공지가 사라진다. `globalThis`는 재평가를 넘어 살아남아 데모가 덜 튄다.
+ *    (BE가 붙으면 이 파일은 사라지고 상태는 DB로 간다 — 이 트릭도 같이 사라진다.)
  */
-export const MOCK_NOTICES: Notice[] = [
+interface NoticeStore {
+  notices: Notice[];
+  sequence: number;
+}
+
+const INITIAL: Notice[] = [
   {
     id: "notice-1",
     title: "회의실 예약과 참석 안내",
@@ -13,3 +23,52 @@ export const MOCK_NOTICES: Notice[] = [
     isRead: false,
   },
 ];
+
+const globalStore = globalThis as typeof globalThis & { __noticeStore?: NoticeStore };
+const store: NoticeStore = (globalStore.__noticeStore ??= {
+  notices: INITIAL,
+  sequence: INITIAL.length,
+});
+
+export function listMockNotices(): Notice[] {
+  return store.notices;
+}
+
+export function findMockNotice(id: string): Notice | null {
+  return store.notices.find((notice) => notice.id === id) ?? null;
+}
+
+/** 안 읽은 공지 수 — 사이드바 미읽음 점·목록 표시가 같은 소스에서 센다. */
+export function countUnreadMockNotices(): number {
+  return store.notices.filter((notice) => !notice.isRead).length;
+}
+
+/** 읽음 처리 — 배열 안 항목을 직접 바꾼다(실제 DB 흉내). */
+export function markMockNoticeRead(id: string): Notice | null {
+  const notice = findMockNotice(id);
+  if (!notice) return null;
+  store.notices = store.notices.map((item) => (item.id === id ? { ...item, isRead: true } : item));
+  return { ...notice, isRead: true };
+}
+
+/** 작성 — 최신 글이 위로 오도록 앞에 붙인다. `publishedAt`은 서버에서 계산해 넘긴다. */
+export function addMockNotice(draft: NoticeDraft, publishedAt: string): Notice {
+  const notice: Notice = {
+    id: `notice-${++store.sequence}`,
+    title: draft.title.trim(),
+    body: draft.body.trim(),
+    publishedAt,
+    isRead: false,
+  };
+  store.notices = [notice, ...store.notices];
+  return notice;
+}
+
+/** 수정 — 제목·내용만 바꾼다(발행일·읽음 상태는 유지). */
+export function updateMockNotice(id: string, draft: NoticeDraft): Notice | null {
+  const notice = findMockNotice(id);
+  if (!notice) return null;
+  const updated: Notice = { ...notice, title: draft.title.trim(), body: draft.body.trim() };
+  store.notices = store.notices.map((item) => (item.id === id ? updated : item));
+  return updated;
+}

--- a/src/features/notice/mock/notices.ts
+++ b/src/features/notice/mock/notices.ts
@@ -1,0 +1,15 @@
+import type { Notice } from "../types";
+
+/**
+ * ⚠️ 목 데이터 — BE 연동 전. 워크벤치 "공지" 화면에서 보여줄 예시 값이다.
+ * `isRead`도 지금은 목 값이다 — 실제 읽음 처리는 후속 작업(Server Action)에서 붙인다(§정직성).
+ */
+export const MOCK_NOTICES: Notice[] = [
+  {
+    id: "notice-1",
+    title: "회의실 예약과 참석 안내",
+    body: "회의는 회의실 예약 화면에서만 개설할 수 있습니다. 예약이 확정되면 참석자에게 회의 개설 및 시작 전 안내가 표시됩니다.",
+    publishedAt: "2026-08-03",
+    isRead: false,
+  },
+];

--- a/src/features/notice/server.ts
+++ b/src/features/notice/server.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import { isMock } from "@/mocks/config";
 
-import { MOCK_NOTICES } from "./mock/notices";
+import { countUnreadMockNotices, findMockNotice, listMockNotices } from "./mock/notices";
 import type { Notice, NoticeSummary } from "./types";
 
 /**
@@ -11,7 +11,7 @@ import type { Notice, NoticeSummary } from "./types";
  */
 export async function getNotices(): Promise<NoticeSummary[]> {
   if (isMock) {
-    return MOCK_NOTICES.map((notice) => ({
+    return listMockNotices().map((notice) => ({
       id: notice.id,
       title: notice.title,
       publishedAt: notice.publishedAt,
@@ -25,11 +25,19 @@ export async function getNotices(): Promise<NoticeSummary[]> {
 
 /**
  * 공지 상세 — 격리막(CLAUDE.md). 없으면 `null`을 돌려 화면이 404로 넘긴다.
- * ⚠️ 읽음 처리는 여기서 하지 않는다 — 조회는 부수효과가 없어야 한다. 읽음 반영은 후속 작업(Server Action).
+ * ⚠️ 읽음 처리는 여기서 하지 않는다 — 조회는 부수효과가 없어야 한다. 읽음은 `markNoticeReadAction`이 한다.
  */
 export async function getNoticeById(id: string): Promise<Notice | null> {
-  if (isMock) return MOCK_NOTICES.find((notice) => notice.id === id) ?? null;
+  if (isMock) return findMockNotice(id);
 
   // ⚠️ 미구현 — API 스펙 확정 후 공지 상세 경로로 fetch하고 매퍼로 UI 계약에 맞춘다.
   throw new Error("공지 상세 API가 아직 연결되지 않았습니다.");
+}
+
+/** 안 읽은 공지 수 — 사이드바 미읽음 점 표시용(0이면 점을 안 찍는다). */
+export async function getUnreadNoticeCount(): Promise<number> {
+  if (isMock) return countUnreadMockNotices();
+
+  // ⚠️ 미구현 — API 스펙 확정 후 미읽음 수 경로로 fetch한다.
+  throw new Error("공지 미읽음 수 API가 아직 연결되지 않았습니다.");
 }

--- a/src/features/notice/server.ts
+++ b/src/features/notice/server.ts
@@ -1,0 +1,35 @@
+import "server-only";
+
+import { isMock } from "@/mocks/config";
+
+import { MOCK_NOTICES } from "./mock/notices";
+import type { Notice, NoticeSummary } from "./types";
+
+/**
+ * 워크벤치 공지 목록 — **격리막**(CLAUDE.md). 목록엔 본문이 필요 없어 요약만 내려준다.
+ * 연동할 때 고칠 곳은 이 파일과 매퍼뿐이고 컴포넌트는 건드리지 않는다.
+ */
+export async function getNotices(): Promise<NoticeSummary[]> {
+  if (isMock) {
+    return MOCK_NOTICES.map((notice) => ({
+      id: notice.id,
+      title: notice.title,
+      publishedAt: notice.publishedAt,
+      isRead: notice.isRead,
+    }));
+  }
+
+  // ⚠️ 미구현 — API 스펙 확정 후 공지 목록 경로로 fetch하고 매퍼로 UI 계약에 맞춘다.
+  throw new Error("공지 목록 API가 아직 연결되지 않았습니다.");
+}
+
+/**
+ * 공지 상세 — 격리막(CLAUDE.md). 없으면 `null`을 돌려 화면이 404로 넘긴다.
+ * ⚠️ 읽음 처리는 여기서 하지 않는다 — 조회는 부수효과가 없어야 한다. 읽음 반영은 후속 작업(Server Action).
+ */
+export async function getNoticeById(id: string): Promise<Notice | null> {
+  if (isMock) return MOCK_NOTICES.find((notice) => notice.id === id) ?? null;
+
+  // ⚠️ 미구현 — API 스펙 확정 후 공지 상세 경로로 fetch하고 매퍼로 UI 계약에 맞춘다.
+  throw new Error("공지 상세 API가 아직 연결되지 않았습니다.");
+}

--- a/src/features/notice/types.ts
+++ b/src/features/notice/types.ts
@@ -1,0 +1,18 @@
+/**
+ * 워크벤치 공지 — 격리막의 UI 계약(CLAUDE.md §Mock 격리막).
+ * 컴포넌트는 이 타입만 알고, 목/실서버 분기는 `server.ts`가 끝낸다.
+ */
+
+/** 공지 한 건(본문 포함). 목록은 본문을 뺀 요약만 쓴다. */
+export interface Notice {
+  id: string;
+  title: string;
+  body: string;
+  /** "YYYY-MM-DD" — 표시는 `formatNoticeDate`로 "2026년 8월 3일" 꼴로 바꾼다 */
+  publishedAt: string;
+  /** 이 사용자가 아직 안 읽었는지 — 미읽음 점 표시용(읽음 처리는 후속 작업) */
+  isRead: boolean;
+}
+
+/** 목록 한 줄 — 본문은 상세에서만 필요하므로 뺀다. */
+export type NoticeSummary = Omit<Notice, "body">;

--- a/src/features/notice/types.ts
+++ b/src/features/notice/types.ts
@@ -16,3 +16,12 @@ export interface Notice {
 
 /** 목록 한 줄 — 본문은 상세에서만 필요하므로 뺀다. */
 export type NoticeSummary = Omit<Notice, "body">;
+
+/** 공지 작성·수정 폼 입력 — 화면과 서버가 **같은 스키마**로 검증한다(규칙이 두 벌이 되면 어긋난다). */
+export interface NoticeDraft {
+  title: string;
+  body: string;
+}
+
+/** 칸별 검증 오류 — 비어 있으면 통과. */
+export type NoticeFormErrors = Partial<Record<keyof NoticeDraft, string>>;

--- a/src/features/notice/validate.ts
+++ b/src/features/notice/validate.ts
@@ -1,0 +1,12 @@
+import type { NoticeDraft, NoticeFormErrors } from "./types";
+
+/**
+ * 공지 작성·수정 검증 — 제목·내용 필수.
+ * ⚠️ 화면(폼)과 서버(Server Action)가 **이 함수 하나**로 본다 — 규칙이 두 벌이면 반드시 어긋난다.
+ */
+export function validateNoticeDraft(draft: NoticeDraft): NoticeFormErrors {
+  const errors: NoticeFormErrors = {};
+  if (!draft.title.trim()) errors.title = "제목을 입력해 주세요";
+  if (!draft.body.trim()) errors.body = "내용을 입력해 주세요";
+  return errors;
+}

--- a/src/features/shell/components/page-header.tsx
+++ b/src/features/shell/components/page-header.tsx
@@ -16,6 +16,11 @@ interface PageHeaderProps {
    * 목록에서 상세로 들어가는 것처럼 한 단계 더 깊은 화면에서만 쓴다.
    */
   backTo?: { href: string; label: string };
+  /**
+   * `backTo`가 없어도 뒤로가기 화살표 **자리만 비워 둔다**. 같은 헤더에서 목록↔상세를 오갈 때
+   * 화살표가 생겼다 사라지며 제목이 좌우로 밀리는 덜컥거림을 막는다 — 자리는 늘 같고 화살표만 토글된다.
+   */
+  reserveBack?: boolean;
   /** 오른쪽 액션 — 버튼 하나 또는 몇 개. 없으면 비워둔다 */
   action?: ReactNode;
 }
@@ -32,11 +37,18 @@ interface PageHeaderProps {
  *    화면마다 머리를 새로 그리면 높이·여백이 갈린다(사이드바와 같은 이유).
  * ⚠️ 탭은 여기에 넣지 않는다. 탭이 필요한 화면은 이 아래에 따로 둔다.
  */
-export function PageHeader({ title, icon: Icon, meta, backTo, action }: PageHeaderProps) {
+export function PageHeader({
+  title,
+  icon: Icon,
+  meta,
+  backTo,
+  reserveBack,
+  action,
+}: PageHeaderProps) {
   return (
     <header className="border-border bg-background flex h-[64px] shrink-0 items-center gap-3 border-b px-8">
       {/* 화살표는 제목 왼쪽에 나란히 둔다 — 제목 위에 경로를 한 줄 더 쓰지 않는다 */}
-      {backTo && (
+      {backTo ? (
         <Link
           href={backTo.href}
           aria-label={`${backTo.label}(으)로 돌아가기`}
@@ -44,7 +56,10 @@ export function PageHeader({ title, icon: Icon, meta, backTo, action }: PageHead
         >
           <ArrowLeft className="size-[18px]" />
         </Link>
-      )}
+      ) : reserveBack ? (
+        /* 화살표 없이 자리만 차지 — 제목이 밀리지 않게(위 reserveBack 주석). 크기는 위 Link와 같다 */
+        <span aria-hidden className="-ml-1.5 size-8 shrink-0" />
+      ) : null}
 
       {/* 제목과 같은 색이다 — 흐리게 두면 제목 옆에 붙은 게 아니라 떨어진 장식처럼 보인다 */}
       {Icon && <Icon className="text-foreground size-5 shrink-0" aria-hidden />}

--- a/src/features/shell/components/role-sidebar.tsx
+++ b/src/features/shell/components/role-sidebar.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  Bell,
   CalendarDays,
   CalendarRange,
   Columns3,
@@ -10,6 +9,7 @@ import {
   HardDrive,
   LayoutDashboard,
   type LucideIcon,
+  Megaphone,
   Search,
   Settings,
   UserRound,
@@ -37,7 +37,7 @@ const NAV_ICON: Partial<Record<NavIconName, LucideIcon>> = {
   project: Folder,
   search: Search,
   calendar: CalendarDays,
-  notice: Bell,
+  notice: Megaphone,
   meeting: Video,
   room: CalendarRange,
   board: Columns3,

--- a/src/features/shell/components/role-sidebar.tsx
+++ b/src/features/shell/components/role-sidebar.tsx
@@ -151,6 +151,12 @@ function SidebarItem({ item, isCurrent }: { item: NavItem; isCurrent: boolean })
       <span className="min-w-0 flex-1 translate-y-px truncate text-[13px] leading-5">
         {item.label}
       </span>
+      {item.dot && (
+        <>
+          <span className="bg-destructive size-[6px] shrink-0 rounded-full" aria-hidden />
+          <span className="sr-only">안 읽음</span>
+        </>
+      )}
       {item.badge !== undefined && (
         <span className="bg-foreground text-background flex h-[17px] min-w-[17px] shrink-0 items-center justify-center rounded-full px-[3.5px] text-[10px] leading-none font-semibold tabular-nums">
           {item.badge}

--- a/src/features/shell/nav.ts
+++ b/src/features/shell/nav.ts
@@ -37,6 +37,11 @@ export interface NavItem {
   isReady?: boolean;
   /** 오른쪽에 붙는 숫자(처리할 일 수) */
   badge?: number;
+  /**
+   * 미읽음 등 "안 본 게 있음"을 알리는 빨간 점. 숫자(`badge`)와 달리 개수는 안 보여준다.
+   * ⚠️ 정적 구성이 아니라 **레이아웃이 서버에서 계산해 끼워 넣는다**(예: 공지 미읽음 수 > 0).
+   */
+  dot?: boolean;
 }
 
 export interface NavSection {

--- a/src/features/shell/nav.ts
+++ b/src/features/shell/nav.ts
@@ -58,7 +58,7 @@ export const OWNER_NAV: NavSection[] = [
       { href: "/app/projects", label: "프로젝트", icon: "project" },
       { href: "/app/search", label: "검색", icon: "search" },
       { href: "/app/calendar", label: "캘린더", icon: "calendar" },
-      { href: "/app/notice", label: "공지사항", icon: "notice" },
+      { href: "/app/notice", label: "공지", icon: "notice", isReady: true },
     ],
   },
   {

--- a/src/features/system/actions.test.ts
+++ b/src/features/system/actions.test.ts
@@ -124,7 +124,7 @@ describe("공지 발행", () => {
     const result = await publishNoticeAction({
       title: "제목",
       content: "",
-      target: NOTICE_TARGET.TEAM,
+      target: NOTICE_TARGET.UNPAID,
     });
 
     expect(result).toEqual({ success: false });

--- a/src/features/system/components/notice-compose-card.test.tsx
+++ b/src/features/system/components/notice-compose-card.test.tsx
@@ -12,7 +12,8 @@ jest.mock("../actions", () => ({
 }));
 
 function setup() {
-  return { user: userEvent.setup(), ...render(<NoticeComposeCard />) };
+  // 기본 대상은 "전체 기업"이라 companies는 쓰이지 않는다(특정 기업 검색용) — 빈 목록으로 충분하다.
+  return { user: userEvent.setup(), ...render(<NoticeComposeCard companies={[]} />) };
 }
 
 beforeEach(() => publishNoticeAction.mockReset());

--- a/src/features/system/server.test.ts
+++ b/src/features/system/server.test.ts
@@ -1,7 +1,7 @@
 // server.ts는 "server-only"를 import한다 — jest(기본 조건)에선 그 모듈이 던지므로 비운다.
 jest.mock("server-only", () => ({}));
 
-import { COMPANY_SIZE, COMPANY_STATUS } from "@/constants/domain";
+import { COMPANY_SORT, COMPANY_STATUS } from "@/constants/domain";
 
 import { MOCK_BILLING_OVERVIEW } from "./mock/billing";
 import { listMockCompanies } from "./mock/companies";
@@ -71,19 +71,17 @@ describe("기업 관리 목록 — 검색·필터·페이지네이션", () => {
     expect(result.items.every((company) => company.status === COMPANY_STATUS.ACTIVE)).toBe(true);
   });
 
-  it("규모·상태를 함께 걸면 둘 다 만족하는 것만 남는다", async () => {
+  it("상태 필터와 정렬을 함께 걸면 상태로 거르고 그 순서로 돌려준다", async () => {
     const result = await getManagedCompanies(
-      { size: COMPANY_SIZE.MEDIUM, status: COMPANY_STATUS.ACTIVE },
+      { status: COMPANY_STATUS.ACTIVE, sort: COMPANY_SORT.MEMBERS_DESC },
       1,
       100,
     );
 
-    expect(
-      result.items.every(
-        (company) =>
-          company.size === COMPANY_SIZE.MEDIUM && company.status === COMPANY_STATUS.ACTIVE,
-      ),
-    ).toBe(true);
+    expect(result.items.every((company) => company.status === COMPANY_STATUS.ACTIVE)).toBe(true);
+    // 구성원 많은순 정렬 — 내림차순으로 정렬돼 있어야 한다.
+    const memberCounts = result.items.map((company) => company.memberCount);
+    expect(memberCounts).toEqual([...memberCounts].sort((a, b) => b - a));
   });
 });
 

--- a/src/lib/mock-actor.ts
+++ b/src/lib/mock-actor.ts
@@ -1,0 +1,16 @@
+import "server-only";
+
+import { ROLE } from "@/constants/domain";
+
+import type { Actor } from "./permission";
+
+/**
+ * 목 현재 사용자.
+ *
+ * ⚠️ 로그인(세션)이 아직 없다(BE 미개발) — 지금은 셸이 가정하는 **OWNER 한 명**이 고정으로 온다.
+ *    auth가 붙으면 httpOnly 쿠키 세션에서 actor를 읽어 **이 함수만** 갈아끼운다 — 이 함수를 쓰는
+ *    화면·Server Action은 그대로다(§Mock 격리막). 그래서 서버 재검사도 여기서 나온 actor로 한다.
+ */
+export function getMockActor(): Actor {
+  return { id: 1, role: ROLE.OWNER };
+}

--- a/src/lib/permission.ts
+++ b/src/lib/permission.ts
@@ -62,6 +62,14 @@ export function canManageMembers(actor: Actor): boolean {
   return actor.role === ROLE.OWNER || isAdmin(actor);
 }
 
+/**
+ * 사내 공지 작성·수정 — OWNER이거나 Admin을 겸한 사람.
+ * ⚠️ 열람은 전원 가능하다(공지는 다 같이 본다) — 작성·수정만 이 권한으로 막는다.
+ */
+export function canManageNotice(actor: Actor): boolean {
+  return actor.role === ROLE.OWNER || isAdmin(actor);
+}
+
 /** 계정 발급 — Admin 겸직자만. OWNER는 발급 대상도 발급자도 아니다. */
 export function canIssueAccount(actor: Actor): boolean {
   return isAdmin(actor);


### PR DESCRIPTION
## 📋 PR 타입
- [x] feature

---

## 🗂 작업 영역
- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실

---

## 🙋 관련 역할
- [x] OWNER
- [x] ADMIN
- [x] 공통

---

## 📝 작업 내용
- 읽음 처리: `markNoticeReadAction`(폼 액션) + 상세 `MarkNoticeRead` 잎사귀, `revalidatePath`로 목록·사이드바 갱신
- 작성/수정: `createNoticeAction`·`updateNoticeAction` + 공용 `NoticeForm`(useActionState, 인라인 검증) + `/new`·`/[id]/edit`
- 권한: `canManageNotice`(OWNER‖ADMIN) — 화면 버튼 가드 + 액션 서버 재검사, 목 actor는 `lib/mock-actor`
- 사이드바 미읽음 점: `nav.dot` + 셸 레이아웃이 미읽음 수 조회해 주입 + `role-sidebar` 렌더
- 목 스토어를 `globalThis` 기반 가변 스토어로(작성·수정·읽음 반영, dev HMR 견딤)

---

## ✅ 작업 체크리스트
- [x] 🔐 권한 2축 — 역할 가드 + **서버 재검사**(리소스 소유권은 공지에 해당 없음)
- [x] 🕵️ 정직성 — 목/미구현/전역-읽음/목-actor 전부 주석·§정직성 명시, 링크는 실제 화면만
- [x] 🎨 디자인 토큰 — 생 hex 없음
- [x] ♿ a11y — label htmlFor · 검증 오류 인라인 + `aria-invalid` · 미읽음 점 `sr-only "안 읽음"` · 버튼/링크 이동
- [x] 🧪 loading/error/empty — 목록·상세 3상태, 폼 검증 오류 인라인
- [x] ♻️ 재사용 — `Button`/`buttonVariants`/`Input`/`Label` + 작성·수정 폼 1개 공용

---

## 🔗 연관 이슈
Closes #85

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트
- **권한 가정**: 사내 공지 작성/수정 = OWNER‖ADMIN. 정책 맞는지 확인(아니면 `canManageNotice`만 고치면 됨)
- 읽음을 **폼 액션**으로 부른 이유(useEffect 직접 호출은 dev에서 목 반영 안 됨) — 코드 주석 참고
- 목 `globalThis` 트릭은 dev 편의용, BE 연동 시 파일째 제거
- 세션(로그인) 붙으면 `getMockActor()`만 실제 세션 actor로 교체 — 컴포넌트·액션 무변경

---

## 📝 추가 메모

-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 공지사항 목록, 상세 보기, 작성·수정·삭제 기능을 추가했습니다.
  * 공지 열람 시 읽음 상태가 자동으로 처리됩니다.
  * 관리자에게만 공지 관리 기능이 표시됩니다.
  * 읽지 않은 공지가 있으면 사이드바에 알림 표시가 나타납니다.
* **사용성 개선**
  * 공지 화면에 로딩 스켈레톤과 오류 시 재시도 화면을 제공합니다.
  * 제목과 본문 입력값을 검증하고 항목별 오류를 안내합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
