### PR TITLE
[FEAT] 팀장 대시보드 화면 #118

### DIFF
--- a/src/app/(shell)/(role)/team/(dashboard)/error.tsx
+++ b/src/app/(shell)/(role)/team/(dashboard)/error.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { ScreenError } from "@/components/common/screen-error";
+
+export default function Error({ reset }: { reset: () => void }) {
+  return <ScreenError title="대시보드를 불러오지 못했습니다" reset={reset} />;
+}

--- a/src/app/(shell)/(role)/team/(dashboard)/layout.tsx
+++ b/src/app/(shell)/(role)/team/(dashboard)/layout.tsx
@@ -1,0 +1,14 @@
+import { LayoutDashboard } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { PageHeader } from "@/features/shell/components/page-header";
+
+/** 팀장 대시보드 상단바 — 사이드바에서 바로 닿는 화면이라 backTo는 두지 않는다. */
+export default function TeamDashboardLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <PageHeader title="대시보드" icon={LayoutDashboard} />
+      {children}
+    </>
+  );
+}

--- a/src/app/(shell)/(role)/team/(dashboard)/loading.tsx
+++ b/src/app/(shell)/(role)/team/(dashboard)/loading.tsx
@@ -1,0 +1,20 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { MEETING_BOX_HEIGHT, MEMBER_BOX_HEIGHT } from "@/features/team/lib";
+
+/** 대시보드를 불러오는 동안. 실제 화면과 같은 골격(고정 높이 박스 포함)이라 레이아웃이 흔들리지 않는다. */
+export default function Loading() {
+  return (
+    <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
+      <div className="mx-auto flex w-full max-w-[1080px] flex-col gap-4">
+        <div className="grid grid-cols-4 gap-3">
+          {Array.from({ length: 4 }, (_, index) => (
+            <Skeleton key={index} className="h-[104px] rounded-xl" />
+          ))}
+        </div>
+
+        <Skeleton className="rounded-xl" style={{ height: MEMBER_BOX_HEIGHT }} />
+        <Skeleton className="rounded-xl" style={{ height: MEETING_BOX_HEIGHT }} />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/(role)/team/(dashboard)/page.tsx
+++ b/src/app/(shell)/(role)/team/(dashboard)/page.tsx
@@ -1,0 +1,113 @@
+import type { Metadata } from "next";
+
+import { DashboardMeetingItem } from "@/components/common/dashboard-meeting-item";
+import { Table, TableBody, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { KpiCard } from "@/features/team/components/kpi-card";
+import { MemberStatusRow } from "@/features/team/components/member-status-row";
+import { MEETING_BOX_HEIGHT, MEMBER_BOX_HEIGHT } from "@/features/team/lib";
+import { getTeamDashboardOverview } from "@/features/team/server";
+
+export const metadata: Metadata = {
+  title: "대시보드",
+};
+
+export default async function TeamDashboardPage() {
+  const {
+    teamName,
+    teamActionCount,
+    memberActionCount,
+    myActionCount,
+    doneActionCount,
+    members,
+    meetings,
+  } = await getTeamDashboardOverview();
+
+  const kpis = [
+    { label: "팀 액션", value: String(teamActionCount), sub: "진행 중" },
+    {
+      label: "팀원 액션",
+      value: String(memberActionCount),
+      sub: "팀 액션 기준",
+      tone: "accent" as const,
+    },
+    { label: "내 액션", value: String(myActionCount), sub: "처리 예정" },
+    { label: "완료 액션", value: String(doneActionCount), sub: "내 누적" },
+  ];
+
+  return (
+    <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
+      <div className="mx-auto flex w-full max-w-[1080px] flex-col gap-4">
+        <div className="grid grid-cols-4 gap-3">
+          {kpis.map((kpi) => (
+            <KpiCard key={kpi.label} {...kpi} />
+          ))}
+        </div>
+
+        <section
+          className="border-border bg-card flex flex-col overflow-hidden rounded-xl border"
+          style={{ height: MEMBER_BOX_HEIGHT }}
+        >
+          <div className="border-border flex shrink-0 items-center justify-between border-b px-4 py-3">
+            <h2 className="text-sm font-semibold">팀원 현황</h2>
+            <span className="text-muted-foreground text-xs">
+              {teamName} · {members.length}명
+            </span>
+          </div>
+          {members.length === 0 ? (
+            <p className="text-muted-foreground flex flex-1 items-center justify-center text-sm">
+              아직 등록된 팀원이 없습니다.
+            </p>
+          ) : (
+            <div className="scrollbar-hidden flex-1 overflow-auto [&_[data-slot=table-container]]:overflow-visible">
+              <Table className="min-w-[560px] table-fixed">
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="text-muted-foreground pl-4 text-xs">이름</TableHead>
+                    <TableHead className="text-muted-foreground text-center text-xs">
+                      직급
+                    </TableHead>
+                    <TableHead className="text-muted-foreground text-center text-xs">
+                      역할
+                    </TableHead>
+                    <TableHead className="text-muted-foreground text-center text-xs">
+                      담당 액션 수
+                    </TableHead>
+                    <TableHead className="text-muted-foreground pr-4 text-center text-xs">
+                      상태
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {members.map((member) => (
+                    <MemberStatusRow key={member.id} member={member} />
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </section>
+
+        <section
+          className="border-border bg-card flex flex-col overflow-hidden rounded-xl border"
+          style={{ height: MEETING_BOX_HEIGHT }}
+        >
+          <div className="border-border flex shrink-0 items-center justify-between border-b px-4 py-3">
+            <h2 className="text-sm font-semibold">최근 팀 회의</h2>
+            <span className="text-muted-foreground text-xs">최신 5건</span>
+          </div>
+          {meetings.length === 0 ? (
+            <p className="text-muted-foreground flex flex-1 items-center justify-center text-sm">
+              예정된 팀 회의가 없습니다.
+            </p>
+          ) : (
+            <ul className="flex-1 overflow-hidden">
+              {meetings.map((meeting, index) => (
+                <DashboardMeetingItem key={meeting.id} meeting={meeting} showDivider={index > 0} />
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/features/team/components/kpi-card.tsx
+++ b/src/features/team/components/kpi-card.tsx
@@ -1,0 +1,30 @@
+import { cn } from "@/lib/utils";
+
+interface KpiCardProps {
+  label: string;
+  value: string;
+  sub: string;
+  /** 강조색 — 없으면 기본 텍스트색 */
+  tone?: "accent" | "danger" | "warning";
+}
+
+/** 대시보드 상단 KPI 4카드가 공유하는 한 칸. */
+export function KpiCard({ label, value, sub, tone }: KpiCardProps) {
+  return (
+    <div className="border-border bg-card flex flex-col gap-1.5 rounded-xl border p-4">
+      <p className="text-muted-foreground text-xs leading-4">{label}</p>
+      <p
+        className={cn(
+          "text-xl leading-7 font-semibold tabular-nums",
+          tone === "accent" && "text-primary",
+          tone === "danger" && "text-destructive",
+          tone === "warning" && "text-warning",
+          !tone && "text-foreground",
+        )}
+      >
+        {value}
+      </p>
+      <p className="text-muted-foreground/70 text-[11px] leading-4">{sub}</p>
+    </div>
+  );
+}

--- a/src/features/team/components/member-status-row.tsx
+++ b/src/features/team/components/member-status-row.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { TableCell, TableRow } from "@/components/ui/table";
+import { MEMBER_STATUS, MEMBER_STATUS_LABEL } from "@/constants/domain";
+import type { TeamDashboardMember } from "@/features/team/types";
+import { useProfileAvatar } from "@/hooks/use-profile-avatar";
+
+interface MemberStatusRowProps {
+  member: TeamDashboardMember;
+}
+
+/**
+ * "팀원 현황" 테이블의 한 행. `<TableBody>` 안에서만 쓴다(루트가 `<tr>`).
+ * 아바타 색은 하드코딩하지 않고 팀 공용 `useProfileAvatar`(id 해시)로 만든다.
+ */
+export function MemberStatusRow({ member }: MemberStatusRowProps) {
+  const avatar = useProfileAvatar(member.name, member.id, 28);
+  const isOnVacation = member.status === MEMBER_STATUS.VACATION;
+
+  return (
+    <TableRow className="h-14">
+      <TableCell className="pl-4">
+        <div className="flex items-center gap-2">
+          {avatar}
+          <span className="truncate">{member.name}</span>
+        </div>
+      </TableCell>
+      <TableCell className="text-muted-foreground text-center">{member.position}</TableCell>
+      <TableCell className="text-muted-foreground text-center">{member.role}</TableCell>
+      <TableCell className="text-muted-foreground text-center font-mono tabular-nums">
+        {member.assignedActionCount}건
+      </TableCell>
+      <TableCell className="pr-4 text-center">
+        <Badge
+          variant={isOnVacation ? "outline" : "secondary"}
+          className={isOnVacation ? "border-warning text-warning" : undefined}
+        >
+          {MEMBER_STATUS_LABEL[member.status]}
+        </Badge>
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/src/features/team/lib.ts
+++ b/src/features/team/lib.ts
@@ -1,0 +1,18 @@
+import { MEETING_ITEM_HEIGHT } from "@/components/common/dashboard-meeting-item";
+
+/*
+ * 대시보드 두 박스의 고정 높이(px). `page.tsx`와 `loading.tsx`가 같은 골격을 그려야 해서
+ * 여기 한 곳에 둔다. **고정 높이 + 내부 스크롤**이라 데이터가 없어도 박스가 찌그러지지 않고,
+ * 많아도 박스가 무한정 길어지지 않는다.
+ */
+
+/** 팀원 현황 박스 — 인원 가변 → 고정 높이 + 넘치면 내부 스크롤. */
+export const MEMBER_BOX_HEIGHT = 320;
+
+/** 회의 위젯 최대 노출 수. 서버가 이만큼 자르고, 박스도 이 수에 맞춰 높이를 잡아 스크롤이 안 생긴다. */
+export const MEETING_MAX_ITEMS = 5;
+
+/** 두 박스 공통 헤더 높이(px) — `px-4 py-3` + 아래 보더 1px. */
+const BOX_HEADER_HEIGHT = 45;
+
+export const MEETING_BOX_HEIGHT = BOX_HEADER_HEIGHT + MEETING_MAX_ITEMS * MEETING_ITEM_HEIGHT;

--- a/src/features/team/mock/dashboard.ts
+++ b/src/features/team/mock/dashboard.ts
@@ -1,0 +1,97 @@
+import { MEETING_STATUS, MEMBER_STATUS } from "@/constants/domain";
+
+import type { TeamDashboardOverview } from "../types";
+
+/**
+ * ⚠️ 목 데이터 — BE 연동 전(ERD·API 스펙 미확정, DECISIONS.md).
+ * 로그인 팀장 = 김서준(개발팀장) 기준. 팀원 = 이하윤·박도현.
+ * 회의 개설 라벨은 부서명("개발팀")이다(오너 대시보드의 "Owner" 자리).
+ */
+export const TEAM_DASHBOARD_MOCK: TeamDashboardOverview = {
+  teamName: "개발팀",
+  // 팀 액션 3개: 앱 개발 착수 · 결제 시스템 연동(GOODS) · 협업툴 리뉴얼 착수(COLLAB)
+  teamActionCount: 3,
+  memberActionCount: 6,
+  myActionCount: 1,
+  doneActionCount: 0,
+  members: [
+    {
+      id: "member-lee",
+      name: "이하윤",
+      position: "선임",
+      role: "프론트엔드",
+      assignedActionCount: 3,
+      status: MEMBER_STATUS.ACTIVE,
+    },
+    {
+      id: "member-park",
+      name: "박도현",
+      position: "주임",
+      role: "백엔드",
+      assignedActionCount: 2,
+      status: MEMBER_STATUS.ACTIVE,
+    },
+  ],
+  meetings: [
+    {
+      id: "tm1",
+      title: "앱 개발 착수 - 기획 회의",
+      projectTag: "GOODS",
+      color: "#7C3AED",
+      status: MEETING_STATUS.DONE,
+      room: "회의실 A",
+      scheduledAt: "2026-07-31T10:00:00",
+      attendeeCount: 3,
+      originLabel: "개발팀",
+      hostLabel: "김서준(팀장)",
+    },
+    {
+      id: "tm2",
+      title: "결제 시스템 연동 - 착수 회의",
+      projectTag: "GOODS",
+      color: "#7C3AED",
+      status: MEETING_STATUS.DONE,
+      room: "회의실 B",
+      scheduledAt: "2026-08-03T14:00:00",
+      attendeeCount: 3,
+      originLabel: "개발팀",
+      hostLabel: "김서준(팀장)",
+    },
+    {
+      id: "tm3",
+      title: "협업툴 리뉴얼 - 스프린트 플래닝",
+      projectTag: "COLLAB",
+      color: "#2563EB",
+      status: MEETING_STATUS.IN_PROGRESS,
+      room: "회의실 A",
+      scheduledAt: "2026-08-05T11:00:00",
+      attendeeCount: 3,
+      originLabel: "개발팀",
+      hostLabel: "이하윤",
+    },
+    {
+      id: "tm4",
+      title: "인증 모듈 설계 리뷰",
+      projectTag: "GOODS",
+      color: "#7C3AED",
+      status: MEETING_STATUS.SCHEDULED,
+      room: "회의실 C",
+      scheduledAt: "2026-08-08T15:00:00",
+      attendeeCount: 2,
+      originLabel: "개발팀",
+      hostLabel: "박도현",
+    },
+    {
+      id: "tm5",
+      title: "실시간 알림 아키텍처 논의",
+      projectTag: "COLLAB",
+      color: "#2563EB",
+      status: MEETING_STATUS.SCHEDULED,
+      room: "회의실 B",
+      scheduledAt: "2026-08-11T10:00:00",
+      attendeeCount: 2,
+      originLabel: "개발팀",
+      hostLabel: "이하윤",
+    },
+  ],
+};

--- a/src/features/team/server.ts
+++ b/src/features/team/server.ts
@@ -1,0 +1,19 @@
+import { MEETING_MAX_ITEMS } from "./lib";
+import { TEAM_DASHBOARD_MOCK } from "./mock/dashboard";
+import type { TeamDashboardOverview } from "./types";
+
+// ⚠️ ERD·API 스펙 미확정(BE 협의 전) — 지금은 목 고정. 확정되면 이 분기만 손댄다.
+const isMock = true;
+
+export async function getTeamDashboardOverview(): Promise<TeamDashboardOverview> {
+  if (isMock) {
+    return {
+      ...TEAM_DASHBOARD_MOCK,
+      // 최신순(내림차순)으로 위에서부터. 박스가 이 수에 딱 맞춰 그려지므로 서버도 같은 수로 자른다.
+      meetings: [...TEAM_DASHBOARD_MOCK.meetings]
+        .sort((a, b) => new Date(b.scheduledAt).getTime() - new Date(a.scheduledAt).getTime())
+        .slice(0, MEETING_MAX_ITEMS),
+    };
+  }
+  throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
+}

--- a/src/features/team/types.ts
+++ b/src/features/team/types.ts
@@ -1,0 +1,34 @@
+import type { DashboardMeeting } from "@/components/common/dashboard-meeting-item";
+import type { MemberStatus } from "@/constants/domain";
+
+export interface TeamDashboardMember {
+  id: string;
+  name: string;
+  /** 직급 (예: "선임") */
+  position: string;
+  /** 부서 내 세부 역할 (예: "프론트엔드"). 온보딩에서 사원마다 반드시 지정된다 */
+  role: string;
+  /** 담당 액션 수 — 대시보드 요약 지표라 집계된 값을 그대로 받는다 */
+  assignedActionCount: number;
+  status: MemberStatus;
+}
+
+export interface TeamDashboardOverview {
+  /** 로그인한 팀장의 부서명 (예: "개발팀") */
+  teamName: string;
+  /**
+   * 팀에 하달된 **팀 액션** 개수. ⚠️ "팀 프로젝트"가 아니다 — 프로젝트는 Owner만 개설하고,
+   * 한 프로젝트가 팀 액션을 여러 개 줄 수 있고 여러 프로젝트에서 팀 액션이 나오므로
+   * "프로젝트 단위"로 셀 수 없다. 팀이 가진 팀 액션 총합만 센다.
+   */
+  teamActionCount: number;
+  /** 팀원 액션 수 (팀 액션 기준 — 팀에 하달된 개인 액션 총합) */
+  memberActionCount: number;
+  /** 팀장 본인 담당 액션 수 */
+  myActionCount: number;
+  /** 팀 누적 완료 액션 수 */
+  doneActionCount: number;
+  members: TeamDashboardMember[];
+  /** 이 팀의 회의만 — 개설 라벨은 부서명(예: "개발팀"). 팀 액션 회의는 여기 안 나온다 */
+  meetings: DashboardMeeting[];
+}


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [x] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [x] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- LEADER 로그인 후 첫 화면인 **팀장 대시보드(`/team`)** 구현 — 오너 대시보드와 동일한 디자인 양식(KPI 4 + 카드 박스 2개)
- **KPI 4** — 팀 액션 · 팀원 액션 · 내 액션 · 완료 액션. ⚠️ "팀 프로젝트"가 아니라 **"팀 액션"**(프로젝트는 Owner만 개설, 팀 액션은 여러 프로젝트에서 복수 도출되므로 프로젝트 단위로 셀 수 없음)
- **팀원 현황** 테이블 — 이름 · 직급 · 역할 · 담당 액션 수 · 상태. 고정 높이 + 내부 스크롤(데이터 0/과다 방어), `table-fixed` 균등 간격
- **최근 팀 회의** — 최신 5건. **대시보드 공용 회의 아이템** 사용, 라벨 2단 = 소속(부서명) + 개설자(팀장이면 "김서준(팀장)", 팀원이면 이름)
- `features/team/`(types·lib·mock·server·components) + `(shell)/(role)/team/(dashboard)/`(page·layout·loading·error) 신설, 격리막 구조

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/team-dashboard#118`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [x] 🔐 권한 2축 — `/team`은 base role LEADER 전용(본인 부서 스코프). 대시보드는 조회 전용이라 리소스 소유권 조건 없음. BE 연동 시 서버 재검사 예정
- [ ] 🧬 zod — ⚠️ 미적용. ERD·API 미확정 목 단계라 스키마를 지어내지 않음. 연동 시 매퍼에 `safeParse` 추가 예정
- [x] 🕵️ 정직성 — 목 데이터·미구현 라우트 주석 명시, 빈 상태 문구 처리
- [x] 🎨 디자인 토큰 사용 (프로젝트 태그 색만 자유 HEX = 정책 허용, 후속 토큰화 예정)

**품질**

- [x] ⚡ 최적화 — Server Component 조회, 시맨틱 태그
- [x] ♿ a11y — h1 1개 + 섹션 h2, 클릭은 Link
- [x] ♻️ 재사용 확인 — 회의 아이템은 **공용 컴포넌트**(`components/common/dashboard-meeting-item`) 사용, ui(Table·Badge)·`useProfileAvatar`·`ScreenError` 재사용
- [x] 🧪 loading / error / empty 3상태
- [x] 브라우저 전용 API — 해당 없음

---

## 🔗 연관 이슈

Closes #118

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- ⚠️ **이 PR의 base는 `develop`이 아니라 `feature/owner-dashboard#82`**(PR #102) 입니다. 팀 대시보드가 그 PR에서 만든 **공용 회의 아이템**(`components/common/dashboard-meeting-item.tsx`)에 의존하기 때문입니다. **#102가 develop에 머지되면 GitHub가 이 PR의 base를 develop으로 자동 리타겟**하고, diff는 팀 변경분만 남습니다. 머지 순서: **#102 → #118**.
- 피그마의 "팀원 진행 현황" 리스트는 하나의 기준 분류라 팀 액션·팀원이 늘면 지저분해지는 확장성 문제로 **제외**하고, 오너와 동일한 "최근 팀 회의" 박스로 대체한 판단.
- 회의 아이템 2단 라벨(소속 + 개설자) 규칙이 나중 회의 목록/탭에도 확장 가능한지.

---

## 📝 추가 메모

- 셸(LEADER 사이드바 역할 전환)은 팀원이 별도 작업 중이라 이 PR 범위 밖. 지금 로컬에선 셸이 OWNER 고정이라 `/team`도 오너 사이드바로 보이지만, 셸 머지되면 팀장 네비로 전환됨.
- 박스 높이는 고정 + 내부 스크롤(스크롤바 숨김) — 데이터 0/과다 양쪽 방어.

