### PR TITLE
[FEAT] 역할별 사이드바 + Admin 겸직 구역 #110

### DIFF
--- a/src/app/(dev)/design/sidebar/page.tsx
+++ b/src/app/(dev)/design/sidebar/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+
+import { NavPreview } from "@/features/shell/components/nav-preview";
+
+export const metadata: Metadata = {
+  title: "역할별 사이드바",
+};
+
+/**
+ * 개발용 — 역할별 사이드바를 한 화면에 늘어놓는다.
+ *
+ * ⚠️ **명세에 없는 화면이다**(§라우트 그룹). 제품 화면이 아니라 배치를 비교하려고 둔 것이라,
+ *    `(dev)` 그룹에 따로 두고 화면 안에도 개발용이라고 적는다 — 다음 사람이 제품 화면으로
+ *    알고 링크를 걸면 안 된다.
+ * ⚠️ 사이드바 어디에서도 여기로 가는 길을 두지 않는다. 주소를 아는 사람만 본다.
+ * ⚠️ 지울지는 팀이 정한다. 배포 대상이 아니면 `(dev)` 폴더째 지우면 끝난다.
+ */
+export default function DesignSidebarPage() {
+  return <NavPreview />;
+}

--- a/src/app/(dev)/design/sidebar/page.tsx
+++ b/src/app/(dev)/design/sidebar/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 
 import { NavPreview } from "@/features/shell/components/nav-preview";
 
@@ -12,9 +13,15 @@ export const metadata: Metadata = {
  * ⚠️ **명세에 없는 화면이다**(§라우트 그룹). 제품 화면이 아니라 배치를 비교하려고 둔 것이라,
  *    `(dev)` 그룹에 따로 두고 화면 안에도 개발용이라고 적는다 — 다음 사람이 제품 화면으로
  *    알고 링크를 걸면 안 된다.
+ * ⚠️ **프로덕션에서는 없는 화면이다.** 로그인 없이 열리는 자리라 그대로 두면 역할별 메뉴
+ *    구성이 통째로 드러난다 — 어떤 관리 기능이 있는지, 누가 무엇을 보는지가 다 적혀 있다.
+ *    라우트 보호(`middleware.ts`)를 새로 두는 대신 여기서 404를 낸다: 개발용 화면 하나
+ *    때문에 전역 가드를 켜면 개발 중 화면 확인이 막힌다(팀 결정).
  * ⚠️ 사이드바 어디에서도 여기로 가는 길을 두지 않는다. 주소를 아는 사람만 본다.
  * ⚠️ 지울지는 팀이 정한다. 배포 대상이 아니면 `(dev)` 폴더째 지우면 끝난다.
  */
 export default function DesignSidebarPage() {
+  if (process.env.NODE_ENV === "production") notFound();
+
   return <NavPreview />;
 }

--- a/src/app/(shell)/layout.tsx
+++ b/src/app/(shell)/layout.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import { getUnreadNoticeCount } from "@/features/notice/server";
 import { RoleSidebar } from "@/features/shell/components/role-sidebar";
 import type { NavSection } from "@/features/shell/nav";
-import { navFor } from "@/features/shell/nav-config";
+import { dashboardFor, navFor } from "@/features/shell/nav-config";
 import { getViewer } from "@/features/shell/viewer";
 
 /**
@@ -52,7 +52,7 @@ export default async function ShellLayout({ children }: { children: ReactNode })
 
   return (
     <div className="bg-background flex h-dvh overflow-hidden">
-      <RoleSidebar sections={sections} user={viewer} />
+      <RoleSidebar sections={sections} home={dashboardFor(viewer.role)} user={viewer} />
 
       {/*
         상단바는 여기서 그리지 않는다 — 제목·액션이 도메인마다 달라서

--- a/src/app/(shell)/layout.tsx
+++ b/src/app/(shell)/layout.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import { getUnreadNoticeCount } from "@/features/notice/server";
 import { RoleSidebar } from "@/features/shell/components/role-sidebar";
 import type { NavSection } from "@/features/shell/nav";
-import { OWNER_NAV } from "@/features/shell/nav";
+import { navFor } from "@/features/shell/nav-config";
 import { getViewer } from "@/features/shell/viewer";
 
 /**
@@ -44,7 +44,11 @@ export default async function ShellLayout({ children }: { children: ReactNode })
     getViewer(),
     getUnreadNoticeCount().catch(() => 0),
   ]);
-  const sections = withNoticeDot(OWNER_NAV, unreadNoticeCount > 0);
+  /*
+    ⚠️ **역할이 목록을 정한다.** 전에는 `OWNER_NAV` 하나를 모두에게 줘서, 팀장·사원으로
+       로그인해도 대표 메뉴가 그대로 떴다. `is_admin` 겸직도 아무 표시가 없었다.
+  */
+  const sections = withNoticeDot(navFor(viewer), unreadNoticeCount > 0);
 
   return (
     <div className="bg-background flex h-dvh overflow-hidden">

--- a/src/constants/role.test.ts
+++ b/src/constants/role.test.ts
@@ -1,0 +1,42 @@
+import { ROLE, ROLE_BADGE_CLASS, ROLE_LABEL, ROLE_MARK_CLASS } from "./role";
+
+/**
+ * 역할 배지 — **색이 역할을 따라가는지**가 핵심이다.
+ * 한 색으로 굳으면 배지 글자만 바뀌고 색은 그대로라, 색으로 역할을 알리는 자리가 거짓말을 한다.
+ */
+describe("역할 배지 색", () => {
+  it("Owner · Leader · Member는 서로 다른 색이다", () => {
+    const distinct = new Set([
+      ROLE_BADGE_CLASS[ROLE.OWNER],
+      ROLE_BADGE_CLASS[ROLE.LEADER],
+      ROLE_BADGE_CLASS[ROLE.MEMBER],
+    ]);
+
+    expect(distinct.size).toBe(3);
+  });
+
+  it("모든 역할에 배지·표식 색이 있다 — 빠지면 색 없는 배지가 뜬다", () => {
+    for (const role of Object.values(ROLE)) {
+      expect(ROLE_BADGE_CLASS[role]).toBeTruthy();
+      expect(ROLE_MARK_CLASS[role]).toBeTruthy();
+      expect(ROLE_LABEL[role]).toBeTruthy();
+    }
+  });
+
+  it("SYSTEM은 회색을 쓴다 — 기업 화면의 역할이 아니라 자기 색이 없다", () => {
+    expect(ROLE_BADGE_CLASS[ROLE.SYSTEM]).toBe(ROLE_BADGE_CLASS[ROLE.MEMBER]);
+    expect(ROLE_MARK_CLASS[ROLE.SYSTEM]).toBe(ROLE_MARK_CLASS[ROLE.MEMBER]);
+  });
+
+  /*
+    ⚠️ Tailwind는 소스에 **적힌 그대로의 클래스만** 찾는다. `bg-role-${role}`처럼 이어 붙이면
+       빌드에서 그 클래스가 안 만들어져 색이 통째로 빠진다 — 화면에서만 드러나는 종류의 사고라
+       여기서 막는다.
+  */
+  it("클래스는 조각을 이어 만들지 않는다 — Tailwind가 못 찾는다", () => {
+    for (const value of [...Object.values(ROLE_BADGE_CLASS), ...Object.values(ROLE_MARK_CLASS)]) {
+      expect(value).not.toContain("${");
+      expect(value).toMatch(/^[a-z0-9-]+(\s[a-z0-9-]+)*$/);
+    }
+  });
+});

--- a/src/constants/role.ts
+++ b/src/constants/role.ts
@@ -64,3 +64,28 @@ export const ASSIGNABLE_ROLES = [ROLE.OWNER, ROLE.LEADER, ROLE.MEMBER] as const;
  *    한 사람이 Leader이면서 Admin일 수 있고, 계정을 나눠 쓰지 않는다.
  */
 export const POSITION_ROLES = [ROLE.LEADER, ROLE.MEMBER] as const;
+
+/**
+ * 역할 배지 색 — **토큰 클래스만** 담는다(§디자인 토큰: 하드코딩 금지).
+ *
+ * ⚠️ 화면마다 이 맵을 다시 적지 않는다. 전에는 사이드바 계정 줄이 `bg-role-owner`를
+ *    통째로 박아 두어, 팀장·사원으로 로그인해도 배지 글자만 바뀌고 **색은 Owner**였다 —
+ *    색으로 역할을 알리는 자리인데 색이 역할을 안 따라갔다.
+ * ⚠️ `SYSTEM`은 자기 색이 없다. 기업 화면의 역할이 아니라 **회색(=member)** 을 그대로 쓴다 —
+ *    없는 토큰을 지어내는 것보다, 눈에 띄지 않는 게 맞는 자리다.
+ * ⚠️ 클래스는 **문자열 그대로** 적는다. 조각을 이어 만들면 Tailwind가 못 찾아 색이 안 나온다.
+ */
+export const ROLE_BADGE_CLASS: Record<Role, string> = {
+  OWNER: "bg-role-owner-surface text-role-owner",
+  LEADER: "bg-role-leader-surface text-role-leader",
+  MEMBER: "bg-role-member-surface text-role-member",
+  SYSTEM: "bg-role-member-surface text-role-member",
+};
+
+/** 이름 첫 글자를 담는 동그라미 — 배지와 같은 계열의 **진한 쪽**을 쓴다 */
+export const ROLE_MARK_CLASS: Record<Role, string> = {
+  OWNER: "bg-role-owner",
+  LEADER: "bg-role-leader",
+  MEMBER: "bg-role-member",
+  SYSTEM: "bg-role-member",
+};

--- a/src/features/shell/components/nav-preview.tsx
+++ b/src/features/shell/components/nav-preview.tsx
@@ -1,0 +1,118 @@
+import { ROLE, type Role, ROLE_LABEL } from "@/constants/role";
+import type { Actor } from "@/lib/permission";
+
+import { navFor } from "../nav-config";
+import type { Viewer } from "../viewer";
+import { RoleSidebar } from "./role-sidebar";
+
+/**
+ * 역할별 사이드바를 **한 화면에 늘어놓는 개발용 화면**.
+ *
+ * ⚠️ **제품 화면이 아니다.** 명세에 없다(§라우트 그룹: 명세에 없는 화면은 안 만든다) —
+ *    목을 네 번 바꿔 가며 확인하는 대신 네 벌을 나란히 놓고 배치를 판단하려고 둔 것이다.
+ *    배포 전에 지울지 팀이 정한다. 그래서 화면 안에도 개발용이라고 적는다(§정직성).
+ * ⚠️ **실제 컴포넌트를 그대로 쓴다.** 그림을 따로 그리면 진짜 사이드바와 어긋나서,
+ *    여기서 괜찮아 보이던 게 실제로는 다르게 나온다.
+ */
+
+interface PreviewCase {
+  key: string;
+  title: string;
+  note: string;
+  viewer: Viewer;
+}
+
+const person = (role: Role, name: string, isAdmin = false): Viewer => ({
+  id: 1,
+  name,
+  role,
+  isAdmin,
+});
+
+/**
+ * 보여줄 경우들.
+ *
+ * ⚠️ **Admin 겸직을 역할마다 따로 둔다.** Admin은 역할이 아니라 덧붙는 권한이라
+ *    (WORKFLOW §9), "Leader + Admin"과 "Member + Admin"이 서로 다른 사이드바가 된다 —
+ *    한 줄로 뭉뚱그리면 그 차이를 못 본다.
+ * ⚠️ Owner는 겸직 경우를 두지 않는다. **Owner는 Admin을 겸할 수 없다**(`canGrantAdmin`).
+ */
+const CASES: PreviewCase[] = [
+  {
+    key: "owner",
+    title: ROLE_LABEL[ROLE.OWNER],
+    note: "회사 운영이 늘 보인다. 계정 발급은 없다 — 발급은 Admin의 일이다",
+    viewer: person(ROLE.OWNER, "박대표"),
+  },
+  {
+    key: "leader",
+    title: ROLE_LABEL[ROLE.LEADER],
+    note: "팀 관리 구역이 붙는다. 회사 운영은 없다",
+    viewer: person(ROLE.LEADER, "김팀장"),
+  },
+  {
+    key: "leader-admin",
+    title: `${ROLE_LABEL[ROLE.LEADER]} + Admin`,
+    note: "팀 관리를 그대로 두고 회사 운영이 덧붙는다 — 역할을 갈아치우지 않는다",
+    viewer: person(ROLE.LEADER, "김팀장", true),
+  },
+  {
+    key: "member",
+    title: ROLE_LABEL[ROLE.MEMBER],
+    note: "워크벤치만 본다",
+    viewer: person(ROLE.MEMBER, "이사원"),
+  },
+  {
+    key: "member-admin",
+    title: `${ROLE_LABEL[ROLE.MEMBER]} + Admin`,
+    note: "사원인 채로 회사 운영이 덧붙는다. 기업 설정·팀장 인수인계는 Owner 것이라 없다",
+    viewer: person(ROLE.MEMBER, "이사원", true),
+  },
+];
+
+export function NavPreview() {
+  return (
+    <div className="bg-background bg-dot-grid min-h-dvh overflow-x-auto p-8">
+      <div className="mx-auto w-fit">
+        <header className="pb-6">
+          <h1 className="text-2xl leading-8 font-semibold tracking-[-0.48px]">역할별 사이드바</h1>
+          {/*
+            ⚠️ **개발용이라고 화면에 적는다.** 안 적으면 다음 사람이 제품 화면으로 알고
+               링크를 걸거나 명세에 없는 화면을 유지보수하게 된다(§정직성).
+          */}
+          <p className="text-muted-foreground pt-1.5 text-[13px] leading-5 break-keep">
+            배치를 비교하려고 둔 개발용 화면입니다. 명세에 없는 화면이라 배포 전에 지울지 정해야
+            합니다. 실제 사이드바 컴포넌트를 그대로 그립니다.
+          </p>
+        </header>
+
+        <div className="flex items-start gap-5">
+          {CASES.map((item) => (
+            <PreviewColumn key={item.key} item={item} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PreviewColumn({ item }: { item: PreviewCase }) {
+  return (
+    <section className="flex w-[220px] shrink-0 flex-col gap-2.5">
+      <div className="min-h-[62px]">
+        <h2 className="text-[15px] leading-6 font-semibold tracking-[-0.2px]">{item.title}</h2>
+        <p className="text-muted-foreground/80 pt-1 text-[12px] leading-[18px] break-keep">
+          {item.note}
+        </p>
+      </div>
+
+      {/*
+        ⚠️ 사이드바는 `h-full`을 전제로 만들어졌다 — 여기서는 **높이를 정해** 담는다.
+           안 그러면 내용만큼만 커져서 아래 테두리가 항목에 붙는다.
+      */}
+      <div className="border-border h-[620px] overflow-hidden rounded-xl border">
+        <RoleSidebar sections={navFor(item.viewer as Actor)} user={item.viewer} />
+      </div>
+    </section>
+  );
+}

--- a/src/features/shell/components/nav-preview.tsx
+++ b/src/features/shell/components/nav-preview.tsx
@@ -1,5 +1,4 @@
 import { ROLE, type Role, ROLE_LABEL } from "@/constants/role";
-import type { Actor } from "@/lib/permission";
 
 import { dashboardFor, navFor } from "../nav-config";
 import type { Viewer } from "../viewer";
@@ -115,7 +114,7 @@ function PreviewColumn({ item }: { item: PreviewCase }) {
       */}
       <div className="border-border overflow-hidden rounded-xl border">
         <RoleSidebar
-          sections={navFor(item.viewer as Actor)}
+          sections={navFor(item.viewer)}
           home={dashboardFor(item.viewer.role)}
           user={item.viewer}
         />

--- a/src/features/shell/components/nav-preview.tsx
+++ b/src/features/shell/components/nav-preview.tsx
@@ -99,7 +99,7 @@ export function NavPreview() {
 function PreviewColumn({ item }: { item: PreviewCase }) {
   return (
     <section className="flex w-[220px] shrink-0 flex-col gap-2.5">
-      <div className="min-h-[62px]">
+      <div className="min-h-[72px]">
         <h2 className="text-[15px] leading-6 font-semibold tracking-[-0.2px]">{item.title}</h2>
         <p className="text-muted-foreground/80 pt-1 text-[12px] leading-[18px] break-keep">
           {item.note}
@@ -107,10 +107,13 @@ function PreviewColumn({ item }: { item: PreviewCase }) {
       </div>
 
       {/*
-        ⚠️ 사이드바는 `h-full`을 전제로 만들어졌다 — 여기서는 **높이를 정해** 담는다.
-           안 그러면 내용만큼만 커져서 아래 테두리가 항목에 붙는다.
+        ⚠️ **높이를 고정하지 않는다.** 620px으로 묶었더니 항목이 많은 역할(Leader + Admin은
+           구역 넷·항목 스물)에서 아래가 잘렸다 — 배치를 비교하려고 만든 화면인데 정작
+           비교할 항목이 안 보였다.
+        ⚠️ 사이드바 안의 `nav`는 `flex-1 overflow-y-auto`라, 높이를 안 주면 내용만큼 늘어나
+           스크롤이 안 생긴다. 열마다 높이가 달라지는 건 의도다 — 그 차이가 곧 정보다.
       */}
-      <div className="border-border h-[620px] overflow-hidden rounded-xl border">
+      <div className="border-border overflow-hidden rounded-xl border">
         <RoleSidebar sections={navFor(item.viewer as Actor)} user={item.viewer} />
       </div>
     </section>

--- a/src/features/shell/components/nav-preview.tsx
+++ b/src/features/shell/components/nav-preview.tsx
@@ -1,7 +1,7 @@
 import { ROLE, type Role, ROLE_LABEL } from "@/constants/role";
 import type { Actor } from "@/lib/permission";
 
-import { navFor } from "../nav-config";
+import { dashboardFor, navFor } from "../nav-config";
 import type { Viewer } from "../viewer";
 import { RoleSidebar } from "./role-sidebar";
 
@@ -114,7 +114,11 @@ function PreviewColumn({ item }: { item: PreviewCase }) {
            스크롤이 안 생긴다. 열마다 높이가 달라지는 건 의도다 — 그 차이가 곧 정보다.
       */}
       <div className="border-border overflow-hidden rounded-xl border">
-        <RoleSidebar sections={navFor(item.viewer as Actor)} user={item.viewer} />
+        <RoleSidebar
+          sections={navFor(item.viewer as Actor)}
+          home={dashboardFor(item.viewer.role)}
+          user={item.viewer}
+        />
       </div>
     </section>
   );

--- a/src/features/shell/components/role-sidebar.tsx
+++ b/src/features/shell/components/role-sidebar.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 
 import { ZLogo } from "@/components/icons/z-logo";
 import { ROLE_LABEL } from "@/constants/domain";
+import { topicParticle } from "@/lib/korean";
 
 import type { NavItem, NavSection } from "../nav";
 import type { Viewer } from "../viewer";
@@ -124,7 +125,7 @@ function SidebarLogo({ home }: { home: NavItem }) {
       <button
         type="button"
         aria-label={`Z ${home.label} — 준비 중`}
-        onClick={() => toast(`${home.label}는 준비 중입니다`)}
+        onClick={() => toast(`${home.label}${topicParticle(home.label)} 준비 중입니다`)}
         className={LOGO_SHAPE}
       >
         {logo}

--- a/src/features/shell/components/role-sidebar.tsx
+++ b/src/features/shell/components/role-sidebar.tsx
@@ -5,8 +5,9 @@ import { usePathname } from "next/navigation";
 import { toast } from "sonner";
 
 import { ZLogo } from "@/components/icons/z-logo";
-import { ROLE_LABEL } from "@/constants/domain";
+import { ROLE_BADGE_CLASS, ROLE_LABEL, ROLE_MARK_CLASS } from "@/constants/role";
 import { topicParticle } from "@/lib/korean";
+import { cn } from "@/lib/utils";
 
 import type { NavItem, NavSection } from "../nav";
 import type { Viewer } from "../viewer";
@@ -140,15 +141,37 @@ function SidebarLogo({ home }: { home: NavItem }) {
   );
 }
 
-/** 하단 계정 줄 — 이름 첫 글자 · 이름 · 역할 배지 */
+/**
+ * 하단 계정 줄 — 이름 첫 글자 · 이름 · 역할 배지.
+ *
+ * ⚠️ **색은 그 사람의 역할에서 온다.** 전에는 `bg-role-owner`가 박혀 있어서 팀장·사원으로
+ *    로그인해도 배지 글자만 바뀌고 색은 Owner였다 — 색으로 역할을 알리는 자리인데
+ *    색이 역할을 안 따라가면 배지가 거짓말을 한다.
+ */
 function AccountRow({ user }: { user: Viewer }) {
   return (
     <div className="border-border flex h-[49px] shrink-0 items-center gap-[7px] border-t px-[17.5px]">
-      <span className="bg-role-owner flex size-[21px] shrink-0 items-center justify-center rounded-full text-[10px] leading-none text-white">
+      {/*
+        ⚠️ 글자색은 `text-white`가 아니라 **`text-background`** 다. 역할 색은 테마에 따라
+           밝기가 뒤집혀서(라이트 `#c2410c` ↔ 다크 `#fb923c`), 흰 글자로 고정하면 다크에서
+           대비가 2.1~2.5:1까지 떨어진다 — 이름 첫 글자는 글자라 4.5:1이 필요하다.
+           `--background`를 쓰면 라이트에서 흰 글자, 다크에서 먹 글자가 되어 양쪽 다 5.2:1 위다.
+      */}
+      <span
+        className={cn(
+          ROLE_MARK_CLASS[user.role],
+          "text-background flex size-[21px] shrink-0 items-center justify-center rounded-full text-[10px] leading-none",
+        )}
+      >
         {user.name.slice(0, 1)}
       </span>
       <span className="min-w-0 flex-1 truncate text-xs leading-[18px]">{user.name}</span>
-      <span className="bg-role-owner-surface text-role-owner shrink-0 rounded px-[5.25px] py-[1.75px] text-[9px] leading-[14px]">
+      <span
+        className={cn(
+          ROLE_BADGE_CLASS[user.role],
+          "shrink-0 rounded px-[5.25px] py-[1.75px] text-[9px] leading-[14px]",
+        )}
+      >
         {ROLE_LABEL[user.role]}
       </span>
     </div>

--- a/src/features/shell/components/role-sidebar.tsx
+++ b/src/features/shell/components/role-sidebar.tsx
@@ -2,17 +2,24 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { toast } from "sonner";
 
 import { ZLogo } from "@/components/icons/z-logo";
 import { ROLE_LABEL } from "@/constants/domain";
 
-import { roleHome } from "../home";
-import type { NavSection } from "../nav";
+import type { NavItem, NavSection } from "../nav";
 import type { Viewer } from "../viewer";
 import { SidebarItem } from "./sidebar-item";
 
 interface RoleSidebarProps {
   sections: NavSection[];
+  /**
+   * 로고를 누르면 갈 곳 — 메뉴 [대시보드]와 **같은 항목**이다(`dashboardFor`).
+   *
+   * ⚠️ 경로만 받지 않는다. `isReady`가 같이 와야 화면이 아직 없을 때 로고도 메뉴와 똑같이
+   *    "준비 중"이라고 말한다 — 경로만 받으면 로고만 404로 데려간다.
+   */
+  home: NavItem;
   /**
    * 지금 보고 있는 사람 — 이름·역할 배지·로고 링크가 이 값에서 나온다.
    *
@@ -48,7 +55,7 @@ function findActiveHref(sections: NavSection[], pathname: string): string | unde
  *
  * ⚠️ 레이아웃은 하나다 — 역할마다 `sections`만 갈아 끼운다(CLAUDE.md §라우트 그룹).
  */
-export function RoleSidebar({ sections, user }: RoleSidebarProps) {
+export function RoleSidebar({ sections, home, user }: RoleSidebarProps) {
   const pathname = usePathname();
   const activeHref = findActiveHref(sections, pathname);
 
@@ -65,13 +72,7 @@ export function RoleSidebar({ sections, user }: RoleSidebarProps) {
       */}
       {/* 로고 아래 선을 두지 않는다 — 사이드바 안에서 또 나누면 조각나 보인다 */}
       <div className="flex h-[56px] shrink-0 items-center px-[18px]">
-        <Link
-          href={roleHome(user.role)}
-          aria-label="Z 홈으로"
-          className="focus-visible:ring-ring rounded transition-opacity hover:opacity-70 focus-visible:ring-2 focus-visible:outline-hidden"
-        >
-          <ZLogo className="text-foreground size-[22px]" title="Z" />
-        </Link>
+        <SidebarLogo home={home} />
       </div>
 
       <nav className="flex-1 overflow-y-auto p-[7px]">
@@ -99,6 +100,42 @@ export function RoleSidebar({ sections, user }: RoleSidebarProps) {
 
       <AccountRow user={user} />
     </aside>
+  );
+}
+
+const LOGO_SHAPE =
+  "focus-visible:ring-ring rounded transition-opacity hover:opacity-70 focus-visible:ring-2 focus-visible:outline-hidden";
+
+/**
+ * 사이드바 로고 — 누르면 **자기 역할의 대시보드**로 간다.
+ *
+ * ⚠️ 랜딩(`/`)으로 보내지 않는다. 로그인 뒤 화면에서 로고를 누르는 건 "첫 화면으로"라는
+ *    뜻인데, 그 사람의 첫 화면은 로그인 전 소개 페이지가 아니라 자기 대시보드다.
+ *    (랜딩·로그인 화면의 로고는 그대로 `/`로 간다 — 거기선 랜딩이 첫 화면이다.)
+ * ⚠️ 화면이 아직 없으면 **링크로 두지 않는다.** 메뉴 [대시보드]는 "준비 중"이라고 말하는데
+ *    로고만 404로 데려가면 같은 곳을 가리키는 둘이 다른 말을 한다(§정직성).
+ *    `SidebarItem`과 같은 규칙이고, 문구도 같은 자리에서 나온다.
+ */
+function SidebarLogo({ home }: { home: NavItem }) {
+  const logo = <ZLogo className="text-foreground size-[22px]" title="Z" />;
+
+  if (!home.isReady) {
+    return (
+      <button
+        type="button"
+        aria-label={`Z ${home.label} — 준비 중`}
+        onClick={() => toast(`${home.label}는 준비 중입니다`)}
+        className={LOGO_SHAPE}
+      >
+        {logo}
+      </button>
+    );
+  }
+
+  return (
+    <Link href={home.href} aria-label={`Z ${home.label}로`} className={LOGO_SHAPE}>
+      {logo}
+    </Link>
   );
 }
 

--- a/src/features/shell/components/sidebar-item.tsx
+++ b/src/features/shell/components/sidebar-item.tsx
@@ -23,6 +23,7 @@ import {
 import Link from "next/link";
 import { toast } from "sonner";
 
+import { topicParticle } from "@/lib/korean";
 import { cn } from "@/lib/utils";
 
 import type { NavIconName, NavItem } from "../nav";
@@ -76,7 +77,8 @@ export function SidebarItem({ item, isCurrent }: { item: NavItem; isCurrent: boo
         */
         aria-label={`${item.label} — 준비 중`}
         // ⚠️ 토스트는 한 줄(220px)이라 짧게 쓴다 — 길면 잘린다(`sonner.tsx`)
-        onClick={() => toast(`${item.label}은 준비 중입니다`)}
+        // ⚠️ 조사를 박아 두지 않는다 — 라벨 대부분이 모음으로 끝나 "프로젝트은"이 된다
+        onClick={() => toast(`${item.label}${topicParticle(item.label)} 준비 중입니다`)}
         // 색은 준비된 메뉴와 똑같이 — 평소 회색, 호버하면 글자가 진해진다
         className={cn(
           SHAPE,

--- a/src/features/shell/components/sidebar-item.tsx
+++ b/src/features/shell/components/sidebar-item.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import {
+  Activity,
+  Building2,
   CalendarDays,
   CalendarRange,
+  ClipboardCheck,
   Columns3,
   CreditCard,
   Folder,
@@ -27,12 +30,15 @@ import type { NavIconName, NavItem } from "../nav";
 /**
  * 이름 → 아이콘. 구성 파일은 서버에서 읽히므로 실제 컴포넌트는 여기서 붙인다.
  *
- * ⚠️ **역할 셸이 쓰는 이름만** 채운다. `approval`·`company`·`monitor`는 운영자 전용이라
- *    여기 없는 게 맞다 — 그 화면은 `system/components/system-sidebar.tsx`가 자기 맵으로 그린다.
- *    두 셸이 한 맵을 나눠 쓰면 역할 사이드바가 운영자 아이콘까지 번들에 끌고 온다.
+ * ⚠️ **역할 셸과 운영자 셸이 같이 쓴다.** 전에는 운영자 쪽이 자기 맵을 따로 들고 있어서,
+ *    같은 아이콘 이름이 두 곳에 적혀 있었다 — 한쪽만 고치면 두 사이드바가 다른 그림을 쓴다.
+ *    `approval`은 역할 셸에서도 인수인계에 쓴다.
  */
 const NAV_ICON: Partial<Record<NavIconName, LucideIcon>> = {
   dashboard: LayoutDashboard,
+  approval: ClipboardCheck,
+  company: Building2,
+  monitor: Activity,
   project: Folder,
   search: Search,
   calendar: CalendarDays,

--- a/src/features/shell/nav-config.test.ts
+++ b/src/features/shell/nav-config.test.ts
@@ -1,7 +1,7 @@
 import { ROLE } from "@/constants/role";
 import type { Actor } from "@/lib/permission";
 
-import { navFor } from "./nav-config";
+import { dashboardFor, navFor } from "./nav-config";
 
 /**
  * 사이드바 구성 — **Admin이 역할을 갈아치우지 않는지**가 핵심이다.
@@ -109,5 +109,31 @@ describe("Admin 겸직", () => {
   it("Owner에게 `isAdmin`이 잘못 켜져도 계정 발급이 생기지 않는다", () => {
     // ⚠️ `canGrantAdmin`이 Owner를 겸직 대상에서 빼므로 판정 자체가 거짓이다
     expect(labels(navFor(actor(ROLE.OWNER, true)), "회사 운영")).not.toContain("계정 발급");
+  });
+});
+
+/**
+ * 로고가 데려갈 곳 — **메뉴 [대시보드]와 한 항목**이어야 한다.
+ * 둘이 갈라지면 메뉴는 "준비 중"이라 말하는데 로고만 404로 데려간다.
+ */
+describe("dashboardFor", () => {
+  it.each([
+    [ROLE.OWNER, "/owner"],
+    [ROLE.LEADER, "/team"],
+    [ROLE.MEMBER, "/my"],
+    [ROLE.SYSTEM, "/system"],
+  ])("%s의 로고는 자기 대시보드로 간다 — 랜딩이 아니다", (role, href) => {
+    expect(dashboardFor(role).href).toBe(href);
+    expect(dashboardFor(role).href).not.toBe("/");
+  });
+
+  it("사이드바 첫 항목과 **같은 객체**다 — 갈라지면 한쪽만 준비 상태를 본다", () => {
+    for (const role of [ROLE.OWNER, ROLE.LEADER, ROLE.MEMBER] as const) {
+      expect(navFor(actor(role))[0]?.items[0]).toBe(dashboardFor(role));
+    }
+  });
+
+  it("겸직해도 로고는 그대로다 — Admin은 첫 화면을 바꾸지 않는다", () => {
+    expect(dashboardFor(actor(ROLE.LEADER, true).role).href).toBe("/team");
   });
 });

--- a/src/features/shell/nav-config.test.ts
+++ b/src/features/shell/nav-config.test.ts
@@ -1,0 +1,113 @@
+import { ROLE } from "@/constants/role";
+import type { Actor } from "@/lib/permission";
+
+import { navFor } from "./nav-config";
+
+/**
+ * 사이드바 구성 — **Admin이 역할을 갈아치우지 않는지**가 핵심이다.
+ * 겸직자가 자기 대시보드나 팀 관리를 잃으면 그게 이 파일에서 가장 크게 터지는 실수다.
+ */
+
+const actor = (role: Actor["role"], isAdmin = false): Actor => ({ id: 1, role, isAdmin });
+
+const titles = (sections: ReturnType<typeof navFor>) => sections.map((s) => s.title ?? "(기본)");
+const labels = (sections: ReturnType<typeof navFor>, title: string) =>
+  sections.find((s) => s.title === title)?.items.map((i) => i.label) ?? [];
+const allHrefs = (sections: ReturnType<typeof navFor>) =>
+  sections.flatMap((s) => s.items.map((i) => i.href));
+
+describe("대시보드", () => {
+  it.each([
+    [ROLE.OWNER, "/owner"],
+    [ROLE.LEADER, "/team"],
+    [ROLE.MEMBER, "/my"],
+  ])("%s의 첫 항목은 자기 대시보드다", (role, href) => {
+    expect(navFor(actor(role))[0]?.items[0]?.href).toBe(href);
+  });
+});
+
+describe("Owner", () => {
+  it("회사 운영을 늘 본다 — `is_admin` 없이도", () => {
+    expect(titles(navFor(actor(ROLE.OWNER)))).toContain("회사 운영");
+  });
+
+  it("**계정 발급이 없다** — 발급은 Admin의 일이고 Owner는 발급자도 대상도 아니다", () => {
+    expect(labels(navFor(actor(ROLE.OWNER)), "회사 운영")).not.toContain("계정 발급");
+  });
+
+  it("기업 설정·팀장 인수인계는 Owner만 본다", () => {
+    const items = labels(navFor(actor(ROLE.OWNER)), "회사 운영");
+    expect(items).toContain("기업 설정");
+    expect(items).toContain("팀장 인수인계");
+  });
+
+  it("내 액션·인수인계가 **없다** — 액션을 받는 자리가 아니고 인수인계를 쓰는 쪽도 아니다", () => {
+    const hrefs = allHrefs(navFor(actor(ROLE.OWNER)));
+    expect(hrefs).not.toContain("/app/my/actions");
+    expect(hrefs).not.toContain("/app/handover");
+  });
+
+  it("팀 관리는 없다 — 부서 스코프는 팀장의 것이다", () => {
+    expect(titles(navFor(actor(ROLE.OWNER)))).not.toContain("팀 관리");
+  });
+});
+
+describe("Leader", () => {
+  it("팀 관리가 붙는다", () => {
+    expect(labels(navFor(actor(ROLE.LEADER)), "팀 관리")).toEqual([
+      "팀원",
+      "팀 액션",
+      "인수인계 승인",
+    ]);
+  });
+
+  it("겸직이 아니면 회사 운영은 없다", () => {
+    expect(titles(navFor(actor(ROLE.LEADER)))).not.toContain("회사 운영");
+  });
+
+  it("내 액션·인수인계를 본다 — Owner와 갈리는 지점이다", () => {
+    const hrefs = allHrefs(navFor(actor(ROLE.LEADER)));
+    expect(hrefs).toContain("/app/my/actions");
+    expect(hrefs).toContain("/app/handover");
+  });
+});
+
+describe("Member", () => {
+  it("워크벤치만 본다 — 팀 관리도 회사 운영도 없다", () => {
+    expect(titles(navFor(actor(ROLE.MEMBER)))).toEqual(["(기본)", "워크벤치"]);
+  });
+});
+
+describe("Admin 겸직", () => {
+  /*
+    ⚠️ 여기가 이 파일의 핵심이다. Admin은 **역할이 아니라 덧붙는 권한**이라(WORKFLOW §9),
+       겸직해도 원래 역할의 구역이 그대로 남아야 한다.
+  */
+  it("팀장이 겸직해도 **팀 관리를 잃지 않는다**", () => {
+    const sections = navFor(actor(ROLE.LEADER, true));
+    expect(titles(sections)).toEqual(["(기본)", "워크벤치", "팀 관리", "회사 운영"]);
+  });
+
+  it("사원이 겸직하면 워크벤치는 그대로 두고 회사 운영만 붙는다", () => {
+    expect(titles(navFor(actor(ROLE.MEMBER, true)))).toEqual(["(기본)", "워크벤치", "회사 운영"]);
+  });
+
+  it("겸직자는 대시보드가 **그대로다** — 관리 화면으로 첫 화면이 바뀌지 않는다", () => {
+    expect(navFor(actor(ROLE.LEADER, true))[0]?.items[0]?.href).toBe("/team");
+  });
+
+  it("겸직자는 **계정 발급을 본다**", () => {
+    expect(labels(navFor(actor(ROLE.MEMBER, true)), "회사 운영")).toContain("계정 발급");
+  });
+
+  it("겸직자에게 기업 설정·팀장 인수인계는 **안 보인다** — 위계상 Owner의 것이다", () => {
+    const items = labels(navFor(actor(ROLE.MEMBER, true)), "회사 운영");
+    expect(items).not.toContain("기업 설정");
+    expect(items).not.toContain("팀장 인수인계");
+  });
+
+  it("Owner에게 `isAdmin`이 잘못 켜져도 계정 발급이 생기지 않는다", () => {
+    // ⚠️ `canGrantAdmin`이 Owner를 겸직 대상에서 빼므로 판정 자체가 거짓이다
+    expect(labels(navFor(actor(ROLE.OWNER, true)), "회사 운영")).not.toContain("계정 발급");
+  });
+});

--- a/src/features/shell/nav-config.test.ts
+++ b/src/features/shell/nav-config.test.ts
@@ -1,6 +1,7 @@
 import { ROLE } from "@/constants/role";
 import type { Actor } from "@/lib/permission";
 
+import { roleHome } from "./home";
 import { dashboardFor, navFor } from "./nav-config";
 
 /**
@@ -136,4 +137,18 @@ describe("dashboardFor", () => {
   it("겸직해도 로고는 그대로다 — Admin은 첫 화면을 바꾸지 않는다", () => {
     expect(dashboardFor(actor(ROLE.LEADER, true).role).href).toBe("/team");
   });
+});
+
+/**
+ * 로그인 뒤 데려다 놓는 곳(`roleHome`)과 로고가 가리키는 곳(`dashboardFor`)은
+ * **같아야 한다.** 갈라지면 로그인 직후 떨어진 화면과 로고가 데려가는 화면이 달라진다 —
+ * 둘 다 "첫 화면"이라고 말하면서 서로 다른 곳을 가리킨다.
+ */
+describe("첫 화면은 한 곳이다", () => {
+  it.each([ROLE.OWNER, ROLE.LEADER, ROLE.MEMBER, ROLE.SYSTEM])(
+    "%s의 roleHome과 로고 목적지가 같다",
+    (role) => {
+      expect(dashboardFor(role).href).toBe(roleHome(role));
+    },
+  );
 });

--- a/src/features/shell/nav-config.ts
+++ b/src/features/shell/nav-config.ts
@@ -83,6 +83,18 @@ const DASHBOARD: Record<Role, NavItem> = {
 };
 
 /**
+ * 사이드바 **로고**가 데려갈 곳 — 메뉴 [대시보드]와 **같은 항목**을 준다.
+ *
+ * ⚠️ 경로를 따로 적지 않는다(`roleHome`으로도 안 짚는다). 로고와 메뉴가 같은 곳을 가리키면서
+ *    한쪽만 `isReady`를 보면 **로고만 404로 보낸다** — 메뉴는 "준비 중"이라고 말하는데
+ *    로고는 없는 화면으로 데려가니, 둘 중 로고가 거짓말을 하는 쪽이 된다(§정직성).
+ *    항목 하나를 나눠 쓰면 화면이 생기는 날 `isReady` 한 줄로 둘이 같이 열린다.
+ */
+export function dashboardFor(role: Role): NavItem {
+  return DASHBOARD[role];
+}
+
+/**
  * 이 사람의 사이드바.
  *
  * ⚠️ **base role로 뼈대를 잡고, `is_admin`이면 회사 운영 구역을 덧붙인다.** 순서가 중요하다 —

--- a/src/features/shell/nav-config.ts
+++ b/src/features/shell/nav-config.ts
@@ -1,0 +1,126 @@
+import { ROLE, type Role } from "@/constants/role";
+import type { Actor } from "@/lib/permission";
+import { canIssueAccount, canManageBilling } from "@/lib/permission";
+
+import type { NavItem, NavSection } from "./nav";
+
+/**
+ * 역할별 사이드바 구성 — **레이아웃은 하나고 이 목록만 갈린다**(CLAUDE.md §라우트 그룹).
+ *
+ * ⚠️ **Admin은 역할이 아니라 덧붙는 구역이다**(WORKFLOW §9). `is_admin`이면 기존 역할을
+ *    그대로 두고 회사 운영 구역만 더한다 — 역할을 갈아치우면 겸직자가 자기 대시보드를 잃는다.
+ * ⚠️ **여기서 감추는 건 UX일 뿐이다.** 메뉴에 없어도 주소를 치면 들어가진다 —
+ *    막는 건 각 화면과 Server Action이 `lib/permission.ts`로 한다(§권한).
+ * ⚠️ 화면이 아직 없으면 `isReady`를 안 붙인다. 그러면 눌러도 404 대신 "준비 중"이 뜬다(§정직성).
+ */
+
+/** 로그인한 전원이 같이 쓰는 워크벤치 — 역할에 따라 **빠지는 항목만** 있다 */
+const COMMON_TOP: NavItem[] = [
+  { href: "/app/projects", label: "프로젝트", icon: "project" },
+  { href: "/app/search", label: "검색", icon: "search" },
+  { href: "/app/calendar", label: "캘린더", icon: "calendar" },
+  { href: "/app/notice", label: "공지", icon: "notice", isReady: true },
+];
+
+const COMMON_WORKBENCH: NavItem[] = [
+  { href: "/app/meeting", label: "회의", icon: "meeting" },
+  { href: "/app/rooms", label: "회의실", icon: "room" },
+  { href: "/app/board", label: "보드", icon: "board" },
+  { href: "/app/people", label: "사람", icon: "people" },
+];
+
+/**
+ * Owner에게는 **없는** 워크벤치 항목.
+ *
+ * ⚠️ `/app/my/actions`는 OWNER 접근 불가, `/app/handover`는 OWNER 제외다
+ *    (CLAUDE.md §라우트 그룹). Owner는 액션을 받는 자리가 아니고, 인수인계를 쓰는 쪽도 아니다.
+ */
+const MEMBER_WORKBENCH: NavItem[] = [
+  { href: "/app/my/actions", label: "내 액션", icon: "board" },
+  { href: "/app/handover", label: "인수인계", icon: "approval" },
+];
+
+const MY_PAGE: NavItem = { href: "/app/me", label: "마이페이지", icon: "me" };
+
+/**
+ * 회사 운영 — **Owner와 Admin 겸직자가 보는 것이 다르다.**
+ *
+ * ⚠️ **계정 발급은 Admin만** 한다(`canIssueAccount`). Owner는 발급 대상도 발급자도 아니다.
+ * ⚠️ **기업 설정·팀장 인수인계는 Owner만** 본다. 위계상 admin이 대신할 수 없다.
+ * ⚠️ 겹치는 넷(사원 관리·회의실·구독·결제·녹음 용량)은 `/manage/*` 하나로 모여 있다 —
+ *    역할 경로에 두면 겸직자에게 주소가 거짓말을 한다(DECISIONS §관리 기능).
+ */
+const MANAGE_SHARED: NavItem[] = [
+  { href: "/manage/members", label: "사원 관리", icon: "members" },
+  { href: "/manage/rooms", label: "회의실 관리", icon: "room" },
+  { href: "/manage/billing", label: "구독·결제", icon: "billing", isReady: true },
+  { href: "/manage/storage", label: "녹음 용량", icon: "storage" },
+];
+
+const ISSUE_ACCOUNT: NavItem = { href: "/manage/new", label: "계정 발급", icon: "members" };
+
+const OWNER_ONLY: NavItem[] = [
+  { href: "/owner/leader-handovers", label: "팀장 인수인계", icon: "approval" },
+  { href: "/owner/setting", label: "기업 설정", icon: "setting" },
+];
+
+/** 팀장 전용 — 자기 부서 스코프 */
+const TEAM_SECTION: NavSection = {
+  title: "팀 관리",
+  items: [
+    { href: "/team/members", label: "팀원", icon: "members" },
+    { href: "/team/action", label: "팀 액션", icon: "board" },
+    { href: "/team/handover", label: "인수인계 승인", icon: "approval" },
+  ],
+};
+
+/** 역할별 대시보드 — 첫 화면이다(`roleHome`과 같은 곳을 가리킨다) */
+const DASHBOARD: Record<Role, NavItem> = {
+  [ROLE.OWNER]: { href: "/owner", label: "대시보드", icon: "dashboard" },
+  [ROLE.LEADER]: { href: "/team", label: "대시보드", icon: "dashboard" },
+  [ROLE.MEMBER]: { href: "/my", label: "대시보드", icon: "dashboard" },
+  [ROLE.SYSTEM]: { href: "/system", label: "대시보드", icon: "dashboard", isReady: true },
+};
+
+/**
+ * 이 사람의 사이드바.
+ *
+ * ⚠️ **base role로 뼈대를 잡고, `is_admin`이면 회사 운영 구역을 덧붙인다.** 순서가 중요하다 —
+ *    admin을 역할처럼 다루면 팀장 겸직자가 팀 관리 구역을 잃는다.
+ * ⚠️ 판정은 `lib/permission.ts`를 쓴다. `role === "owner"` 같은 비교를 여기 적으면
+ *    정책이 바뀔 때 권한 파일과 사이드바가 서로 다른 말을 한다(§권한).
+ */
+export function navFor(viewer: Actor): NavSection[] {
+  const isOwner = viewer.role === ROLE.OWNER;
+
+  const workbench = isOwner
+    ? [...COMMON_WORKBENCH, MY_PAGE]
+    : [...COMMON_WORKBENCH, ...MEMBER_WORKBENCH, MY_PAGE];
+
+  const sections: NavSection[] = [
+    { items: [DASHBOARD[viewer.role], ...COMMON_TOP] },
+    { title: "워크벤치", items: workbench },
+  ];
+
+  if (viewer.role === ROLE.LEADER) sections.push(TEAM_SECTION);
+
+  /*
+    회사 운영 — 볼 수 있는 사람만. Owner는 늘 보고, 겸직자는 `is_admin`으로 붙는다.
+    ⚠️ 판정을 `canManageBilling`으로 한다. 이 구역의 핵심이 구독·결제라 그 판정과 같은 문이어야
+       "메뉴는 보이는데 화면은 막힌다"가 안 생긴다.
+  */
+  if (canManageBilling(viewer)) {
+    sections.push({
+      title: "회사 운영",
+      items: [
+        ...MANAGE_SHARED.slice(0, 1),
+        // 계정 발급은 Admin 겸직자만 — 사원 관리 바로 옆이 자연스럽다
+        ...(canIssueAccount(viewer) ? [ISSUE_ACCOUNT] : []),
+        ...MANAGE_SHARED.slice(1),
+        ...(isOwner ? OWNER_ONLY : []),
+      ],
+    });
+  }
+
+  return sections;
+}

--- a/src/features/shell/nav.ts
+++ b/src/features/shell/nav.ts
@@ -50,45 +50,7 @@ export interface NavSection {
   items: NavItem[];
 }
 
-/**
- * OWNER 사이드바 구성.
- *
- * ⚠️ 역할마다 **레이아웃이 아니라 이 목록만** 달라진다(CLAUDE.md §라우트 그룹:
- *    레이아웃 1개 + 역할별 네비 구성). ADMIN·LEADER·MEMBER용은 각자 화면을 만들 때 추가한다.
- */
-export const OWNER_NAV: NavSection[] = [
-  {
-    items: [
-      { href: "/owner", label: "대시보드", icon: "dashboard" },
-      { href: "/app/projects", label: "프로젝트", icon: "project" },
-      { href: "/app/search", label: "검색", icon: "search" },
-      { href: "/app/calendar", label: "캘린더", icon: "calendar" },
-      { href: "/app/notice", label: "공지", icon: "notice", isReady: true },
-    ],
-  },
-  {
-    title: "워크벤치",
-    items: [
-      { href: "/app/meeting", label: "회의", icon: "meeting" },
-      { href: "/app/rooms", label: "회의실", icon: "room" },
-      { href: "/app/board", label: "보드", icon: "board" },
-      { href: "/app/people", label: "사람", icon: "people" },
-      { href: "/app/me", label: "마이페이지", icon: "me" },
-    ],
-  },
-  {
-    title: "회사 운영",
-    items: [
-      /*
-        ⚠️ 관리 기능은 **`/manage/*` 하나**로 모은다(팀 URL 문서 2026-08-05).
-           OWNER와 Admin 겸직자가 같이 쓰는 화면이라 `/owner/*`에 두면 겸직자에게 주소가
-           거짓말을 하고, 두 곳에 나눠 두면 같은 화면이 두 벌이 된다.
-           가드는 `역할 === admin`이 아니라 **`role === "owner" || isAdmin`** 이다.
-      */
-      { href: "/manage/members", label: "사원 관리", icon: "members" },
-      { href: "/manage/billing", label: "구독·결제", icon: "billing", isReady: true },
-      { href: "/manage/storage", label: "녹음 용량", icon: "storage" },
-      { href: "/owner/setting", label: "기업 설정", icon: "setting" },
-    ],
-  },
-];
+/*
+  ⚠️ **구성은 `nav-config.ts`에 있다.** 이 파일은 모양(타입)만 정한다 —
+     전에는 여기 `OWNER_NAV` 하나뿐이라 역할이 늘 때마다 타입 파일이 같이 부풀었다.
+*/

--- a/src/features/system/components/system-sidebar.tsx
+++ b/src/features/system/components/system-sidebar.tsx
@@ -80,7 +80,7 @@ export function SystemSidebar({ sections, account }: SystemSidebarProps) {
 
       {/* ⚠️ 높이·표식 크기는 역할 셸의 계정 줄과 같다. 다른 건 배지 대신 이메일이 오는 것뿐이다 */}
       <div className="border-border flex h-[49px] shrink-0 items-center gap-[7px] border-t px-[17.5px]">
-        <span className="bg-role-owner flex size-[21px] shrink-0 items-center justify-center rounded-full text-[10px] leading-none text-white">
+        <span className="bg-role-owner text-background flex size-[21px] shrink-0 items-center justify-center rounded-full text-[10px] leading-none">
           운
         </span>
         <div className="min-w-0 flex-1">

--- a/src/features/system/components/system-sidebar.tsx
+++ b/src/features/system/components/system-sidebar.tsx
@@ -1,34 +1,11 @@
 "use client";
 
-import {
-  Activity,
-  Building2,
-  ClipboardCheck,
-  CreditCard,
-  LayoutDashboard,
-  type LucideIcon,
-  Megaphone,
-} from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { toast } from "sonner";
 
 import { ZLogo } from "@/components/icons/z-logo";
-import type { NavIconName, NavItem, NavSection } from "@/features/shell/nav";
-import { cn } from "@/lib/utils";
-
-/**
- * 이름 → 아이콘. 구성 파일은 서버에서 읽히므로 실제 컴포넌트는 여기서 붙인다.
- * SYSTEM_NAV가 쓰는 이름만 채운다 — `Partial`이라 나머지는 fallback 아이콘으로 대체된다.
- */
-const NAV_ICON: Partial<Record<NavIconName, LucideIcon>> = {
-  dashboard: LayoutDashboard,
-  approval: ClipboardCheck,
-  company: Building2,
-  billing: CreditCard,
-  monitor: Activity,
-  notice: Megaphone,
-};
+import { SidebarItem } from "@/features/shell/components/sidebar-item";
+import type { NavSection } from "@/features/shell/nav";
 
 interface SystemSidebarProps {
   sections: NavSection[];
@@ -59,9 +36,11 @@ function findActiveHref(sections: NavSection[], pathname: string): string | unde
 /**
  * SYSTEM(서비스 운영자) 전용 사이드바.
  *
- * ⚠️ `RoleSidebar`와 구조는 비슷하지만 별도 컴포넌트다 — 헤더 표기("Z 운영자")와
- *    하단 계정 줄(역할 배지 없이 이메일만)이 달라서 그대로 재사용하면 SYSTEM 분기가
- *    RoleSidebar 안에 섞여 들어간다.
+ * ⚠️ `RoleSidebar`와 **치수·항목 렌더가 같다**(공용 `SidebarItem`). 전에는 항목을 따로 구현해
+ *    높이 28px·아이콘 12px·글자 12px로 역할 셸(34/14/13)과 달랐고, 아이콘 맵도 두 벌이었다 —
+ *    같은 서비스의 사이드바가 화면마다 다르게 생기고 고칠 곳이 두 곳이 된다.
+ * ⚠️ 그래도 **컴포넌트는 따로 둔다.** 하단 계정 줄이 다르다(역할 배지 대신 이메일) —
+ *    한 컴포넌트에 넣으면 `RoleSidebar` 안에 SYSTEM 분기가 섞인다.
  */
 export function SystemSidebar({ sections, account }: SystemSidebarProps) {
   const pathname = usePathname();
@@ -79,16 +58,16 @@ export function SystemSidebar({ sections, account }: SystemSidebarProps) {
         </Link>
       </div>
 
-      <nav className="flex-1 overflow-y-auto p-1.5">
+      <nav className="flex-1 overflow-y-auto p-[7px]">
         {sections.map((section, index) => (
-          <div key={section.title ?? "primary"} className={index > 0 ? "pt-2" : undefined}>
+          <div key={section.title ?? "primary"} className={index > 0 ? "pt-2.5" : undefined}>
             {section.title && (
-              <p className="text-muted-foreground/80 px-2 pb-1 text-[10px] leading-4 tracking-[0.275px]">
+              <p className="text-muted-foreground/80 px-[10.5px] pt-3.5 pb-[5.25px] text-[11px] leading-4 tracking-[0.275px]">
                 {section.title}
               </p>
             )}
 
-            <ul className="flex flex-col gap-[1.5px]">
+            <ul className="flex flex-col gap-[1.75px]">
               {section.items.map((item) => (
                 <li key={item.href}>
                   <SidebarItem item={item} isCurrent={item.href === activeHref} />
@@ -99,63 +78,18 @@ export function SystemSidebar({ sections, account }: SystemSidebarProps) {
         ))}
       </nav>
 
-      <div className="border-border flex h-11 shrink-0 items-center gap-1.5 border-t px-4">
-        <span className="bg-role-owner flex size-[19px] shrink-0 items-center justify-center rounded-full text-[9px] leading-none text-white">
+      {/* ⚠️ 높이·표식 크기는 역할 셸의 계정 줄과 같다. 다른 건 배지 대신 이메일이 오는 것뿐이다 */}
+      <div className="border-border flex h-[49px] shrink-0 items-center gap-[7px] border-t px-[17.5px]">
+        <span className="bg-role-owner flex size-[21px] shrink-0 items-center justify-center rounded-full text-[10px] leading-none text-white">
           운
         </span>
         <div className="min-w-0 flex-1">
-          <p className="text-foreground truncate text-[11px] leading-[14px]">운영자 계정</p>
+          <p className="text-foreground truncate text-xs leading-[18px]">운영자 계정</p>
           <p className="text-muted-foreground truncate text-[10px] leading-[13px]">
             {account.email}
           </p>
         </div>
       </div>
     </aside>
-  );
-}
-
-function SidebarItem({ item, isCurrent }: { item: NavItem; isCurrent: boolean }) {
-  const Icon = NAV_ICON[item.icon] ?? LayoutDashboard;
-  const inner = (
-    <>
-      <Icon className="size-3 shrink-0" aria-hidden />
-      <span className="min-w-0 flex-1 translate-y-px truncate text-xs leading-5">{item.label}</span>
-    </>
-  );
-
-  const shape = "flex h-7 items-center gap-2 rounded-md px-2 transition-colors";
-
-  // ⚠️ 아직 없는 화면은 링크로 두지 않는다 — 누르면 404가 뜬다(CLAUDE.md §정직성).
-  if (!item.isReady) {
-    return (
-      <button
-        type="button"
-        aria-disabled
-        // ⚠️ 토스트는 한 줄(220px)이라 짧게 쓴다 — 길면 잘린다(`sonner.tsx`)
-        onClick={() => toast(`${item.label}은 준비 중입니다`)}
-        className={cn(
-          shape,
-          "text-muted-foreground hover:bg-foreground/5 hover:text-foreground focus-visible:ring-ring w-full text-left focus-visible:ring-2 focus-visible:outline-hidden",
-        )}
-      >
-        {inner}
-      </button>
-    );
-  }
-
-  return (
-    <Link
-      href={item.href}
-      aria-current={isCurrent ? "page" : undefined}
-      className={cn(
-        shape,
-        "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-hidden",
-        isCurrent
-          ? "bg-foreground/10 text-foreground font-medium"
-          : "text-muted-foreground hover:bg-foreground/5 hover:text-foreground",
-      )}
-    >
-      {inner}
-    </Link>
   );
 }

--- a/src/features/system/components/system-sidebar.tsx
+++ b/src/features/system/components/system-sidebar.tsx
@@ -61,10 +61,14 @@ export function SystemSidebar({ sections, account }: SystemSidebarProps) {
       <nav className="flex-1 overflow-y-auto p-[7px]">
         {sections.map((section, index) => (
           <div key={section.title ?? "primary"} className={index > 0 ? "pt-2.5" : undefined}>
+            {/* ⚠️ 구분선까지 `RoleSidebar`와 같다 — 하나만 빠지면 두 셸이 다르게 생긴다 */}
             {section.title && (
-              <p className="text-muted-foreground/80 px-[10.5px] pt-3.5 pb-[5.25px] text-[11px] leading-4 tracking-[0.275px]">
-                {section.title}
-              </p>
+              <>
+                <div className="border-border/70 mx-[10.5px] border-t" />
+                <p className="text-muted-foreground/80 px-[10.5px] pt-3.5 pb-[5.25px] text-[11px] leading-4 tracking-[0.275px]">
+                  {section.title}
+                </p>
+              </>
             )}
 
             <ul className="flex flex-col gap-[1.75px]">

--- a/src/features/system/nav.ts
+++ b/src/features/system/nav.ts
@@ -8,7 +8,11 @@ import type { NavSection } from "@/features/shell/nav";
  */
 export const SYSTEM_NAV: NavSection[] = [
   {
-    title: "운영 메뉴",
+    /*
+      ⚠️ **제목을 두지 않는다.** 구역이 하나뿐이라 이름표가 가리킬 대상이 없고,
+         `RoleSidebar`는 제목이 있는 구역 위에 구분선을 긋는다 — 여기서만 제목을 두면
+         로고 바로 아래에 선이 생겨 역할 셸과 다르게 보인다(로고 아래 선은 두지 않는다).
+    */
     items: [
       { href: "/system", label: "대시보드", icon: "dashboard", isReady: true },
       { href: "/system/approval", label: "기업 승인", icon: "approval", isReady: true },

--- a/src/lib/korean.test.ts
+++ b/src/lib/korean.test.ts
@@ -1,0 +1,47 @@
+import { objectParticle, subjectParticle, topicParticle } from "./korean";
+
+/**
+ * 조사 고르기 — **사이드바 라벨이 실제로 지나가는 값**으로 묶는다.
+ * 메뉴 이름은 모음으로 끝나는 게 더 많아서, 한쪽으로 고정하면 대부분이 틀린 말이 된다.
+ */
+describe("topicParticle", () => {
+  it.each(["프로젝트", "캘린더", "회의", "보드", "마이페이지", "인수인계", "대시보드"])(
+    "받침 없는 `%s`에는 `는`",
+    (word) => {
+      expect(topicParticle(word)).toBe("는");
+    },
+  );
+
+  it.each(["검색", "회의실", "사람", "팀원", "녹음 용량", "계정 발급", "기업 설정"])(
+    "받침 있는 `%s`에는 `은`",
+    (word) => {
+      expect(topicParticle(word)).toBe("은");
+    },
+  );
+
+  it("띄어쓴 이름은 **마지막 글자**로 판단한다 — `녹음 용량`은 `량`이 받침을 갖는다", () => {
+    expect(topicParticle("녹음 용량")).toBe("은");
+    expect(topicParticle("팀 액션")).toBe("은");
+  });
+
+  it("한글이 아니면 받침이 있는 쪽으로 본다 — `Admin은`이 `Admin는`보다 덜 어색하다", () => {
+    expect(topicParticle("Admin")).toBe("은");
+    expect(topicParticle("STT")).toBe("은");
+  });
+
+  it("빈 문자열에도 터지지 않는다", () => {
+    expect(topicParticle("")).toBe("은");
+  });
+});
+
+describe("나머지 조사", () => {
+  it("주격 — 받침 유무로 갈린다", () => {
+    expect(subjectParticle("프로젝트")).toBe("가");
+    expect(subjectParticle("검색")).toBe("이");
+  });
+
+  it("목적격 — 받침 유무로 갈린다", () => {
+    expect(objectParticle("프로젝트")).toBe("를");
+    expect(objectParticle("검색")).toBe("을");
+  });
+});

--- a/src/lib/korean.ts
+++ b/src/lib/korean.ts
@@ -1,0 +1,46 @@
+/**
+ * 한글 조사 — 앞말의 **받침**을 보고 고른다.
+ *
+ * ⚠️ 문구에 조사를 박아 두면 안 된다. `${label}은 준비 중입니다`처럼 한쪽으로 고정하면
+ *    "프로젝트은"·"캘린더은"처럼 라벨 대부분이 틀린 말로 나온다 — 메뉴 이름은 모음으로
+ *    끝나는 게 더 많다.
+ * ⚠️ 라벨은 상수에서 오고 앞으로도 늘어난다. 새 라벨을 넣는 사람이 조사까지 확인하게 두면
+ *    언젠가 틀린다 — 넣는 자리에서 고르게 한다.
+ */
+
+/** 한글 음절 영역(가 ~ 힣) */
+const SYLLABLE_START = 0xac00;
+const SYLLABLE_END = 0xd7a3;
+/** 한 초성·중성 묶음이 갖는 종성 가짓수(받침 없음 포함) */
+const FINAL_COUNT = 28;
+
+/**
+ * 마지막 글자에 받침이 있는지.
+ *
+ * ⚠️ 한글이 아니면(영문·숫자·기호) **받침이 있는 것으로 본다.** `Admin은`·`STT은`처럼
+ *    자음으로 끝나 읽히는 경우가 흔해서, 둘 중에는 이쪽이 덜 어색하다.
+ */
+function hasFinalConsonant(word: string): boolean {
+  const last = word.trim().at(-1);
+  if (!last) return true;
+
+  const code = last.charCodeAt(0);
+  if (code < SYLLABLE_START || code > SYLLABLE_END) return true;
+
+  return (code - SYLLABLE_START) % FINAL_COUNT !== 0;
+}
+
+/** 주제 조사 — `프로젝트`+`는`, `검색`+`은` */
+export function topicParticle(word: string): "은" | "는" {
+  return hasFinalConsonant(word) ? "은" : "는";
+}
+
+/** 주격 조사 — `프로젝트`+`가`, `검색`+`이` */
+export function subjectParticle(word: string): "이" | "가" {
+  return hasFinalConsonant(word) ? "이" : "가";
+}
+
+/** 목적격 조사 — `프로젝트`+`를`, `검색`+`을` */
+export function objectParticle(word: string): "을" | "를" {
+  return hasFinalConsonant(word) ? "을" : "를";
+}


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가
- [x] design — UI/UX 변경

---

## 🗂 작업 영역

- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [x] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)

---

## 🙋 관련 역할

- [x] OWNER (대표)
- [x] ADMIN (관리자)
- [x] LEADER (팀장)
- [x] MEMBER (사원)
- [x] SYSTEM (서비스 운영자 — 확장, 데모 제외)

---

## 📝 작업 내용

**사이드바가 Owner 것 하나뿐이었습니다.** 팀장·사원으로 로그인해도 대표 메뉴가 그대로 떴고, Admin 권한을 받아도 아무것도 안 늘어났습니다.

### 역할이 뼈대를 잡고, Admin은 덧붙습니다

`docs/WORKFLOW.md` §9의 **"Admin은 4번째 역할이 아니다"** 를 그대로 구현했습니다. 겸직해도 **원래 역할의 구역이 그대로 남습니다** — 역할처럼 다루면 팀장 겸직자가 팀 관리를 잃습니다.

| | 기본 | 워크벤치 | 팀 관리 | 회사 운영 |
| --- | --- | --- | --- | --- |
| Owner | `/owner` | 내 액션·인수인계 **없음** | — | ✅ |
| Leader | `/team` | 전부 | ✅ | — |
| Leader + Admin | `/team` | 전부 | **✅ 유지** | ✅ |
| Member | `/my` | 전부 | — | — |
| Member + Admin | `/my` | 전부 | — | ✅ |

### md를 대조하다 나온 차이 둘

**① Owner와 Admin의 회사 운영 구역이 다릅니다.**

| 항목 | Owner | Admin 겸직 |
| --- | --- | --- |
| 사원 관리 · 회의실 · 구독·결제 · 녹음 용량 | ✅ | ✅ |
| **계정 발급** | ❌ | ✅ |
| **기업 설정 · 팀장 인수인계** | ✅ | ❌ |

계정 발급은 `canIssueAccount`가 이미 **Admin만**으로 판정합니다 — Owner는 발급 대상도 발급자도 아닙니다. 기업 설정·팀장 인수인계는 위계상 admin이 대신할 수 없습니다.

**② Owner에게는 내 액션·인수인계가 없습니다.** `/app/my/actions`는 OWNER 접근 불가, `/app/handover`는 OWNER 제외입니다(§라우트 그룹). Owner는 액션을 받는 자리가 아니고 인수인계를 쓰는 쪽도 아닙니다.

### 운영자 사이드바를 같은 모양으로

`SystemSidebar`가 **항목 렌더를 자기 안에 또 구현**하고 있었습니다.

| | 전 | 후 |
| --- | --- | --- |
| 항목 높이 | 28px | **34px** |
| 아이콘 | 12px | **14px** |
| 글자 | 12px | **13px** |
| 구역 제목 | 10px, 구분선 없음 | **11px + 구분선** |
| 항목 컴포넌트 | 자기 구현 | **공용 `SidebarItem`** |
| 아이콘 맵 | 또 하나 | **공용** |

`system-sidebar.tsx` 161 → 95줄. **컴포넌트 자체는 남깁니다** — 하단 계정 줄이 다릅니다(역할 배지 대신 이메일). 한 컴포넌트에 넣으면 `RoleSidebar` 안에 SYSTEM 분기가 섞입니다.

### 개발용 화면 — `/design/sidebar`

다섯 경우를 **나란히** 놓고 봅니다. 목을 다섯 번 바꿔 가며 확인하는 것보다 배치를 판단하기 쉽습니다.

⚠️ **명세에 없는 화면입니다.** `(dev)` 그룹에 따로 두고, 화면 안에도 개발용이라고 적었습니다. 사이드바 어디에서도 여기로 가는 길을 두지 않았습니다 — 주소를 아는 사람만 봅니다. **배포 대상이 아니면 `(dev)` 폴더째 지우면 끝납니다.**

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/shell-role-nav#110`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 판정은 전부 `lib/permission.ts`(`canManageBilling` · `canIssueAccount`)를 씁니다. `role === "owner"` 비교를 사이드바에 적지 않았습니다. **사이드바에서 감추는 건 UX일 뿐**이고 각 화면·Server Action이 다시 봅니다
- [x] 🧬 zod — 스키마 무변경
- [x] 🕵️ **정직성** — 화면이 없는 메뉴는 `isReady` 없이 둬서 눌러도 404 대신 "준비 중"이 뜹니다. 개발용 화면은 화면 안에 그렇게 적었습니다
- [x] 🎨 디자인 토큰 — 새 색 없음. 운영자 쪽 치수를 역할 셸에 맞췄습니다
- [x] ⚡ 최적화 — 구성은 서버에서 읽고 아이콘만 클라이언트에서 붙입니다(함수는 직렬화 안 됩니다)
- [x] ♿ a11y — `aria-current` · 준비 중 메뉴의 이름 · 포커스 링 그대로
- [x] ♻️ **재사용 확인** — 운영자 쪽 중복 구현을 지우고 공용 `SidebarItem`으로 합쳤습니다
- [x] 🧪 loading / error / empty 3상태 — 사이드바는 정적 구성입니다

---

## 🔗 연관 이슈

Closes #110

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- **회사 운영 구역의 문을 `canManageBilling`으로 연 것** — 이 구역의 핵심이 구독·결제라 그 판정과 같은 문이어야 "메뉴는 보이는데 화면은 막힌다"가 안 생깁니다. 다만 이름이 billing이라 구역 전체의 문으로 읽기엔 어색합니다. `canAccessManage` 같은 이름이 나을지 봐 주세요.
- **`/design/sidebar`를 남길지** — 개발용이라 배포 전에 지우는 게 맞다고 봅니다. 다만 역할이 늘거나 메뉴가 바뀔 때 다섯 벌을 한눈에 보는 값이 커서, 남기자면 `NEXT_PUBLIC_*`로 프로덕션에서 404를 내는 방법도 있습니다.
- **`OWNER_NAV`를 지운 것** — `nav.ts`는 이제 타입만 갖습니다. 구성이 늘 때마다 타입 파일이 같이 부풀지 않게 갈랐습니다.

---

## 📝 추가 메모

**확인한 것**

- eslint 0 · tsc 0 · `npx jest` **249개** 통과(18개 추가) · `npm run build` 성공
- `/design/sidebar`에서 다섯 경우의 구역·항목을 브라우저로 읽어 대조했습니다 — Leader + Admin이 `기본 · 워크벤치 · 팀 관리 · 회사 운영` 넷을 다 갖고, Owner의 회사 운영에 계정 발급이 없고, 겸직자에게 기업 설정이 없는 것까지
- `/system`에서 운영자 사이드바가 역할 셸과 같은 치수로 나오는 것을 확인했습니다

**테스트가 지키는 것** — Admin 겸직이 역할을 갈아치우지 않는지가 핵심입니다. 겸직자의 대시보드가 그대로인지, 팀장 겸직자가 팀 관리를 유지하는지, Owner에게 `isAdmin`이 잘못 켜져도 계정 발급이 안 생기는지(`canGrantAdmin`이 막습니다)를 테스트로 묶었습니다.

---

## 🔎 자체 리뷰로 고친 것 (추가 커밋)

리뷰 요청 뒤 이 PR을 다시 훑으면서 **주제 안에서 빠뜨린 것 셋**을 찾아 고쳤습니다.

### ① 로고만 404로 데려갔습니다

로고와 메뉴 [대시보드]는 같은 곳을 가리키는데 굴기가 달랐습니다.

| | 전 | 후 |
| --- | --- | --- |
| 메뉴 [대시보드] | "준비 중" 토스트 | 그대로 |
| **사이드바 로고** | `/owner`로 이동 → **404** | **같은 "준비 중" 토스트** |

`dashboardFor(role)`을 내어 **둘이 한 항목을 나눠 씁니다.** 화면이 생기는 날 `isReady` 한 줄로 같이 열립니다. `roleHome`과 갈라지지 않는지도 테스트로 묶었습니다 — 둘 다 "첫 화면"인데 어긋나면 로그인 직후 떨어지는 곳과 로고가 데려가는 곳이 달라집니다.

⚠️ **랜딩·로그인 화면의 로고는 그대로 `/`로 갑니다.** 거기선 랜딩이 첫 화면입니다.

### ② 계정 줄 배지가 역할과 무관하게 Owner 색이었습니다

이 PR이 고치려던 "모두에게 대표 사이드바가 뜬다"가 **계정 줄에 그대로 남아 있었습니다.** `bg-role-owner`가 박혀 있어 팀장·사원으로 로그인해도 글자만 `Leader`·`Member`로 바뀌고 색은 주황이었습니다.

`ROLE_BADGE_CLASS`·`ROLE_MARK_CLASS`를 `constants/role.ts`에 두고 라벨과 같은 자리에서 가져옵니다. SYSTEM은 자기 토큰이 없어 회색(member)을 씁니다.

**대비도 같이 고쳤습니다.** 이름 첫 글자가 `text-white`로 고정돼 있었는데, 역할 색은 테마에 따라 밝기가 뒤집힙니다(라이트 `#c2410c` ↔ 다크 `#fb923c`).

| | 라이트 | 다크 |
| --- | --- | --- |
| `text-white` (전) | 5.18 ~ 7.63 | **2.14 ~ 2.52** ❌ |
| `text-background` (후) | 4.88 ~ 7.63 | **5.63 ~ 8.33** ✅ |

### ③ "프로젝트은 준비 중입니다"

토스트에 조사를 박아 둬서(`${label}은`) 라벨 대부분이 틀린 말로 떴습니다 — 사이드바 이름은 모음으로 끝나는 게 더 많습니다.

`lib/korean.ts`에 받침을 보고 조사를 고르는 함수를 두고 두 토스트가 같이 씁니다. 라벨은 상수에서 오고 앞으로도 늘어나니, 넣는 사람이 조사까지 확인하게 두지 않고 **넣는 자리에서** 고르게 했습니다.

**남은 것** — `bg-role-*` 클래스 맵이 랜딩 쪽에 아직 4벌 더 있습니다(`roles/page.tsx` · `role-mocks.ts` · `role-views.ts` · `role-badge.tsx`). 사용자 이미지·역할 뱃지 통일 작업에서 같이 정리하기로 해 이 PR에서는 사이드바 몫만 고쳤습니다.

**다시 확인한 것** — eslint 0 · tsc 0 · `npx jest` **282개** 통과 · `npm run build` 성공. `/design/sidebar`에서 라이트·다크 양쪽의 배지 색과 대비를 브라우저로 계산해 대조했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 사용자 역할과 권한에 따라 사이드바 메뉴와 대시보드가 자동으로 표시됩니다.
  - Owner, Leader, Member 및 관리자 권한 조합별 메뉴를 지원합니다.
  - 회사 운영·계정 발급 등 추가 권한 메뉴가 적절한 사용자에게 제공됩니다.
  - 역할별 사이드바를 비교할 수 있는 개발용 미리보기 화면이 추가되었습니다.
  - 사이드바 항목에 새로운 아이콘이 적용되었습니다.

- **개선**
  - 운영자용 사이드바가 공통 탐색 구성과 일관된 디자인을 사용합니다.
  - 역할별 메뉴와 접근 제한 검증이 강화되었습니다.
  - 준비되지 않은 대시보드 선택 시 안내 메시지가 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

