### PR TITLE
[FIX] 셸 안에서 오류 화면이 56px 잘림 #107

### DIFF
--- a/src/app/(shell)/(role)/manage/billing/(overview)/error.tsx
+++ b/src/app/(shell)/(role)/manage/billing/(overview)/error.tsx
@@ -4,5 +4,5 @@ import { ScreenError } from "@/components/common/screen-error";
 
 /** 화면 전체가 실패하면 토스트가 아니라 여기서 알린다(DECISIONS §토스트). */
 export default function OwnerBillingError({ reset }: { error: Error; reset: () => void }) {
-  return <ScreenError title="구독 정보를 불러오지 못했습니다" reset={reset} />;
+  return <ScreenError title="구독 정보를 불러오지 못했습니다" reset={reset} isInsideShell />;
 }

--- a/src/app/(shell)/app/notice/[id]/error.tsx
+++ b/src/app/(shell)/app/notice/[id]/error.tsx
@@ -3,5 +3,5 @@
 import { ScreenError } from "@/components/common/screen-error";
 
 export default function Error({ reset }: { reset: () => void }) {
-  return <ScreenError title="공지를 불러오지 못했어요" reset={reset} />;
+  return <ScreenError title="공지를 불러오지 못했습니다" reset={reset} isInsideShell />;
 }

--- a/src/app/(shell)/app/notice/error.tsx
+++ b/src/app/(shell)/app/notice/error.tsx
@@ -3,5 +3,5 @@
 import { ScreenError } from "@/components/common/screen-error";
 
 export default function Error({ reset }: { reset: () => void }) {
-  return <ScreenError title="공지를 불러오지 못했어요" reset={reset} />;
+  return <ScreenError title="공지를 불러오지 못했습니다" reset={reset} isInsideShell />;
 }

--- a/src/app/(system)/system/(dashboard)/error.tsx
+++ b/src/app/(system)/system/(dashboard)/error.tsx
@@ -3,5 +3,5 @@
 import { ScreenError } from "@/components/common/screen-error";
 
 export default function Error({ reset }: { reset: () => void }) {
-  return <ScreenError title="대시보드를 불러오지 못했습니다" reset={reset} />;
+  return <ScreenError title="대시보드를 불러오지 못했습니다" reset={reset} isInsideShell />;
 }

--- a/src/app/(system)/system/approval/error.tsx
+++ b/src/app/(system)/system/approval/error.tsx
@@ -3,5 +3,5 @@
 import { ScreenError } from "@/components/common/screen-error";
 
 export default function Error({ reset }: { reset: () => void }) {
-  return <ScreenError title="기업 승인 목록을 불러오지 못했습니다" reset={reset} />;
+  return <ScreenError title="기업 승인 목록을 불러오지 못했습니다" reset={reset} isInsideShell />;
 }

--- a/src/app/(system)/system/billing/error.tsx
+++ b/src/app/(system)/system/billing/error.tsx
@@ -3,5 +3,5 @@
 import { ScreenError } from "@/components/common/screen-error";
 
 export default function Error({ reset }: { reset: () => void }) {
-  return <ScreenError title="구독·매출 정보를 불러오지 못했습니다" reset={reset} />;
+  return <ScreenError title="구독·매출 정보를 불러오지 못했습니다" reset={reset} isInsideShell />;
 }

--- a/src/app/(system)/system/companies/error.tsx
+++ b/src/app/(system)/system/companies/error.tsx
@@ -3,5 +3,5 @@
 import { ScreenError } from "@/components/common/screen-error";
 
 export default function Error({ reset }: { reset: () => void }) {
-  return <ScreenError title="기업 목록을 불러오지 못했습니다" reset={reset} />;
+  return <ScreenError title="기업 목록을 불러오지 못했습니다" reset={reset} isInsideShell />;
 }

--- a/src/app/(system)/system/monitor/error.tsx
+++ b/src/app/(system)/system/monitor/error.tsx
@@ -3,5 +3,7 @@
 import { ScreenError } from "@/components/common/screen-error";
 
 export default function Error({ reset }: { reset: () => void }) {
-  return <ScreenError title="시스템 모니터링 정보를 불러오지 못했어요" reset={reset} />;
+  return (
+    <ScreenError title="시스템 모니터링 정보를 불러오지 못했습니다" reset={reset} isInsideShell />
+  );
 }

--- a/src/app/(system)/system/notice/error.tsx
+++ b/src/app/(system)/system/notice/error.tsx
@@ -3,5 +3,5 @@
 import { ScreenError } from "@/components/common/screen-error";
 
 export default function Error({ reset }: { reset: () => void }) {
-  return <ScreenError title="공지 정보를 불러오지 못했어요" reset={reset} />;
+  return <ScreenError title="공지 정보를 불러오지 못했습니다" reset={reset} isInsideShell />;
 }

--- a/src/components/common/screen-error.test.tsx
+++ b/src/components/common/screen-error.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+
+import { ScreenError } from "./screen-error";
+
+/**
+ * 오류 화면이 **어디에서 뜨느냐**에 따라 달라지는 두 가지를 묶는다.
+ *
+ * ⚠️ 겉모습이 아니라 **제목 층위**를 본다. 셸 안에서는 위에 `PageHeader`의 `h1`이 남아 있어서
+ *    여기서 또 `h1`을 그리면 한 페이지에 제목이 둘이 된다 — 그러면 이 단언이 깨진다.
+ */
+describe("ScreenError", () => {
+  const noop = () => {};
+
+  it("셸 밖에서는 `h1`이다 — 이 화면이 페이지를 통째로 대체한다", () => {
+    render(<ScreenError title="공지를 불러오지 못했습니다" reset={noop} />);
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "공지를 불러오지 못했습니다",
+    );
+  });
+
+  it("셸 안에서는 `h1`을 쓰지 않는다 — 상단바의 `h1`과 둘이 된다", () => {
+    render(<ScreenError title="공지를 불러오지 못했습니다" reset={noop} isInsideShell />);
+
+    expect(screen.queryByRole("heading", { level: 1 })).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+      "공지를 불러오지 못했습니다",
+    );
+  });
+
+  it("어느 쪽이든 [다시 시도]는 있다 — 오류에서 빠져나갈 유일한 조작이다", () => {
+    render(<ScreenError title="불러오지 못했습니다" reset={noop} isInsideShell />);
+
+    expect(screen.getByRole("button", { name: "다시 시도" })).toBeInTheDocument();
+  });
+});

--- a/src/components/common/screen-error.tsx
+++ b/src/components/common/screen-error.tsx
@@ -27,11 +27,23 @@ interface ScreenErrorProps {
    *    **아래 56px이 잘리고**(스크롤도 안 된다) 카드가 그만큼 아래로 밀린다.
    * ⚠️ 셸 밖(온보딩·`/subscription`·public)에서는 **끈 채로 둔다.** 거기서는 이 화면이
    *    페이지를 통째로 대체하고 위에 상시 상단바가 없어서 `min-h-dvh`가 맞다.
+   * ⚠️ **`(shell)`뿐 아니라 `(system)`도 셸이다.** 두 레이아웃 다 `flex h-dvh overflow-hidden`에
+   *    `PageHeader`(56px)를 얹는 같은 구조라, 라우트 그룹 이름이 아니라 **위에 상단바가 남는지**로
+   *    판단한다. 그룹 이름으로 외우면 셸이 하나 더 생길 때 똑같이 잘린다.
    */
   isInsideShell?: boolean;
 }
 
 export function ScreenError({ title, reset, isInsideShell }: ScreenErrorProps) {
+  /*
+    ⚠️ 셸 안에서는 **`h1`을 쓰지 않는다.** 위에 `PageHeader`의 `h1`이 그대로 남아 있어서
+       여기서 또 `h1`을 그리면 한 페이지에 제목이 둘이 된다 — 스크린 리더는 무엇이 이 화면의
+       제목인지 못 가리고, RTL `getByRole("heading", { level: 1 })`도 복수 매치로 깨진다
+       (CLAUDE.md §SEO — h1 1개).
+    ⚠️ 셸 밖에서는 이 화면이 페이지를 통째로 대체하므로 `h1`이 맞다.
+  */
+  const Heading = isInsideShell ? "h2" : "h1";
+
   return (
     <div
       className={cn(
@@ -41,7 +53,7 @@ export function ScreenError({ title, reset, isInsideShell }: ScreenErrorProps) {
       )}
     >
       <div className="flex flex-col gap-2">
-        <h1 className="text-lg font-semibold tracking-tight break-keep">{title}</h1>
+        <Heading className="text-lg font-semibold tracking-tight break-keep">{title}</Heading>
         <p className="text-muted-foreground text-[13px] leading-[21px] break-keep">
           잠시 후 다시 시도해 주세요. 계속 안 되면 담당자에게 알려주세요.
         </p>

--- a/src/components/common/screen-error.tsx
+++ b/src/components/common/screen-error.tsx
@@ -3,24 +3,43 @@
 import { RotateCw } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 /**
  * 화면을 못 불러왔을 때 쓰는 공용 오류 화면.
  *
  * ⚠️ 조용히 빈 화면을 보여주지 않는다(CLAUDE.md §정직성). 무엇을 못 불러왔는지 말하고
  *    다시 시도할 길을 준다.
- * ⚠️ 여기서는 셸을 쓰지 않는다. 셸이 터졌을 수도 있어서 이 화면만은 아무것에도 기대지 않는다.
+ * ⚠️ 여기서는 셸을 **그리지** 않는다. 셸이 터졌을 수도 있어서 이 화면만은 아무것에도 기대지 않는다.
+ *    다만 셸 **안**에서 뜰 수는 있다(라우트가 셸 아래면 상단바가 그대로 남는다) —
+ *    그때는 `isInsideShell`로 높이를 바꾼다.
  * ⚠️ `console`은 커밋 금지다 — 오류 수집 경로가 정해지면 그때 붙인다.
  */
 interface ScreenErrorProps {
   /** 무엇을 못 불러왔는지 — 화면마다 다르다 */
   title: string;
   reset: () => void;
+  /**
+   * 셸(사이드바·상단바) **안**에서 뜨는 오류인지.
+   *
+   * ⚠️ 켜면 화면 전체가 아니라 **남은 높이**를 채운다. 셸 본문은 `h-dvh overflow-hidden`인데
+   *    그 안에서 상단바(56px) 다음에 `min-h-dvh`를 두면 `56 + 100dvh`가 되어
+   *    **아래 56px이 잘리고**(스크롤도 안 된다) 카드가 그만큼 아래로 밀린다.
+   * ⚠️ 셸 밖(온보딩·`/subscription`·public)에서는 **끈 채로 둔다.** 거기서는 이 화면이
+   *    페이지를 통째로 대체하고 위에 상시 상단바가 없어서 `min-h-dvh`가 맞다.
+   */
+  isInsideShell?: boolean;
 }
 
-export function ScreenError({ title, reset }: ScreenErrorProps) {
+export function ScreenError({ title, reset, isInsideShell }: ScreenErrorProps) {
   return (
-    <div className="bg-background flex min-h-dvh flex-col items-center justify-center gap-4 px-6 text-center">
+    <div
+      className={cn(
+        "bg-background flex flex-col items-center justify-center gap-4 px-6 text-center",
+        // `min-h-0`이 있어야 flex 자식이 부모보다 커지지 않는다 — 없으면 내용 높이만큼 삐져나간다
+        isInsideShell ? "min-h-0 flex-1" : "min-h-dvh",
+      )}
+    >
       <div className="flex flex-col gap-2">
         <h1 className="text-lg font-semibold tracking-tight break-keep">{title}</h1>
         <p className="text-muted-foreground text-[13px] leading-[21px] break-keep">


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

**셸 안에서 오류 화면이 56px 잘렸습니다. 잘린 부분은 스크롤로도 못 봤습니다.**

셸 본문은 `h-dvh overflow-hidden`이고, 그 안에 **상단바(56px)** 다음에 `error.tsx`가 들어갑니다. 그런데 공용 `ScreenError`가 `min-h-dvh`(화면 전체 높이)를 요구했습니다.

```text
56px(상단바) + 100dvh(오류 화면) > 100dvh(셸 본문)
```

브라우저에서 잰 값입니다(뷰포트 760px).

| | 전 |
| --- | --- |
| 오류 상자 | y=**56** ~ **816** (높이 760) |
| 뷰포트 밖으로 넘친 양 | **56px** |
| 오류 카드 중앙 | y=436 (정중앙은 380) |

`overflow-hidden`이라 넘친 56px은 **잘려서 영영 안 보입니다.**

**오류 화면은 이미 뭔가 잘못됐을 때 뜨는 자리입니다.** 거기서 또 깨져 있으면 사용자는 서비스가 죽었다고 판단합니다.

### 고친 방법

`ScreenError`에 **`isInsideShell`** 을 달았습니다. 켜면 화면 전체가 아니라 **남은 높이**를 채웁니다.

```tsx
isInsideShell ? "min-h-0 flex-1" : "min-h-dvh"
```

셸 본문이 `flex-column`이고 상단바가 형제라, `flex-1`이면 남은 높이(704px)를 정확히 채웁니다. `min-h-0`이 있어야 flex 자식이 부모보다 커지지 않습니다 — 없으면 내용 높이만큼 다시 삐져나갑니다.

**`min-h-dvh`는 지우지 않았습니다.** 셸 밖(온보딩 · `/subscription` · public)에서는 `error.tsx`가 페이지를 통째로 대체하고 위에 상시 상단바가 없어서, 화면 전체를 채우는 게 맞습니다.

### 4곳을 개별로 고치지 않은 이유

원인이 하나(공용 컴포넌트가 한 가지 높이만 지원)라, 호출부를 각각 고치면 다음에 셸 안에 화면이 생길 때 같은 실수를 반복합니다.

| 호출부 | 이 PR |
| --- | --- |
| `manage/billing` · `app/notice` · `app/notice/[id]` | ✅ |
| `manage/storage` | #100 (PR #101)에서 한 줄 — **파일이 그 브랜치에 있습니다** |
| 오너 대시보드 | 해당 PR에서 한 줄 — 작업자 전달 필요 |

`isInsideShell`은 **선택 prop**이라 안 넘기는 곳이 있어도 빌드는 안 깨집니다. 지금까지처럼 동작할 뿐입니다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`fix/shell-error-height#107`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 권한 2축 검사 — 해당 없음(레이아웃입니다)
- [x] 🧬 zod — 스키마 무변경
- [x] 🕵️ 정직성 — 오류 화면이 잘려서 안 보이던 것을 고치는 변경입니다
- [x] 🎨 디자인 토큰 — 새 색 없음. 높이 계산만 바꿉니다

**품질**

- [x] ⚡ 최적화 — 무변경
- [x] ♿ a11y — 마크업·문구 그대로. 잘려서 안 보이던 [다시 시도]가 이제 보입니다
- [x] ♻️ **재사용 확인** — 호출부를 각각 고치지 않고 공용 컴포넌트에서 한 번에 풀었습니다
- [x] 🧪 loading / error / empty 3상태 — 이 PR이 그 `error` 자체입니다
- [x] 브라우저 전용 API — 해당 없음

---

## 🔗 연관 이슈

Closes #107

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- **prop 이름을 `isInsideShell`로 한 것** — `fill`이나 `variant="fill"`은 *어떻게* 그리는지를 말하는데, 부르는 쪽이 알아야 하는 건 *어디에 있는지*입니다. 셸 안이면 켜면 됩니다.
- **`min-h-0`이 필요한 이유** — flex 자식의 기본 `min-height`가 `auto`라 내용보다 작아지지 못합니다. `flex-1`만 주면 내용이 길 때 다시 부모를 뚫습니다.
- 셸 밖 화면(온보딩·게이트·public)은 **일부러 안 건드렸습니다.** 거기서 `flex-1`을 주면 부모가 flex가 아니라서 높이가 0이 되고, 오류 카드가 화면 맨 위에 붙습니다.

---

## 📝 추가 메모

**같은 줄에 있던 카피도 고쳤습니다** — `공지를 불러오지 못했어요` → `못했습니다`. §카피가 2026-08-04에 ~합니다체로 바뀌었는데 이 두 줄이 남아 있었습니다. 손대는 줄이라 같이 고쳤습니다.

**확인한 것** — eslint 0 · tsc 0 · `npx jest` 231개 통과 · `npm run build` 성공. 셸 본문이 `display:flex / flex-direction:column / overflow:hidden`이고 상단바(56px)가 형제인 것을 브라우저에서 확인했습니다.

---

## 🔎 자체 리뷰로 고친 것 (추가 커밋)

### ① 운영자 화면 6개가 빠져 있었습니다

`(shell)` 3곳만 고치고 **`(system)` 6곳을 빠뜨렸습니다.** `(system)/layout.tsx`도 `(shell)`과 똑같이 `flex h-dvh overflow-hidden`에 `PageHeader`(56px)를 얹는 구조라, 같은 잘림이 그대로 남아 있었습니다.

창이 낮으면 **[다시 시도] 버튼이 잘린 영역에 들어갑니다** — 부모가 `overflow-hidden`이라 스크롤도 안 되니 오류에서 빠져나갈 유일한 조작이 사라집니다.

| | 전 | 후 |
| --- | --- | --- |
| `(shell)` 아래 | 3곳 켜짐 | 3곳 |
| `(system)` 아래 | **0곳** | **6곳** |
| 셸 밖(온보딩·public) | 15곳 꺼짐 | 15곳 (그대로가 맞습니다) |

판단 기준을 **라우트 그룹 이름이 아니라 "위에 상단바가 남는지"** 로 주석에 다시 적었습니다. 그룹 이름으로 외우면 셸이 하나 더 생길 때 똑같이 잘립니다.

⚠️ 운영자 화면은 원칙적으로 안 건드리지만 **공용 컴포넌트 변경의 파급**이라 함께 고치고 커밋을 갈랐습니다. 같은 줄에 남아 있던 해요체 둘도 합니다체로 맞췄습니다(§카피).

### ② 한 페이지에 `h1`이 둘이었습니다

셸 안에서 뜨면 위에 `PageHeader`의 `<h1>`이 그대로 남는데 `ScreenError`가 또 `<h1>`을 그렸습니다. 스크린 리더가 화면 제목을 못 가리고, RTL `getByRole("heading", { level: 1 })`도 복수 매치로 깨집니다(§SEO — h1 1개).

셸 안에서는 `h2`로 내리고, 셸 밖에서는 이 화면이 페이지를 통째로 대체하므로 `h1`을 그대로 둡니다. **이 PR이 `isInsideShell`을 정식화하면서 생긴 상태**라 같이 정리했습니다.

**테스트를 붙였습니다** — `screen-error.test.tsx`가 셸 안/밖의 제목 층위와 [다시 시도]의 존재를 묶습니다.

**다시 확인한 것** — eslint 0 · tsc 0 · `npx jest` 통과 · 셸 아래 error 화면 9곳 전부 켜짐 / 셸 밖 15곳 전부 꺼짐을 기계적으로 대조했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 셸 내부 오류 화면이 남은 공간을 올바르게 채우도록 레이아웃을 개선했습니다.
  * 셸 안팎의 오류 화면 제목 구조와 높이를 상황에 맞게 조정했습니다.
  * 공지사항, 결제 관리 및 시스템 화면의 오류 제목과 실패 안내 문구를 개선했습니다.
  * 오류 화면의 **다시 시도** 기능은 기존과 동일하게 유지됩니다.

* **테스트**
  * 셸 내부 및 외부 오류 화면의 표시 방식과 다시 시도 버튼을 검증했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

