### PR TITLE
[FEAT] 오너 대시보드 화면 #82

### DIFF
--- a/src/app/(shell)/(role)/owner/(dashboard)/error.tsx
+++ b/src/app/(shell)/(role)/owner/(dashboard)/error.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { ScreenError } from "@/components/common/screen-error";
+
+export default function Error({ reset }: { reset: () => void }) {
+  return <ScreenError title="대시보드를 불러오지 못했습니다" reset={reset} />;
+}

--- a/src/app/(shell)/(role)/owner/(dashboard)/layout.tsx
+++ b/src/app/(shell)/(role)/owner/(dashboard)/layout.tsx
@@ -1,0 +1,14 @@
+import { LayoutDashboard } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { PageHeader } from "@/features/shell/components/page-header";
+
+/** 대시보드 상단바 — 사이드바에서 바로 닿는 화면이라 backTo는 두지 않는다. */
+export default function OwnerDashboardLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <PageHeader title="대시보드" icon={LayoutDashboard} />
+      {children}
+    </>
+  );
+}

--- a/src/app/(shell)/(role)/owner/(dashboard)/loading.tsx
+++ b/src/app/(shell)/(role)/owner/(dashboard)/loading.tsx
@@ -1,0 +1,20 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { LEADER_BOX_HEIGHT, MEETING_BOX_HEIGHT } from "@/features/owner/lib";
+
+/** 대시보드를 불러오는 동안. 실제 화면과 같은 골격(고정 높이 두 박스 포함)이라 레이아웃이 흔들리지 않는다. */
+export default function Loading() {
+  return (
+    <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
+      <div className="mx-auto flex w-full max-w-[1080px] flex-col gap-4">
+        <div className="grid grid-cols-4 gap-3">
+          {Array.from({ length: 4 }, (_, index) => (
+            <Skeleton key={index} className="h-[104px] rounded-xl" />
+          ))}
+        </div>
+
+        <Skeleton className="rounded-xl" style={{ height: LEADER_BOX_HEIGHT }} />
+        <Skeleton className="rounded-xl" style={{ height: MEETING_BOX_HEIGHT }} />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/(role)/owner/(dashboard)/page.tsx
+++ b/src/app/(shell)/(role)/owner/(dashboard)/page.tsx
@@ -1,0 +1,119 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { Table, TableBody, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { KpiCard } from "@/features/owner/components/kpi-card";
+import { LeaderStatusRow } from "@/features/owner/components/leader-status-row";
+import { ProjectMeetingItem } from "@/features/owner/components/project-meeting-item";
+import { getDaysUntilDue, LEADER_BOX_HEIGHT, MEETING_BOX_HEIGHT } from "@/features/owner/lib";
+import { getOwnerDashboardOverview } from "@/features/owner/server";
+
+export const metadata: Metadata = {
+  title: "대시보드",
+};
+
+export default async function OwnerDashboardPage() {
+  const { projects, activeMemberCount, onLeaveMemberCount, leaderRows, projectMeetings } =
+    await getOwnerDashboardOverview();
+
+  const imminentProjectCount = projects.filter((project) => {
+    const daysUntilDue = getDaysUntilDue(project.dueDate);
+    return daysUntilDue >= 0 && daysUntilDue <= 7;
+  }).length;
+
+  const kpis = [
+    { label: "전체 프로젝트", value: String(projects.length), sub: "진행 중" },
+    {
+      label: "마감 D-7",
+      value: String(imminentProjectCount),
+      sub: "즉시 확인 필요",
+      tone: "danger" as const,
+    },
+    { label: "전체 사원", value: String(activeMemberCount), sub: "재직 중" },
+    {
+      label: "휴직자",
+      value: String(onLeaveMemberCount),
+      sub: "현재 휴직",
+      tone: "warning" as const,
+    },
+  ];
+
+  return (
+    <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
+      <div className="mx-auto flex w-full max-w-[1080px] flex-col gap-4">
+        <div className="grid grid-cols-4 gap-3">
+          {kpis.map((kpi) => (
+            <KpiCard key={kpi.label} {...kpi} />
+          ))}
+        </div>
+
+        <section
+          className="border-border bg-card flex flex-col overflow-hidden rounded-xl border"
+          style={{ height: LEADER_BOX_HEIGHT }}
+        >
+          <div className="border-border flex shrink-0 items-center border-b px-4 py-3">
+            <h2 className="text-sm font-semibold">팀장 현황</h2>
+          </div>
+          {leaderRows.length === 0 ? (
+            <p className="text-muted-foreground flex flex-1 items-center justify-center text-sm">
+              아직 등록된 팀장이 없습니다.
+            </p>
+          ) : (
+            <div className="scrollbar-hidden flex-1 overflow-y-auto">
+              <Table className="table-fixed">
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="text-muted-foreground pl-4 text-xs">이름</TableHead>
+                    <TableHead className="text-muted-foreground text-center text-xs">
+                      이메일
+                    </TableHead>
+                    <TableHead className="text-muted-foreground text-center text-xs">
+                      부서
+                    </TableHead>
+                    <TableHead className="text-muted-foreground text-center text-xs">
+                      상태
+                    </TableHead>
+                    <TableHead className="text-muted-foreground pr-4 text-center text-xs">
+                      휴직기간
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {leaderRows.map((leader) => (
+                    <LeaderStatusRow key={leader.id} leader={leader} />
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </section>
+
+        <section
+          className="border-border bg-card flex flex-col overflow-hidden rounded-xl border"
+          style={{ height: MEETING_BOX_HEIGHT }}
+        >
+          <div className="border-border flex shrink-0 items-center justify-between border-b px-4 py-3">
+            <h2 className="text-sm font-semibold">최근 프로젝트 회의</h2>
+            <Link
+              href="/app/meeting"
+              className="text-muted-foreground hover:text-foreground text-xs transition-colors"
+            >
+              전체 보기 →
+            </Link>
+          </div>
+          {projectMeetings.length === 0 ? (
+            <p className="text-muted-foreground flex flex-1 items-center justify-center text-sm">
+              예정된 프로젝트 회의가 없습니다.
+            </p>
+          ) : (
+            <ul className="flex-1 overflow-hidden">
+              {projectMeetings.map((meeting, index) => (
+                <ProjectMeetingItem key={meeting.id} meeting={meeting} showDivider={index > 0} />
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/(role)/owner/(dashboard)/page.tsx
+++ b/src/app/(shell)/(role)/owner/(dashboard)/page.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 
+import { DashboardMeetingItem } from "@/components/common/dashboard-meeting-item";
 import { Table, TableBody, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { KpiCard } from "@/features/owner/components/kpi-card";
 import { LeaderStatusRow } from "@/features/owner/components/leader-status-row";
-import { ProjectMeetingItem } from "@/features/owner/components/project-meeting-item";
 import { getDaysUntilDue, LEADER_BOX_HEIGHT, MEETING_BOX_HEIGHT } from "@/features/owner/lib";
 import { getOwnerDashboardOverview } from "@/features/owner/server";
 
@@ -111,7 +111,7 @@ export default async function OwnerDashboardPage() {
           ) : (
             <ul className="flex-1 overflow-hidden">
               {projectMeetings.map((meeting, index) => (
-                <ProjectMeetingItem key={meeting.id} meeting={meeting} showDivider={index > 0} />
+                <DashboardMeetingItem key={meeting.id} meeting={meeting} showDivider={index > 0} />
               ))}
             </ul>
           )}

--- a/src/app/(shell)/(role)/owner/(dashboard)/page.tsx
+++ b/src/app/(shell)/(role)/owner/(dashboard)/page.tsx
@@ -59,8 +59,11 @@ export default async function OwnerDashboardPage() {
               아직 등록된 팀장이 없습니다.
             </p>
           ) : (
-            <div className="scrollbar-hidden flex-1 overflow-y-auto">
-              <Table className="table-fixed">
+            // 가로·세로 스크롤을 모두 이 컨테이너가 갖고(스크롤바 숨김), 좁은 화면에서 컬럼이
+            // 과도하게 줄지 않게 테이블에 최소 폭을 준다. shadcn Table이 자체적으로 두는
+            // table-container(overflow-x-auto)를 visible로 눌러 스크롤 소유권을 여기로 넘긴다.
+            <div className="scrollbar-hidden flex-1 overflow-auto [&_[data-slot=table-container]]:overflow-visible">
+              <Table className="min-w-[560px] table-fixed">
                 <TableHeader>
                   <TableRow>
                     <TableHead className="text-muted-foreground pl-4 text-xs">이름</TableHead>

--- a/src/components/common/dashboard-meeting-item.test.ts
+++ b/src/components/common/dashboard-meeting-item.test.ts
@@ -1,0 +1,11 @@
+import { formatMeetingDate } from "./dashboard-meeting-item";
+
+describe("formatMeetingDate", () => {
+  it("월 일(요일) 시:분 형식으로 포맷한다", () => {
+    expect(formatMeetingDate("2026-08-20T10:00:00")).toBe("8월 20일(목) 10:00");
+  });
+
+  it("한 자리 시·분도 두 자리로 채운다", () => {
+    expect(formatMeetingDate("2026-09-01T09:05:00")).toBe("9월 1일(화) 09:05");
+  });
+});

--- a/src/components/common/dashboard-meeting-item.tsx
+++ b/src/components/common/dashboard-meeting-item.tsx
@@ -2,19 +2,47 @@ import Link from "next/link";
 
 import { Badge } from "@/components/ui/badge";
 import { MEETING_STATUS, MEETING_STATUS_LABEL, type MeetingStatus } from "@/constants/domain";
-import { formatMeetingDate, MEETING_ITEM_HEIGHT } from "@/features/owner/lib";
-import type { OwnerDashboardMeeting } from "@/features/owner/types";
 import { cn } from "@/lib/utils";
 
-interface ProjectMeetingItemProps {
-  meeting: OwnerDashboardMeeting;
-  /** 목록의 첫 항목이 아니면 위쪽 구분선을 그린다 */
-  showDivider: boolean;
+/**
+ * 대시보드 "회의" 위젯 한 줄의 UI 계약 — 오너·팀장 대시보드가 **공용**으로 쓴다.
+ * ⚠️ 유일한 차이는 `hostLabel`이다: 오너 개설이면 `"Owner"`, 팀 회의면 부서명(`"개발팀"`).
+ *    그 외 구조는 두 대시보드가 완전히 동일하다.
+ */
+export interface DashboardMeeting {
+  id: string;
+  title: string;
+  projectTag: string;
+  /** 자유 HEX(프로젝트 태그 색) */
+  color: string;
+  status: MeetingStatus;
+  /** 회의실 장소 이름(예: "회의실 A") */
+  room: string;
+  scheduledAt: string;
+  attendeeCount: number;
+  /** 개설 주체 라벨 — 오너 개설="Owner", 팀 회의=부서명 */
+  hostLabel: string;
 }
 
 /**
- * 회의 상태 색 — 이 위젯은 상태 흐름(예정→진행중→완료)이 한눈에 보여야 해서 색으로 구분한다.
- * 값은 토큰이라 다크모드가 따라온다: 예정=파랑(primary) · 진행중=초록(success) · 완료=회색(muted).
+ * 회의 한 줄 높이(px). 대시보드 박스 높이가 이 값 × 최대 수에서 나오므로 한 곳에 둔다.
+ * 박스에 정확히 N건이 채워져 스크롤이 안 생기게 하는 기준이다.
+ */
+export const MEETING_ITEM_HEIGHT = 72;
+
+const WEEKDAY_LABEL = ["일", "월", "화", "수", "목", "금", "토"];
+
+/** 카피 규칙: 날짜 `8월 5일(화) 10:00` 포맷(CLAUDE.md §디자인 토큰). 테스트를 위해 export. */
+export function formatMeetingDate(dateIso: string): string {
+  const date = new Date(dateIso);
+  const hour = String(date.getHours()).padStart(2, "0");
+  const minute = String(date.getMinutes()).padStart(2, "0");
+  return `${date.getMonth() + 1}월 ${date.getDate()}일(${WEEKDAY_LABEL[date.getDay()]}) ${hour}:${minute}`;
+}
+
+/**
+ * 회의 상태 색 — 상태 흐름(예정→진행중→완료)이 한눈에 보이게 색으로 구분한다(토큰이라 다크 자동).
+ * 예정=파랑(primary) · 진행중=초록(success) · 완료=회색(muted).
  */
 const STATUS_TONE: Record<MeetingStatus, string> = {
   [MEETING_STATUS.SCHEDULED]: "bg-primary/10 text-primary",
@@ -22,13 +50,14 @@ const STATUS_TONE: Record<MeetingStatus, string> = {
   [MEETING_STATUS.DONE]: "bg-muted text-muted-foreground",
 };
 
-/**
- * "최근 프로젝트 회의" 목록의 한 행.
- * ⚠️ 높이는 `MEETING_ITEM_HEIGHT` 고정이다 — 박스 높이가 이 값 × 최대 수로 잡혀 있어,
- *    한 줄이라도 높이가 달라지면 5건이 박스에 안 맞아 스크롤이 생긴다.
- * 좌: 회의명 · 프로젝트 태그 · Owner · 상태 / 우: 회의실 · 시간 · 참석 인원.
- */
-export function ProjectMeetingItem({ meeting, showDivider }: ProjectMeetingItemProps) {
+interface DashboardMeetingItemProps {
+  meeting: DashboardMeeting;
+  /** 목록의 첫 항목이 아니면 위쪽 구분선을 그린다 */
+  showDivider: boolean;
+}
+
+/** 좌: 태그·회의명·개설 라벨 / 우: 회의실·시간·참석 + 상태 라벨(맨 오른쪽). */
+export function DashboardMeetingItem({ meeting, showDivider }: DashboardMeetingItemProps) {
   return (
     <li
       className={cn(showDivider && "border-border border-t")}
@@ -38,7 +67,7 @@ export function ProjectMeetingItem({ meeting, showDivider }: ProjectMeetingItemP
         href={`/app/meeting/${meeting.id}`}
         className="hover:bg-muted flex h-full items-center transition-colors"
       >
-        {/* 프로젝트 색 왼쪽 막대 — 콩 원 대신 행 위아래 끝에 딱 붙는 얇은 세로선 */}
+        {/* 프로젝트 색 왼쪽 막대 — 행 위아래 끝에 딱 붙는 얇은 세로선 */}
         <span
           className="h-full w-1 shrink-0"
           style={{ backgroundColor: meeting.color }}
@@ -46,7 +75,7 @@ export function ProjectMeetingItem({ meeting, showDivider }: ProjectMeetingItemP
         />
 
         <div className="flex min-w-0 flex-1 items-center gap-3 px-4">
-          {/* 좌: (상단) 프로젝트 태그 / (하단) 회의명 + Owner */}
+          {/* 좌: (상단) 프로젝트 태그 / (하단) 회의명 + 개설 라벨 */}
           <div className="flex min-w-0 flex-1 flex-col justify-center gap-1">
             <span
               className="w-fit rounded px-1.5 py-0.5 font-mono text-[10px] font-semibold"
@@ -57,7 +86,7 @@ export function ProjectMeetingItem({ meeting, showDivider }: ProjectMeetingItemP
             <div className="flex min-w-0 items-center gap-2">
               <span className="truncate text-[15px]">{meeting.title}</span>
               <Badge variant="secondary" className="shrink-0">
-                Owner
+                {meeting.hostLabel}
               </Badge>
             </div>
           </div>

--- a/src/components/common/dashboard-meeting-item.tsx
+++ b/src/components/common/dashboard-meeting-item.tsx
@@ -6,8 +6,10 @@ import { cn } from "@/lib/utils";
 
 /**
  * 대시보드 "회의" 위젯 한 줄의 UI 계약 — 오너·팀장 대시보드가 **공용**으로 쓴다.
- * ⚠️ 유일한 차이는 `hostLabel`이다: 오너 개설이면 `"Owner"`, 팀 회의면 부서명(`"개발팀"`).
- *    그 외 구조는 두 대시보드가 완전히 동일하다.
+ * 라벨은 2단이다:
+ *   - `originLabel`(항상): 회의의 소속·권한 — 오너 개설="Owner", 팀 회의=부서명("개발팀").
+ *   - `hostLabel`(선택): **개설자(주최자) 사람** — 비오너 회의만. 오너 회의는 개설 주체를
+ *     "Owner"로 추상화하므로 없다. 이 규칙은 나중의 회의 목록·탭에도 그대로 적용된다.
  */
 export interface DashboardMeeting {
   id: string;
@@ -20,8 +22,10 @@ export interface DashboardMeeting {
   room: string;
   scheduledAt: string;
   attendeeCount: number;
-  /** 개설 주체 라벨 — 오너 개설="Owner", 팀 회의=부서명 */
-  hostLabel: string;
+  /** 소속·권한 라벨 — 오너 개설="Owner", 팀 회의=부서명("개발팀") */
+  originLabel: string;
+  /** 개설자 사람 — 팀장이면 "김서준(팀장)", 팀원이면 "이하윤". 오너 회의는 없음(undefined) */
+  hostLabel?: string;
 }
 
 /**
@@ -85,9 +89,15 @@ export function DashboardMeetingItem({ meeting, showDivider }: DashboardMeetingI
             </span>
             <div className="flex min-w-0 items-center gap-2">
               <span className="truncate text-[15px]">{meeting.title}</span>
+              {/* 소속·권한 라벨(항상) + 개설자 라벨(비오너 회의만) */}
               <Badge variant="secondary" className="shrink-0">
-                {meeting.hostLabel}
+                {meeting.originLabel}
               </Badge>
+              {meeting.hostLabel && (
+                <Badge variant="outline" className="shrink-0">
+                  {meeting.hostLabel}
+                </Badge>
+              )}
             </div>
           </div>
 

--- a/src/features/owner/components/kpi-card.tsx
+++ b/src/features/owner/components/kpi-card.tsx
@@ -1,0 +1,29 @@
+import { cn } from "@/lib/utils";
+
+interface KpiCardProps {
+  label: string;
+  value: string;
+  sub: string;
+  /** 강조색 — 없으면 기본 텍스트색 */
+  tone?: "danger" | "warning";
+}
+
+/** 대시보드 상단 KPI 4카드가 공유하는 한 칸. */
+export function KpiCard({ label, value, sub, tone }: KpiCardProps) {
+  return (
+    <div className="border-border bg-card flex flex-col gap-1.5 rounded-xl border p-4">
+      <p className="text-muted-foreground text-xs leading-4">{label}</p>
+      <p
+        className={cn(
+          "text-xl leading-7 font-semibold tabular-nums",
+          tone === "danger" && "text-destructive",
+          tone === "warning" && "text-warning",
+          !tone && "text-foreground",
+        )}
+      >
+        {value}
+      </p>
+      <p className="text-muted-foreground/70 text-[11px] leading-4">{sub}</p>
+    </div>
+  );
+}

--- a/src/features/owner/components/leader-status-row.tsx
+++ b/src/features/owner/components/leader-status-row.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { TableCell, TableRow } from "@/components/ui/table";
+import { MEMBER_STATUS, MEMBER_STATUS_LABEL } from "@/constants/domain";
+import type { OwnerDashboardLeaderRow } from "@/features/owner/types";
+import { useProfileAvatar } from "@/hooks/use-profile-avatar";
+
+interface LeaderStatusRowProps {
+  leader: OwnerDashboardLeaderRow;
+}
+
+/**
+ * "팀장 현황" 테이블의 한 행. `<TableBody>` 안에서만 쓴다(루트가 `<tr>`).
+ * ⚠️ 아바타 색은 하드코딩하지 않고 팀 공용 `useProfileAvatar`(이름+부서 해시)로 만든다 —
+ *    BE에 프로필 이미지 필드가 없어 FE가 일관 색을 생성한다(같은 사람은 늘 같은 색).
+ */
+export function LeaderStatusRow({ leader }: LeaderStatusRowProps) {
+  const avatar = useProfileAvatar(leader.name, leader.department, 28);
+  const isOnVacation = leader.status === MEMBER_STATUS.VACATION;
+
+  return (
+    <TableRow className="h-14">
+      <TableCell className="pl-4">
+        <div className="flex items-center gap-2">
+          {avatar}
+          <span className="truncate">{leader.name}</span>
+        </div>
+      </TableCell>
+      <TableCell className="text-muted-foreground truncate text-center" title={leader.email}>
+        {leader.email}
+      </TableCell>
+      <TableCell className="text-muted-foreground text-center">{leader.department}</TableCell>
+      <TableCell className="text-center">
+        <Badge
+          variant={isOnVacation ? "outline" : "secondary"}
+          className={isOnVacation ? "border-warning text-warning" : undefined}
+        >
+          {MEMBER_STATUS_LABEL[leader.status]}
+        </Badge>
+      </TableCell>
+      <TableCell className="text-muted-foreground pr-4 text-center font-mono">
+        {leader.leavePeriod ?? "-"}
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/src/features/owner/components/project-meeting-item.tsx
+++ b/src/features/owner/components/project-meeting-item.tsx
@@ -1,0 +1,87 @@
+import Link from "next/link";
+
+import { Badge } from "@/components/ui/badge";
+import { MEETING_STATUS, MEETING_STATUS_LABEL, type MeetingStatus } from "@/constants/domain";
+import { formatMeetingDate, MEETING_ITEM_HEIGHT } from "@/features/owner/lib";
+import type { OwnerDashboardMeeting } from "@/features/owner/types";
+import { cn } from "@/lib/utils";
+
+interface ProjectMeetingItemProps {
+  meeting: OwnerDashboardMeeting;
+  /** 목록의 첫 항목이 아니면 위쪽 구분선을 그린다 */
+  showDivider: boolean;
+}
+
+/**
+ * 회의 상태 색 — 이 위젯은 상태 흐름(예정→진행중→완료)이 한눈에 보여야 해서 색으로 구분한다.
+ * 값은 토큰이라 다크모드가 따라온다: 예정=파랑(primary) · 진행중=초록(success) · 완료=회색(muted).
+ */
+const STATUS_TONE: Record<MeetingStatus, string> = {
+  [MEETING_STATUS.SCHEDULED]: "bg-primary/10 text-primary",
+  [MEETING_STATUS.IN_PROGRESS]: "bg-success/12 text-success",
+  [MEETING_STATUS.DONE]: "bg-muted text-muted-foreground",
+};
+
+/**
+ * "최근 프로젝트 회의" 목록의 한 행.
+ * ⚠️ 높이는 `MEETING_ITEM_HEIGHT` 고정이다 — 박스 높이가 이 값 × 최대 수로 잡혀 있어,
+ *    한 줄이라도 높이가 달라지면 5건이 박스에 안 맞아 스크롤이 생긴다.
+ * 좌: 회의명 · 프로젝트 태그 · Owner · 상태 / 우: 회의실 · 시간 · 참석 인원.
+ */
+export function ProjectMeetingItem({ meeting, showDivider }: ProjectMeetingItemProps) {
+  return (
+    <li
+      className={cn(showDivider && "border-border border-t")}
+      style={{ height: MEETING_ITEM_HEIGHT }}
+    >
+      <Link
+        href={`/app/meeting/${meeting.id}`}
+        className="hover:bg-muted flex h-full items-center transition-colors"
+      >
+        {/* 프로젝트 색 왼쪽 막대 — 콩 원 대신 행 위아래 끝에 딱 붙는 얇은 세로선 */}
+        <span
+          className="h-full w-1 shrink-0"
+          style={{ backgroundColor: meeting.color }}
+          aria-hidden
+        />
+
+        <div className="flex min-w-0 flex-1 items-center gap-3 px-4">
+          {/* 좌: (상단) 프로젝트 태그 / (하단) 회의명 + Owner */}
+          <div className="flex min-w-0 flex-1 flex-col justify-center gap-1">
+            <span
+              className="w-fit rounded px-1.5 py-0.5 font-mono text-[10px] font-semibold"
+              style={{ backgroundColor: `${meeting.color}1a`, color: meeting.color }}
+            >
+              {meeting.projectTag}
+            </span>
+            <div className="flex min-w-0 items-center gap-2">
+              <span className="truncate text-[15px]">{meeting.title}</span>
+              <Badge variant="secondary" className="shrink-0">
+                Owner
+              </Badge>
+            </div>
+          </div>
+
+          {/* 우: 회의실 · 시간 · 참석 인원 + 상태 라벨(맨 오른쪽 끝) */}
+          <div className="flex shrink-0 items-center gap-3">
+            <div className="text-muted-foreground flex items-center gap-2 text-xs">
+              <span>{meeting.room}</span>
+              <span aria-hidden>·</span>
+              <span className="font-mono">{formatMeetingDate(meeting.scheduledAt)}</span>
+              <span aria-hidden>·</span>
+              <span>참석 {meeting.attendeeCount}명</span>
+            </div>
+            <span
+              className={cn(
+                "inline-flex h-5 shrink-0 items-center rounded-full px-2 text-xs font-medium",
+                STATUS_TONE[meeting.status],
+              )}
+            >
+              {MEETING_STATUS_LABEL[meeting.status]}
+            </span>
+          </div>
+        </div>
+      </Link>
+    </li>
+  );
+}

--- a/src/features/owner/lib.test.ts
+++ b/src/features/owner/lib.test.ts
@@ -1,4 +1,4 @@
-import { formatMeetingDate, getDaysUntilDue } from "./lib";
+import { getDaysUntilDue } from "./lib";
 
 describe("getDaysUntilDue", () => {
   beforeEach(() => {
@@ -19,15 +19,5 @@ describe("getDaysUntilDue", () => {
 
   it("지난 날짜는 음수를 반환한다", () => {
     expect(getDaysUntilDue("2026-08-01")).toBe(-4);
-  });
-});
-
-describe("formatMeetingDate", () => {
-  it("월 일(요일) 시:분 형식으로 포맷한다", () => {
-    expect(formatMeetingDate("2026-08-20T10:00:00")).toBe("8월 20일(목) 10:00");
-  });
-
-  it("한 자리 시·분도 두 자리로 채운다", () => {
-    expect(formatMeetingDate("2026-09-01T09:05:00")).toBe("9월 1일(화) 09:05");
   });
 });

--- a/src/features/owner/lib.test.ts
+++ b/src/features/owner/lib.test.ts
@@ -1,0 +1,33 @@
+import { formatMeetingDate, getDaysUntilDue } from "./lib";
+
+describe("getDaysUntilDue", () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-08-05T00:00:00"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("오늘이 마감이면 0을 반환한다", () => {
+    expect(getDaysUntilDue("2026-08-05")).toBe(0);
+  });
+
+  it("미래 날짜는 남은 일수를 반환한다", () => {
+    expect(getDaysUntilDue("2026-08-12")).toBe(7);
+  });
+
+  it("지난 날짜는 음수를 반환한다", () => {
+    expect(getDaysUntilDue("2026-08-01")).toBe(-4);
+  });
+});
+
+describe("formatMeetingDate", () => {
+  it("월 일(요일) 시:분 형식으로 포맷한다", () => {
+    expect(formatMeetingDate("2026-08-20T10:00:00")).toBe("8월 20일(목) 10:00");
+  });
+
+  it("한 자리 시·분도 두 자리로 채운다", () => {
+    expect(formatMeetingDate("2026-09-01T09:05:00")).toBe("9월 1일(화) 09:05");
+  });
+});

--- a/src/features/owner/lib.ts
+++ b/src/features/owner/lib.ts
@@ -1,24 +1,22 @@
+import { MEETING_ITEM_HEIGHT } from "@/components/common/dashboard-meeting-item";
+
 /*
  * 대시보드 두 박스의 고정 높이(px). `page.tsx`와 `loading.tsx`가 같은 골격을 그려야 해서
  * 여기 한 곳에 둔다.
  * ⚠️ 두 박스의 성격이 다르다:
  *   - 팀장 현황: 인원이 가변 → 고정 높이 + 넘치면 내부 스크롤.
  *   - 회의: 최대 `MEETING_MAX_ITEMS`건이 하드 캡 → 높이를 그 수에 딱 맞춰 잡아 **스크롤이 안 생긴다.**
+ *     한 줄 높이(`MEETING_ITEM_HEIGHT`)는 공용 회의 아이템이 정본이라 거기서 가져온다.
  */
 
 /** 회의 위젯 최대 노출 수. 서버가 이만큼 자르고(server.ts), 박스도 이 수에 맞춰 높이를 잡는다. */
 export const MEETING_MAX_ITEMS = 5;
-
-/** 회의 한 줄 높이(px). 박스 높이가 이 값 × 최대 수에서 나오므로 둘이 어긋나지 않게 한 곳에 둔다. */
-export const MEETING_ITEM_HEIGHT = 72;
 
 /** 두 박스 공통 헤더 높이(px) — `px-4 py-3` + 아래 보더 1px. */
 const BOX_HEADER_HEIGHT = 45;
 
 export const LEADER_BOX_HEIGHT = 420;
 export const MEETING_BOX_HEIGHT = BOX_HEADER_HEIGHT + MEETING_MAX_ITEMS * MEETING_ITEM_HEIGHT;
-
-const WEEKDAY_LABEL = ["일", "월", "화", "수", "목", "금", "토"];
 
 /**
  * 마감 경과와 같은 파생값 — 상태 필드에 저장하지 않고 항상 계산한다(CLAUDE.md §도메인 상수).
@@ -30,12 +28,4 @@ export function getDaysUntilDue(dateIso: string): number {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   return Math.round((due.getTime() - today.getTime()) / 86_400_000);
-}
-
-/** 카피 규칙: 날짜 `8월 5일(화)` 포맷 고정(CLAUDE.md §디자인 토큰) */
-export function formatMeetingDate(dateIso: string): string {
-  const date = new Date(dateIso);
-  const hour = String(date.getHours()).padStart(2, "0");
-  const minute = String(date.getMinutes()).padStart(2, "0");
-  return `${date.getMonth() + 1}월 ${date.getDate()}일(${WEEKDAY_LABEL[date.getDay()]}) ${hour}:${minute}`;
 }

--- a/src/features/owner/lib.ts
+++ b/src/features/owner/lib.ts
@@ -1,0 +1,38 @@
+/*
+ * 대시보드 두 박스의 고정 높이(px). `page.tsx`와 `loading.tsx`가 같은 골격을 그려야 해서
+ * 여기 한 곳에 둔다.
+ * ⚠️ 두 박스의 성격이 다르다:
+ *   - 팀장 현황: 인원이 가변 → 고정 높이 + 넘치면 내부 스크롤.
+ *   - 회의: 최대 `MEETING_MAX_ITEMS`건이 하드 캡 → 높이를 그 수에 딱 맞춰 잡아 **스크롤이 안 생긴다.**
+ */
+
+/** 회의 위젯 최대 노출 수. 서버가 이만큼 자르고(server.ts), 박스도 이 수에 맞춰 높이를 잡는다. */
+export const MEETING_MAX_ITEMS = 5;
+
+/** 회의 한 줄 높이(px). 박스 높이가 이 값 × 최대 수에서 나오므로 둘이 어긋나지 않게 한 곳에 둔다. */
+export const MEETING_ITEM_HEIGHT = 72;
+
+/** 두 박스 공통 헤더 높이(px) — `px-4 py-3` + 아래 보더 1px. */
+const BOX_HEADER_HEIGHT = 45;
+
+export const LEADER_BOX_HEIGHT = 420;
+export const MEETING_BOX_HEIGHT = BOX_HEADER_HEIGHT + MEETING_MAX_ITEMS * MEETING_ITEM_HEIGHT;
+
+const WEEKDAY_LABEL = ["일", "월", "화", "수", "목", "금", "토"];
+
+/** 마감 경과와 같은 파생값 — 상태 필드에 저장하지 않고 항상 계산한다(CLAUDE.md §도메인 상수) */
+export function getDaysUntilDue(dateIso: string): number {
+  const due = new Date(dateIso);
+  due.setHours(0, 0, 0, 0);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return Math.round((due.getTime() - today.getTime()) / 86_400_000);
+}
+
+/** 카피 규칙: 날짜 `8월 5일(화)` 포맷 고정(CLAUDE.md §디자인 토큰) */
+export function formatMeetingDate(dateIso: string): string {
+  const date = new Date(dateIso);
+  const hour = String(date.getHours()).padStart(2, "0");
+  const minute = String(date.getMinutes()).padStart(2, "0");
+  return `${date.getMonth() + 1}월 ${date.getDate()}일(${WEEKDAY_LABEL[date.getDay()]}) ${hour}:${minute}`;
+}

--- a/src/features/owner/lib.ts
+++ b/src/features/owner/lib.ts
@@ -20,10 +20,13 @@ export const MEETING_BOX_HEIGHT = BOX_HEADER_HEIGHT + MEETING_MAX_ITEMS * MEETIN
 
 const WEEKDAY_LABEL = ["일", "월", "화", "수", "목", "금", "토"];
 
-/** 마감 경과와 같은 파생값 — 상태 필드에 저장하지 않고 항상 계산한다(CLAUDE.md §도메인 상수) */
+/**
+ * 마감 경과와 같은 파생값 — 상태 필드에 저장하지 않고 항상 계산한다(CLAUDE.md §도메인 상수).
+ * ⚠️ `dueDate`는 `"2026-08-05"` 같은 **날짜 전용** 값이다. `new Date("2026-08-05")`는 UTC 자정으로
+ *    해석돼 음수 오프셋 타임존에서 하루 어긋난다 — `T00:00:00`을 붙여 **로컬 자정**으로 파싱한다.
+ */
 export function getDaysUntilDue(dateIso: string): number {
-  const due = new Date(dateIso);
-  due.setHours(0, 0, 0, 0);
+  const due = new Date(`${dateIso}T00:00:00`);
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   return Math.round((due.getTime() - today.getTime()) / 86_400_000);

--- a/src/features/owner/mock/dashboard.ts
+++ b/src/features/owner/mock/dashboard.ts
@@ -80,6 +80,7 @@ export const OWNER_DASHBOARD_MOCK: OwnerDashboardOverview = {
       room: "회의실 A",
       scheduledAt: "2026-07-30T10:00:00",
       attendeeCount: 4,
+      hostLabel: "Owner",
     },
     {
       id: "m2",
@@ -90,6 +91,7 @@ export const OWNER_DASHBOARD_MOCK: OwnerDashboardOverview = {
       room: "대회의실",
       scheduledAt: "2026-08-01T14:00:00",
       attendeeCount: 4,
+      hostLabel: "Owner",
     },
     {
       id: "m3",
@@ -100,6 +102,7 @@ export const OWNER_DASHBOARD_MOCK: OwnerDashboardOverview = {
       room: "회의실 B",
       scheduledAt: "2026-08-05T11:00:00",
       attendeeCount: 3,
+      hostLabel: "Owner",
     },
     {
       id: "m4",
@@ -110,6 +113,7 @@ export const OWNER_DASHBOARD_MOCK: OwnerDashboardOverview = {
       room: "회의실 C",
       scheduledAt: "2026-08-08T15:00:00",
       attendeeCount: 3,
+      hostLabel: "Owner",
     },
     {
       id: "m5",
@@ -120,6 +124,7 @@ export const OWNER_DASHBOARD_MOCK: OwnerDashboardOverview = {
       room: "회의실 A",
       scheduledAt: "2026-08-12T10:00:00",
       attendeeCount: 2,
+      hostLabel: "Owner",
     },
   ],
 };

--- a/src/features/owner/mock/dashboard.ts
+++ b/src/features/owner/mock/dashboard.ts
@@ -1,0 +1,125 @@
+import { MEETING_STATUS, MEMBER_STATUS, PROJECT_STATUS } from "@/constants/domain";
+
+import type { OwnerDashboardOverview } from "../types";
+
+/**
+ * ⚠️ 목 데이터 — BE 연동 전(ERD·API 스펙 미확정, DECISIONS.md).
+ * 오너 대시보드는 이미 집계된 요약 지표를 받는다는 전제라, FE가 프로젝트·회의
+ * 원본을 다시 순회해 집계하지 않는다(연동 시 이 파일과 server.ts만 교체).
+ */
+export const OWNER_DASHBOARD_MOCK: OwnerDashboardOverview = {
+  projects: [
+    {
+      id: "goods",
+      name: "연예인 굿즈 쇼핑몰 앱 구축",
+      tag: "GOODS",
+      color: "#7C3AED",
+      dueDate: "2026-09-20",
+      status: PROJECT_STATUS.IN_PROGRESS,
+    },
+    {
+      id: "brand",
+      name: "3분기 마케팅 브랜드 리뉴얼",
+      tag: "BRAND",
+      color: "#DB2777",
+      dueDate: "2026-09-30",
+      status: PROJECT_STATUS.IN_PROGRESS,
+    },
+    {
+      id: "collab",
+      name: "사내 협업툴 리뉴얼",
+      tag: "COLLAB",
+      color: "#2563EB",
+      dueDate: "2026-10-15",
+      status: PROJECT_STATUS.IN_PROGRESS,
+    },
+  ],
+  activeMemberCount: 10,
+  onLeaveMemberCount: 0,
+  leaderRows: [
+    {
+      id: "leader-kim",
+      name: "김서준",
+      email: "seojun.kim@zteam.io",
+      department: "개발팀",
+      status: MEMBER_STATUS.ACTIVE,
+      leavePeriod: null,
+    },
+    {
+      id: "leader-choi",
+      name: "최유진",
+      email: "yujin.choi@zteam.io",
+      department: "마케팅팀",
+      status: MEMBER_STATUS.ACTIVE,
+      leavePeriod: null,
+    },
+    {
+      id: "leader-kang",
+      name: "강서연",
+      email: "seoyeon.kang@zteam.io",
+      department: "디자인팀",
+      status: MEMBER_STATUS.ACTIVE,
+      leavePeriod: null,
+    },
+    {
+      id: "leader-oh",
+      name: "오현우",
+      email: "hyunwoo.oh@zteam.io",
+      department: "전략기획팀",
+      status: MEMBER_STATUS.ACTIVE,
+      leavePeriod: null,
+    },
+  ],
+  projectMeetings: [
+    {
+      id: "m1",
+      title: "7월 운영 점검 회의",
+      projectTag: "GOODS",
+      color: "#7C3AED",
+      status: MEETING_STATUS.DONE,
+      room: "회의실 A",
+      scheduledAt: "2026-07-30T10:00:00",
+      attendeeCount: 4,
+    },
+    {
+      id: "m2",
+      title: "8월 킥오프 미팅",
+      projectTag: "GOODS",
+      color: "#7C3AED",
+      status: MEETING_STATUS.DONE,
+      room: "대회의실",
+      scheduledAt: "2026-08-01T14:00:00",
+      attendeeCount: 4,
+    },
+    {
+      id: "m3",
+      title: "브랜드 리뉴얼 킥오프",
+      projectTag: "BRAND",
+      color: "#DB2777",
+      status: MEETING_STATUS.IN_PROGRESS,
+      room: "회의실 B",
+      scheduledAt: "2026-08-05T11:00:00",
+      attendeeCount: 3,
+    },
+    {
+      id: "m4",
+      title: "협업툴 리뉴얼 프로젝트 킥오프",
+      projectTag: "COLLAB",
+      color: "#2563EB",
+      status: MEETING_STATUS.SCHEDULED,
+      room: "회의실 C",
+      scheduledAt: "2026-08-08T15:00:00",
+      attendeeCount: 3,
+    },
+    {
+      id: "m5",
+      title: "9월 스프린트 리뷰",
+      projectTag: "GOODS",
+      color: "#7C3AED",
+      status: MEETING_STATUS.SCHEDULED,
+      room: "회의실 A",
+      scheduledAt: "2026-08-12T10:00:00",
+      attendeeCount: 2,
+    },
+  ],
+};

--- a/src/features/owner/mock/dashboard.ts
+++ b/src/features/owner/mock/dashboard.ts
@@ -80,7 +80,7 @@ export const OWNER_DASHBOARD_MOCK: OwnerDashboardOverview = {
       room: "회의실 A",
       scheduledAt: "2026-07-30T10:00:00",
       attendeeCount: 4,
-      hostLabel: "Owner",
+      originLabel: "Owner",
     },
     {
       id: "m2",
@@ -91,7 +91,7 @@ export const OWNER_DASHBOARD_MOCK: OwnerDashboardOverview = {
       room: "대회의실",
       scheduledAt: "2026-08-01T14:00:00",
       attendeeCount: 4,
-      hostLabel: "Owner",
+      originLabel: "Owner",
     },
     {
       id: "m3",
@@ -102,7 +102,7 @@ export const OWNER_DASHBOARD_MOCK: OwnerDashboardOverview = {
       room: "회의실 B",
       scheduledAt: "2026-08-05T11:00:00",
       attendeeCount: 3,
-      hostLabel: "Owner",
+      originLabel: "Owner",
     },
     {
       id: "m4",
@@ -113,7 +113,7 @@ export const OWNER_DASHBOARD_MOCK: OwnerDashboardOverview = {
       room: "회의실 C",
       scheduledAt: "2026-08-08T15:00:00",
       attendeeCount: 3,
-      hostLabel: "Owner",
+      originLabel: "Owner",
     },
     {
       id: "m5",
@@ -124,7 +124,7 @@ export const OWNER_DASHBOARD_MOCK: OwnerDashboardOverview = {
       room: "회의실 A",
       scheduledAt: "2026-08-12T10:00:00",
       attendeeCount: 2,
-      hostLabel: "Owner",
+      originLabel: "Owner",
     },
   ],
 };

--- a/src/features/owner/server.ts
+++ b/src/features/owner/server.ts
@@ -1,0 +1,20 @@
+import { MEETING_MAX_ITEMS } from "./lib";
+import { OWNER_DASHBOARD_MOCK } from "./mock/dashboard";
+import type { OwnerDashboardOverview } from "./types";
+
+// ⚠️ ERD·API 스펙 미확정(BE 협의 전) — 지금은 목 고정. 확정되면 이 분기만 손댄다.
+const isMock = true;
+
+export async function getOwnerDashboardOverview(): Promise<OwnerDashboardOverview> {
+  if (isMock) {
+    return {
+      ...OWNER_DASHBOARD_MOCK,
+      // 최신순(내림차순)으로 위에서부터 내려온다. 박스가 이 수에 딱 맞춰 그려지므로
+      // (스크롤 없음) 서버도 같은 수로 자른다.
+      projectMeetings: [...OWNER_DASHBOARD_MOCK.projectMeetings]
+        .sort((a, b) => new Date(b.scheduledAt).getTime() - new Date(a.scheduledAt).getTime())
+        .slice(0, MEETING_MAX_ITEMS),
+    };
+  }
+  throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
+}

--- a/src/features/owner/types.ts
+++ b/src/features/owner/types.ts
@@ -1,0 +1,42 @@
+import type { MeetingStatus, MemberStatus, ProjectStatus } from "@/constants/domain";
+
+export interface OwnerDashboardProject {
+  id: string;
+  name: string;
+  tag: string;
+  /** 자유 HEX(프로젝트 태그 색) — 고정 팔레트로 강제하지 않는다 */
+  color: string;
+  dueDate: string;
+  status: ProjectStatus;
+}
+
+export interface OwnerDashboardLeaderRow {
+  id: string;
+  name: string;
+  email: string;
+  department: string;
+  status: MemberStatus;
+  /** 휴직 상태일 때만 채워지는 기간 문자열(예: "8월 1일~15일"). 재직이면 null */
+  leavePeriod: string | null;
+}
+
+export interface OwnerDashboardMeeting {
+  id: string;
+  title: string;
+  projectTag: string;
+  color: string;
+  status: MeetingStatus;
+  /** 회의실 장소 이름(예: "회의실 A") */
+  room: string;
+  scheduledAt: string;
+  attendeeCount: number;
+}
+
+export interface OwnerDashboardOverview {
+  projects: OwnerDashboardProject[];
+  activeMemberCount: number;
+  onLeaveMemberCount: number;
+  leaderRows: OwnerDashboardLeaderRow[];
+  /** Owner 주최 프로젝트 회의만 (2절) — 팀 액션 회의는 여기 안 나온다 */
+  projectMeetings: OwnerDashboardMeeting[];
+}

--- a/src/features/owner/types.ts
+++ b/src/features/owner/types.ts
@@ -1,4 +1,5 @@
-import type { MeetingStatus, MemberStatus, ProjectStatus } from "@/constants/domain";
+import type { DashboardMeeting } from "@/components/common/dashboard-meeting-item";
+import type { MemberStatus, ProjectStatus } from "@/constants/domain";
 
 export interface OwnerDashboardProject {
   id: string;
@@ -20,23 +21,11 @@ export interface OwnerDashboardLeaderRow {
   leavePeriod: string | null;
 }
 
-export interface OwnerDashboardMeeting {
-  id: string;
-  title: string;
-  projectTag: string;
-  color: string;
-  status: MeetingStatus;
-  /** 회의실 장소 이름(예: "회의실 A") */
-  room: string;
-  scheduledAt: string;
-  attendeeCount: number;
-}
-
 export interface OwnerDashboardOverview {
   projects: OwnerDashboardProject[];
   activeMemberCount: number;
   onLeaveMemberCount: number;
   leaderRows: OwnerDashboardLeaderRow[];
-  /** Owner 주최 프로젝트 회의만 (2절) — 팀 액션 회의는 여기 안 나온다 */
-  projectMeetings: OwnerDashboardMeeting[];
+  /** Owner 주최 프로젝트 회의만 (2절) — 팀 액션 회의는 여기 안 나온다. 개설 라벨은 "Owner" */
+  projectMeetings: DashboardMeeting[];
 }


### PR DESCRIPTION
## 📋 PR 타입

> 해당하는 타입을 선택해 주세요 (복수 선택 가능)

- [x] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [x] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [x] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- OWNER 로그인 후 첫 화면인 **오너 대시보드(`/owner`)** 를 스텁에서 실제 화면으로 구현 — 회사 전체 상황(프로젝트·사원·팀장·프로젝트 회의)을 한눈에 요약
- **KPI 4카드**(전체 프로젝트·마감 D-7·전체 사원·휴직자) — 마감 D-7은 저장값이 아니라 마감일로 **계산**해 집계(파생값 비저장 규칙)
- **팀장 현황 테이블**(이름·이메일·부서·상태·휴직기간) — 인원 가변이라 고정 높이 + 내부 스크롤, 아바타는 공용 `useProfileAvatar`(색 하드코딩 금지)
- **최근 프로젝트 회의**(Owner 주최, 최신순 5건) — 박스 높이를 5건에 딱 맞춰 스크롤 제거, 좌측 태그/제목·우측 회의실·시간·참석, 맨 오른쪽 상태 라벨(예정=파랑·진행중=초록·완료=회색)
- `features/owner/`에 격리막 구조(types·mock·server·매퍼 자리) 신설 — BE 연동 시 `server.ts`만 교체
- loading/error/empty 3상태 + 순수 함수 단위 테스트, 폭은 `/manage/billing`과 통일(`max-w-[1080px]`)

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/owner-dashboard#82`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — `/owner`는 base role OWNER 전용(라우트 가드). 대시보드는 조회 전용이라 리소스 소유권 조건 없음. BE 연동 시 서버 재검사 예정
- [ ] 🧬 **zod** — ⚠️ 미적용. ERD·API 미확정이라 목 고정 단계, 실응답 shape이 없어 스키마를 지어내지 않음. 연동 시 매퍼에 `safeParse` 추가 예정(주석 명시)
- [x] 🕵️ **정직성** — 목 데이터·미구현 라우트(`/app/meeting` 링크)를 주석에 명시, 빈 상태 문구 처리
- [x] 🎨 디자인 토큰 사용 — `bg-card`·`text-muted-foreground`·`text-primary/success` 등 토큰만, 다크 대응 자동(프로젝트 태그 색만 자유 HEX = 정책 허용)

**품질**

- [x] ⚡ 최적화 — Server Component 조회, 시맨틱 태그(`main`·`section`·`h1/h2`·`ul/li`), 이미지 없음
- [x] ♿ a11y — `h1` 1개 + 섹션 `h2`, 클릭은 `<a>`(`Link`), 장식 요소 `aria-hidden`
- [x] ♻️ 재사용 확인 — `ui`(Table·Badge·Avatar·Skeleton)·공용 `useProfileAvatar`·`ScreenError` 재사용, 한 화면 전용만 `features/owner/components/`에 신규
- [x] 🧪 `loading` / `error` / `empty` 3상태
- [x] 브라우저 전용 API — 해당 없음(캡처·STT 미사용)

---

## 🔗 연관 이슈

Closes #82

---

## 📸 스크린샷 (선택)

<img width="2880" height="1458" alt="image" src="https://github.com/user-attachments/assets/5bf06cb1-79cf-4ff3-a838-28867af29f53" />


---

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

- **회의 박스 스크롤 없는 구조** — `MEETING_MAX_ITEMS(5) × 줄 높이`로 박스 높이를 계산(`lib.ts`)해 정확히 5건이 채워지게 함. 서버도 같은 상수로 slice — 이 커플링이 이해되는지
- **격리막 방향** — 컴포넌트가 `types.ts` 계약만 의존하고 `server.ts`의 `isMock` 분기로 mock을 반환하는 구조가 규칙에 맞는지(연동 시 컴포넌트 0줄 수정 목표)
- 팀장 현황에서 "프로젝트" 컬럼을 뺀 판단(팀장은 프로젝트 비소유 → 팀 액션 담당)이 맞는지

---

## 📝 추가 메모

- 디자인은 Figma 초안을 따온 뒤 실제 화면 톤에 맞춰 조정하는 팀 방침을 따름 — 세부 톤은 후속 조정 가능
- "전체 보기" 링크 대상 `/app/meeting`은 아직 미구현 라우트 — 회의 목록 화면 붙으면 연결됨
- 이 브랜치는 develop 최신을 머지한 상태(`canvas-confetti` 의존성 설치 + `.next` 캐시 정리 완료), typecheck 통과 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 소유자용 대시보드를 추가했습니다.
  - 프로젝트 현황, 구성원 수, 팀장 상태와 마감 임박 프로젝트를 한눈에 확인할 수 있습니다.
  - 최근 프로젝트 회의의 일정, 참석 인원, 상태를 확인하고 상세 화면으로 이동할 수 있습니다.
  - 데이터가 없을 때 안내하는 빈 상태 화면을 제공합니다.
  - 로딩 중 스켈레톤 화면과 오류 발생 시 재시도 기능을 제공합니다.
  - 회의 날짜와 시간이 읽기 쉬운 형식으로 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->