### PR TITLE
[FEAT] 결제 권한 없으면 창으로 막고, 결제 수단 한 장 + 화면 표식 #94 #96 #97

### DIFF
--- a/src/app/(gate)/subscription/loading.tsx
+++ b/src/app/(gate)/subscription/loading.tsx
@@ -1,6 +1,12 @@
 import { Skeleton } from "@/components/ui/skeleton";
 
-/** 구독 상태를 불러오는 동안 — 실제 화면과 같은 골격이라 레이아웃이 흔들리지 않는다. */
+/**
+ * 구독 상태를 불러오는 동안 — **결제할 수 있는 사람** 기준의 골격이다.
+ *
+ * ⚠️ 여기서는 보는 사람이 누구인지 알 수 없다. 권한은 서버 컴포넌트가 세션을 읽어야 나오는데
+ *    뼈대는 그 전에 그려지기 때문이다 — 그래서 결제 권한이 없는 사람에게는 카드 자리가
+ *    잠깐 비쳤다가 창으로 바뀐다. 뼈대를 지우면 그동안 화면이 통째로 비어서 더 나쁘다.
+ */
 export default function Loading() {
   return (
     <div className="bg-background bg-dot-grid flex min-h-dvh flex-col">

--- a/src/app/(shell)/(role)/manage/billing/(overview)/loading.tsx
+++ b/src/app/(shell)/(role)/manage/billing/(overview)/loading.tsx
@@ -7,6 +7,8 @@ import { Skeleton } from "@/components/ui/skeleton";
  *    탭 셋이 남아 있었다 — 로딩이 끝나는 순간 그 줄이 사라지면서 아래가 통째로 위로 밀린다.
  * ⚠️ 카드는 **네 장**이다(플랜 · 사용량 · 결제 수단 · 결제 내역). 간격도 본문과 같은 `gap-7`이다.
  *    수를 줄여 두면 채워질 때 아래로 길어지면서 스크롤이 튄다.
+ * ⚠️ 결제 수단은 **한 줄뿐**이다(카드는 회사당 한 장, 2026-08-05). 여러 장 목록이던 시절의
+ *    높이를 그대로 두면 채워지는 순간 45px이 접히면서 아래가 위로 딸려 올라간다.
  */
 export default function ManageBillingLoading() {
   return (
@@ -15,7 +17,7 @@ export default function ManageBillingLoading() {
         <div className="flex flex-col gap-7">
           <Skeleton className="h-[188px] w-full rounded-2xl" />
           <Skeleton className="h-[268px] w-full rounded-2xl" />
-          <Skeleton className="h-[196px] w-full rounded-2xl" />
+          <Skeleton className="h-[152px] w-full rounded-2xl" />
           <Skeleton className="h-[228px] w-full rounded-2xl" />
         </div>
       </div>

--- a/src/components/common/result-dialog.tsx
+++ b/src/components/common/result-dialog.tsx
@@ -27,6 +27,15 @@ interface ResultDialogProps {
   children?: ReactNode;
   /** 다음 행동 — 링크든 버튼이든 하나만 둔다 */
   action?: ReactNode;
+  /**
+   * 닫을 수 있는가(기본 `true`).
+   *
+   * ⚠️ `false`면 X를 지운다. **뒤에 볼 것이 없는 창**에만 쓴다 — 닫아서 빈 화면이 남으면
+   *    막힌 게 아니라 고장 난 것처럼 보인다.
+   * ⚠️ Esc·바깥 클릭은 여기서 막지 않는다. 그 둘은 `onOpenChange`를 부를 뿐이라,
+   *    쓰는 쪽이 상태를 안 바꾸면(`isOpen`을 계속 참으로 두면) 열린 채로 남는다.
+   */
+  isDismissible?: boolean;
 }
 
 /**
@@ -50,6 +59,7 @@ export function ResultDialog({
   children,
   action,
   badge,
+  isDismissible = true,
 }: ResultDialogProps) {
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
@@ -57,7 +67,7 @@ export function ResultDialog({
         ⚠️ `gap-0` — DialogContent가 자체 `gap-4`를 갖고 있어 아래 `mt-*`와 겹쳐 간격이 두 배가 된다.
            여백은 여기서 한 곳으로만 준다.
       */}
-      <DialogContent className="gap-0 p-8 sm:max-w-[420px]">
+      <DialogContent showCloseButton={isDismissible} className="gap-0 p-8 sm:max-w-[420px]">
         <DialogHeader className="items-center gap-5 text-center">
           <DialogMark badge={badge} />
 

--- a/src/features/billing/actions.ts
+++ b/src/features/billing/actions.ts
@@ -86,6 +86,8 @@ export async function confirmSubscriptionAction(): Promise<ActionResult> {
  *
  * ⚠️ 빌링키는 **서버에만** 있다. 그 키로 결제가 일어나므로 브라우저로 내보내지 않는다.
  * ⚠️ 화면에는 표시용 정보(브랜드 · 뒤 4자리 · 만료월)만 돌려준다.
+ * ⚠️ **더하는 게 아니라 갈아 끼운다.** 카드는 회사당 한 장이라, 이미 있으면 그 자리를 덮는다 —
+ *    BE도 빌링키를 1:1로 들고 있어야 한다(§BE 전달 사항).
  */
 export async function registerCardAction(
   auth: CardAuthResult,
@@ -101,7 +103,6 @@ export async function registerCardAction(
         brand: "MASTER",
         last4: `${Math.floor(Math.random() * 9000) + 1000}`,
         expiry: "12/29",
-        isDefault: false,
       },
     };
   }
@@ -110,38 +111,11 @@ export async function registerCardAction(
   return { isSuccess: false, message: "결제 수단을 저장하지 못했습니다" };
 }
 
-/** 기본 결제 수단을 바꾼다 */
-export async function setDefaultMethodAction(methodId: string): Promise<ActionResult> {
-  if (!(await assertCanManage())) return FORBIDDEN;
-
-  if (isMock) {
-    revalidatePath("/manage/billing");
-    return { isSuccess: true };
-  }
-
-  // TODO(BE 협의): `PATCH /companies/me/payment-methods/{methodId}/default`
-  void methodId;
-  return { isSuccess: false, message: "기본 결제 수단을 바꾸지 못했습니다" };
-}
-
-/**
- * 결제 수단을 지운다.
- *
- * ⚠️ **마지막 하나는 서버가 막아야 한다.** 지울 수단이 없으면 다음 청구가 실패하는데,
- *    화면에서만 막으면 액션을 직접 불러 지울 수 있다.
- */
-export async function removeMethodAction(methodId: string): Promise<ActionResult> {
-  if (!(await assertCanManage())) return FORBIDDEN;
-
-  if (isMock) {
-    revalidatePath("/manage/billing");
-    return { isSuccess: true };
-  }
-
-  // TODO(BE 협의): `DELETE /companies/me/payment-methods/{methodId}`
-  void methodId;
-  return { isSuccess: false, message: "결제 수단을 지우지 못했습니다" };
-}
+/*
+  ⚠️ **기본 지정·삭제 액션을 두지 않는다.** 카드가 한 장뿐이라 기본을 고를 것도 없고,
+     지우면 다음 청구가 실패하는데 대신 올릴 카드도 없다 — 바꾸는 길은 `registerCardAction`
+     하나뿐이다. 그만두려면 카드를 지우는 게 아니라 **구독을 해지**한다.
+*/
 
 /**
  * 해지하거나, 해지를 되돌린다.

--- a/src/features/billing/components/billing-view.tsx
+++ b/src/features/billing/components/billing-view.tsx
@@ -3,12 +3,7 @@
 import { useState } from "react";
 import { toast } from "sonner";
 
-import {
-  registerCardAction,
-  removeMethodAction,
-  setDefaultMethodAction,
-  toggleCancelAction,
-} from "../actions";
+import { registerCardAction, toggleCancelAction } from "../actions";
 import { requestCardAuth } from "../payment-method";
 import {
   type BillingOverview,
@@ -50,7 +45,7 @@ interface BillingViewProps {
  */
 export function BillingView({ overview, config, today, canManage }: BillingViewProps) {
   const [subscription, setSubscription] = useState(overview.subscription);
-  const [methods, setMethods] = useState<readonly PaymentMethod[]>(overview.methods);
+  const [method, setMethod] = useState<PaymentMethod | null>(overview.method);
 
   const isCanceling = subscription.status === SUBSCRIPTION_STATUS.CANCELING;
 
@@ -77,19 +72,19 @@ export function BillingView({ overview, config, today, canManage }: BillingViewP
   };
 
   /*
-    결제 수단 추가 — **연동 자리를 미리 갈라 뒀다**(`payment-method.ts`).
+    결제 수단 변경 — **연동 자리를 미리 갈라 뒀다**(`payment-method.ts`).
     ⚠️ 카드 정보는 이 화면을 지나가지 않는다. 결제사 창에서 인증만 받고, 빌링키는 서버가
        발급·보관한다 — 프론트가 만지면 PCI-DSS 대상이 된다.
     ⚠️ PG가 정해지면 `requestCardAuth` 한 함수만 바꾸면 되고 여기는 그대로다.
-  */
-  /*
-    ⚠️ **던질 수 있는 호출이다.** 결제사 창을 닫거나 서버가 거절하면 `requestCardAuth`·
-       `registerCardMethod`가 예외를 낸다 — 잡지 않으면 아무 일도 안 일어난 것처럼 보이고
-       콘솔에만 남는다(§정직성).
+    ⚠️ **더하는 게 아니라 갈아 끼운다.** 카드는 회사당 한 장이라 이미 있으면 그 자리를 덮는다.
+    ⚠️ **던질 수 있는 호출이다.** 결제사 창을 닫거나 서버가 거절하면 예외가 난다 —
+       잡지 않으면 아무 일도 안 일어난 것처럼 보이고 콘솔에만 남는다(§정직성).
     ⚠️ 여기서는 창이 아니라 토스트다. 카드 등록은 결제와 달리 **돈이 빠지지 않아서**,
        멈춰 세울 만큼의 일이 아니다(DECISIONS §토스트).
   */
-  const handleAddMethod = async () => {
+  const handleChangeMethod = async () => {
+    const isFirst = method === null;
+
     try {
       /*
         ⚠️ **결제사 창만 브라우저에서 연다.** 카드 번호는 그 창에서만 입력되고, 우리는
@@ -101,36 +96,16 @@ export function BillingView({ overview, config, today, canManage }: BillingViewP
 
       if (!result.isSuccess || !result.method) {
         // ⚠️ 토스트는 한 줄(220px)이라 짧게 쓴다 — 길면 잘린다(`sonner.tsx`)
-        toast(result.message ?? "결제 수단을 추가하지 못했습니다");
+        toast(result.message ?? "결제 수단을 바꾸지 못했습니다");
         return;
       }
-      const added = result.method;
-      setMethods((prev) => [...prev, { ...added, isDefault: prev.length === 0 }]);
-      toast("결제 수단을 추가했습니다");
+
+      setMethod(result.method);
+      toast(isFirst ? "결제 수단을 등록했습니다" : "결제 수단을 변경했습니다");
     } catch {
       // 결제사 창을 닫은 경우 — 여기서만 예외로 온다
-      toast("결제 수단을 추가하지 못했습니다");
+      toast("결제 수단을 바꾸지 못했습니다");
     }
-  };
-
-  const handleSetDefault = async (id: string) => {
-    const result = await setDefaultMethodAction(id).catch(() => null);
-    if (!result?.isSuccess) {
-      toast(result?.message ?? "기본 결제 수단을 바꾸지 못했습니다");
-      return;
-    }
-    setMethods((prev) => prev.map((method) => ({ ...method, isDefault: method.id === id })));
-    toast("기본 결제 수단을 변경했습니다");
-  };
-
-  const handleRemoveMethod = async (id: string) => {
-    const result = await removeMethodAction(id).catch(() => null);
-    if (!result?.isSuccess) {
-      toast(result?.message ?? "결제 수단을 지우지 못했습니다");
-      return;
-    }
-    setMethods((prev) => prev.filter((method) => method.id !== id));
-    toast("결제 수단을 삭제했습니다");
   };
 
   return (
@@ -139,11 +114,9 @@ export function BillingView({ overview, config, today, canManage }: BillingViewP
         <div className="flex flex-col gap-7">
           <PlanPanel subscription={subscription} config={config} today={today} />
           <PaymentMethodsPanel
-            methods={methods}
+            method={method}
             canManage={canManage}
-            onAdd={handleAddMethod}
-            onSetDefault={handleSetDefault}
-            onRemove={handleRemoveMethod}
+            onChange={handleChangeMethod}
           />
           <PaymentHistoryPanel payments={overview.payments} />
           {/* ⚠️ 아직 못 쓰는 상태(결제 전·만료)에는 해지할 게 없으니 두지 않는다 */}

--- a/src/features/billing/components/payment-methods-panel.tsx
+++ b/src/features/billing/components/payment-methods-panel.tsx
@@ -1,32 +1,33 @@
 "use client";
 
-import { CreditCard, Plus, X } from "lucide-react";
+import { CreditCard } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
 
 import type { PaymentMethod } from "../subscription";
 
 interface PaymentMethodsPanelProps {
-  methods: readonly PaymentMethod[];
+  /** 등록된 카드 — 아직 없으면 `null` */
+  method: PaymentMethod | null;
   canManage: boolean;
-  onAdd: () => void;
-  onSetDefault: (id: string) => void;
-  onRemove: (id: string) => void;
+  /** 카드를 갈아 끼운다 — 없으면 처음 등록이고, 있으면 덮어쓴다 */
+  onChange: () => void;
 }
 
 /**
- * 결제 수단 탭.
+ * 결제 수단 — **회사당 한 장뿐이다**(2026-08-05 확정).
  *
+ * ⚠️ **더하는 화면이 아니다.** 구독이 회사당 하나이고 청구도 한 번이라 두 번째 카드가
+ *    나갈 자리가 없다. 여러 장을 두면 `기본` 지정·삭제 금지 규칙이 따라붙는데,
+ *    정작 결제는 한 장으로만 나가서 화면만 복잡해진다.
+ * ⚠️ **지우는 길도 두지 않는다.** 지우면 다음 청구가 실패하는데 대신 올릴 카드가 없다 —
+ *    그만두려면 카드를 지우는 게 아니라 **구독을 해지**한다(아래 해지 카드).
  * ⚠️ **카드 입력칸을 직접 만들지 않는다.** 우리 폼으로 원번호를 받으면 PCI-DSS 대상이 된다 —
- *    등록·변경은 결제사(Toss) 창이 통째로 그린다(§checkout과 같은 이유).
- * ⚠️ 그래서 `추가`는 지금 **목**이다. 실제로는 결제사 창이 뜨고 성공 응답을 받은 뒤에
- *    목록이 갱신된다 — 부르는 쪽 토스트에 그렇다고 밝힌다(§정직성).
+ *    등록·변경은 결제사 창이 통째로 그리고, 우리는 인증 결과만 받는다.
+ * ⚠️ 그래서 버튼은 지금 **목**이다. 실제로는 결제사 창이 뜨고, 성공 응답을 서버가 빌링키로
+ *    바꿔 저장한 뒤에야 이 줄이 갱신된다(§정직성).
  */
-export function PaymentMethodsPanel({
-  methods,
-  canManage,
-  onAdd,
-  onSetDefault,
-  onRemove,
-}: PaymentMethodsPanelProps) {
+export function PaymentMethodsPanel({ method, canManage, onChange }: PaymentMethodsPanelProps) {
   return (
     <section className="border-border bg-card rounded-2xl border">
       <h2 className="flex items-center gap-2 px-7 py-6 text-[15px] leading-6 font-semibold tracking-[-0.2px]">
@@ -35,79 +36,44 @@ export function PaymentMethodsPanel({
         결제 수단
       </h2>
 
-      {methods.length === 0 ? (
-        /* ⚠️ 빈 상태 — 무엇이 없는지와 다음에 뭘 하면 되는지를 같이 적는다(§3상태) */
-        <p className="text-muted-foreground border-border border-t px-6 py-10 text-center text-[13px] leading-5 break-keep">
-          등록된 결제 수단이 없습니다.
-        </p>
-      ) : (
-        <ul className="border-border border-t">
-          {methods.map((method) => (
-            <li
-              key={method.id}
-              className="border-border flex items-center gap-3 px-6 py-4 not-first:border-t"
-            >
-              <span className="border-border bg-secondary flex h-8 w-11 shrink-0 items-center justify-center rounded-md border">
-                <CreditCard className="text-muted-foreground size-4" aria-hidden />
-              </span>
+      <div className="border-border flex items-center gap-3 border-t px-6 py-5">
+        <span className="border-border bg-secondary flex h-8 w-11 shrink-0 items-center justify-center rounded-md border">
+          <CreditCard className="text-muted-foreground size-4" aria-hidden />
+        </span>
 
-              <span className="min-w-0 flex-1">
-                <span className="block text-[13px] leading-5 tabular-nums">
-                  {method.brand} •••• {method.last4}
-                </span>
-                <span className="text-muted-foreground block text-[12px] leading-4 tabular-nums">
-                  만료 {method.expiry}
-                </span>
-              </span>
+        {method ? (
+          <span className="min-w-0 flex-1">
+            <span className="block text-[13px] leading-5 tabular-nums">
+              {method.brand} •••• {method.last4}
+            </span>
+            <span className="text-muted-foreground block text-[12px] leading-4 tabular-nums">
+              만료 {method.expiry}
+            </span>
+          </span>
+        ) : (
+          /*
+            ⚠️ 이 자리는 **거의 안 보인다.** 온보딩 4단계에서 결제를 마쳐야 워크스페이스가
+               열리므로, 여기까지 온 회사에는 카드가 있다.
+               그래도 비워 두지 않는 건 BE가 값을 안 줄 때 `•••• undefined`가 찍히는 것보다
+               "없다"고 말하는 편이 낫기 때문이다(§정직성).
+          */
+          <span className="text-muted-foreground min-w-0 flex-1 text-[13px] leading-5">
+            등록된 결제 수단이 없습니다
+          </span>
+        )}
 
-              {method.isDefault ? (
-                <span className="bg-secondary text-muted-foreground border-border shrink-0 rounded border px-2 py-0.5 text-[11px] leading-4">
-                  기본
-                </span>
-              ) : (
-                canManage && (
-                  <button
-                    type="button"
-                    onClick={() => onSetDefault(method.id)}
-                    className="text-muted-foreground hover:text-foreground focus-visible:ring-ring shrink-0 rounded text-[12px] leading-4 hover:underline focus-visible:ring-2 focus-visible:outline-hidden"
-                  >
-                    기본으로
-                  </button>
-                )
-              )}
-
-              {/*
-                ⚠️ 기본 수단은 뺄 수 없다. 빼면 다음 결제가 실패하는데, 그 사실을 모른 채
-                   지우게 두면 안 된다 — 다른 수단을 먼저 기본으로 올리게 한다.
-              */}
-              {canManage && !method.isDefault && (
-                <button
-                  type="button"
-                  aria-label={`${method.brand} ${method.last4} 빼기`}
-                  onClick={() => onRemove(method.id)}
-                  className="text-muted-foreground hover:text-foreground hover:bg-foreground/10 focus-visible:ring-ring flex size-6 shrink-0 items-center justify-center rounded transition-colors focus-visible:ring-2 focus-visible:outline-hidden"
-                >
-                  <X className="size-3.5" />
-                </button>
-              )}
-            </li>
-          ))}
-        </ul>
-      )}
-
-      {canManage && (
-        <div className="border-border border-t">
-          <button
+        {canManage && (
+          <Button
             type="button"
-            onClick={onAdd}
-            className="text-muted-foreground hover:text-foreground hover:bg-secondary/60 focus-visible:ring-ring flex w-full items-center justify-center gap-1.5 rounded-b-xl py-3.5 text-[13px] leading-5 transition-colors focus-visible:ring-2 focus-visible:outline-hidden"
+            variant="outline"
+            onClick={onChange}
+            className="h-8 shrink-0 px-3 text-[12px] leading-none"
           >
-            <Plus className="size-3.5" aria-hidden />
-            {/* 한글 글자가 상자 안에서 위쪽에 앉아 아이콘보다 떠 보인다 — 1px 내려 맞춘다 */}
-            <span className="translate-y-px">결제 수단 추가</span>
-          </button>
-        </div>
-      )}
+            {/* 한글 글자가 상자 안에서 위쪽에 앉아 보인다 — 1px 내려 맞춘다 */}
+            <span className="translate-y-px">{method ? "변경" : "등록"}</span>
+          </Button>
+        )}
+      </div>
     </section>
   );
 }

--- a/src/features/billing/components/plan-panel.tsx
+++ b/src/features/billing/components/plan-panel.tsx
@@ -1,3 +1,5 @@
+import { CalendarDays, type LucideIcon, ReceiptText, Sparkles, Wallet } from "lucide-react";
+
 import { formatWon } from "../pricing";
 import { canUseWorkspace, type Subscription, SUBSCRIPTION_STATUS_LABEL } from "../subscription";
 import type { BillingConfig } from "../types";
@@ -29,18 +31,23 @@ export function PlanPanel({ subscription, config, today }: PlanPanelProps) {
     <div className="flex flex-col gap-5">
       <section className="border-border bg-card rounded-2xl border">
         {/*
-          ⚠️ 결제 화면처럼 **큰 표식을 두지 않는다.** 저기는 이름 아래 금액이 한 줄 더 있어
-             40px 사각형과 균형이 맞지만, 여기는 이름 한 줄뿐이라 표식이 글자를 눌러 버린다.
-             대신 다른 카드들과 **같은 점 표식**을 써서 결을 맞춘다.
+          ⚠️ 표식은 **결제 화면(`PlanSummaryCard`)과 같은 것**이다. 랜딩에서 보고, 결제할 때 보고,
+             관리 화면에서 다시 보는 게 같은 물건이라 표식도 같아야 한다.
+          ⚠️ 이름 아래 한 줄을 같이 둔다 — 이름만 있으면 40px 사각형이 글자를 눌러 버린다.
+             단 **금액을 적지 않는다.** 바로 아래 `월 기본료` 칸과 같은 말이 두 번이 된다.
         */}
         <div className="flex items-center gap-3 p-7 pb-6">
+          <span className="bg-foreground text-background flex size-10 shrink-0 items-center justify-center rounded-xl">
+            <Sparkles className="size-[18px]" aria-hidden />
+          </span>
+
           <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2">
-              <h2 className="flex items-center gap-2 text-[17px] leading-7 font-semibold tracking-[-0.3px]">
-                <span className="bg-foreground size-2 rounded-full" aria-hidden />
-                {subscription.planName} 플랜
-              </h2>
-            </div>
+            <h2 className="text-[17px] leading-7 font-semibold tracking-[-0.3px]">
+              {subscription.planName} 플랜
+            </h2>
+            <p className="text-muted-foreground text-[13px] leading-5">
+              인원 제한 없이 회사당 하나
+            </p>
             {/*
               ⚠️ **기능을 나열하지 않는다.** 아홉 개를 가운뎃점으로 이으면 한 줄짜리 글자
                  덩어리가 되어 아무도 안 읽는다. 여기는 이미 쓰고 있는 사람이 보는 관리 화면이라
@@ -78,13 +85,15 @@ export function PlanPanel({ subscription, config, today }: PlanPanelProps) {
              남은 셋은 전부 **돈과 직접 이어지는 값**이다.
         */}
         <dl className="grid grid-cols-2 gap-3 px-7 pb-7 md:grid-cols-3">
-          <Metric label="월 기본료" value={formatWon(config.baseFee)} />
+          <Metric icon={Wallet} label="월 기본료" value={formatWon(config.baseFee)} />
           <Metric
+            icon={CalendarDays}
             label="다음 결제일"
             value={subscription.nextBillingDate ?? "—"}
             hint={isUnpaid ? "결제 후 확정됩니다" : undefined}
           />
           <Metric
+            icon={ReceiptText}
             label="다음 청구 예상"
             value={formatWon(subscription.estimatedAmount)}
             hint={
@@ -106,16 +115,34 @@ export function PlanPanel({ subscription, config, today }: PlanPanelProps) {
 }
 
 /**
- * 지표 한 칸.
+ * 지표 한 칸 — 결제 화면의 포함량 칸(`Included`)과 **같은 모양**이다.
  *
- * ⚠️ 테두리 격자가 아니라 **연한 카드**다 — 결제 화면의 포함량 칸(`Included`)과 같은 모양이라,
- *    두 화면을 오갈 때 같은 종류의 값으로 읽힌다.
+ * ⚠️ 세 줄을 칸 **가운데**로 모은다. 왼쪽에 붙여 두면 숫자 오른쪽이 비어 칸이 헐거워 보이고,
+ *    세 칸이 나란히 설 때 값의 눈높이가 안 맞는다.
+ * ⚠️ **테두리를 같이 준다.** 라이트에서 `--secondary`는 흰 카드와 2%밖에 차이가 없어서
+ *    옅게만 깔면 칸이 있는지조차 안 보인다 — 이 서비스의 라이트 층은 색이 아니라 보더로 나뉜다.
+ * ⚠️ 라벨에 **아이콘**을 붙인다. 셋 다 금액·날짜라 글자만으로는 어느 칸인지 훑어서 안 잡힌다 —
+ *    색을 못 쓰는 자리라(색은 에러뿐) 구분은 아이콘과 명도가 맡는다(§디자인 토큰).
  */
-function Metric({ label, value, hint }: { label: string; value: string; hint?: string }) {
+function Metric({
+  icon: Icon,
+  label,
+  value,
+  hint,
+}: {
+  icon: LucideIcon;
+  label: string;
+  value: string;
+  hint?: string;
+}) {
   return (
-    <div className="bg-secondary/40 rounded-xl px-5 py-4">
-      <dt className="text-muted-foreground text-[12px] leading-4">{label}</dt>
-      <dd className="pt-1.5 text-[20px] leading-7 font-semibold tracking-[-0.4px] tabular-nums">
+    <div className="border-border bg-secondary/60 rounded-xl border px-5 py-4 text-center">
+      <dt className="text-muted-foreground flex items-center justify-center gap-1.5 text-[12px] leading-4">
+        <Icon className="size-3.5 shrink-0" aria-hidden />
+        {/* 한글 글자가 아이콘보다 떠 보인다 — 1px 내려 맞춘다 */}
+        <span className="translate-y-px">{label}</span>
+      </dt>
+      <dd className="pt-2 text-[20px] leading-7 font-semibold tracking-[-0.4px] tabular-nums">
         {value}
       </dd>
       {hint && <p className="text-muted-foreground/70 pt-0.5 text-[11px] leading-4">{hint}</p>}

--- a/src/features/billing/components/plan-panel.tsx
+++ b/src/features/billing/components/plan-panel.tsx
@@ -1,4 +1,4 @@
-import { CalendarDays, type LucideIcon, ReceiptText, Sparkles, Wallet } from "lucide-react";
+import { Sparkles } from "lucide-react";
 
 import { formatWon } from "../pricing";
 import { canUseWorkspace, type Subscription, SUBSCRIPTION_STATUS_LABEL } from "../subscription";
@@ -85,15 +85,13 @@ export function PlanPanel({ subscription, config, today }: PlanPanelProps) {
              남은 셋은 전부 **돈과 직접 이어지는 값**이다.
         */}
         <dl className="grid grid-cols-2 gap-3 px-7 pb-7 md:grid-cols-3">
-          <Metric icon={Wallet} label="월 기본료" value={formatWon(config.baseFee)} />
+          <Metric label="월 기본료" value={formatWon(config.baseFee)} />
           <Metric
-            icon={CalendarDays}
             label="다음 결제일"
             value={subscription.nextBillingDate ?? "—"}
             hint={isUnpaid ? "결제 후 확정됩니다" : undefined}
           />
           <Metric
-            icon={ReceiptText}
             label="다음 청구 예상"
             value={formatWon(subscription.estimatedAmount)}
             hint={
@@ -115,34 +113,20 @@ export function PlanPanel({ subscription, config, today }: PlanPanelProps) {
 }
 
 /**
- * 지표 한 칸 — 결제 화면의 포함량 칸(`Included`)과 **같은 모양**이다.
+ * 지표 한 칸.
  *
- * ⚠️ 세 줄을 칸 **가운데**로 모은다. 왼쪽에 붙여 두면 숫자 오른쪽이 비어 칸이 헐거워 보이고,
+ * ⚠️ 테두리 격자가 아니라 **연한 카드**다 — 결제 화면의 포함량 칸(`Included`)과 같은 모양이라,
+ *    두 화면을 오갈 때 같은 종류의 값으로 읽힌다.
+ * ⚠️ 값을 칸 **가운데**로 모은다. 왼쪽에 붙여 두면 숫자 오른쪽이 비어 칸이 헐거워 보이고,
  *    세 칸이 나란히 설 때 값의 눈높이가 안 맞는다.
- * ⚠️ **테두리를 같이 준다.** 라이트에서 `--secondary`는 흰 카드와 2%밖에 차이가 없어서
- *    옅게만 깔면 칸이 있는지조차 안 보인다 — 이 서비스의 라이트 층은 색이 아니라 보더로 나뉜다.
- * ⚠️ 라벨에 **아이콘**을 붙인다. 셋 다 금액·날짜라 글자만으로는 어느 칸인지 훑어서 안 잡힌다 —
- *    색을 못 쓰는 자리라(색은 에러뿐) 구분은 아이콘과 명도가 맡는다(§디자인 토큰).
+ * ⚠️ **아이콘은 두지 않는다.** 셋 다 금액·날짜라 무슨 그림을 붙여도 뜻이 겹치고,
+ *    작은 칸에서 라벨보다 그림이 먼저 눈에 들어와 정작 숫자가 뒤로 밀린다.
  */
-function Metric({
-  icon: Icon,
-  label,
-  value,
-  hint,
-}: {
-  icon: LucideIcon;
-  label: string;
-  value: string;
-  hint?: string;
-}) {
+function Metric({ label, value, hint }: { label: string; value: string; hint?: string }) {
   return (
-    <div className="border-border bg-secondary/60 rounded-xl border px-5 py-4 text-center">
-      <dt className="text-muted-foreground flex items-center justify-center gap-1.5 text-[12px] leading-4">
-        <Icon className="size-3.5 shrink-0" aria-hidden />
-        {/* 한글 글자가 아이콘보다 떠 보인다 — 1px 내려 맞춘다 */}
-        <span className="translate-y-px">{label}</span>
-      </dt>
-      <dd className="pt-2 text-[20px] leading-7 font-semibold tracking-[-0.4px] tabular-nums">
+    <div className="bg-secondary/40 rounded-xl px-5 py-4 text-center">
+      <dt className="text-muted-foreground text-[12px] leading-4">{label}</dt>
+      <dd className="pt-1.5 text-[20px] leading-7 font-semibold tracking-[-0.4px] tabular-nums">
         {value}
       </dd>
       {hint && <p className="text-muted-foreground/70 pt-0.5 text-[11px] leading-4">{hint}</p>}

--- a/src/features/billing/components/subscription-blocked-dialog.tsx
+++ b/src/features/billing/components/subscription-blocked-dialog.tsx
@@ -32,7 +32,11 @@ export function SubscriptionBlockedDialog({ status }: { status: SubscriptionStat
       onOpenChange={() => {}}
       badge="alert"
       isDismissible={false}
-      title={isUnpaid ? "아직 결제가 확인되지 않았습니다" : "구독이 종료되었습니다"}
+      /*
+        ⚠️ 제목은 `SubscriptionGate`와 **같은 말**이다. 같은 상태를 두 화면이 다르게 부르면
+           대표와 사원이 같은 상황을 이야기할 때 말이 어긋난다.
+      */
+      title={isUnpaid ? "결제가 확인되지 않았습니다" : "구독이 종료되었습니다"}
       /*
         ⚠️ **두 가지만 말한다** — 왜 못 들어오는지, 누가 풀 수 있는지.
            "결제가 끝나면 바로 들어올 수 있습니다" 같은 말을 덧붙이면 같은 말이 두 번이 된다.

--- a/src/features/billing/components/subscription-blocked-dialog.tsx
+++ b/src/features/billing/components/subscription-blocked-dialog.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import Link from "next/link";
+
+import { ResultDialog } from "@/components/common/result-dialog";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+import { SUBSCRIPTION_STATUS, type SubscriptionStatus } from "../subscription";
+
+/**
+ * 결제 권한이 없는 사람이 만료된 회사로 로그인했을 때 — **여기서 막는다.**
+ *
+ * ⚠️ **결제 화면을 보여주지 않는다.** 눌러도 못 하는 결제 칸을 주는 건 안내가 아니라
+ *    막다른 길이다. 이 사람이 할 수 있는 일은 없으므로 화면을 만들지 않고 창으로 끝낸다.
+ * ⚠️ 모양은 **공통 결과 창**(`ResultDialog`)이다. 결제 실패 창과 같은 것을 쓴다 —
+ *    돈 때문에 막히는 자리가 화면마다 다르게 생기면 같은 서비스로 안 읽힌다(§컴포넌트 위생).
+ * ⚠️ **닫을 수 없다.** X도 없고 바깥을 눌러도 안 닫힌다 — 닫으면 뒤에 아무것도 없는
+ *    빈 화면만 남아서, 막힌 게 아니라 고장 난 것처럼 보인다.
+ * ⚠️ 나가는 길은 **로그인 화면**뿐이다. 지금은 세션이 없어 링크로 보내지만,
+ *    세션이 붙으면 여기서 로그아웃을 부른다.
+ *    TODO(BE 연동): `logoutAction`으로 쿠키를 지우고 `/login`으로 보낸다
+ *    (경로는 `lib/endpoints.ts`의 `auth.logout`).
+ */
+export function SubscriptionBlockedDialog({ status }: { status: SubscriptionStatus }) {
+  const isUnpaid = status === SUBSCRIPTION_STATUS.UNPAID;
+
+  return (
+    <ResultDialog
+      isOpen
+      // 닫히지 않는다 — 상태를 바꾸지 않으므로 열린 채로 남는다
+      onOpenChange={() => {}}
+      badge="alert"
+      isDismissible={false}
+      title={isUnpaid ? "아직 결제가 확인되지 않았습니다" : "구독이 종료되었습니다"}
+      /*
+        ⚠️ **두 가지만 말한다** — 왜 못 들어오는지, 누가 풀 수 있는지.
+           "결제가 끝나면 바로 들어올 수 있습니다" 같은 말을 덧붙이면 같은 말이 두 번이 된다.
+      */
+      description={
+        <>
+          결제가 끝나야 워크스페이스가 열립니다.
+          <br />
+          결제는 대표 또는 Admin 권한을 가진 분만 할 수 있습니다.
+        </>
+      }
+      action={
+        <Link
+          href="/login"
+          className={cn(buttonVariants({ variant: "ink" }), "h-11 w-full text-[14px] leading-none")}
+        >
+          로그인 화면으로
+        </Link>
+      }
+    />
+  );
+}

--- a/src/features/billing/components/subscription-gate.test.tsx
+++ b/src/features/billing/components/subscription-gate.test.tsx
@@ -1,0 +1,70 @@
+import { render } from "@testing-library/react";
+
+import { ROLE } from "@/constants/role";
+
+import { SUBSCRIPTION_STATUS, type SubscriptionStatus } from "../subscription";
+import { SubscriptionGate } from "./subscription-gate";
+
+/*
+  ⚠️ `next/cache`를 막는다. 이 화면은 결제 칸(`SubscribeCard`)을 거쳐 서버 액션을 import하는데,
+     `next/cache`가 모듈을 읽는 순간 엣지 런타임 전역(`Request`·`TextEncoder`)을 찾아
+     jsdom에서 터진다. **여기서 보는 건 권한 없는 경로라 결제 칸을 아예 안 그린다** —
+     화면을 테스트에 맞춰 고치는 대신 못 도는 모듈만 막는다.
+*/
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn(), revalidateTag: jest.fn() }));
+
+/**
+ * 결제 권한이 **없는** 사람이 보는 쪽을 지킨다.
+ *
+ * ⚠️ 안내가 창에만 있으면 안 된다. 창은 포털이라 **서버가 그린 HTML에 한 글자도 안 들어간다** —
+ *    하이드레이션 전까지, 그리고 번들이 늦거나 실패하면 영영 로고 한 줄만 남는다.
+ *    창 뒤에 같은 말을 남겨 두면 JS 없이도 왜 막혔는지 읽힌다.
+ * ⚠️ **`getByRole`로 찾지 않는다.** 창이 열려 있는 동안 Base UI가 배경을 `aria-hidden`으로
+ *    덮어서 접근성 트리에서 빠지는데, 그건 모달의 정상 동작이다(그때는 창 제목이 화면 제목
+ *    노릇을 한다). 여기서 지키려는 건 **DOM에 남아 있는지**라 마크업을 직접 본다.
+ */
+
+const config = {
+  currency: "KRW",
+  monthlyPrice: 50000,
+  includedSeats: 10,
+  extraSeatPrice: 5000,
+  includedStorageGb: 100,
+  extraStoragePrice: 1000,
+} as never;
+
+const blocked = (status: SubscriptionStatus = SUBSCRIPTION_STATUS.EXPIRED) =>
+  render(<SubscriptionGate config={config} status={status} role={ROLE.MEMBER} canManage={false} />)
+    .container;
+
+describe("결제 권한이 없는 사람", () => {
+  it("창 밖 본문에도 안내가 남는다 — JS 없이도 왜 막혔는지 읽힌다", () => {
+    const main = blocked().querySelector("main");
+
+    expect(main?.textContent).toContain("결제가 끝나야 워크스페이스가 열립니다");
+    expect(main?.textContent).toContain("대표 또는 Admin 권한을 가진 분만");
+  });
+
+  it("페이지 제목(`h1`)이 있다 — 권한 있는 사람에게만 제목이 있으면 안 된다", () => {
+    const headings = blocked().querySelectorAll("h1");
+
+    expect(headings).toHaveLength(1);
+    expect(headings[0]?.textContent).toBe("구독이 종료되었습니다");
+  });
+
+  it("미납이면 제목이 달라진다 — 종료와 미납은 다른 상황이다", () => {
+    expect(blocked(SUBSCRIPTION_STATUS.UNPAID).querySelector("h1")?.textContent).toBe(
+      "결제가 확인되지 않았습니다",
+    );
+  });
+
+  /*
+    ⚠️ 눌러도 못 하는 결제 칸을 주는 건 안내가 아니라 막다른 길이다 —
+       말만 남기고 나가는 길(로그인 화면으로)은 창이 준다.
+  */
+  it("결제 버튼은 주지 않는다", () => {
+    const buttons = [...blocked().querySelectorAll("button")].map((b) => b.textContent ?? "");
+
+    expect(buttons.some((text) => /결제하기|구독하기/.test(text))).toBe(false);
+  });
+});

--- a/src/features/billing/components/subscription-gate.tsx
+++ b/src/features/billing/components/subscription-gate.tsx
@@ -41,7 +41,6 @@ interface SubscriptionGateProps {
  */
 export function SubscriptionGate({ config, status, role, canManage }: SubscriptionGateProps) {
   const [isDone, setIsDone] = useState(false);
-  const isUnpaid = status === SUBSCRIPTION_STATUS.UNPAID;
 
   /*
     결제할 수 없는 사람 — **창으로 막는다.** 뒤에는 브랜드 바만 남긴다.
@@ -56,6 +55,8 @@ export function SubscriptionGate({ config, status, role, canManage }: Subscripti
       </div>
     );
   }
+
+  const isUnpaid = status === SUBSCRIPTION_STATUS.UNPAID;
 
   return (
     <div className="bg-background bg-dot-grid flex min-h-dvh flex-col">

--- a/src/features/billing/components/subscription-gate.tsx
+++ b/src/features/billing/components/subscription-gate.tsx
@@ -12,6 +12,7 @@ import { type Subscription, SUBSCRIPTION_STATUS } from "../subscription";
 import type { BillingConfig } from "../types";
 import { PaymentDoneDialog } from "./payment-done-dialog";
 import { SubscribeCard } from "./subscribe-card";
+import { SubscriptionBlockedDialog } from "./subscription-blocked-dialog";
 
 interface SubscriptionGateProps {
   config: BillingConfig;
@@ -29,8 +30,9 @@ interface SubscriptionGateProps {
  *    안 눌리는지 알 수 없다. 온보딩 4단계처럼 껍데기를 벗기고 결제 칸만 남긴다.
  * ⚠️ 결제 칸은 온보딩·구독 관리와 **같은 것**(`SubscribeCard`)을 쓴다. 돈을 내는 자리가
  *    화면마다 다르게 생기면 같은 서비스로 안 읽힌다(§컴포넌트 위생).
- * ⚠️ **결제 권한이 없는 사람에게는 결제 칸을 보여주지 않는다.** 눌러도 못 하는 버튼을 주는 건
- *    안내가 아니라 막다른 길이다 — 누구에게 말해야 하는지를 적는다(§정직성).
+ * ⚠️ **결제 권한이 없는 사람에게는 이 화면을 아예 안 준다.** 눌러도 못 하는 버튼은 물론이고,
+ *    결제하라는 안내 화면조차 그 사람에게는 할 일이 없는 화면이다 —
+ *    공통 결과 창(`SubscriptionBlockedDialog`)으로 막고 끝낸다(§정직성).
  * ⚠️ 결제를 마치면 **`/billing/checkout`과 같은 완료 창**(`PaymentDoneDialog`)이 뜬다.
  *    온보딩 완료 화면은 못 쓴다 — 거기는 부서·직급·초대 수를 요약하는 자리라, 이미 다 만들어
  *    놓고 결제만 끊긴 회사에게는 맞지 않는 말이다.
@@ -40,6 +42,20 @@ interface SubscriptionGateProps {
 export function SubscriptionGate({ config, status, role, canManage }: SubscriptionGateProps) {
   const [isDone, setIsDone] = useState(false);
   const isUnpaid = status === SUBSCRIPTION_STATUS.UNPAID;
+
+  /*
+    결제할 수 없는 사람 — **창으로 막는다.** 뒤에는 브랜드 바만 남긴다.
+    ⚠️ 결제 칸을 감춘 화면을 대신 보여주지 않는다. 제목·안내·카드가 전부 "결제해라"는 말인데
+       정작 그럴 수 없는 사람이라, 읽을수록 무엇을 하라는 건지 알 수 없어진다.
+  */
+  if (!canManage) {
+    return (
+      <div className="bg-background bg-dot-grid flex min-h-dvh flex-col">
+        <BrandBar />
+        <SubscriptionBlockedDialog status={status} />
+      </div>
+    );
+  }
 
   return (
     <div className="bg-background bg-dot-grid flex min-h-dvh flex-col">
@@ -64,24 +80,11 @@ export function SubscriptionGate({ config, status, role, canManage }: Subscripti
                  지금 말할 수 있는 건 "결제해야 다시 열린다"까지다.
             */}
             <p className="text-muted-foreground text-[13px] leading-5 break-keep">
-              {canManage
-                ? "결제를 마치면 워크스페이스가 다시 열립니다."
-                : "대표 또는 Admin 권한을 가진 분에게 결제를 요청해 주세요."}
+              결제를 마치면 워크스페이스가 다시 열립니다.
             </p>
           </div>
 
-          {canManage ? (
-            <SubscribeCard config={config} onSubscribe={() => setIsDone(true)} />
-          ) : (
-            /*
-              권한이 없는 사람 — 결제 칸 대신 **누구에게 말해야 하는지**를 준다.
-              ⚠️ 담당자 이름·연락처를 적고 싶지만 세션이 없어 모른다. 지어내지 않는다.
-            */
-            <p className="border-border bg-card text-muted-foreground rounded-2xl border p-7 text-[13px] leading-[21px] break-keep">
-              결제는 대표 또는 Admin 권한을 가진 분만 할 수 있습니다. 결제가 끝나면 이 화면 없이
-              바로 들어올 수 있습니다.
-            </p>
-          )}
+          <SubscribeCard config={config} onSubscribe={() => setIsDone(true)} />
         </div>
       </main>
 

--- a/src/features/billing/components/subscription-gate.tsx
+++ b/src/features/billing/components/subscription-gate.tsx
@@ -51,6 +51,31 @@ export function SubscriptionGate({ config, status, role, canManage }: Subscripti
     return (
       <div className="bg-background bg-dot-grid flex min-h-dvh flex-col">
         <BrandBar />
+
+        {/*
+          ⚠️ **같은 말을 창 뒤에도 그대로 둔다.** 창은 포털이라 서버가 그린 HTML에 한 글자도
+             안 들어간다 — 이것만 두면 하이드레이션 전까지, 그리고 번들이 늦거나 실패하면
+             영영, 로고 한 줄만 있는 빈 화면이 남는다. 왜 못 들어오는지는 JS 없이도
+             읽혀야 한다(§정직성).
+          ⚠️ 이 페이지의 **`h1`도 여기 있다.** 창 제목은 `h2`로 나가서(Base UI `Dialog.Title`),
+             이게 없으면 권한 있는 사람의 화면에는 있는 제목이 권한 없는 사람에게만 사라진다.
+          ⚠️ **결제 칸은 여전히 안 그린다.** 눌러도 못 하는 버튼을 주는 건 안내가 아니라
+             막다른 길이다 — 말만 남기고 조작은 창이 준다.
+        */}
+        <main className="flex min-h-0 flex-1 flex-col overflow-y-auto px-[21px] py-6">
+          <div className="m-auto flex w-full max-w-[420px] flex-col gap-[7px] pb-16 text-center">
+            <h1 className="text-2xl leading-[30px] font-semibold tracking-[-0.48px] break-keep">
+              {status === SUBSCRIPTION_STATUS.UNPAID
+                ? "결제가 확인되지 않았습니다"
+                : "구독이 종료되었습니다"}
+            </h1>
+            <p className="text-muted-foreground text-[13px] leading-5 break-keep">
+              결제가 끝나야 워크스페이스가 열립니다. 결제는 대표 또는 Admin 권한을 가진 분만 할 수
+              있습니다.
+            </p>
+          </div>
+        </main>
+
         <SubscriptionBlockedDialog status={status} />
       </div>
     );

--- a/src/features/billing/components/usage-panel.tsx
+++ b/src/features/billing/components/usage-panel.tsx
@@ -1,3 +1,5 @@
+import { CircleAlert, Info } from "lucide-react";
+
 import { formatGb, formatTokens, formatWon } from "../pricing";
 import type { Subscription } from "../subscription";
 import type { BillingConfig } from "../types";
@@ -85,11 +87,15 @@ function UsageBanner({ tokens, storage }: { tokens: UsageAxis; storage: UsageAxi
   if (overAxes.length > 0) {
     const total = overAxes.reduce((sum, axis) => sum + axis.overageAmount, 0);
     return (
-      <p className="border-destructive/30 bg-destructive/5 mt-5 rounded-lg border px-3.5 py-3 text-[12px] leading-[18px] break-keep">
-        <span className="font-semibold">
-          {overAxes.map((axis) => axis.label).join(" · ")} 포함량 초과
-        </span>{" "}
-        지금까지 {formatWon(total)}이며, 다음 결제일에 기본료와 함께 청구됩니다.
+      /* ⚠️ 표식을 앞에 둔다 — 글자만 있으면 본문에 섞여 그냥 설명으로 읽힌다 */
+      <p className="border-destructive/30 bg-destructive/5 mt-5 flex items-start gap-2 rounded-lg border px-3.5 py-3 text-[12px] leading-[18px] break-keep">
+        <CircleAlert className="text-destructive mt-px size-3.5 shrink-0" aria-hidden />
+        <span>
+          <span className="font-semibold">
+            {overAxes.map((axis) => axis.label).join(" · ")} 포함량 초과
+          </span>{" "}
+          지금까지 {formatWon(total)}이며, 다음 결제일에 기본료와 함께 청구됩니다.
+        </span>
       </p>
     );
   }
@@ -105,13 +111,20 @@ function UsageBanner({ tokens, storage }: { tokens: UsageAxis; storage: UsageAxi
   if (nearAxes.length === 0) return null;
 
   return (
-    <p className="border-border bg-secondary mt-5 rounded-lg border px-3.5 py-3 text-[12px] leading-[18px] break-keep">
-      {/*
-        ⚠️ 문턱은 **상수에서 읽는다.** `80%`라고 적어 두면 문턱을 조정할 때 띄우는 조건만
-           바뀌고 문구는 옛 숫자를 말한다 — 화면이 거짓말을 하게 된다.
-      */}
-      {nearAxes.map((axis) => axis.label).join(" · ")} 사용량이 {USAGE_WARN_RATIO * 100}%를
-      넘었습니다. 포함량을 넘기면 초과분이 다음 결제일에 기본료와 함께 추가로 청구됩니다.
+    /*
+      ⚠️ 표식은 두되 **색은 안 쓴다.** 아직 넘긴 게 아니라 알려 주는 말이라, 빨갛게 하면
+         이미 돈이 더 나가는 줄 읽힌다 — 색으로 알리는 건 에러뿐이다(§디자인 토큰).
+    */
+    <p className="border-border bg-secondary mt-5 flex items-start gap-2 rounded-lg border px-3.5 py-3 text-[12px] leading-[18px] break-keep">
+      <Info className="text-muted-foreground mt-px size-3.5 shrink-0" aria-hidden />
+      <span>
+        {/*
+          ⚠️ 문턱은 **상수에서 읽는다.** `80%`라고 적어 두면 문턱을 조정할 때 띄우는 조건만
+             바뀌고 문구는 옛 숫자를 말한다 — 화면이 거짓말을 하게 된다.
+        */}
+        {nearAxes.map((axis) => axis.label).join(" · ")} 사용량이 {USAGE_WARN_RATIO * 100}%를
+        넘었습니다. 포함량을 넘기면 초과분이 다음 결제일에 기본료와 함께 추가로 청구됩니다.
+      </span>
     </p>
   );
 }

--- a/src/features/billing/server.ts
+++ b/src/features/billing/server.ts
@@ -57,7 +57,7 @@ const MOCK: BillingOverview = {
       meetingCount: 6,
     },
   },
-  methods: [{ id: "pm_1", brand: "VISA", last4: "4242", expiry: "09/27", isDefault: true }],
+  method: { id: "pm_1", brand: "VISA", last4: "4242", expiry: "09/27" },
   payments: [
     {
       id: "pay_7",

--- a/src/features/billing/subscription.ts
+++ b/src/features/billing/subscription.ts
@@ -103,6 +103,14 @@ export interface Subscription {
 
 /* ───────── 결제 수단 ───────── */
 
+/**
+ * 등록된 카드 — **회사당 한 장뿐이다**(2026-08-05 확정).
+ *
+ * ⚠️ 목록이 아니다. 구독이 회사당 하나이고 청구도 한 번이라 **두 번째 카드가 나갈 자리가 없다** —
+ *    여러 장을 두면 `기본` 지정·삭제 금지 규칙이 따라붙는데, 정작 결제는 한 장으로만 나간다.
+ * ⚠️ 그래서 `isDefault`가 없다. 한 장뿐이면 늘 그 장이다.
+ * ⚠️ 카드를 바꾸는 건 **더하는 게 아니라 갈아 끼우는 일**이다(BE도 빌링키 1:1).
+ */
 export interface PaymentMethod {
   id: string;
   /** 카드 브랜드 표기 — `VISA` 처럼 그대로 나간다 */
@@ -111,7 +119,6 @@ export interface PaymentMethod {
   last4: string;
   /** `09/27` */
   expiry: string;
-  isDefault: boolean;
 }
 
 /* ───────── 결제 내역 ───────── */
@@ -143,6 +150,7 @@ export interface PaymentRecord {
 /** 화면 한 장이 필요로 하는 전부 — 세 탭이 같은 요청 하나로 채워진다 */
 export interface BillingOverview {
   subscription: Subscription;
-  methods: readonly PaymentMethod[];
+  /** 등록된 카드 — 아직 없으면 `null` */
+  method: PaymentMethod | null;
   payments: readonly PaymentRecord[];
 }


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가
- [x] design — UI/UX 변경

---

## 🗂 작업 영역

- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [x] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)

---

## 🙋 관련 역할

- [x] LEADER (팀장)
- [x] MEMBER (사원)

---

## 📝 작업 내용

**구독이 끊긴 회사에 결제 권한이 없는 사람이 들어오면, 화면 대신 창으로 막습니다.**

전에는 `/subscription`이 권한 없는 사람에게 결제 칸을 감춘 **안내 화면**을 보여줬습니다. 세 가지가 문제였습니다.

- 제목("결제가 확인되지 않았습니다") · 그 아래 문장 · 카드 안 문장이 **같은 말을 세 번** 합니다.
- 전부 "결제해라"는 말인데 **정작 그 사람은 결제할 수 없습니다.**
- **나갈 방법이 없습니다** — 로그아웃도, 다른 링크도 없습니다.

할 일이 없는 사람에게 화면을 한 장 주는 것보다, **왜 못 들어오는지와 누가 풀 수 있는지** 두 줄로 끝내는 편이 정직합니다.

| | 전 | 후 |
| --- | --- | --- |
| 권한 없음 | 제목 + 안내 문장 + 카드 (같은 말 3번, 출구 없음) | 공통 결과 창 2줄 + [로그인 화면으로] |
| 권한 있음 | 결제 칸 | **그대로** |

**바뀐 파일**

- `subscription-blocked-dialog.tsx` (신규) — 결제 실패 창과 **같은 `ResultDialog`** 를 씁니다. 돈 때문에 막히는 자리가 화면마다 다르게 생기면 같은 서비스로 안 읽힙니다.
- `result-dialog.tsx` — `isDismissible` 추가. `false`면 X를 지웁니다. **뒤에 볼 것이 없는 창**에만 씁니다 — 닫아서 빈 화면이 남으면 막힌 게 아니라 고장 난 것처럼 보입니다.
- `subscription-gate.tsx` — 권한 없는 갈래를 통째로 걷어내고 위 창으로 보냅니다 (103줄).

**왜 로그인 화면이 아니라 `/subscription`인가**

1. **로그인은 성공했습니다.** 아이디·비밀번호가 맞았고 세션도 생겼습니다. 못 들어가는 건 인증이 아니라 **회사의 구독 상태**라, 로그인 화면에 얹으면 "내 계정에 문제가 있나"로 읽힙니다.
2. **로그인 화면만으로는 못 막습니다.** 어제 로그인해 둔 사람이 오늘 북마크로 `/app/board`를 열면 로그인 화면을 안 거칩니다. 막는 자리는 한 곳이어야 합니다.
3. **대표와 사원이 같은 자리여야 합니다.** 대표는 거기서 결제합니다. 사원만 다른 화면에서 막으면 정책이 바뀔 때 두 곳을 고쳐야 합니다.

---

## 💳 결제 수단을 회사당 한 장으로 (#96)

리뷰 중에 결제 수단 카드가 **여러 장을 전제로** 만들어져 있는 게 걸려서 같이 정리했습니다.

**두 번째 카드가 나갈 자리가 없습니다.** 구독이 회사당 하나이고 청구도 한 번이라 결제는 한 장으로만 나갑니다. 게다가 **자동 폴백이 없어서**, 기본 카드가 실패해도 다른 카드로 재시도하지 않습니다 — 여러 장을 두는 유일한 실익이 없었습니다.

지금 화면 복잡도의 대부분이 그 전제에서 나온 것이었습니다.

| 있던 것 | 왜 있었나 | 지금 |
| --- | --- | --- |
| `기본` 배지 | 여러 장 중 어느 게 나가는지 알려야 해서 | 없음 |
| `기본으로` 버튼 | 다른 장을 올려야 해서 | 없음 |
| X 삭제 + "기본은 못 지운다" | 지우면 청구가 실패해서 | 없음 — 그만두려면 **구독 해지** |
| 0장~N장 분기 | 목록이라 | 있음 / 없음 두 가지 |

```text
[💳] VISA •••• 4242          [변경]
     만료 09/27
```

**바뀐 것**

- UI 계약: `methods: PaymentMethod[]` → **`method: PaymentMethod | null`**. `isDefault` 제거 (한 장뿐이면 늘 그 장입니다)
- `setDefaultMethodAction` · `removeMethodAction` **삭제** — 부를 자리가 없습니다(#89에서 만든 둘입니다)
- `registerCardAction`을 **갈아 끼우는 일**로 다시 적었습니다. 더하는 게 아니라 이미 있으면 덮어씁니다
- 로딩 뼈대 `196px → 152px`. 여러 장이던 시절 높이라 **채워지는 순간 45px이 접혀** 아래가 위로 딸려 올라갔습니다

**빈 상태는 사실상 안 생깁니다.** 온보딩 4단계에서 결제를 마쳐야 워크스페이스가 열리므로 여기까지 온 회사에는 카드가 있습니다. 그래도 `등록된 결제 수단이 없습니다` 한 줄을 남긴 건, BE가 값을 안 줄 때 `•••• undefined`가 찍히는 것보다 낫기 때문입니다(§정직성).

**BE에 전달할 사항** — 빌링키는 회사당 하나입니다. 등록 엔드포인트 하나가 **등록과 변경을 겸하고**, 기본 지정·삭제 엔드포인트는 필요 없습니다. (이슈 #96 본문에 정리해 뒀습니다)

---

## 🎨 구독·결제 화면 표식 (#97)

글자만 있어서 어느 칸이 무엇인지 훑어서 안 잡혔습니다. 전부 `lucide-react`입니다(§디자인 토큰 ❌이모지).

- **플랜 카드 머리** — `/plans`·결제 화면(`PlanSummaryCard`)과 **같은 표식**을 씁니다. 랜딩에서 보고, 결제할 때 보고, 관리 화면에서 다시 보는 게 같은 물건이라 표식도 같아야 합니다. 이름 아래 한 줄을 같이 두되 **금액은 안 적습니다** — 바로 아래 `월 기본료` 칸과 두 벌이 됩니다.
- **지표 세 칸** — 결제 화면의 포함량 칸(`Included`)과 같은 모양으로 바꿨습니다. **아이콘 + 가운데 정렬 + 보더.** 라이트에서 `--secondary`는 흰 카드와 2%밖에 차이가 없어서, 보더가 없으면 칸이 있는지조차 안 보입니다.
- **사용량 배너** — 표식을 앞에 뒀습니다. 초과는 빨강(에러), **80% 경고는 색 없이** 회색 표식입니다. 아직 안 넘겼는데 빨갛게 하면 이미 돈이 더 나가는 줄 읽힙니다(§디자인 토큰: 색으로 알리는 건 에러뿐).

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/billing-subscription-blocked#94`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 판정은 `canManageBilling` 한 곳입니다(역할 상수 하드코딩 없음). 화면에서 막는 건 UX일 뿐이고, 결제 Server Action은 이미 `assertCanManage`로 서버에서 다시 봅니다(#89)
- [x] 🧬 zod — 스키마 무변경
- [x] 🕵️ **정직성** — 로그아웃 기능이 레포에 없어(`endpoints.ts`에 경로만 있음) `/login` 링크로 두고 **`TODO(BE 연동)`** 를 남겼습니다. 되는 척하지 않습니다
- [x] 🎨 디자인 토큰 — 새 색·새 모양 없음. 공통 창을 그대로 씁니다

**품질**

- [x] ⚡ 최적화 — 무거운 것 없음
- [x] ♿ a11y — `ResultDialog`의 `role="dialog"` · 포커스 · 제목/설명 연결을 그대로 씁니다. 닫기 경로가 하나뿐이라 포커스가 갈 곳을 잃지 않습니다
- [x] ♻️ **재사용 확인** — 창을 새로 그리지 않았습니다. `ResultDialog` → `DialogMark`를 그대로 씁니다
- [x] 🧪 loading / error / empty 3상태 — 페이지는 Server Component이고 `loading.tsx`가 이미 있습니다
- [x] 브라우저 전용 API — 해당 없음

---

## 🔗 연관 이슈

Closes #94
Closes #96
Closes #97

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- **창을 못 닫게 한 방식** — `showCloseButton={false}`만 씁니다. Esc·바깥 클릭은 따로 안 막았는데, 그 둘은 `onOpenChange`를 부를 뿐이고 쓰는 쪽이 `isOpen`을 계속 참으로 두기 때문에 결과가 같습니다. 브라우저에서 Esc를 눌러 확인했습니다.
- **[로그인 화면으로]가 로그아웃이 아닌 것** — 지금은 세션이 없어 링크로 둡니다. 세션이 붙으면 여기서 로그아웃을 불러야 하고, 그 전까지는 쿠키가 남은 채 로그인 화면으로 갑니다.
- **결제 수단을 한 장으로 고정한 것** — 화면 정리가 아니라 **정책**입니다. BE 빌링키 설계에 영향이 갑니다
- 문구를 **두 줄로 끊은 것**(`<br />`) — "결제가 끝나야 열린다"와 "대표·Admin만 할 수 있다"는 성격이 달라서 한 문단으로 붙이면 둘 다 안 읽힙니다.

---

## 📝 추가 메모

**이번 범위가 아닌 것 둘** — 세션이 붙어야 할 수 있는 일입니다(이슈 #94 본문에도 적었습니다).

1. **아무도 `/subscription`으로 보내지 않습니다.** `loginRedirect()`는 목적지를 돌려주지만 `middleware.ts`가 없습니다 — 개발 중 화면 확인 때문에 일부러 안 넣기로 했습니다.
2. **셸이 구독 상태를 안 봅니다.** 만료된 회사의 사원이 `/app/*`을 직접 열면 그냥 들어갑니다. 미들웨어에서 한 번에 처리하는 게 맞다고 팀에서 정했습니다.

**확인한 것**

- eslint 0 · tsc 0 · `npx jest` 231개 통과 · `npm run build` 성공
- 목을 MEMBER로 바꿔 `/subscription` 확인 — 창이 뜨고 **X 없음**, Esc를 눌러도 안 닫힘, 버튼은 [로그인 화면으로] 하나
- 목을 OWNER로 되돌려 확인 — 결제 칸(Team 플랜 · AI 토큰 · 저장 공간 · 기능 9가지)이 그대로 뜸
- `/manage/billing`에서 [변경]을 눌러 목 동작 확인 — `VISA •••• 4242` → `MASTER •••• 8720`으로 **갈아 끼워지고**(줄이 늘지 않음), 토스트는 `결제 수단을 변경했습니다`
- 1440px에서 카드 높이 측정 — 결제 수단 **151px**, 뼈대 152px
- 라이트·다크 양쪽으로 `/manage/billing` 확인 — 지표 칸 보더가 라이트에서도 보이고, 배너 표식이 문장 앞에 섬


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 구독 상태에 따라 결제 차단 안내 대화상자를 표시합니다.
  * 결제 권한이 없는 경우 로그인 화면으로 이동할 수 있습니다.
  * 대화상자의 닫기 버튼 표시 여부를 설정할 수 있습니다.
  * 회사별 결제 수단을 하나의 카드로 관리하며, 기존 카드 변경 또는 신규 등록을 지원합니다.

* **개선**
  * 결제 권한이 있는 사용자에게만 구독 결제 화면과 완료 처리를 제공합니다.
  * 결제 수단이 없을 때 빈 상태 안내를 표시합니다.
  * 결제 플랜과 사용량 정보를 아이콘과 함께 더 명확하게 표시합니다.
  * 결제 화면의 로딩 레이아웃을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


