### PR TITLE
[FEAT] 개인 캘린더 — 상세 조회 리스트 아이템 마커 정렬 · 완료 상태 라벨 #133

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -45,3 +45,17 @@ if (!Element.prototype.setPointerCapture) {
 if (!Element.prototype.releasePointerCapture) {
   Element.prototype.releasePointerCapture = () => {};
 }
+
+/*
+  ⚠️ jsdom엔 ResizeObserver가 없다 — 목록 넘침을 감지하는 화면(`calendar-day-detail-panel.tsx`)이
+     실제로 이걸 쓴다. 크기 변화를 흉내 낼 필요는 없고, 생성·해제가 안 터지기만 하면 된다.
+*/
+if (typeof window !== "undefined" && !window.ResizeObserver) {
+  class ResizeObserverPolyfill {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  window.ResizeObserver = ResizeObserverPolyfill;
+}

--- a/src/app/(shell)/app/me/page.tsx
+++ b/src/app/(shell)/app/me/page.tsx
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
 export default function AppMePage() {
   return (
     <div className="flex-1 overflow-y-auto px-8 py-7">
-      <div className="mx-auto w-full max-w-[720px]">
+      <div className="mx-auto w-full max-w-[1440px]">
         <ScreenScaleCard />
       </div>
     </div>

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -11,10 +11,12 @@ function Checkbox({ className, ...props }: CheckboxProps) {
   return (
     <CheckboxPrimitive.Root
       data-slot="checkbox"
-      className={cn(
-        "peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground",
-        className
-      )}
+      className={(state) =>
+        cn(
+          "peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground",
+          typeof className === "function" ? className(state) : className
+        )
+      }
       {...props}
     >
       <CheckboxPrimitive.Indicator

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -5,12 +5,14 @@ import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox"
 import { cn } from "@/lib/utils"
 import { CheckIcon } from "lucide-react"
 
-function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
+interface CheckboxProps extends CheckboxPrimitive.Root.Props {}
+
+function Checkbox({ className, ...props }: CheckboxProps) {
   return (
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary",
+        "peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground",
         className
       )}
       {...props}

--- a/src/features/calendar/components/calendar-board.tsx
+++ b/src/features/calendar/components/calendar-board.tsx
@@ -46,6 +46,9 @@ function defaultSelectedDate(month: string): Date {
  *    (`items-stretch`) 오른쪽 패널의 `border-l`이 캘린더가 아니라 안쪽 콘텐츠 높이만큼만
  *    그려지는 문제가 있었다. 캘린더(`personal-calendar.tsx`)도 같은 계산 함수로 같은 값을
  *    쓰니 항상 일치한다.
+ * ⚠️ 이 고정 높이·좌우 배치는 **`lg` 이상에서만** 켠다. 좁은 화면에서 캘린더와 패널을
+ *    나란히 두면 둘 다 찌그러진다 — 그 아래에서는 위아래로 쌓고 높이도 내용에 맞춘다
+ *    (`--calendar-total-height`는 CSS 변수로만 내려두고, `lg:` 접두사가 붙은 높이 클래스로 그 폭에서만 켠다).
  */
 export function CalendarBoard({ initialEvents, month }: CalendarBoardProps) {
   const [events, setEvents] = useState(initialEvents);
@@ -84,7 +87,10 @@ export function CalendarBoard({ initialEvents, month }: CalendarBoardProps) {
   }
 
   return (
-    <div className="flex items-stretch gap-6" style={{ height: calendarHeight }}>
+    <div
+      className="flex flex-col gap-6 lg:h-[var(--calendar-total-height)] lg:flex-row lg:items-stretch"
+      style={{ "--calendar-total-height": calendarHeight } as React.CSSProperties}
+    >
       <div className="min-w-0 flex-1">
         <PersonalCalendarLoader
           events={events}

--- a/src/features/calendar/components/calendar-day-detail-panel.tsx
+++ b/src/features/calendar/components/calendar-day-detail-panel.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import { format } from "date-fns";
 import { ko } from "date-fns/locale";
+import { useEffect, useRef, useState } from "react";
 
 import type { PersonalCalendarEvent } from "../types";
 import { CalendarEventListItem } from "./calendar-event-list-item";
@@ -15,15 +18,42 @@ interface CalendarDayDetailPanelProps {
 /**
  * 캘린더 오른쪽에 고정으로 붙는 날짜 상세조회 패널. 셀 클릭마다 `calendar-board.tsx`가 이 props를 갈아 끼운다.
  * ⚠️ `lg` 미만에서는 캘린더 아래로 쌓인다(`calendar-board.tsx`) — 그때는 왼쪽 경계선 대신
- *    위쪽 경계선을 쓰고, 고정 높이 대신 최소 높이만 준다.
+ *    위쪽 경계선을 쓰고, 고정 높이 대신 최소 높이만 준다. 폭 제한(`max-w-[230px]`)도 `lg`에서만
+ *    건다 — 그 아래에서는 좁은 화면 전체를 다 쓴다.
  */
 export function CalendarDayDetailPanel({
   selectedDate,
   events,
   onToggleCompletion,
 }: CalendarDayDetailPanelProps) {
+  const listRef = useRef<HTMLUListElement>(null);
+  const [hasMoreBelow, setHasMoreBelow] = useState(false);
+
+  // ⚠️ 전역 규칙(globals.css)이 스크롤바를 감춘다 — 아래쪽 그라데이션으로 "더 있다"를 대신
+  //    알린다. 단, 실제로 넘칠 때만 — 짧은 목록엔 안 그리고, 끝까지 내리면 사라진다.
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+
+    function updateOverflow() {
+      if (!list) return;
+      const remaining = list.scrollHeight - list.clientHeight - list.scrollTop;
+      setHasMoreBelow(remaining > 1);
+    }
+
+    updateOverflow();
+    list.addEventListener("scroll", updateOverflow);
+    const resizeObserver = new ResizeObserver(updateOverflow);
+    resizeObserver.observe(list);
+
+    return () => {
+      list.removeEventListener("scroll", updateOverflow);
+      resizeObserver.disconnect();
+    };
+  }, [events]);
+
   return (
-    <aside className="border-border flex min-h-[240px] w-full max-w-[230px] shrink-0 flex-col border-t pt-6 lg:h-full lg:min-h-0 lg:w-[230px] lg:border-t-0 lg:border-l lg:pt-0 lg:pl-6">
+    <aside className="border-border flex min-h-[240px] w-full shrink-0 flex-col border-t pt-6 lg:h-full lg:min-h-0 lg:w-[230px] lg:max-w-[230px] lg:border-t-0 lg:border-l lg:pt-0 lg:pl-6">
       <div className="flex items-baseline justify-between gap-2 pb-4">
         <h2 className="text-base font-semibold">
           {format(selectedDate, "yyyy년 M월 d일(EEE)", { locale: ko })}
@@ -36,10 +66,8 @@ export function CalendarDayDetailPanel({
           이 날짜엔 일정이 없어요
         </p>
       ) : (
-        // ⚠️ 사이트 전역 규칙(globals.css)이 스크롤바를 감춘다 — 여기는 대신 아래쪽에
-        //    옅은 그라데이션을 얹어 "더 있을 수 있다"는 신호를 남긴다(막대 대신 갚는 방식).
         <div className="relative min-h-0 flex-1">
-          <ul className="flex h-full flex-col gap-2 overflow-y-auto">
+          <ul ref={listRef} className="flex h-full flex-col gap-2 overflow-y-auto">
             {events.map((event) => (
               <CalendarEventListItem
                 key={event.id}
@@ -48,10 +76,12 @@ export function CalendarDayDetailPanel({
               />
             ))}
           </ul>
-          <div
-            aria-hidden
-            className="from-card pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-gradient-to-t to-transparent"
-          />
+          {hasMoreBelow && (
+            <div
+              aria-hidden
+              className="from-card pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-gradient-to-t to-transparent"
+            />
+          )}
         </div>
       )}
     </aside>

--- a/src/features/calendar/components/calendar-day-detail-panel.tsx
+++ b/src/features/calendar/components/calendar-day-detail-panel.tsx
@@ -12,14 +12,18 @@ interface CalendarDayDetailPanelProps {
   onToggleCompletion?: (id: string) => void;
 }
 
-/** 캘린더 오른쪽에 고정으로 붙는 날짜 상세조회 패널. 셀 클릭마다 `calendar-board.tsx`가 이 props를 갈아 끼운다. */
+/**
+ * 캘린더 오른쪽에 고정으로 붙는 날짜 상세조회 패널. 셀 클릭마다 `calendar-board.tsx`가 이 props를 갈아 끼운다.
+ * ⚠️ `lg` 미만에서는 캘린더 아래로 쌓인다(`calendar-board.tsx`) — 그때는 왼쪽 경계선 대신
+ *    위쪽 경계선을 쓰고, 고정 높이 대신 최소 높이만 준다.
+ */
 export function CalendarDayDetailPanel({
   selectedDate,
   events,
   onToggleCompletion,
 }: CalendarDayDetailPanelProps) {
   return (
-    <aside className="border-border flex h-full w-full max-w-[230px] shrink-0 flex-col border-l pl-6 lg:w-[230px]">
+    <aside className="border-border flex min-h-[240px] w-full max-w-[230px] shrink-0 flex-col border-t pt-6 lg:h-full lg:min-h-0 lg:w-[230px] lg:border-t-0 lg:border-l lg:pt-0 lg:pl-6">
       <div className="flex items-baseline justify-between gap-2 pb-4">
         <h2 className="text-base font-semibold">
           {format(selectedDate, "yyyy년 M월 d일(EEE)", { locale: ko })}
@@ -32,15 +36,23 @@ export function CalendarDayDetailPanel({
           이 날짜엔 일정이 없어요
         </p>
       ) : (
-        <ul className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto">
-          {events.map((event) => (
-            <CalendarEventListItem
-              key={event.id}
-              event={event}
-              onToggleCompletion={onToggleCompletion}
-            />
-          ))}
-        </ul>
+        // ⚠️ 사이트 전역 규칙(globals.css)이 스크롤바를 감춘다 — 여기는 대신 아래쪽에
+        //    옅은 그라데이션을 얹어 "더 있을 수 있다"는 신호를 남긴다(막대 대신 갚는 방식).
+        <div className="relative min-h-0 flex-1">
+          <ul className="flex h-full flex-col gap-2 overflow-y-auto">
+            {events.map((event) => (
+              <CalendarEventListItem
+                key={event.id}
+                event={event}
+                onToggleCompletion={onToggleCompletion}
+              />
+            ))}
+          </ul>
+          <div
+            aria-hidden
+            className="from-card pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-gradient-to-t to-transparent"
+          />
+        </div>
       )}
     </aside>
   );

--- a/src/features/calendar/components/calendar-event-list-item.tsx
+++ b/src/features/calendar/components/calendar-event-list-item.tsx
@@ -18,32 +18,53 @@ export function CalendarEventListItem({ event, onToggleCompletion }: CalendarEve
   const isTodo = event.tag === CALENDAR_ITEM_TAG.PERSONAL_TODO;
 
   return (
-    <li className="border-border bg-card flex items-start gap-2 rounded-lg border p-3">
-      {isTodo ? (
-        <Checkbox
-          checked={event.isCompleted}
-          onCheckedChange={() => onToggleCompletion?.(event.id)}
-          aria-label={`${event.title} 완료 처리`}
-          className="mt-0.5 shrink-0"
-        />
-      ) : (
-        <span
-          aria-hidden
-          className="mt-1 size-2 shrink-0 rounded-full"
-          style={{ backgroundColor: event.color ?? CALENDAR_TAG_DOT_COLOR[event.tag] }}
-        />
-      )}
-      <div className="flex min-w-0 flex-col gap-0.5">
-        <p
-          className={cn(
-            "truncate text-sm font-medium",
-            event.isCompleted && "text-muted-foreground line-through",
+    <li className="border-border bg-card flex items-start justify-between gap-2 rounded-lg border p-3">
+      <div className="flex min-w-0 items-start gap-2">
+        {/*
+          ⚠️ 체크박스(16px)와 색점(8px)의 실제 크기가 달라서, 이 자리를 고정폭(size-4)으로
+          감싸지 않으면 제목 시작 x좌표가 항목 종류에 따라 흔들린다 — 둘 다 이 상자 안에서
+          가운데 정렬해 시작점을 맞춘다.
+        */}
+        <div className="mt-0.5 flex size-4 shrink-0 items-center justify-center">
+          {isTodo ? (
+            <Checkbox
+              checked={event.isCompleted}
+              onCheckedChange={() => onToggleCompletion?.(event.id)}
+              aria-label={`${event.title} 완료 처리`}
+            />
+          ) : (
+            <span
+              aria-hidden
+              className="size-2 rounded-full"
+              style={{ backgroundColor: event.color ?? CALENDAR_TAG_DOT_COLOR[event.tag] }}
+            />
           )}
-        >
-          {event.title}
-        </p>
-        <p className="text-muted-foreground text-xs">{CALENDAR_ITEM_TAG_LABEL[event.tag]}</p>
+        </div>
+
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <p
+            className={cn(
+              "truncate text-sm font-medium",
+              event.isCompleted && "text-muted-foreground line-through",
+            )}
+          >
+            {event.title}
+          </p>
+          <p className="text-muted-foreground text-xs">{CALENDAR_ITEM_TAG_LABEL[event.tag]}</p>
+        </div>
       </div>
+
+      {/* 진행중=초록 · 완료=보라 — globals.css의 상태점 색(`--status-progress`/`--status-done`) 그대로. */}
+      <span
+        className={cn(
+          "inline-flex h-5 shrink-0 items-center rounded-full px-2 text-xs font-medium whitespace-nowrap",
+          event.isCompleted
+            ? "bg-status-done/12 text-status-done"
+            : "bg-status-progress/12 text-status-progress",
+        )}
+      >
+        {event.isCompleted ? "완료" : "진행중"}
+      </span>
     </li>
   );
 }

--- a/src/features/calendar/components/calendar-event-list-item.tsx
+++ b/src/features/calendar/components/calendar-event-list-item.tsx
@@ -2,7 +2,12 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { cn } from "@/lib/utils";
 
 import { CALENDAR_TAG_DOT_COLOR } from "../tag-colors";
-import { CALENDAR_ITEM_TAG, CALENDAR_ITEM_TAG_LABEL, type PersonalCalendarEvent } from "../types";
+import {
+  CALENDAR_ITEM_TAG,
+  CALENDAR_ITEM_TAG_LABEL,
+  getCalendarCompletionLabel,
+  type PersonalCalendarEvent,
+} from "../types";
 
 interface CalendarEventListItemProps {
   event: PersonalCalendarEvent;
@@ -61,7 +66,7 @@ export function CalendarEventListItem({ event, onToggleCompletion }: CalendarEve
                 : "bg-status-progress/12 text-status-progress",
             )}
           >
-            {event.isCompleted ? "완료" : "진행중"}
+            {getCalendarCompletionLabel(event.isCompleted)}
           </span>
         </div>
       </div>

--- a/src/features/calendar/components/calendar-event-list-item.tsx
+++ b/src/features/calendar/components/calendar-event-list-item.tsx
@@ -18,53 +18,53 @@ export function CalendarEventListItem({ event, onToggleCompletion }: CalendarEve
   const isTodo = event.tag === CALENDAR_ITEM_TAG.PERSONAL_TODO;
 
   return (
-    <li className="border-border bg-card flex items-start justify-between gap-2 rounded-lg border p-3">
-      <div className="flex min-w-0 items-start gap-2">
-        {/*
-          ⚠️ 체크박스(16px)와 색점(8px)의 실제 크기가 달라서, 이 자리를 고정폭(size-4)으로
-          감싸지 않으면 제목 시작 x좌표가 항목 종류에 따라 흔들린다 — 둘 다 이 상자 안에서
-          가운데 정렬해 시작점을 맞춘다.
-        */}
-        <div className="mt-0.5 flex size-4 shrink-0 items-center justify-center">
-          {isTodo ? (
-            <Checkbox
-              checked={event.isCompleted}
-              onCheckedChange={() => onToggleCompletion?.(event.id)}
-              aria-label={`${event.title} 완료 처리`}
-            />
-          ) : (
-            <span
-              aria-hidden
-              className="size-2 rounded-full"
-              style={{ backgroundColor: event.color ?? CALENDAR_TAG_DOT_COLOR[event.tag] }}
-            />
-          )}
-        </div>
-
-        <div className="flex min-w-0 flex-col gap-0.5">
-          <p
-            className={cn(
-              "truncate text-sm font-medium",
-              event.isCompleted && "text-muted-foreground line-through",
-            )}
-          >
-            {event.title}
-          </p>
-          <p className="text-muted-foreground text-xs">{CALENDAR_ITEM_TAG_LABEL[event.tag]}</p>
-        </div>
+    <li className="border-border bg-card flex items-start gap-2 rounded-lg border p-3">
+      {/*
+        ⚠️ 체크박스(16px)와 색점(8px)의 실제 크기가 달라서, 이 자리를 고정폭(size-4)으로
+        감싸지 않으면 제목 시작 x좌표가 항목 종류에 따라 흔들린다 — 둘 다 이 상자 안에서
+        가운데 정렬해 시작점을 맞춘다.
+      */}
+      <div className="mt-0.5 flex size-4 shrink-0 items-center justify-center">
+        {isTodo ? (
+          <Checkbox
+            checked={event.isCompleted}
+            onCheckedChange={() => onToggleCompletion?.(event.id)}
+            aria-label={`${event.title} 완료 처리`}
+          />
+        ) : (
+          <span
+            aria-hidden
+            className="size-2 rounded-full"
+            style={{ backgroundColor: event.color ?? CALENDAR_TAG_DOT_COLOR[event.tag] }}
+          />
+        )}
       </div>
 
-      {/* 진행중=초록 · 완료=보라 — globals.css의 상태점 색(`--status-progress`/`--status-done`) 그대로. */}
-      <span
-        className={cn(
-          "inline-flex h-5 shrink-0 items-center rounded-full px-2 text-xs font-medium whitespace-nowrap",
-          event.isCompleted
-            ? "bg-status-done/12 text-status-done"
-            : "bg-status-progress/12 text-status-progress",
-        )}
-      >
-        {event.isCompleted ? "완료" : "진행중"}
-      </span>
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <p
+          className={cn(
+            "truncate text-sm font-medium",
+            event.isCompleted && "text-muted-foreground line-through",
+          )}
+        >
+          {event.title}
+        </p>
+
+        {/* 태그 라벨과 같은 줄, 오른쪽 끝 — 진행중=초록 · 완료=보라(globals.css 상태점 색 재사용). */}
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-muted-foreground text-xs">{CALENDAR_ITEM_TAG_LABEL[event.tag]}</p>
+          <span
+            className={cn(
+              "inline-flex h-5 shrink-0 items-center rounded-full px-2 text-xs font-medium whitespace-nowrap",
+              event.isCompleted
+                ? "bg-status-done/12 text-status-done"
+                : "bg-status-progress/12 text-status-progress",
+            )}
+          >
+            {event.isCompleted ? "완료" : "진행중"}
+          </span>
+        </div>
+      </div>
     </li>
   );
 }

--- a/src/features/calendar/components/calendar-toolbar.tsx
+++ b/src/features/calendar/components/calendar-toolbar.tsx
@@ -36,7 +36,9 @@ export function CalendarToolbar({ date, onNavigate, action }: CalendarToolbarPro
         >
           <ChevronLeft />
         </Button>
-        <p className="w-28 text-center text-base font-semibold tabular-nums">{monthLabel}</p>
+        <p className="w-28 shrink-0 text-center text-base font-semibold tabular-nums">
+          {monthLabel}
+        </p>
         <Button
           type="button"
           variant="outline"

--- a/src/features/calendar/components/calendar-toolbar.tsx
+++ b/src/features/calendar/components/calendar-toolbar.tsx
@@ -1,3 +1,5 @@
+import { format } from "date-fns";
+import { ko } from "date-fns/locale";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import type { ReactNode } from "react";
 import type { ToolbarProps } from "react-big-calendar";
@@ -12,8 +14,16 @@ interface CalendarToolbarProps extends ToolbarProps<PersonalCalendarEvent> {
   action?: ReactNode;
 }
 
-/** 커스텀 툴바 — 왼쪽에 `<` 라벨 `>`을 붙여 그리고, 오른쪽 끝엔 범례+액션을 한 줄로 둔다. */
-export function CalendarToolbar({ label, onNavigate, action }: CalendarToolbarProps) {
+/**
+ * 커스텀 툴바 — 왼쪽에 `<` 라벨 `>`을 붙여 그리고, 오른쪽 끝엔 범례+액션을 한 줄로 둔다.
+ * ⚠️ 라벨은 RBC가 주는 `label`(로케일 연결이 안 돼 "September 2026"처럼 영문으로 나온다) 대신
+ *    `date`로 직접 "2026년 9월" 꼴을 만든다(CLAUDE.md §카피: 날짜는 한글로).
+ * ⚠️ 라벨에 **고정 너비**를 준다 — "9월"·"12월"처럼 글자수가 달라지면 라벨 폭이 흔들려서
+ *    바로 옆 다음 달 버튼(`>`) 위치가 매번 바뀐다. 연속으로 눌러도 버튼이 같은 자리에 있어야 한다.
+ */
+export function CalendarToolbar({ date, onNavigate, action }: CalendarToolbarProps) {
+  const monthLabel = format(date, "yyyy년 M월", { locale: ko });
+
   return (
     <div className="mb-3 flex items-center justify-between">
       <div className="flex items-center gap-2">
@@ -26,7 +36,7 @@ export function CalendarToolbar({ label, onNavigate, action }: CalendarToolbarPr
         >
           <ChevronLeft />
         </Button>
-        <p className="text-base font-semibold">{label}</p>
+        <p className="w-28 text-center text-base font-semibold tabular-nums">{monthLabel}</p>
         <Button
           type="button"
           variant="outline"

--- a/src/features/calendar/components/personal-calendar.css
+++ b/src/features/calendar/components/personal-calendar.css
@@ -89,8 +89,13 @@
   cursor: default;
 }
 
+/*
+  ⚠️ 좌우 padding을 두면 막대가 셀 폭을 다 못 채운다 — 세그먼트 폭 자체가 RBC가 계산한
+  퍼센트(`flexBasis`/`maxWidth`)라서, 옆에 여백을 주는 순간 막대 우측 끝이 셀 경계까지
+  못 닿는다(브라우저별 서브픽셀 반올림이 겹치면 더 도드라진다). 위아래 간격만 남긴다.
+*/
 .rbc-row-segment {
-  padding: 0 2px 4px;
+  padding: 0 0 4px;
 }
 
 .rbc-event.rbc-selected,

--- a/src/features/calendar/types.ts
+++ b/src/features/calendar/types.ts
@@ -19,6 +19,16 @@ export const CALENDAR_ITEM_TAG_LABEL: Record<CalendarItemTag, string> = {
   PERSONAL_ACTION: "개인 액션",
 };
 
+/** 완료 여부 배지 문구 — Todo·액션 공통(`calendar-event-list-item.tsx`). */
+export const CALENDAR_COMPLETION_LABEL = {
+  DONE: "완료",
+  IN_PROGRESS: "진행중",
+} as const;
+
+export function getCalendarCompletionLabel(isCompleted: boolean): string {
+  return isCompleted ? CALENDAR_COMPLETION_LABEL.DONE : CALENDAR_COMPLETION_LABEL.IN_PROGRESS;
+}
+
 /** 캘린더 한 칸에 그려지는 항목. react-big-calendar의 start/end 접근자가 그대로 이 필드명을 쓴다. */
 export interface PersonalCalendarEvent {
   id: string;


### PR DESCRIPTION
## 📋 PR 타입

- [x] design — UI/UX 변경

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

- `src/features/calendar/components/calendar-event-list-item.tsx`:
  - 체크박스/색점을 `size-4` 고정 폭 컨테이너로 감싸 정렬 통일
  - 진행중(초록)/완료(보라) 상태 배지 추가(`--status-progress`/`--status-done` 토큰)

---

## ✅ 작업 체크리스트

**기본**

- [ ] 브랜치 명명 규칙 준수 (`fix/calendar-list-item-align#{이슈번호}` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [ ] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [ ] 🔐 권한 2축 검사 — 해당 없음
- [ ] 🧬 zod — 해당 없음
- [x] 🕵️ 정직성 — 해당 없음
- [x] 🎨 디자인 토큰 사용 — 새 hex 없이 기존 `--status-*` 토큰만 재사용, 다크/라이트 자동 대응

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [x] ♿ a11y — 체크박스 `aria-label` 유지, 배지는 텍스트라 스크린리더가 그대로 읽음
- [x] ♻️ 재사용 확인 — `system` 도메인의 `StatusBadge`와 같은 raw span + 시맨틱 토큰 방식 재사용
- [x] 🧪 기존 테스트(26개) 회귀 없음 확인
- [ ] 브라우저 전용 API — 해당 없음

---

## 🔗 연관 이슈

Closes #133

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- 상태 배지 위치(카드 오른쪽 끝)가 디자인 톤에 맞는지, 다른 자리(제목 아래 등)가 더 나을지

---

## 📝 추가 메모

없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 캘린더 이벤트 목록의 제목 정렬이 일관되게 개선되었습니다.
  * 이벤트 태그 옆에 완료 또는 진행 중 상태 배지가 표시됩니다.
  * 작은 화면에서 캘린더와 상세 패널이 세로로 배치됩니다.
  * 상세 일정 목록에 추가 내용이 있을 때 스크롤 안내가 표시됩니다.
  * 월 이름과 탐색 버튼 표시가 안정적으로 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
