### PR TITLE
[FIX] base를 바꾼 PR은 CI가 돌지 않는다 #126

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,12 @@ name: CI
 on:
   pull_request:
     branches: [develop, main]
+    # ⚠️ `edited`를 넣는다. 기본값은 opened·synchronize·reopened뿐이라, **base를 바꾼 PR은
+    #    CI가 안 돈다** — base 변경은 `edited`로 온다. 실제로 팀장·사원 대시보드 PR이
+    #    다른 feature 브랜치를 base로 열려 CI가 한 번도 안 돌았고, develop으로 고친 뒤에도
+    #    새 푸시가 있기 전까지 검사 없이 머지 가능해 보였다.
+    #    `edited`는 제목·본문 수정에도 오지만, 그 경우 한 번 더 도는 게 안 도는 것보다 낫다.
+    types: [opened, synchronize, reopened, edited]
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
## 📋 PR 타입

- [x] chore — 설정/빌드 작업

---

## 🗂 작업 영역

- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

**base를 바꾼 PR은 CI가 돌지 않았습니다.**

`ci.yml`이 `pull_request`의 기본 이벤트(`opened` · `synchronize` · `reopened`)에서만 도는데, **base 브랜치 변경은 `edited`로 옵니다.**

### 실제로 겪은 일

`[FEAT] 팀장 대시보드 화면 #118`(#119)과 `[FEAT] 사원 대시보드 화면 #122`(#123)이 base를 `develop`이 아니라 `feature/owner-dashboard#82`로 열려 있었습니다.

| 시점 | 결과 |
| --- | --- |
| base가 `feature/owner-dashboard#82`일 때 | `branches: [develop, main]`에 안 걸림 → **CI가 한 번도 안 돎** |
| base를 `develop`으로 고친 뒤 | `edited` 이벤트라 **여전히 안 돎** |
| 그동안 PR 상태 | 검사를 한 번도 안 거쳤는데 **머지 가능해 보임** |

`feature/owner-dashboard#82`는 이미 develop에 머지된(`b101f3a`) 브랜치라, 그걸 base로 둔 두 PR은 diff도 실제보다 좁게 보였습니다.

### 고친 것

```yaml
on:
  pull_request:
    branches: [develop, main]
    types: [opened, synchronize, reopened, edited]
```

⚠️ `edited`는 제목·본문 수정에도 옵니다. 그래도 **한 번 더 도는 게 안 도는 것보다 낫습니다** — 안 도는 쪽은 검사 없이 머지되는 길을 열어 둡니다. `concurrency` + `cancel-in-progress: true`가 이미 있어 중복 실행은 앞의 것이 취소됩니다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`fix/ci-base-change-trigger#126`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 권한 2축 검사 — 해당 없음(워크플로우 설정, 런타임 코드 아님)
- [x] 🧬 zod — 스키마 무변경
- [x] 🕵️ **정직성** — 이 PR이 고치는 것 자체가 "검사 안 했는데 한 것처럼 보이는" 상태입니다
- [x] 🎨 디자인 토큰 — 해당 없음

**품질**

- [x] ⚡ 최적화 — 해당 없음
- [x] ♿ a11y — 해당 없음
- [x] ♻️ 재사용 확인 — 기존 워크플로우 한 곳만 고쳤습니다(새 파일 없음)
- [x] 🧪 loading / error / empty 3상태 — 화면 없음
- [x] 브라우저 전용 API — 사용 없음

---

## 🔗 연관 이슈

Closes #126

---

## 📸 스크린샷 (선택)

화면 변경이 없습니다. 대신 트리거 결과로 대신합니다.

| Before | After |
| ------ | ----- |
| `#119` · `#123` — CI 실행 이력 **0건** | 닫았다 다시 열어 `verify=SUCCESS` |

---

## 💬 리뷰 포인트

- **`edited`를 넣는 대신 필수 체크(Required status checks)로 막는 방법**도 있습니다. 브랜치 보호에서 `verify`를 필수로 걸면 CI가 안 돈 PR은 머지 자체가 막힙니다 — 그쪽이 더 확실하지만 레포 설정이라 이 PR로는 못 합니다. **둘 다 하는 게 맞다**고 봅니다.
- **`edited`가 제목·본문 수정에도 도는 것을 감수할지** — 실행 횟수가 늘어납니다. 아깝다면 `types` 대신 필수 체크만으로 가는 선택지도 있습니다.

---

## 📝 추가 메모

**확인한 것**

- `js-yaml`로 파싱해 `types`가 의도대로 들어갔는지 대조했습니다
- #119·#123은 급한 대로 **닫았다 다시 열어**(`reopened`) CI를 돌렸고, 둘 다 `verify=SUCCESS`입니다
- #119는 로컬에서 develop과 합쳐 미리 확인했습니다 — 충돌 0 · tsc 0 · lint 0 · 374개 테스트 통과

**남은 것** — base가 잘못 잡힌 PR이 또 생기지 않게 하려면 브랜치 보호의 필수 체크가 필요합니다. 레포 설정 권한이 있는 분이 봐 주세요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
