### PR TITLE
[FEAT] 이름·직급 기반 프로필 아바타 색상 생성 훅 #91

### DIFF
--- a/src/hooks/use-profile-avatar.tsx
+++ b/src/hooks/use-profile-avatar.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { type ReactElement, useMemo } from "react";
+
+/**
+ * ⚠️ 디자인 수정 지점 — 팔레트 교체 시 각 항목의 bg/text hex 값만 바꾼다.
+ *    배열 순서·개수를 바꾸면 기존 인물들의 색 배정이 전부 밀려서 바뀐다.
+ */
+const AVATAR_PALETTE = [
+  { bg: "#DCFCE7", text: "#166534" }, // 그린
+  { bg: "#DBEAFE", text: "#1E40AF" }, // 블루
+  { bg: "#FCE7F3", text: "#9D174D" }, // 핑크
+  { bg: "#FEF3C7", text: "#92400E" }, // 앰버
+  { bg: "#EDE9FE", text: "#5B21B6" }, // 바이올렛
+  { bg: "#E0F2FE", text: "#075985" }, // 스카이
+  { bg: "#FFEDD5", text: "#9A3412" }, // 오렌지
+  { bg: "#F1F5F9", text: "#334155" }, // 슬레이트
+  { bg: "#CCFBF1", text: "#115E59" }, // 틸
+  { bg: "#FAE8FF", text: "#86198F" }, // 퍼플핑크
+  { bg: "#FEF9C3", text: "#854D0E" }, // 옐로우
+  { bg: "#E7E5E4", text: "#44403C" }, // 웜그레이
+  { bg: "#D1FAE5", text: "#065F46" }, // 에메랄드
+  { bg: "#DDD6FE", text: "#4C1D95" }, // 인디고
+  { bg: "#FFE4E6", text: "#9F1239" }, // 로즈
+  { bg: "#CFFAFE", text: "#155E75" }, // 시안
+] as const;
+
+function hashString(value: string): number {
+  let hash = 0;
+  for (let i = 0; i < value.length; i++) {
+    hash = (hash << 5) - hash + value.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash);
+}
+
+interface ProfileAvatarColor {
+  bgColor: string;
+  textColor: string;
+}
+
+/**
+ * 이름+직급을 해싱해 항상 같은 파스텔 색을 돌려준다(BE에 프로필 필드가 없어 FE에서 결정).
+ * 동명이인은 role까지 키에 포함해 구분한다 — role이 바뀌면 색도 바뀐다(트레이드오프 감수).
+ */
+function getProfileAvatarColor(name: string, role: string): ProfileAvatarColor {
+  const key = `${name}-${role}`;
+  const index = hashString(key) % AVATAR_PALETTE.length;
+  const palette = AVATAR_PALETTE[index] ?? AVATAR_PALETTE[0];
+  return { bgColor: palette.bg, textColor: palette.text };
+}
+
+/** 원형 배경 안에 꽉 채워 그리는 사람 실루엣. 하단은 원 밖으로 잘리도록 slice 처리한다. */
+function ProfileAvatarIcon({ color }: { color: string }) {
+  return (
+    <svg
+      width="100%"
+      height="100%"
+      viewBox="0 0 100 100"
+      preserveAspectRatio="xMidYMax slice"
+      style={{ display: "block" }}
+      aria-hidden="true"
+    >
+      <circle cx="50" cy="38" r="18" fill={color} />
+      <path d="M50 58c-22 0-34 14-34 34h68c0-20-12-34-34-34z" fill={color} />
+    </svg>
+  );
+}
+
+/**
+ * 이름+직급만 넘기면 바로 렌더링 가능한 원형 프로필 아바타(JSX)를 돌려준다.
+ * BE에 프로필 이미지 필드가 없어서, 같은 사람은 항상 같은 파스텔 색+실루엣이 나오도록 FE에서 생성한다.
+ *
+ * @param name 이름 — 표시 및 색상 해시 키에 사용
+ * @param role 직급/역할 — 동명이인 구분용으로 색상 해시 키에 함께 포함(role이 바뀌면 색도 바뀜)
+ * @param size 아바타 지름(px). 기본값 40
+ * @returns 그대로 렌더링하면 되는 원형 아바타 JSX 엘리먼트 (배경색+실루엣 포함)
+ *
+ * @example
+ * const avatar = useProfileAvatar(member.name, member.role);
+ * return <div>{avatar}</div>;
+ */
+export function useProfileAvatar(name: string, role: string, size: number = 40): ReactElement {
+  const { bgColor, textColor } = useMemo(() => getProfileAvatarColor(name, role), [name, role]);
+
+  return useMemo(
+    () => (
+      <div
+        style={{
+          width: size,
+          height: size,
+          borderRadius: "9999px",
+          overflow: "hidden",
+          backgroundColor: bgColor,
+          flexShrink: 0,
+        }}
+      >
+        <ProfileAvatarIcon color={textColor} />
+      </div>
+    ),
+    [size, bgColor, textColor],
+  );
+}


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [x] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

- `src/hooks/use-profile-avatar.tsx` 추가: 이름+직급 해싱 → 16색 파스텔 팔레트 인덱싱
- `useProfileAvatar(name, role, size?)` 훅이 배경색+실루엣이 합쳐진 원형 아바타 JSX를 바로 반환
- 동명이인 구분을 위해 직급(role)까지 해시 키에 포함(BE 프로필 필드 부재로 인한 FE 전용 대체 로직)

---

## ✅ 작업 체크리스트

**기본**

- [ ] 브랜치 명명 규칙 준수 (`feature/profile-avatar-color#{이슈번호}` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [ ] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 해당 없음(권한 무관 공통 표시 로직)
- [ ] 🧬 **zod** — 해당 없음(BE 응답 매핑 아님, 순수 FE 계산)
- [x] 🕵️ **정직성** — BE에 실제 프로필 필드가 없다는 점, FE 파생값이라는 점을 코드 주석에 명시함
- [ ] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨
  — ⚠️ 예외: 아바타 팔레트는 인물 식별용 고정 배열이라 디자인 토큰(CSS 변수) 대신 상수 hex 사용. 아래 리뷰 포인트 참고.

**품질**

- [ ] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그)
- [x] ♿ a11y (label · role · alt · **키보드**) — 아이콘 `aria-hidden`, 장식 요소만이라 별도 텍스트 대체 불필요
- [x] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인) — 기존 아바타 컴포넌트 없음 확인 후 신규 작성
- [ ] 🧪 `loading` / `error` / `empty` 3상태 — 해당 없음(비동기 아님)
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음 — 해당 없음

---

## 🔗 연관 이슈

Closes #91

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- 아바타 팔레트(`AVATAR_PALETTE`)를 디자인 토큰 CSS 변수가 아니라 코드 내 고정 hex 배열로 둔 이유:
  디자인 시스템 토큰(라이트/다크 공용)과 달리, 이건 "인물별 고정 식별색"이라 전역 테마 전환과 무관하게 고정되어야 함.
  디자인팀 팔레트 교체 시에도 hex 값만 바꾸면 되도록 별도 분리해둠 — 승인 부탁드립니다.
- 동명이인 구분을 위해 `name + role`을 해시 키로 사용 — role(직급) 변경 시 아바타 색도 바뀌는 트레이드오프 감수함.

---

## 📝 추가 메모

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 이름과 직급을 기반으로 일관된 색상을 자동 선택하는 프로필 아바타를 추가했습니다.
  * 사람 실루엣이 포함된 원형 아바타를 지정한 크기로 표시할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->