### PR TITLE
[FEAT] 사원 대시보드 화면 #122

### DIFF
--- a/src/app/(shell)/(role)/my/(dashboard)/error.tsx
+++ b/src/app/(shell)/(role)/my/(dashboard)/error.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { ScreenError } from "@/components/common/screen-error";
+
+export default function Error({ reset }: { reset: () => void }) {
+  return <ScreenError title="대시보드를 불러오지 못했습니다" reset={reset} />;
+}

--- a/src/app/(shell)/(role)/my/(dashboard)/layout.tsx
+++ b/src/app/(shell)/(role)/my/(dashboard)/layout.tsx
@@ -1,0 +1,14 @@
+import { LayoutDashboard } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { PageHeader } from "@/features/shell/components/page-header";
+
+/** 사원 대시보드 상단바 — 사이드바에서 바로 닿는 화면이라 backTo는 두지 않는다. */
+export default function MemberDashboardLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <PageHeader title="대시보드" icon={LayoutDashboard} />
+      {children}
+    </>
+  );
+}

--- a/src/app/(shell)/(role)/my/(dashboard)/loading.tsx
+++ b/src/app/(shell)/(role)/my/(dashboard)/loading.tsx
@@ -1,0 +1,14 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { MEETING_BOX_HEIGHT } from "@/features/member/lib";
+
+/** 대시보드를 불러오는 동안. 실제 화면과 같은 골격(위 D-7 채움 + 아래 회의 고정)이라 흔들리지 않는다. */
+export default function Loading() {
+  return (
+    <main className="scrollbar-hidden flex min-h-0 flex-1 flex-col overflow-y-auto px-8 py-7">
+      <div className="mx-auto flex min-h-0 w-full max-w-[1080px] flex-1 flex-col gap-4">
+        <Skeleton className="min-h-0 flex-1 rounded-xl" />
+        <Skeleton className="shrink-0 rounded-xl" style={{ height: MEETING_BOX_HEIGHT }} />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/(role)/my/(dashboard)/page.tsx
+++ b/src/app/(shell)/(role)/my/(dashboard)/page.tsx
@@ -1,0 +1,64 @@
+import type { Metadata } from "next";
+
+import { DashboardMeetingItem } from "@/components/common/dashboard-meeting-item";
+import { MemberActionItem } from "@/features/member/components/member-action-item";
+import { DUE_SOON_BOX_MIN_HEIGHT, MEETING_BOX_HEIGHT } from "@/features/member/lib";
+import { getMemberDashboardOverview } from "@/features/member/server";
+
+export const metadata: Metadata = {
+  title: "대시보드",
+};
+
+export default async function MemberDashboardPage() {
+  const { dueSoonActions, attendedMeetings } = await getMemberDashboardOverview();
+
+  return (
+    <main className="scrollbar-hidden flex min-h-0 flex-1 flex-col overflow-y-auto px-8 py-7">
+      <div className="mx-auto flex min-h-0 w-full max-w-[1080px] flex-1 flex-col gap-4">
+        {/* D-7 액션 — 남는 세로 공간을 채우고(최소 높이 보장) 넘치면 내부 스크롤 */}
+        <section
+          className="border-border bg-card flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border"
+          style={{ minHeight: DUE_SOON_BOX_MIN_HEIGHT }}
+        >
+          <div className="border-border flex shrink-0 items-center justify-between border-b px-4 py-3">
+            <h2 className="text-sm font-semibold">D-7 액션</h2>
+            <span className="text-muted-foreground text-xs">마감 임박·연체</span>
+          </div>
+          {dueSoonActions.length === 0 ? (
+            <p className="text-muted-foreground flex flex-1 items-center justify-center text-sm">
+              마감이 임박한 액션이 없습니다.
+            </p>
+          ) : (
+            <ul className="scrollbar-hidden flex-1 overflow-y-auto">
+              {dueSoonActions.map((action, index) => (
+                <MemberActionItem key={action.id} action={action} showDivider={index > 0} />
+              ))}
+            </ul>
+          )}
+        </section>
+
+        {/* 참석 회의 — 최신 5건 고정 */}
+        <section
+          className="border-border bg-card flex shrink-0 flex-col overflow-hidden rounded-xl border"
+          style={{ height: MEETING_BOX_HEIGHT }}
+        >
+          <div className="border-border flex shrink-0 items-center justify-between border-b px-4 py-3">
+            <h2 className="text-sm font-semibold">참석 회의</h2>
+            <span className="text-muted-foreground text-xs">최신 5건</span>
+          </div>
+          {attendedMeetings.length === 0 ? (
+            <p className="text-muted-foreground flex flex-1 items-center justify-center text-sm">
+              참석할 회의가 없습니다.
+            </p>
+          ) : (
+            <ul className="flex-1 overflow-hidden">
+              {attendedMeetings.map((meeting, index) => (
+                <DashboardMeetingItem key={meeting.id} meeting={meeting} showDivider={index > 0} />
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/features/member/components/member-action-item.tsx
+++ b/src/features/member/components/member-action-item.tsx
@@ -1,0 +1,87 @@
+import Link from "next/link";
+
+import {
+  ACTION_STATUS,
+  ACTION_STATUS_LABEL,
+  type ActionStatus,
+  isDelayed,
+} from "@/constants/domain";
+import { formatDday } from "@/features/member/lib";
+import type { MemberAction } from "@/features/member/types";
+import { cn } from "@/lib/utils";
+
+/**
+ * 상태 색 — 지연=빨강(마감 경과)·진행중=초록·할일=회색(CLAUDE.md §디자인 토큰).
+ * 완료는 D-7 박스에 안 오므로 다루지 않는다.
+ */
+const STATUS_TONE: Record<ActionStatus, string> = {
+  [ACTION_STATUS.TODO]: "bg-muted text-muted-foreground",
+  [ACTION_STATUS.IN_PROGRESS]: "bg-success/12 text-success",
+  [ACTION_STATUS.DONE]: "bg-muted text-muted-foreground",
+};
+
+interface MemberActionItemProps {
+  action: MemberAction;
+  /** 목록의 첫 항목이 아니면 위쪽 구분선을 그린다 */
+  showDivider: boolean;
+}
+
+/**
+ * 내 액션 한 줄 — 회의 아이템과 같은 결.
+ * 좌: 프로젝트 색 막대 · 액션명 · 프로젝트 태그 / 우: 마감일(D-day) · 상태 라벨.
+ * ⚠️ 팀명·담당자는 두지 않는다(내 대시보드에선 항상 나·내 팀이라 중복).
+ */
+export function MemberActionItem({ action, showDivider }: MemberActionItemProps) {
+  const delayed = isDelayed(action);
+  const statusLabel = delayed ? "지연" : ACTION_STATUS_LABEL[action.status];
+  const statusTone = delayed ? "bg-destructive/10 text-destructive" : STATUS_TONE[action.status];
+
+  return (
+    <li className={cn("h-14", showDivider && "border-border border-t")}>
+      <Link
+        href={`/app/actions/${action.id}`}
+        className="hover:bg-muted flex h-full items-center transition-colors"
+      >
+        {/* 프로젝트 색 왼쪽 막대 — 행 위아래 끝에 딱 붙는 얇은 세로선 */}
+        <span
+          className="h-full w-1 shrink-0"
+          style={{ backgroundColor: action.color }}
+          aria-hidden
+        />
+
+        <div className="flex min-w-0 flex-1 items-center gap-3 px-4">
+          {/* 좌: 액션명 + 프로젝트 태그 */}
+          <div className="flex min-w-0 flex-1 items-center gap-2">
+            <span className="truncate text-sm">{action.title}</span>
+            <span
+              className="shrink-0 rounded px-1.5 py-0.5 font-mono text-[10px] font-semibold"
+              style={{ backgroundColor: `${action.color}1a`, color: action.color }}
+            >
+              {action.projectTag}
+            </span>
+          </div>
+
+          {/* 우: 마감일(D-day) + 상태 라벨 */}
+          <div className="flex shrink-0 items-center gap-3">
+            <span
+              className={cn(
+                "font-mono text-xs tabular-nums",
+                delayed ? "text-destructive" : "text-muted-foreground",
+              )}
+            >
+              {formatDday(action.dueDate)}
+            </span>
+            <span
+              className={cn(
+                "inline-flex h-5 shrink-0 items-center rounded-full px-2 text-xs font-medium",
+                statusTone,
+              )}
+            >
+              {statusLabel}
+            </span>
+          </div>
+        </div>
+      </Link>
+    </li>
+  );
+}

--- a/src/features/member/lib.ts
+++ b/src/features/member/lib.ts
@@ -1,0 +1,43 @@
+import { MEETING_ITEM_HEIGHT } from "@/components/common/dashboard-meeting-item";
+import { ACTION_STATUS, type ActionStatus } from "@/constants/domain";
+
+/**
+ * D-7 박스 최소 높이(px). 뷰포트를 채우도록 flex로 늘어나되, 짧은 화면에서도 이 높이는 보장한다.
+ * 회의 박스는 아래에 고정으로 붙고, 이 박스가 남는 세로 공간을 채운 뒤 내부 스크롤한다.
+ */
+export const DUE_SOON_BOX_MIN_HEIGHT = 280;
+
+/** 참석 회의 최대 노출 수 */
+export const MEETING_MAX_ITEMS = 5;
+
+/** 두 박스 공통 헤더 높이(px) — `px-4 py-3` + 아래 보더 1px. */
+const BOX_HEADER_HEIGHT = 45;
+
+/** 참석 회의 박스 — 최신 5건에 딱 맞춰 고정(스크롤 없음). 아이템 높이는 공용 컴포넌트가 정본. */
+export const MEETING_BOX_HEIGHT = BOX_HEADER_HEIGHT + MEETING_MAX_ITEMS * MEETING_ITEM_HEIGHT;
+
+/**
+ * 마감까지 남은 일수 — 파생값이라 저장하지 않고 계산한다(CLAUDE.md §도메인 상수).
+ * ⚠️ 날짜 전용 값을 UTC가 아니라 로컬 자정으로 파싱하려고 `T00:00:00`을 붙인다.
+ */
+export function getDaysUntilDue(dateIso: string): number {
+  const due = new Date(`${dateIso}T00:00:00`);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return Math.round((due.getTime() - today.getTime()) / 86_400_000);
+}
+
+/** D-day 라벨 — 오늘=`D-day`, 미래=`D-n`, 연체=`D+n`. */
+export function formatDday(dateIso: string): string {
+  const days = getDaysUntilDue(dateIso);
+  if (days === 0) return "D-day";
+  return days > 0 ? `D-${days}` : `D+${-days}`;
+}
+
+/**
+ * D-7 박스 대상 여부 — **미완료이면서 마감이 7일 이내(연체 포함)**.
+ * 연체(음수)도 가장 급하므로 포함한다.
+ */
+export function isDueSoon(action: { status: ActionStatus; dueDate: string }): boolean {
+  return action.status !== ACTION_STATUS.DONE && getDaysUntilDue(action.dueDate) <= 7;
+}

--- a/src/features/member/mock/dashboard.ts
+++ b/src/features/member/mock/dashboard.ts
@@ -1,0 +1,142 @@
+import type { DashboardMeeting } from "@/components/common/dashboard-meeting-item";
+import { ACTION_STATUS, MEETING_STATUS } from "@/constants/domain";
+
+import type { MemberAction } from "../types";
+
+/**
+ * ⚠️ 목 데이터 — BE 연동 전(ERD·API 스펙 미확정, DECISIONS.md).
+ * 로그인 사원 = 이하윤(개발팀·프론트엔드) 기준. 아래는 이하윤 본인의 액션·참석 회의다.
+ * 오늘(2026-08-05) 기준으로 마감 임박·연체가 섞이도록 날짜를 잡았다.
+ */
+
+/** 내 액션 전체 — 서버가 D-7 필터·정렬을 얹는다 */
+export const MEMBER_ACTIONS_MOCK: MemberAction[] = [
+  {
+    id: "ma1",
+    title: "로그인 폼 검증 로직 구현",
+    projectTag: "GOODS",
+    color: "#7C3AED",
+    status: ACTION_STATUS.IN_PROGRESS,
+    dueDate: "2026-08-03", // 연체(D+2)
+  },
+  {
+    id: "ma2",
+    title: "접근성 점검 - 키보드 내비게이션",
+    projectTag: "COLLAB",
+    color: "#2563EB",
+    status: ACTION_STATUS.IN_PROGRESS,
+    dueDate: "2026-08-04", // 연체(D+1)
+  },
+  {
+    id: "ma3",
+    title: "PG사 연동 문서 검토",
+    projectTag: "GOODS",
+    color: "#7C3AED",
+    status: ACTION_STATUS.TODO,
+    dueDate: "2026-08-06", // D-1
+  },
+  {
+    id: "ma4",
+    title: "온보딩 플로우 와이어프레임 검토",
+    projectTag: "GOODS",
+    color: "#7C3AED",
+    status: ACTION_STATUS.IN_PROGRESS,
+    dueDate: "2026-08-08", // D-3
+  },
+  {
+    id: "ma5",
+    title: "회원가입 API 연동",
+    projectTag: "GOODS",
+    color: "#7C3AED",
+    status: ACTION_STATUS.TODO,
+    dueDate: "2026-08-11", // D-6
+  },
+  {
+    id: "ma6",
+    title: "상품 목록 무한 스크롤 구현",
+    projectTag: "GOODS",
+    color: "#7C3AED",
+    status: ACTION_STATUS.TODO,
+    dueDate: "2026-08-12", // D-7
+  },
+  {
+    id: "ma7",
+    title: "실시간 알림 UI 작업",
+    projectTag: "COLLAB",
+    color: "#2563EB",
+    status: ACTION_STATUS.TODO,
+    dueDate: "2026-08-30", // D-25 (D-7 박스 제외)
+  },
+  {
+    id: "ma8",
+    title: "프로젝트 타임라인 화면 구현",
+    projectTag: "COLLAB",
+    color: "#2563EB",
+    status: ACTION_STATUS.TODO,
+    dueDate: "2026-09-21", // D-47 (D-7 박스 제외)
+  },
+];
+
+/** 내가 참석자로 지정된 회의 — 개설 라벨은 부서명("개발팀")+개설자 사람 */
+export const MEMBER_ATTENDED_MEETINGS_MOCK: DashboardMeeting[] = [
+  {
+    id: "mm1",
+    title: "앱 개발 착수 - 기획 회의",
+    projectTag: "GOODS",
+    color: "#7C3AED",
+    status: MEETING_STATUS.DONE,
+    room: "회의실 A",
+    scheduledAt: "2026-07-31T10:00:00",
+    attendeeCount: 3,
+    originLabel: "개발팀",
+    hostLabel: "김서준(팀장)",
+  },
+  {
+    id: "mm2",
+    title: "결제 시스템 연동 - 착수 회의",
+    projectTag: "GOODS",
+    color: "#7C3AED",
+    status: MEETING_STATUS.DONE,
+    room: "회의실 B",
+    scheduledAt: "2026-08-03T14:00:00",
+    attendeeCount: 3,
+    originLabel: "개발팀",
+    hostLabel: "김서준(팀장)",
+  },
+  {
+    id: "mm3",
+    title: "협업툴 리뉴얼 - 스프린트 플래닝",
+    projectTag: "COLLAB",
+    color: "#2563EB",
+    status: MEETING_STATUS.IN_PROGRESS,
+    room: "회의실 A",
+    scheduledAt: "2026-08-05T11:00:00",
+    attendeeCount: 3,
+    originLabel: "개발팀",
+    hostLabel: "김서준(팀장)",
+  },
+  {
+    id: "mm4",
+    title: "온보딩 플로우 리뷰",
+    projectTag: "GOODS",
+    color: "#7C3AED",
+    status: MEETING_STATUS.SCHEDULED,
+    room: "회의실 C",
+    scheduledAt: "2026-08-08T15:00:00",
+    attendeeCount: 2,
+    originLabel: "개발팀",
+    hostLabel: "이하윤",
+  },
+  {
+    id: "mm5",
+    title: "실시간 알림 아키텍처 논의",
+    projectTag: "COLLAB",
+    color: "#2563EB",
+    status: MEETING_STATUS.SCHEDULED,
+    room: "회의실 B",
+    scheduledAt: "2026-08-11T10:00:00",
+    attendeeCount: 2,
+    originLabel: "개발팀",
+    hostLabel: "박도현",
+  },
+];

--- a/src/features/member/server.ts
+++ b/src/features/member/server.ts
@@ -1,0 +1,22 @@
+import { getDaysUntilDue, isDueSoon, MEETING_MAX_ITEMS } from "./lib";
+import { MEMBER_ACTIONS_MOCK, MEMBER_ATTENDED_MEETINGS_MOCK } from "./mock/dashboard";
+import type { MemberDashboardOverview } from "./types";
+
+// ⚠️ ERD·API 스펙 미확정(BE 협의 전) — 지금은 목 고정. 확정되면 이 분기만 손댄다.
+const isMock = true;
+
+export async function getMemberDashboardOverview(): Promise<MemberDashboardOverview> {
+  if (isMock) {
+    return {
+      // 마감 7일 이내(연체 포함)·미완료만, 마감 임박순(연체가 맨 위). 개수 제한 없음 → 박스 내부 스크롤
+      dueSoonActions: MEMBER_ACTIONS_MOCK.filter(isDueSoon).sort(
+        (a, b) => getDaysUntilDue(a.dueDate) - getDaysUntilDue(b.dueDate),
+      ),
+      // 최신순 5건
+      attendedMeetings: [...MEMBER_ATTENDED_MEETINGS_MOCK]
+        .sort((a, b) => new Date(b.scheduledAt).getTime() - new Date(a.scheduledAt).getTime())
+        .slice(0, MEETING_MAX_ITEMS),
+    };
+  }
+  throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
+}

--- a/src/features/member/types.ts
+++ b/src/features/member/types.ts
@@ -1,0 +1,23 @@
+import type { DashboardMeeting } from "@/components/common/dashboard-meeting-item";
+import type { ActionStatus } from "@/constants/domain";
+
+/**
+ * 내 액션 한 건. ⚠️ 담당자·팀명은 담지 않는다 — 내 대시보드에선 담당자=항상 나,
+ * 팀명=항상 내 팀이라 중복·노이즈다. 어느 프로젝트에서 나온 일인지(`projectTag`)만 남긴다.
+ */
+export interface MemberAction {
+  id: string;
+  title: string;
+  projectTag: string;
+  /** 자유 HEX(프로젝트 태그 색) */
+  color: string;
+  status: ActionStatus;
+  dueDate: string;
+}
+
+export interface MemberDashboardOverview {
+  /** 마감 7일 이내(연체 포함)·미완료인 내 액션 — 마감 임박순. 개수 제한 없음(박스 내부 스크롤) */
+  dueSoonActions: MemberAction[];
+  /** 내가 참석자로 지정된 회의 최신 5건 */
+  attendedMeetings: DashboardMeeting[];
+}


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가
- [x] design — UI/UX 변경

---

## 🗂 작업 영역

- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독

---

## 🙋 관련 역할

- [x] MEMBER (사원)

---

## 📝 작업 내용

- MEMBER 로그인 후 첫 화면인 **사원 대시보드(`/my`)** 구현. 오너·팀 대시보드와 동일한 가로 전폭 카드 양식(피그마의 반반 2열은 미채택).
- **KPI 카드 없음** — 멤버는 비중복·유의미 4지표가 없어(내 액션·지연·완료는 되나 D-7/참석회의 KPI는 아래 박스와 중복) 제거.
- **D-7 액션 박스** — 내 액션 중 마감 7일 이내(연체 포함)·미완료만, 마감 임박순(연체 상단). 박스 최소 높이 + 뷰포트 채움(flex) + 내부 스크롤(스크롤바 숨김).
- **액션 아이템** — `액션명 [프로젝트 태그]` / 우측 `마감일(D-day)` + `상태 라벨`(지연=빨강/진행중=초록/할일=회색). **팀명·담당자 라벨 제외**(내 대시보드에선 항상 나·내 팀이라 중복). 회의 아이템과 같은 결.
- **참석 회의 박스** — 내가 참석자인 회의 최신 5건, 대시보드 공용 회의 아이템(소속=부서명 + 개설자 라벨).
- `features/member/` + `(shell)/(role)/my/(dashboard)/` 신설, 격리막 구조.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/member-dashboard#122`)
- [x] 커밋 컨벤션 준수
- [x] `Closes #` 기입
- [x] console·주석코드 없음
- [x] 민감 정보 없음

**Z 필수**

- [x] 🔐 권한 2축 — `/my`는 base role MEMBER 전용, 본인 액션·본인 참석 회의만. 조회 전용
- [ ] 🧬 zod — ⚠️ 미적용(ERD·API 미확정 목 단계). 연동 시 매퍼에 `safeParse`
- [x] 🕵️ 정직성 — 목 주석 명시, empty 문구 처리
- [x] 🎨 디자인 토큰 사용

**품질**

- [x] ⚡ Server Component 조회, 시맨틱 태그
- [x] ♿ a11y — h1/h2, 클릭은 Link
- [x] ♻️ 재사용 — 회의 아이템은 공용 컴포넌트 재사용
- [x] 🧪 loading / error / empty 3상태

---

## 🔗 연관 이슈

Closes #122

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- ⚠️ **base가 `develop`이 아니라 `feature/owner-dashboard#82`(PR #102)** — 공용 회의 아이템 의존. #102 머지 시 GitHub가 base를 develop로 자동 리타겟. 머지 순서: **#102 → (#118/#119, #122)**.
- KPI 제거 판단(멤버는 두 박스로 충분, 4지표 중복)과 내 액션에서 팀명·담당자 제외 판단.
- D-7 박스: 최소 높이 + flex 채움 + 내부 스크롤. 회의 박스(5건 고정)와 합쳐 세로 배치.

---

## 📝 추가 메모

- 셸(MEMBER 사이드바)은 팀원 별도 작업이라 범위 밖(지금 로컬은 오너 사이드바로 뜸).
- 액션 아이템은 현재 사원 대시보드 전용(member-local). 타 화면에서 필요해지면 회의 아이템처럼 공용 추출.
- D-7 박스 최소 높이는 `features/member/lib.ts`의 `DUE_SOON_BOX_MIN_HEIGHT`에서 조절.

