### PR TITLE
[FEAT] 공용 프로젝트 전체 조회 #134

### DIFF
--- a/src/app/(shell)/app/projects/error.tsx
+++ b/src/app/(shell)/app/projects/error.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { ScreenError } from "@/components/common/screen-error";
+
+interface ProjectsErrorProps {
+  reset: () => void;
+}
+
+export default function Error({ reset }: ProjectsErrorProps) {
+  return <ScreenError title="프로젝트를 불러오지 못했습니다" reset={reset} />;
+}

--- a/src/app/(shell)/app/projects/error.tsx
+++ b/src/app/(shell)/app/projects/error.tsx
@@ -7,5 +7,6 @@ interface ProjectsErrorProps {
 }
 
 export default function Error({ reset }: ProjectsErrorProps) {
-  return <ScreenError title="프로젝트를 불러오지 못했습니다" reset={reset} />;
+  // 셸(상단바 h1) 안에서 뜨므로 isInsideShell — h1 중복·높이 잘림을 막는다
+  return <ScreenError title="프로젝트를 불러오지 못했습니다" reset={reset} isInsideShell />;
 }

--- a/src/app/(shell)/app/projects/layout.tsx
+++ b/src/app/(shell)/app/projects/layout.tsx
@@ -1,33 +1,16 @@
-import { Plus } from "lucide-react";
-import Link from "next/link";
 import type { ReactNode } from "react";
 
-import { buttonVariants } from "@/components/ui/button";
 import { PageHeader } from "@/features/shell/components/page-header";
-import { getViewer } from "@/features/shell/viewer";
-import { canCreateProject } from "@/lib/permission";
-import { cn } from "@/lib/utils";
 
 /**
- * 프로젝트 화면 공통 상단바. `새 프로젝트`는 **Owner만**(생성 권한).
- * ⚠️ 버튼 숨김은 UX일 뿐이다 — 실제 생성은 Server Action에서 `canCreateProject`로 다시 본다.
- * 사이드바에서 바로 닿는 화면이라 뒤로가기는 두지 않는다.
+ * 프로젝트 화면 공통 상단바 — 제목만.
+ * ⚠️ 상단바엔 어떤 버튼도 올리지 않는다(팀 규칙) — 생성 버튼은 페이지 본문 안에 둔다.
+ * 사이드바에서 바로 닿는 화면이라 뒤로가기도 없다.
  */
-export default async function ProjectsLayout({ children }: { children: ReactNode }) {
-  const viewer = await getViewer();
-
+export default function ProjectsLayout({ children }: { children: ReactNode }) {
   return (
     <>
-      <PageHeader
-        title="프로젝트"
-        action={
-          canCreateProject(viewer) ? (
-            <Link href="/app/projects/new" className={cn(buttonVariants({ variant: "ink" }))}>
-              <Plus />새 프로젝트
-            </Link>
-          ) : undefined
-        }
-      />
+      <PageHeader title="프로젝트" />
       {children}
     </>
   );

--- a/src/app/(shell)/app/projects/layout.tsx
+++ b/src/app/(shell)/app/projects/layout.tsx
@@ -1,0 +1,34 @@
+import { Plus } from "lucide-react";
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import { buttonVariants } from "@/components/ui/button";
+import { PageHeader } from "@/features/shell/components/page-header";
+import { getViewer } from "@/features/shell/viewer";
+import { canCreateProject } from "@/lib/permission";
+import { cn } from "@/lib/utils";
+
+/**
+ * 프로젝트 화면 공통 상단바. `새 프로젝트`는 **Owner만**(생성 권한).
+ * ⚠️ 버튼 숨김은 UX일 뿐이다 — 실제 생성은 Server Action에서 `canCreateProject`로 다시 본다.
+ * 사이드바에서 바로 닿는 화면이라 뒤로가기는 두지 않는다.
+ */
+export default async function ProjectsLayout({ children }: { children: ReactNode }) {
+  const viewer = await getViewer();
+
+  return (
+    <>
+      <PageHeader
+        title="프로젝트"
+        action={
+          canCreateProject(viewer) ? (
+            <Link href="/app/projects/new" className={cn(buttonVariants({ variant: "ink" }))}>
+              <Plus />새 프로젝트
+            </Link>
+          ) : undefined
+        }
+      />
+      {children}
+    </>
+  );
+}

--- a/src/app/(shell)/app/projects/loading.tsx
+++ b/src/app/(shell)/app/projects/loading.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+/** 실제 화면과 같은 골격(탭 + 목록 카드). */
+export default function Loading() {
+  return (
+    <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
+      <div className="mx-auto flex w-full max-w-[1080px] flex-col gap-4">
+        <Skeleton className="h-9 w-52 rounded-lg" />
+        <Skeleton className="h-60 w-full rounded-xl" />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/app/projects/page.tsx
+++ b/src/app/(shell)/app/projects/page.tsx
@@ -5,8 +5,9 @@ import Link from "next/link";
 import { buttonVariants } from "@/components/ui/button";
 import { ProjectFilterTabs } from "@/features/project/components/project-filter-tabs";
 import { ProjectListItem } from "@/features/project/components/project-list-item";
-import { parseProjectStatus } from "@/features/project/lib";
-import { getProjectList } from "@/features/project/server";
+import { ProjectToolbar } from "@/features/project/components/project-toolbar";
+import { parseProjectSort, parseProjectStatus } from "@/features/project/lib";
+import { getProjectList, getProjectStatusCounts } from "@/features/project/server";
 import { getViewer } from "@/features/shell/viewer";
 import { canCreateProject } from "@/lib/permission";
 import { cn } from "@/lib/utils";
@@ -16,20 +17,26 @@ export const metadata: Metadata = {
 };
 
 interface ProjectsPageProps {
-  searchParams: Promise<{ status?: string }>;
+  searchParams: Promise<{ status?: string; q?: string; sort?: string }>;
 }
 
 export default async function ProjectsPage({ searchParams }: ProjectsPageProps) {
-  const { status } = await searchParams;
-  const active = parseProjectStatus(status);
-  const [projects, viewer] = await Promise.all([getProjectList(active), getViewer()]);
+  const { status, q, sort } = await searchParams;
+  const activeStatus = parseProjectStatus(status);
+  const activeSort = parseProjectSort(sort);
+
+  const [projects, counts, viewer] = await Promise.all([
+    getProjectList({ status: activeStatus, keyword: q, sort: activeSort }),
+    getProjectStatusCounts(q),
+    getViewer(),
+  ]);
 
   return (
     <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
       <div className="mx-auto flex w-full max-w-[1080px] flex-col gap-4">
         {/* 상단바엔 버튼을 두지 않는다(팀 규칙) — 생성 버튼은 본문 안, Owner 전용 */}
         <div className="flex items-center justify-between gap-4">
-          <ProjectFilterTabs active={active} />
+          <ProjectFilterTabs active={activeStatus} counts={counts} keyword={q} sort={activeSort} />
           {canCreateProject(viewer) && (
             <Link
               href="/app/projects/new"
@@ -40,10 +47,17 @@ export default async function ProjectsPage({ searchParams }: ProjectsPageProps) 
           )}
         </div>
 
+        <div className="flex items-center justify-between gap-4">
+          <ProjectToolbar />
+          <span className="text-muted-foreground shrink-0 text-sm tabular-nums">
+            전체 {projects.length}개
+          </span>
+        </div>
+
         <section className="border-border bg-card overflow-hidden rounded-xl border">
           {projects.length === 0 ? (
             <p className="text-muted-foreground flex items-center justify-center px-4 py-16 text-sm">
-              해당 상태의 프로젝트가 없습니다.
+              {q?.trim() ? "검색 결과가 없습니다." : "해당 상태의 프로젝트가 없습니다."}
             </p>
           ) : (
             <ul className="divide-border divide-y">

--- a/src/app/(shell)/app/projects/page.tsx
+++ b/src/app/(shell)/app/projects/page.tsx
@@ -1,9 +1,15 @@
+import { Plus } from "lucide-react";
 import type { Metadata } from "next";
+import Link from "next/link";
 
+import { buttonVariants } from "@/components/ui/button";
 import { ProjectFilterTabs } from "@/features/project/components/project-filter-tabs";
 import { ProjectListItem } from "@/features/project/components/project-list-item";
 import { parseProjectStatus } from "@/features/project/lib";
 import { getProjectList } from "@/features/project/server";
+import { getViewer } from "@/features/shell/viewer";
+import { canCreateProject } from "@/lib/permission";
+import { cn } from "@/lib/utils";
 
 export const metadata: Metadata = {
   title: "프로젝트",
@@ -16,12 +22,23 @@ interface ProjectsPageProps {
 export default async function ProjectsPage({ searchParams }: ProjectsPageProps) {
   const { status } = await searchParams;
   const active = parseProjectStatus(status);
-  const projects = await getProjectList(active);
+  const [projects, viewer] = await Promise.all([getProjectList(active), getViewer()]);
 
   return (
     <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
       <div className="mx-auto flex w-full max-w-[1080px] flex-col gap-4">
-        <ProjectFilterTabs active={active} />
+        {/* 상단바엔 버튼을 두지 않는다(팀 규칙) — 생성 버튼은 본문 안, Owner 전용 */}
+        <div className="flex items-center justify-between gap-4">
+          <ProjectFilterTabs active={active} />
+          {canCreateProject(viewer) && (
+            <Link
+              href="/app/projects/new"
+              className={cn(buttonVariants({ variant: "ink" }), "shrink-0")}
+            >
+              <Plus />새 프로젝트
+            </Link>
+          )}
+        </div>
 
         <section className="border-border bg-card overflow-hidden rounded-xl border">
           {projects.length === 0 ? (

--- a/src/app/(shell)/app/projects/page.tsx
+++ b/src/app/(shell)/app/projects/page.tsx
@@ -54,10 +54,10 @@ export default async function ProjectsPage({ searchParams }: ProjectsPageProps) 
           </span>
         </div>
 
-        {/* 최소 높이를 둬서 목록이 짧거나 비어도 화면에 안정적으로 자리잡게 한다(탭 전환 시 높이 안 튐) */}
-        <section className="border-border bg-card flex min-h-[360px] flex-col overflow-hidden rounded-xl border">
+        {/* 데이터가 있으면 내용 높이만큼만, 비어 있을 때만 최소 높이를 둬 텅 빈 카드가 안 되게 한다 */}
+        <section className="border-border bg-card overflow-hidden rounded-xl border">
           {projects.length === 0 ? (
-            <p className="text-muted-foreground flex flex-1 items-center justify-center px-4 text-sm">
+            <p className="text-muted-foreground flex min-h-[360px] items-center justify-center px-4 text-sm">
               {q?.trim() ? "검색 결과가 없습니다." : "해당 상태의 프로젝트가 없습니다."}
             </p>
           ) : (

--- a/src/app/(shell)/app/projects/page.tsx
+++ b/src/app/(shell)/app/projects/page.tsx
@@ -54,9 +54,10 @@ export default async function ProjectsPage({ searchParams }: ProjectsPageProps) 
           </span>
         </div>
 
-        <section className="border-border bg-card overflow-hidden rounded-xl border">
+        {/* 최소 높이를 둬서 목록이 짧거나 비어도 화면에 안정적으로 자리잡게 한다(탭 전환 시 높이 안 튐) */}
+        <section className="border-border bg-card flex min-h-[360px] flex-col overflow-hidden rounded-xl border">
           {projects.length === 0 ? (
-            <p className="text-muted-foreground flex items-center justify-center px-4 py-16 text-sm">
+            <p className="text-muted-foreground flex flex-1 items-center justify-center px-4 text-sm">
               {q?.trim() ? "검색 결과가 없습니다." : "해당 상태의 프로젝트가 없습니다."}
             </p>
           ) : (

--- a/src/app/(shell)/app/projects/page.tsx
+++ b/src/app/(shell)/app/projects/page.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from "next";
+
+import { ProjectFilterTabs } from "@/features/project/components/project-filter-tabs";
+import { ProjectListItem } from "@/features/project/components/project-list-item";
+import { parseProjectStatus } from "@/features/project/lib";
+import { getProjectList } from "@/features/project/server";
+
+export const metadata: Metadata = {
+  title: "프로젝트",
+};
+
+interface ProjectsPageProps {
+  searchParams: Promise<{ status?: string }>;
+}
+
+export default async function ProjectsPage({ searchParams }: ProjectsPageProps) {
+  const { status } = await searchParams;
+  const active = parseProjectStatus(status);
+  const projects = await getProjectList(active);
+
+  return (
+    <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
+      <div className="mx-auto flex w-full max-w-[1080px] flex-col gap-4">
+        <ProjectFilterTabs active={active} />
+
+        <section className="border-border bg-card overflow-hidden rounded-xl border">
+          {projects.length === 0 ? (
+            <p className="text-muted-foreground flex items-center justify-center px-4 py-16 text-sm">
+              해당 상태의 프로젝트가 없습니다.
+            </p>
+          ) : (
+            <ul className="divide-border divide-y">
+              {projects.map((project) => (
+                <ProjectListItem key={project.id} project={project} />
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/app/projects/page.tsx
+++ b/src/app/(shell)/app/projects/page.tsx
@@ -17,17 +17,23 @@ export const metadata: Metadata = {
 };
 
 interface ProjectsPageProps {
-  searchParams: Promise<{ status?: string; q?: string; sort?: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+/** 같은 키가 여러 번 오면(`?q=a&q=b`) 첫 값만 쓴다 — 파서·trim이 배열을 못 받는다. */
+function first(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
 }
 
 export default async function ProjectsPage({ searchParams }: ProjectsPageProps) {
-  const { status, q, sort } = await searchParams;
-  const activeStatus = parseProjectStatus(status);
-  const activeSort = parseProjectSort(sort);
+  const params = await searchParams;
+  const keyword = first(params.q);
+  const activeStatus = parseProjectStatus(first(params.status));
+  const activeSort = parseProjectSort(first(params.sort));
 
   const [projects, counts, viewer] = await Promise.all([
-    getProjectList({ status: activeStatus, keyword: q, sort: activeSort }),
-    getProjectStatusCounts(q),
+    getProjectList({ status: activeStatus, keyword, sort: activeSort }),
+    getProjectStatusCounts(keyword),
     getViewer(),
   ]);
 
@@ -36,7 +42,12 @@ export default async function ProjectsPage({ searchParams }: ProjectsPageProps) 
       <div className="mx-auto flex w-full max-w-[1080px] flex-col gap-4">
         {/* 상단바엔 버튼을 두지 않는다(팀 규칙) — 생성 버튼은 본문 안, Owner 전용 */}
         <div className="flex items-center justify-between gap-4">
-          <ProjectFilterTabs active={activeStatus} counts={counts} keyword={q} sort={activeSort} />
+          <ProjectFilterTabs
+            active={activeStatus}
+            counts={counts}
+            keyword={keyword}
+            sort={activeSort}
+          />
           {canCreateProject(viewer) && (
             <Link
               href="/app/projects/new"
@@ -58,7 +69,7 @@ export default async function ProjectsPage({ searchParams }: ProjectsPageProps) 
         <section className="border-border bg-card overflow-hidden rounded-xl border">
           {projects.length === 0 ? (
             <p className="text-muted-foreground flex min-h-[360px] items-center justify-center px-4 text-sm">
-              {q?.trim() ? "검색 결과가 없습니다." : "해당 상태의 프로젝트가 없습니다."}
+              {keyword?.trim() ? "검색 결과가 없습니다." : "해당 상태의 프로젝트가 없습니다."}
             </p>
           ) : (
             <ul className="divide-border divide-y">

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,25 @@
+import { Progress as ProgressPrimitive } from "@base-ui/react/progress"
+import type { ComponentProps } from "react"
+
+import { cn } from "@/lib/utils"
+
+/**
+ * 진척 바. base-ui `Progress`라 값(0~100)에 맞춰 인디케이터 폭이 자동으로 잡힌다.
+ * ⚠️ 트랙 폭은 부르는 쪽이 정한다(`className`으로 `w-32` 등) — 화면마다 길이가 다르다.
+ */
+function Progress({ className, value, ...props }: ComponentProps<typeof ProgressPrimitive.Root>) {
+  return (
+    <ProgressPrimitive.Root
+      data-slot="progress"
+      value={value}
+      className={cn("w-full", className)}
+      {...props}
+    >
+      <ProgressPrimitive.Track className="bg-muted relative h-1.5 w-full overflow-hidden rounded-full">
+        <ProgressPrimitive.Indicator className="bg-foreground h-full rounded-full transition-all" />
+      </ProgressPrimitive.Track>
+    </ProgressPrimitive.Root>
+  )
+}
+
+export { Progress }

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -39,7 +39,7 @@ function TooltipContent({
         <TooltipPrimitive.Popup
           data-slot="tooltip-content"
           className={cn(
-            "bg-foreground text-background z-50 max-w-xs rounded-md px-2.5 py-1.5 text-xs shadow-md",
+            "bg-popover text-popover-foreground border-border z-50 max-w-xs rounded-md border px-2.5 py-1.5 text-xs shadow-md",
             "origin-[var(--transform-origin)] data-[starting-style]:opacity-0 data-[ending-style]:opacity-0",
             className,
           )}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -30,12 +30,16 @@ function TooltipTrigger(props: ComponentProps<typeof TooltipPrimitive.Trigger>) 
 function TooltipContent({
   className,
   sideOffset = 6,
+  side = "top",
   children,
   ...props
-}: ComponentProps<typeof TooltipPrimitive.Popup> & { sideOffset?: number }) {
+}: ComponentProps<typeof TooltipPrimitive.Popup> & {
+  sideOffset?: number;
+  side?: ComponentProps<typeof TooltipPrimitive.Positioner>["side"];
+}) {
   return (
     <TooltipPrimitive.Portal>
-      <TooltipPrimitive.Positioner sideOffset={sideOffset}>
+      <TooltipPrimitive.Positioner side={side} sideOffset={sideOffset}>
         <TooltipPrimitive.Popup
           data-slot="tooltip-content"
           className={cn(

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,55 @@
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip"
+import type { ComponentProps } from "react"
+
+import { cn } from "@/lib/utils"
+
+/**
+ * hover/포커스 시 뜨는 말풍선. base-ui `Tooltip`.
+ * ⚠️ 트리거가 `<a>`·`<button>` 안에 들어갈 땐 `render`로 비상호작용 요소(span 등)를 넘긴다 —
+ *    기본 트리거는 `<button>`이라 링크·버튼 안에 겹쳐 넣으면 마크업이 깨진다.
+ */
+function TooltipProvider({
+  delay = 200,
+  ...props
+}: ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return <TooltipPrimitive.Provider data-slot="tooltip-provider" delay={delay} {...props} />
+}
+
+function Tooltip(props: ComponentProps<typeof TooltipPrimitive.Root>) {
+  return (
+    <TooltipProvider>
+      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+    </TooltipProvider>
+  )
+}
+
+function TooltipTrigger(props: ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 6,
+  children,
+  ...props
+}: ComponentProps<typeof TooltipPrimitive.Popup> & { sideOffset?: number }) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Positioner sideOffset={sideOffset}>
+        <TooltipPrimitive.Popup
+          data-slot="tooltip-content"
+          className={cn(
+            "bg-foreground text-background z-50 max-w-xs rounded-md px-2.5 py-1.5 text-xs shadow-md",
+            "origin-[var(--transform-origin)] data-[starting-style]:opacity-0 data-[ending-style]:opacity-0",
+            className,
+          )}
+          {...props}
+        >
+          {children}
+        </TooltipPrimitive.Popup>
+      </TooltipPrimitive.Positioner>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/src/constants/project.ts
+++ b/src/constants/project.ts
@@ -18,3 +18,21 @@ export const PROJECT_STATUS_LABEL: Record<ProjectStatus, string> = {
   IN_PROGRESS: "진행중",
   DONE: "완료",
 };
+
+/**
+ * 프로젝트 목록 정렬 기준. 화면엔 한글 라벨, 코드엔 영문 상수.
+ * ⚠️ '마감 늦은순'은 '마감 임박순'과 결이 겹쳐 두지 않는다.
+ */
+export const PROJECT_SORT = {
+  DUE_ASC: "DUE_ASC",
+  NAME: "NAME",
+} as const;
+export type ProjectSort = (typeof PROJECT_SORT)[keyof typeof PROJECT_SORT];
+
+export const PROJECT_SORT_LABEL: Record<ProjectSort, string> = {
+  DUE_ASC: "마감 임박순",
+  NAME: "이름순",
+};
+
+/** 기본 정렬 — 마감 임박순(스펙). */
+export const DEFAULT_PROJECT_SORT: ProjectSort = PROJECT_SORT.DUE_ASC;

--- a/src/features/project/components/project-filter-tabs.tsx
+++ b/src/features/project/components/project-filter-tabs.tsx
@@ -1,14 +1,34 @@
 import Link from "next/link";
 
 import type { ProjectStatus } from "@/constants/domain";
-import { PROJECT_FILTER_TABS } from "@/features/project/lib";
+import {
+  DEFAULT_PROJECT_SORT,
+  PROJECT_FILTER_TABS,
+  type ProjectSort,
+} from "@/features/project/lib";
 import { cn } from "@/lib/utils";
+
+interface ProjectFilterTabsProps {
+  active: ProjectStatus;
+  /** 상태별 개수(검색 결과 기준) — 탭 뒤 배지 */
+  counts: Record<ProjectStatus, number>;
+  /** 탭을 바꿔도 검색·정렬은 유지한다 */
+  keyword?: string;
+  sort?: ProjectSort;
+}
 
 /**
  * 상태 필터 탭 — `?status=`를 바꾸는 링크라 서버우선(클라 상태 없음).
- * 활성 탭만 먹색으로 채운다(피그마).
+ * 활성 탭만 먹색으로 채우고, 뒤에 개수 배지를 단다. 검색어·정렬은 링크에 실어 보존한다.
  */
-export function ProjectFilterTabs({ active }: { active: ProjectStatus }) {
+export function ProjectFilterTabs({ active, counts, keyword, sort }: ProjectFilterTabsProps) {
+  const hrefFor = (status: ProjectStatus) => {
+    const params = new URLSearchParams({ status });
+    if (keyword?.trim()) params.set("q", keyword.trim());
+    if (sort && sort !== DEFAULT_PROJECT_SORT) params.set("sort", sort);
+    return `/app/projects?${params.toString()}`;
+  };
+
   return (
     <div role="tablist" aria-label="프로젝트 상태 필터" className="flex gap-1">
       {PROJECT_FILTER_TABS.map((tab) => {
@@ -16,17 +36,25 @@ export function ProjectFilterTabs({ active }: { active: ProjectStatus }) {
         return (
           <Link
             key={tab.status}
-            href={`/app/projects?status=${tab.status}`}
+            href={hrefFor(tab.status)}
             role="tab"
             aria-selected={selected}
             className={cn(
-              "rounded-lg px-3 py-1.5 text-sm font-medium transition-colors",
+              "flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors",
               selected
                 ? "bg-foreground text-background"
                 : "text-muted-foreground hover:bg-muted hover:text-foreground",
             )}
           >
             {tab.label}
+            <span
+              className={cn(
+                "tabular-nums",
+                selected ? "text-background/70" : "text-muted-foreground/70",
+              )}
+            >
+              {counts[tab.status]}
+            </span>
           </Link>
         );
       })}

--- a/src/features/project/components/project-filter-tabs.tsx
+++ b/src/features/project/components/project-filter-tabs.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link";
+
+import type { ProjectStatus } from "@/constants/domain";
+import { PROJECT_FILTER_TABS } from "@/features/project/lib";
+import { cn } from "@/lib/utils";
+
+/**
+ * 상태 필터 탭 — `?status=`를 바꾸는 링크라 서버우선(클라 상태 없음).
+ * 활성 탭만 먹색으로 채운다(피그마).
+ */
+export function ProjectFilterTabs({ active }: { active: ProjectStatus }) {
+  return (
+    <div role="tablist" aria-label="프로젝트 상태 필터" className="flex gap-1">
+      {PROJECT_FILTER_TABS.map((tab) => {
+        const selected = tab.status === active;
+        return (
+          <Link
+            key={tab.status}
+            href={`/app/projects?status=${tab.status}`}
+            role="tab"
+            aria-selected={selected}
+            className={cn(
+              "rounded-lg px-3 py-1.5 text-sm font-medium transition-colors",
+              selected
+                ? "bg-foreground text-background"
+                : "text-muted-foreground hover:bg-muted hover:text-foreground",
+            )}
+          >
+            {tab.label}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/project/components/project-filter-tabs.tsx
+++ b/src/features/project/components/project-filter-tabs.tsx
@@ -1,11 +1,7 @@
 import Link from "next/link";
 
-import type { ProjectStatus } from "@/constants/domain";
-import {
-  DEFAULT_PROJECT_SORT,
-  PROJECT_FILTER_TABS,
-  type ProjectSort,
-} from "@/features/project/lib";
+import { DEFAULT_PROJECT_SORT, type ProjectSort, type ProjectStatus } from "@/constants/domain";
+import { PROJECT_FILTER_TABS } from "@/features/project/lib";
 import { cn } from "@/lib/utils";
 
 interface ProjectFilterTabsProps {
@@ -30,15 +26,14 @@ export function ProjectFilterTabs({ active, counts, keyword, sort }: ProjectFilt
   };
 
   return (
-    <div role="tablist" aria-label="프로젝트 상태 필터" className="flex gap-1">
+    <nav aria-label="프로젝트 상태 필터" className="flex gap-1">
       {PROJECT_FILTER_TABS.map((tab) => {
         const selected = tab.status === active;
         return (
           <Link
             key={tab.status}
             href={hrefFor(tab.status)}
-            role="tab"
-            aria-selected={selected}
+            aria-current={selected ? "page" : undefined}
             className={cn(
               "flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors",
               selected
@@ -58,6 +53,6 @@ export function ProjectFilterTabs({ active, counts, keyword, sort }: ProjectFilt
           </Link>
         );
       })}
-    </div>
+    </nav>
   );
 }

--- a/src/features/project/components/project-list-item.tsx
+++ b/src/features/project/components/project-list-item.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { getProgressPercent, splitDepartments } from "@/features/project/lib";
 import type { ProjectListItem as ProjectListItemModel } from "@/features/project/types";
 import { formatMonthDayWeekday } from "@/lib/date";
@@ -17,6 +18,12 @@ export function ProjectListItem({ project }: { project: ProjectListItemModel }) 
   const percent = getProgressPercent(project.actionDone, project.actionTotal);
   const { visible, overflow } = splitDepartments(project.departments);
   const due = formatMonthDayWeekday(project.dueDate);
+
+  const visibleTeamBadges = visible.map((team) => (
+    <Badge key={team} variant="outline" className="shrink-0">
+      {team}
+    </Badge>
+  ));
 
   return (
     <li className="relative">
@@ -59,23 +66,26 @@ export function ProjectListItem({ project }: { project: ProjectListItemModel }) 
 
           <span className="text-muted-foreground text-sm tabular-nums">{due}</span>
 
-          {/* 참여 팀 — 2개까지 + 나머지 +N(hover 시 전체) */}
-          <div className="flex items-center gap-1">
-            {visible.map((team) => (
-              <Badge key={team} variant="outline" className="shrink-0">
-                {team}
-              </Badge>
-            ))}
-            {overflow > 0 && (
-              <Badge
-                variant="secondary"
-                className="shrink-0"
-                title={project.departments.join(", ")}
-              >
-                +{overflow}
-              </Badge>
-            )}
-          </div>
+          {/* 참여 팀 — 2개까지 + 나머지 +N. 초과가 있으면 영역 전체 hover 시 전체 팀 목록 */}
+          {overflow > 0 ? (
+            <Tooltip>
+              <TooltipTrigger render={<span className="flex items-center gap-1" />}>
+                {visibleTeamBadges}
+                <Badge variant="secondary" className="shrink-0">
+                  +{overflow}
+                </Badge>
+              </TooltipTrigger>
+              <TooltipContent>
+                <ul className="space-y-0.5">
+                  {project.departments.map((team) => (
+                    <li key={team}>{team}</li>
+                  ))}
+                </ul>
+              </TooltipContent>
+            </Tooltip>
+          ) : (
+            <span className="flex items-center gap-1">{visibleTeamBadges}</span>
+          )}
         </div>
       </Link>
     </li>

--- a/src/features/project/components/project-list-item.tsx
+++ b/src/features/project/components/project-list-item.tsx
@@ -1,0 +1,83 @@
+import Link from "next/link";
+
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import { getProgressPercent, splitDepartments } from "@/features/project/lib";
+import type { ProjectListItem as ProjectListItemModel } from "@/features/project/types";
+import { formatMonthDayWeekday } from "@/lib/date";
+
+/** 프로젝트는 전부 Owner가 개설한다 — 최상위 표시(라벨 통일 규칙). 필드가 아니라 상수. */
+const OWNER_LABEL = "Owner";
+
+/**
+ * 프로젝트 한 줄 — 회의 아이템과 같은 결.
+ * 좌: 태그 · 프로젝트명 + Owner 라벨 / 우: 진척 바 · 마감일 · 참여 팀(2개+`+N`, hover 시 전체).
+ */
+export function ProjectListItem({ project }: { project: ProjectListItemModel }) {
+  const percent = getProgressPercent(project.actionDone, project.actionTotal);
+  const { visible, overflow } = splitDepartments(project.departments);
+  const due = formatMonthDayWeekday(project.dueDate);
+
+  return (
+    <li className="relative">
+      {/* 태그색 스트립 — 행 왼쪽 끝 */}
+      <span
+        className="absolute inset-y-0 left-0 w-1"
+        style={{ backgroundColor: project.color }}
+        aria-hidden
+      />
+
+      <Link
+        href={`/app/projects/${project.tag}`}
+        className="hover:bg-muted flex items-center gap-3 py-3.5 pr-4 pl-5 transition-colors"
+      >
+        {/* 좌: (상단) 태그 / (하단) 프로젝트명 + Owner 라벨 */}
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <span
+            className="w-fit rounded px-1.5 py-0.5 font-mono text-[10px] font-semibold"
+            style={{ backgroundColor: `${project.color}1a`, color: project.color }}
+          >
+            {project.tag}
+          </span>
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="truncate text-[15px]">{project.name}</span>
+            <Badge variant="secondary" className="shrink-0">
+              {OWNER_LABEL}
+            </Badge>
+          </div>
+        </div>
+
+        {/* 우: 진척 바 · 마감일 · 참여 팀 */}
+        <div className="flex shrink-0 items-center gap-4">
+          <div className="flex items-center gap-2">
+            <Progress value={percent} className="w-32" />
+            <span className="text-muted-foreground text-xs tabular-nums">
+              <span className="text-foreground font-medium">{percent}%</span> ({project.actionDone}/
+              {project.actionTotal})
+            </span>
+          </div>
+
+          <span className="text-muted-foreground text-sm tabular-nums">{due}</span>
+
+          {/* 참여 팀 — 2개까지 + 나머지 +N(hover 시 전체) */}
+          <div className="flex items-center gap-1">
+            {visible.map((team) => (
+              <Badge key={team} variant="outline" className="shrink-0">
+                {team}
+              </Badge>
+            ))}
+            {overflow > 0 && (
+              <Badge
+                variant="secondary"
+                className="shrink-0"
+                title={project.departments.join(", ")}
+              >
+                +{overflow}
+              </Badge>
+            )}
+          </div>
+        </div>
+      </Link>
+    </li>
+  );
+}

--- a/src/features/project/components/project-list-item.tsx
+++ b/src/features/project/components/project-list-item.tsx
@@ -7,12 +7,11 @@ import { getProgressPercent, splitDepartments } from "@/features/project/lib";
 import type { ProjectListItem as ProjectListItemModel } from "@/features/project/types";
 import { formatMonthDayWeekday } from "@/lib/date";
 
-/** 프로젝트는 전부 Owner가 개설한다 — 최상위 표시(라벨 통일 규칙). 필드가 아니라 상수. */
-const OWNER_LABEL = "Owner";
-
 /**
  * 프로젝트 한 줄 — 회의 아이템과 같은 결.
- * 좌(클릭 시 프로젝트 상세): 태그 · 프로젝트명 + Owner 라벨 · 세부 설명 첫 줄 / 우: 진척 · 마감일.
+ * 좌(클릭 시 프로젝트 상세): 태그 · 프로젝트명 · 세부 설명 첫 줄 / 우: 진척 · 마감일.
+ * ⚠️ "Owner" 라벨은 두지 않는다 — 프로젝트는 전부 Owner 개설이라 이 전용 목록에선 모든 행이 같아 노이즈다.
+ *    (최상위 구분 라벨은 프로젝트·회의·액션이 섞이는 혼합 화면에서만 의미가 있다.)
  * 맨 오른쪽 참여 팀은 **링크 밖**이라 눌러도 이동하지 않는다 — 팀 상세는 없고, 팀 액션은 추후
  * 프로젝트 상세 타임라인에서 보여준다. 2개까지 + `+N`, hover 시 전체 목록.
  */
@@ -48,12 +47,7 @@ export function ProjectListItem({ project }: { project: ProjectListItemModel }) 
           >
             {project.tag}
           </span>
-          <div className="flex min-w-0 items-center gap-2">
-            <span className="truncate text-[15px]">{project.name}</span>
-            <Badge variant="secondary" className="shrink-0">
-              {OWNER_LABEL}
-            </Badge>
-          </div>
+          <span className="truncate text-[15px]">{project.name}</span>
           {/* 세부 설명은 본문이 길 수 있어 첫 줄만 자른다(뒤는 …) */}
           <p className="text-muted-foreground line-clamp-1 text-xs">{project.description}</p>
         </div>

--- a/src/features/project/components/project-list-item.tsx
+++ b/src/features/project/components/project-list-item.tsx
@@ -6,6 +6,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { getProgressPercent, splitDepartments } from "@/features/project/lib";
 import type { ProjectListItem as ProjectListItemModel } from "@/features/project/types";
 import { formatMonthDayWeekday } from "@/lib/date";
+import { pickPaletteColor } from "@/lib/palette";
 
 /**
  * 프로젝트 한 줄 — 회의 아이템과 같은 결.
@@ -19,6 +20,8 @@ export function ProjectListItem({ project }: { project: ProjectListItemModel }) 
   const percent = getProgressPercent(project.actionDone, project.actionTotal);
   const { visible, overflow } = splitDepartments(project.departments);
   const due = formatMonthDayWeekday(project.dueDate);
+  // 태그 색은 고정 팔레트(globals.css `--tag-*`)에서 태그명으로 뽑는다 — 라이트/다크는 CSS가 대응
+  const tagColor = pickPaletteColor(project.tag);
 
   const visibleTeamBadges = visible.map((team) => (
     <Badge key={team} variant="outline" className="shrink-0">
@@ -31,7 +34,7 @@ export function ProjectListItem({ project }: { project: ProjectListItemModel }) 
       {/* 태그색 스트립 — 행 왼쪽 끝 */}
       <span
         className="absolute inset-y-0 left-0 w-1"
-        style={{ backgroundColor: project.color }}
+        style={{ backgroundColor: tagColor.solidColor }}
         aria-hidden
       />
 
@@ -43,7 +46,7 @@ export function ProjectListItem({ project }: { project: ProjectListItemModel }) 
         <div className="flex min-w-0 flex-1 flex-col gap-1">
           <span
             className="w-fit rounded px-1.5 py-0.5 font-mono text-[10px] font-semibold"
-            style={{ backgroundColor: `${project.color}1a`, color: project.color }}
+            style={{ backgroundColor: tagColor.bgColor, color: tagColor.textColor }}
           >
             {project.tag}
           </span>

--- a/src/features/project/components/project-list-item.tsx
+++ b/src/features/project/components/project-list-item.tsx
@@ -52,6 +52,8 @@ export function ProjectListItem({ project }: { project: ProjectListItemModel }) 
               {OWNER_LABEL}
             </Badge>
           </div>
+          {/* 세부 설명은 본문이 길 수 있어 첫 줄만 자른다(뒤는 …) */}
+          <p className="text-muted-foreground line-clamp-1 text-xs">{project.description}</p>
         </div>
 
         {/* 우: 진척 바 · 마감일 · 참여 팀 */}

--- a/src/features/project/components/project-list-item.tsx
+++ b/src/features/project/components/project-list-item.tsx
@@ -12,7 +12,9 @@ const OWNER_LABEL = "Owner";
 
 /**
  * 프로젝트 한 줄 — 회의 아이템과 같은 결.
- * 좌: 태그 · 프로젝트명 + Owner 라벨 / 우: 진척 바 · 마감일 · 참여 팀(2개+`+N`, hover 시 전체).
+ * 좌(클릭 시 프로젝트 상세): 태그 · 프로젝트명 + Owner 라벨 · 세부 설명 첫 줄 / 우: 진척 · 마감일.
+ * 맨 오른쪽 참여 팀은 **링크 밖**이라 눌러도 이동하지 않는다 — 팀 상세는 없고, 팀 액션은 추후
+ * 프로젝트 상세 타임라인에서 보여준다. 2개까지 + `+N`, hover 시 전체 목록.
  */
 export function ProjectListItem({ project }: { project: ProjectListItemModel }) {
   const percent = getProgressPercent(project.actionDone, project.actionTotal);
@@ -26,7 +28,7 @@ export function ProjectListItem({ project }: { project: ProjectListItemModel }) 
   ));
 
   return (
-    <li className="relative">
+    <li className="hover:bg-muted relative flex items-center gap-3 py-3.5 pr-4 pl-5 transition-colors">
       {/* 태그색 스트립 — 행 왼쪽 끝 */}
       <span
         className="absolute inset-y-0 left-0 w-1"
@@ -34,11 +36,11 @@ export function ProjectListItem({ project }: { project: ProjectListItemModel }) 
         aria-hidden
       />
 
+      {/* 클릭 영역 = 프로젝트 상세로 */}
       <Link
         href={`/app/projects/${project.tag}`}
-        className="hover:bg-muted flex items-center gap-3 py-3.5 pr-4 pl-5 transition-colors"
+        className="flex min-w-0 flex-1 items-center gap-3"
       >
-        {/* 좌: (상단) 태그 / (하단) 프로젝트명 + Owner 라벨 */}
         <div className="flex min-w-0 flex-1 flex-col gap-1">
           <span
             className="w-fit rounded px-1.5 py-0.5 font-mono text-[10px] font-semibold"
@@ -56,37 +58,37 @@ export function ProjectListItem({ project }: { project: ProjectListItemModel }) 
           <p className="text-muted-foreground line-clamp-1 text-xs">{project.description}</p>
         </div>
 
-        {/* 우: 진척 바 · 마감일 · 참여 팀 */}
         <div className="flex shrink-0 items-center gap-4">
           <div className="flex items-center gap-2">
             <Progress value={percent} className="w-32" />
             <span className="text-foreground text-xs font-medium tabular-nums">{percent}%</span>
           </div>
-
           <span className="text-muted-foreground text-sm tabular-nums">{due}</span>
-
-          {/* 참여 팀 — 2개까지 + 나머지 +N. 초과가 있으면 영역 전체 hover 시 전체 팀 목록 */}
-          {overflow > 0 ? (
-            <Tooltip>
-              <TooltipTrigger render={<span className="flex items-center gap-1" />}>
-                {visibleTeamBadges}
-                <Badge variant="secondary" className="shrink-0">
-                  +{overflow}
-                </Badge>
-              </TooltipTrigger>
-              <TooltipContent>
-                <ul className="space-y-0.5">
-                  {project.departments.map((team) => (
-                    <li key={team}>{team}</li>
-                  ))}
-                </ul>
-              </TooltipContent>
-            </Tooltip>
-          ) : (
-            <span className="flex items-center gap-1">{visibleTeamBadges}</span>
-          )}
         </div>
       </Link>
+
+      {/* 참여 팀 — 링크 밖(이동 없음). 초과가 있으면 영역 전체 hover 시 전체 목록 */}
+      <div className="shrink-0" aria-label={`참여 팀: ${project.departments.join(", ")}`}>
+        {overflow > 0 ? (
+          <Tooltip>
+            <TooltipTrigger render={<span className="flex items-center gap-1" />}>
+              {visibleTeamBadges}
+              <Badge variant="secondary" className="shrink-0">
+                +{overflow}
+              </Badge>
+            </TooltipTrigger>
+            <TooltipContent>
+              <ul className="space-y-0.5">
+                {project.departments.map((team) => (
+                  <li key={team}>{team}</li>
+                ))}
+              </ul>
+            </TooltipContent>
+          </Tooltip>
+        ) : (
+          <span className="flex items-center gap-1">{visibleTeamBadges}</span>
+        )}
+      </div>
     </li>
   );
 }

--- a/src/features/project/components/project-list-item.tsx
+++ b/src/features/project/components/project-list-item.tsx
@@ -60,10 +60,7 @@ export function ProjectListItem({ project }: { project: ProjectListItemModel }) 
         <div className="flex shrink-0 items-center gap-4">
           <div className="flex items-center gap-2">
             <Progress value={percent} className="w-32" />
-            <span className="text-muted-foreground text-xs tabular-nums">
-              <span className="text-foreground font-medium">{percent}%</span> ({project.actionDone}/
-              {project.actionTotal})
-            </span>
+            <span className="text-foreground text-xs font-medium tabular-nums">{percent}%</span>
           </div>
 
           <span className="text-muted-foreground text-sm tabular-nums">{due}</span>

--- a/src/features/project/components/project-list-item.tsx
+++ b/src/features/project/components/project-list-item.tsx
@@ -63,7 +63,10 @@ export function ProjectListItem({ project }: { project: ProjectListItemModel }) 
             <Progress value={percent} className="w-32" />
             <span className="text-foreground text-xs font-medium tabular-nums">{percent}%</span>
           </div>
-          <span className="text-muted-foreground text-sm tabular-nums">{due}</span>
+          {/* 날짜만 두면 마감으로 안 읽혀 '까지'를 붙인다 */}
+          <span className="text-muted-foreground text-sm tabular-nums">
+            {due ? `${due}까지` : "-"}
+          </span>
         </div>
       </Link>
 
@@ -77,12 +80,9 @@ export function ProjectListItem({ project }: { project: ProjectListItemModel }) 
                 +{overflow}
               </Badge>
             </TooltipTrigger>
-            <TooltipContent>
-              <ul className="space-y-0.5">
-                {project.departments.map((team) => (
-                  <li key={team}>{team}</li>
-                ))}
-              </ul>
+            {/* 아래쪽·가로 나열 — 세로 목록은 선택형 드롭다운처럼 보인다 */}
+            <TooltipContent side="bottom" className="max-w-none">
+              <span className="whitespace-nowrap">{project.departments.join(" · ")}</span>
             </TooltipContent>
           </Tooltip>
         ) : (

--- a/src/features/project/components/project-toolbar.tsx
+++ b/src/features/project/components/project-toolbar.tsx
@@ -12,7 +12,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { DEFAULT_PROJECT_SORT, PROJECT_SORT, PROJECT_SORT_LABEL } from "@/features/project/lib";
+import { DEFAULT_PROJECT_SORT, PROJECT_SORT, PROJECT_SORT_LABEL } from "@/constants/domain";
+import { parseProjectSort } from "@/features/project/lib";
 
 const SORT_OPTIONS = Object.values(PROJECT_SORT);
 
@@ -56,9 +57,10 @@ export function ProjectToolbar() {
 
       <Select
         items={PROJECT_SORT_LABEL}
-        value={searchParams.get("sort") ?? DEFAULT_PROJECT_SORT}
+        value={parseProjectSort(searchParams.get("sort") ?? undefined)}
         onValueChange={(value) =>
-          pushWith({ sort: value === DEFAULT_PROJECT_SORT ? "" : (value ?? "") })
+          // 검색어(q)도 같이 실어 보낸다 — 입력 중(미제출) 검색어가 정렬 바꿀 때 날아가지 않게
+          pushWith({ q: keyword, sort: value === DEFAULT_PROJECT_SORT ? "" : (value ?? "") })
         }
       >
         <SelectTrigger aria-label="정렬 기준" className="w-36">

--- a/src/features/project/components/project-toolbar.tsx
+++ b/src/features/project/components/project-toolbar.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { Search } from "lucide-react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
+
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { DEFAULT_PROJECT_SORT, PROJECT_SORT, PROJECT_SORT_LABEL } from "@/features/project/lib";
+
+const SORT_OPTIONS = Object.values(PROJECT_SORT);
+
+/**
+ * 프로젝트명 검색 + 정렬. 결과는 **URL 쿼리로 표현**하고 실제 필터/정렬은 서버(페이지)가 한다
+ * (CLAUDE.md §서버우선) — 상태 탭(`status`)은 그대로 두고 `q`·`sort`만 바꾼다.
+ */
+export function ProjectToolbar() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [keyword, setKeyword] = useState(searchParams.get("q") ?? "");
+
+  const pushWith = (updates: Record<string, string>) => {
+    const params = new URLSearchParams(searchParams.toString());
+    for (const [key, value] of Object.entries(updates)) {
+      if (!value) params.delete(key);
+      else params.set(key, value);
+    }
+    router.push(`/app/projects?${params.toString()}`);
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <div className="relative w-full max-w-56">
+        <Search
+          className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2"
+          aria-hidden
+        />
+        <Input
+          value={keyword}
+          onChange={(event) => setKeyword(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") pushWith({ q: keyword });
+          }}
+          onBlur={() => pushWith({ q: keyword })}
+          placeholder="프로젝트명 검색"
+          aria-label="프로젝트명 검색"
+          className="pl-8"
+        />
+      </div>
+
+      <Select
+        items={PROJECT_SORT_LABEL}
+        value={searchParams.get("sort") ?? DEFAULT_PROJECT_SORT}
+        onValueChange={(value) =>
+          pushWith({ sort: value === DEFAULT_PROJECT_SORT ? "" : (value ?? "") })
+        }
+      >
+        <SelectTrigger aria-label="정렬 기준" className="w-32">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent side="bottom" alignItemWithTrigger={false}>
+          {SORT_OPTIONS.map((sort) => (
+            <SelectItem key={sort} value={sort}>
+              {PROJECT_SORT_LABEL[sort]}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/src/features/project/components/project-toolbar.tsx
+++ b/src/features/project/components/project-toolbar.tsx
@@ -61,7 +61,7 @@ export function ProjectToolbar() {
           pushWith({ sort: value === DEFAULT_PROJECT_SORT ? "" : (value ?? "") })
         }
       >
-        <SelectTrigger aria-label="정렬 기준" className="w-32">
+        <SelectTrigger aria-label="정렬 기준" className="w-36">
           <SelectValue />
         </SelectTrigger>
         <SelectContent side="bottom" alignItemWithTrigger={false}>

--- a/src/features/project/lib.test.ts
+++ b/src/features/project/lib.test.ts
@@ -1,12 +1,10 @@
-import { PROJECT_STATUS } from "@/constants/domain";
+import { DEFAULT_PROJECT_SORT, PROJECT_SORT, PROJECT_STATUS } from "@/constants/domain";
 
 import {
-  DEFAULT_PROJECT_SORT,
   DEFAULT_PROJECT_STATUS,
   getProgressPercent,
   parseProjectSort,
   parseProjectStatus,
-  PROJECT_SORT,
   sortProjects,
   splitDepartments,
 } from "./lib";

--- a/src/features/project/lib.test.ts
+++ b/src/features/project/lib.test.ts
@@ -86,14 +86,6 @@ describe("sortProjects", () => {
     expect(sortProjects([a, b, c], PROJECT_SORT.DUE_ASC).map((p) => p.id)).toEqual(["b", "a", "c"]);
   });
 
-  it("마감 늦은순은 내림차순", () => {
-    expect(sortProjects([a, b, c], PROJECT_SORT.DUE_DESC).map((p) => p.id)).toEqual([
-      "c",
-      "a",
-      "b",
-    ]);
-  });
-
   it("이름순은 한글 가나다", () => {
     expect(sortProjects([a, b, c], PROJECT_SORT.NAME).map((p) => p.id)).toEqual(["a", "c", "b"]);
   });

--- a/src/features/project/lib.test.ts
+++ b/src/features/project/lib.test.ts
@@ -1,0 +1,48 @@
+import { PROJECT_STATUS } from "@/constants/domain";
+
+import {
+  DEFAULT_PROJECT_STATUS,
+  getProgressPercent,
+  parseProjectStatus,
+  splitDepartments,
+} from "./lib";
+
+describe("getProgressPercent", () => {
+  it("완료/전체를 반올림한 백분율로 준다", () => {
+    expect(getProgressPercent(0, 11)).toBe(0);
+    expect(getProgressPercent(3, 4)).toBe(75);
+    expect(getProgressPercent(1, 3)).toBe(33);
+  });
+
+  it("액션이 없으면 0 — 0으로 나누지 않는다", () => {
+    expect(getProgressPercent(0, 0)).toBe(0);
+  });
+});
+
+describe("splitDepartments", () => {
+  it("기본 2개까지 노출하고 나머지는 초과 수로 센다", () => {
+    expect(splitDepartments(["개발팀", "마케팅팀", "디자인팀"])).toEqual({
+      visible: ["개발팀", "마케팅팀"],
+      overflow: 1,
+    });
+  });
+
+  it("한도 이하면 초과는 0이다", () => {
+    expect(splitDepartments(["마케팅팀", "디자인팀"])).toEqual({
+      visible: ["마케팅팀", "디자인팀"],
+      overflow: 0,
+    });
+  });
+});
+
+describe("parseProjectStatus", () => {
+  it("아는 상태 값은 그대로 통과한다", () => {
+    expect(parseProjectStatus("TODO")).toBe(PROJECT_STATUS.TODO);
+    expect(parseProjectStatus("DONE")).toBe(PROJECT_STATUS.DONE);
+  });
+
+  it("모르는 값·빈 값은 기본 탭(진행중)으로", () => {
+    expect(parseProjectStatus("nonsense")).toBe(DEFAULT_PROJECT_STATUS);
+    expect(parseProjectStatus(undefined)).toBe(PROJECT_STATUS.IN_PROGRESS);
+  });
+});

--- a/src/features/project/lib.test.ts
+++ b/src/features/project/lib.test.ts
@@ -17,7 +17,6 @@ function project(overrides: Partial<ProjectListItem>): ProjectListItem {
     name: "프로젝트",
     description: "",
     tag: "TAG",
-    color: "#000000",
     departments: [],
     actionTotal: 0,
     actionDone: 0,

--- a/src/features/project/lib.test.ts
+++ b/src/features/project/lib.test.ts
@@ -1,11 +1,33 @@
 import { PROJECT_STATUS } from "@/constants/domain";
 
 import {
+  DEFAULT_PROJECT_SORT,
   DEFAULT_PROJECT_STATUS,
   getProgressPercent,
+  parseProjectSort,
   parseProjectStatus,
+  PROJECT_SORT,
+  sortProjects,
   splitDepartments,
 } from "./lib";
+import type { ProjectListItem } from "./types";
+
+/** 정렬 검증용 최소 프로젝트 — 이름·마감일만 다르게 둔다. */
+function project(overrides: Partial<ProjectListItem>): ProjectListItem {
+  return {
+    id: "p",
+    name: "프로젝트",
+    description: "",
+    tag: "TAG",
+    color: "#000000",
+    departments: [],
+    actionTotal: 0,
+    actionDone: 0,
+    dueDate: "2026-09-01",
+    status: PROJECT_STATUS.IN_PROGRESS,
+    ...overrides,
+  };
+}
 
 describe("getProgressPercent", () => {
   it("완료/전체를 반올림한 백분율로 준다", () => {
@@ -44,5 +66,41 @@ describe("parseProjectStatus", () => {
   it("모르는 값·빈 값은 기본 탭(진행중)으로", () => {
     expect(parseProjectStatus("nonsense")).toBe(DEFAULT_PROJECT_STATUS);
     expect(parseProjectStatus(undefined)).toBe(PROJECT_STATUS.IN_PROGRESS);
+  });
+});
+
+describe("parseProjectSort", () => {
+  it("아는 정렬 값은 통과, 모르면 기본(마감 임박순)", () => {
+    expect(parseProjectSort("NAME")).toBe(PROJECT_SORT.NAME);
+    expect(parseProjectSort("nonsense")).toBe(DEFAULT_PROJECT_SORT);
+    expect(parseProjectSort(undefined)).toBe(PROJECT_SORT.DUE_ASC);
+  });
+});
+
+describe("sortProjects", () => {
+  const a = project({ id: "a", name: "가나다", dueDate: "2026-09-05" });
+  const b = project({ id: "b", name: "다라마", dueDate: "2026-09-01" });
+  const c = project({ id: "c", name: "나다라", dueDate: "2026-09-12" });
+
+  it("마감 임박순은 오름차순", () => {
+    expect(sortProjects([a, b, c], PROJECT_SORT.DUE_ASC).map((p) => p.id)).toEqual(["b", "a", "c"]);
+  });
+
+  it("마감 늦은순은 내림차순", () => {
+    expect(sortProjects([a, b, c], PROJECT_SORT.DUE_DESC).map((p) => p.id)).toEqual([
+      "c",
+      "a",
+      "b",
+    ]);
+  });
+
+  it("이름순은 한글 가나다", () => {
+    expect(sortProjects([a, b, c], PROJECT_SORT.NAME).map((p) => p.id)).toEqual(["a", "c", "b"]);
+  });
+
+  it("입력 배열을 건드리지 않는다(불변)", () => {
+    const input = [a, b, c];
+    sortProjects(input, PROJECT_SORT.NAME);
+    expect(input.map((p) => p.id)).toEqual(["a", "b", "c"]);
   });
 });

--- a/src/features/project/lib.ts
+++ b/src/features/project/lib.ts
@@ -1,4 +1,11 @@
-import { PROJECT_STATUS, PROJECT_STATUS_LABEL, type ProjectStatus } from "@/constants/domain";
+import {
+  DEFAULT_PROJECT_SORT,
+  PROJECT_SORT,
+  PROJECT_STATUS,
+  PROJECT_STATUS_LABEL,
+  type ProjectSort,
+  type ProjectStatus,
+} from "@/constants/domain";
 
 import type { ProjectListItem } from "./types";
 
@@ -14,20 +21,6 @@ export const DEFAULT_PROJECT_STATUS: ProjectStatus = PROJECT_STATUS.IN_PROGRESS;
 
 /** 담당 부서 라벨을 몇 개까지 노출하는지 — 나머지는 `+N`. */
 export const MAX_VISIBLE_DEPARTMENTS = 2;
-
-/** 정렬 기준 — 마감 임박순이 기본(스펙). '마감 늦은순'은 임박순과 결이 겹쳐 두지 않는다. */
-export const PROJECT_SORT = {
-  DUE_ASC: "DUE_ASC",
-  NAME: "NAME",
-} as const;
-export type ProjectSort = (typeof PROJECT_SORT)[keyof typeof PROJECT_SORT];
-
-export const PROJECT_SORT_LABEL: Record<ProjectSort, string> = {
-  DUE_ASC: "마감 임박순",
-  NAME: "이름순",
-};
-
-export const DEFAULT_PROJECT_SORT: ProjectSort = PROJECT_SORT.DUE_ASC;
 
 /** URL의 `?status=` 값을 안전하게 상태로 — 모르는 값이면 기본 탭. */
 export function parseProjectStatus(value: string | undefined): ProjectStatus {

--- a/src/features/project/lib.ts
+++ b/src/features/project/lib.ts
@@ -15,17 +15,15 @@ export const DEFAULT_PROJECT_STATUS: ProjectStatus = PROJECT_STATUS.IN_PROGRESS;
 /** 담당 부서 라벨을 몇 개까지 노출하는지 — 나머지는 `+N`. */
 export const MAX_VISIBLE_DEPARTMENTS = 2;
 
-/** 정렬 기준 — 마감 임박순이 기본(스펙). */
+/** 정렬 기준 — 마감 임박순이 기본(스펙). '마감 늦은순'은 임박순과 결이 겹쳐 두지 않는다. */
 export const PROJECT_SORT = {
   DUE_ASC: "DUE_ASC",
-  DUE_DESC: "DUE_DESC",
   NAME: "NAME",
 } as const;
 export type ProjectSort = (typeof PROJECT_SORT)[keyof typeof PROJECT_SORT];
 
 export const PROJECT_SORT_LABEL: Record<ProjectSort, string> = {
   DUE_ASC: "마감 임박순",
-  DUE_DESC: "마감 늦은순",
   NAME: "이름순",
 };
 
@@ -45,8 +43,6 @@ export function parseProjectSort(value: string | undefined): ProjectSort {
 export function sortProjects(list: ProjectListItem[], sort: ProjectSort): ProjectListItem[] {
   const sorted = [...list];
   switch (sort) {
-    case PROJECT_SORT.DUE_DESC:
-      return sorted.sort((a, b) => b.dueDate.localeCompare(a.dueDate));
     case PROJECT_SORT.NAME:
       return sorted.sort((a, b) => a.name.localeCompare(b.name, "ko"));
     case PROJECT_SORT.DUE_ASC:

--- a/src/features/project/lib.ts
+++ b/src/features/project/lib.ts
@@ -1,5 +1,7 @@
 import { PROJECT_STATUS, PROJECT_STATUS_LABEL, type ProjectStatus } from "@/constants/domain";
 
+import type { ProjectListItem } from "./types";
+
 /** 목록 위에 오는 상태 필터 탭 — 값·라벨은 도메인 상수에서 온다(라벨 하드코딩 금지). */
 export const PROJECT_FILTER_TABS: { status: ProjectStatus; label: string }[] = [
   { status: PROJECT_STATUS.TODO, label: PROJECT_STATUS_LABEL[PROJECT_STATUS.TODO] },
@@ -13,9 +15,44 @@ export const DEFAULT_PROJECT_STATUS: ProjectStatus = PROJECT_STATUS.IN_PROGRESS;
 /** 담당 부서 라벨을 몇 개까지 노출하는지 — 나머지는 `+N`. */
 export const MAX_VISIBLE_DEPARTMENTS = 2;
 
+/** 정렬 기준 — 마감 임박순이 기본(스펙). */
+export const PROJECT_SORT = {
+  DUE_ASC: "DUE_ASC",
+  DUE_DESC: "DUE_DESC",
+  NAME: "NAME",
+} as const;
+export type ProjectSort = (typeof PROJECT_SORT)[keyof typeof PROJECT_SORT];
+
+export const PROJECT_SORT_LABEL: Record<ProjectSort, string> = {
+  DUE_ASC: "마감 임박순",
+  DUE_DESC: "마감 늦은순",
+  NAME: "이름순",
+};
+
+export const DEFAULT_PROJECT_SORT: ProjectSort = PROJECT_SORT.DUE_ASC;
+
 /** URL의 `?status=` 값을 안전하게 상태로 — 모르는 값이면 기본 탭. */
 export function parseProjectStatus(value: string | undefined): ProjectStatus {
   return PROJECT_FILTER_TABS.find((tab) => tab.status === value)?.status ?? DEFAULT_PROJECT_STATUS;
+}
+
+/** URL의 `?sort=` 값을 안전하게 정렬 기준으로 — 모르는 값이면 기본(마감 임박순). */
+export function parseProjectSort(value: string | undefined): ProjectSort {
+  return Object.values(PROJECT_SORT).find((sort) => sort === value) ?? DEFAULT_PROJECT_SORT;
+}
+
+/** 정렬 적용(불변) — 서버가 목록에 얹는다. 순수 함수라 그대로 테스트한다. */
+export function sortProjects(list: ProjectListItem[], sort: ProjectSort): ProjectListItem[] {
+  const sorted = [...list];
+  switch (sort) {
+    case PROJECT_SORT.DUE_DESC:
+      return sorted.sort((a, b) => b.dueDate.localeCompare(a.dueDate));
+    case PROJECT_SORT.NAME:
+      return sorted.sort((a, b) => a.name.localeCompare(b.name, "ko"));
+    case PROJECT_SORT.DUE_ASC:
+    default:
+      return sorted.sort((a, b) => a.dueDate.localeCompare(b.dueDate));
+  }
 }
 
 /** 진척율(%) — 액션이 없으면 0. 파생값이라 저장하지 않고 계산한다. */

--- a/src/features/project/lib.ts
+++ b/src/features/project/lib.ts
@@ -1,0 +1,33 @@
+import { PROJECT_STATUS, PROJECT_STATUS_LABEL, type ProjectStatus } from "@/constants/domain";
+
+/** 목록 위에 오는 상태 필터 탭 — 값·라벨은 도메인 상수에서 온다(라벨 하드코딩 금지). */
+export const PROJECT_FILTER_TABS: { status: ProjectStatus; label: string }[] = [
+  { status: PROJECT_STATUS.TODO, label: PROJECT_STATUS_LABEL[PROJECT_STATUS.TODO] },
+  { status: PROJECT_STATUS.IN_PROGRESS, label: PROJECT_STATUS_LABEL[PROJECT_STATUS.IN_PROGRESS] },
+  { status: PROJECT_STATUS.DONE, label: PROJECT_STATUS_LABEL[PROJECT_STATUS.DONE] },
+];
+
+/** 기본 탭 — 피그마에서 활성인 '진행중'. */
+export const DEFAULT_PROJECT_STATUS: ProjectStatus = PROJECT_STATUS.IN_PROGRESS;
+
+/** 담당 부서 라벨을 몇 개까지 노출하는지 — 나머지는 `+N`. */
+export const MAX_VISIBLE_DEPARTMENTS = 2;
+
+/** URL의 `?status=` 값을 안전하게 상태로 — 모르는 값이면 기본 탭. */
+export function parseProjectStatus(value: string | undefined): ProjectStatus {
+  return PROJECT_FILTER_TABS.find((tab) => tab.status === value)?.status ?? DEFAULT_PROJECT_STATUS;
+}
+
+/** 진척율(%) — 액션이 없으면 0. 파생값이라 저장하지 않고 계산한다. */
+export function getProgressPercent(done: number, total: number): number {
+  if (total <= 0) return 0;
+  return Math.round((done / total) * 100);
+}
+
+/** 부서 라벨을 노출분/초과수로 가른다. `{ visible: ["개발팀","마케팅팀"], overflow: 1 }`. */
+export function splitDepartments(
+  departments: string[],
+  max = MAX_VISIBLE_DEPARTMENTS,
+): { visible: string[]; overflow: number } {
+  return { visible: departments.slice(0, max), overflow: Math.max(0, departments.length - max) };
+}

--- a/src/features/project/mock/projects.ts
+++ b/src/features/project/mock/projects.ts
@@ -14,7 +14,6 @@ export const TOP_LEVEL_PROJECTS: ProjectListItem[] = [
     description:
       "아티스트 공식 굿즈를 판매하는 모바일 커머스 앱을 신규 구축한다. 회원가입·결제·상품 관리 전반을 포함하며 개발·마케팅·디자인 3개 팀이 참여한다.",
     tag: "GOODS",
-    color: "#7C3AED",
     departments: ["개발팀", "마케팅팀", "디자인팀"],
     actionTotal: 11,
     actionDone: 0,
@@ -27,7 +26,6 @@ export const TOP_LEVEL_PROJECTS: ProjectListItem[] = [
     description:
       "3분기 브랜드 아이덴티티를 리뉴얼한다. 로고·가이드라인 개편과 캠페인 자산 제작을 마케팅·디자인팀이 함께 진행한다.",
     tag: "BRAND",
-    color: "#DB2777",
     departments: ["마케팅팀", "디자인팀"],
     actionTotal: 4,
     actionDone: 0,
@@ -40,7 +38,6 @@ export const TOP_LEVEL_PROJECTS: ProjectListItem[] = [
     description:
       "사내에서 쓰는 협업 도구를 재정비한다. 회의·문서·일정 흐름을 하나로 잇는 개편을 개발·전략기획팀이 담당한다.",
     tag: "COLLAB",
-    color: "#2563EB",
     departments: ["개발팀", "전략기획팀"],
     actionTotal: 4,
     actionDone: 0,

--- a/src/features/project/mock/projects.ts
+++ b/src/features/project/mock/projects.ts
@@ -1,0 +1,44 @@
+import { PROJECT_STATUS } from "@/constants/domain";
+
+import type { ProjectListItem } from "../types";
+
+/**
+ * ⚠️ 목 데이터 — BE 연동 전(ERD·API 스펙 미확정, DECISIONS.md).
+ * 워크플로우 문서의 대표 프로젝트 3개(GOODS·BRAND·COLLAB) 기준. 전부 Owner(박대표)가 개설했고
+ * 현재 진행중이라 진척율은 착수 직후(0%)다. 마감 임박순 정렬은 서버가 얹는다.
+ */
+export const TOP_LEVEL_PROJECTS: ProjectListItem[] = [
+  {
+    id: "p-goods",
+    name: "연예인 굿즈 쇼핑몰 앱 구축",
+    tag: "GOODS",
+    color: "#7C3AED",
+    departments: ["개발팀", "마케팅팀", "디자인팀"],
+    actionTotal: 11,
+    actionDone: 0,
+    dueDate: "2026-09-05",
+    status: PROJECT_STATUS.IN_PROGRESS,
+  },
+  {
+    id: "p-brand",
+    name: "3분기 마케팅 브랜드 리뉴얼",
+    tag: "BRAND",
+    color: "#DB2777",
+    departments: ["마케팅팀", "디자인팀"],
+    actionTotal: 4,
+    actionDone: 0,
+    dueDate: "2026-09-12",
+    status: PROJECT_STATUS.IN_PROGRESS,
+  },
+  {
+    id: "p-collab",
+    name: "사내 협업툴 리뉴얼",
+    tag: "COLLAB",
+    color: "#2563EB",
+    departments: ["개발팀", "전략기획팀"],
+    actionTotal: 4,
+    actionDone: 0,
+    dueDate: "2026-09-19",
+    status: PROJECT_STATUS.IN_PROGRESS,
+  },
+];

--- a/src/features/project/mock/projects.ts
+++ b/src/features/project/mock/projects.ts
@@ -11,6 +11,8 @@ export const TOP_LEVEL_PROJECTS: ProjectListItem[] = [
   {
     id: "p-goods",
     name: "연예인 굿즈 쇼핑몰 앱 구축",
+    description:
+      "아티스트 공식 굿즈를 판매하는 모바일 커머스 앱을 신규 구축한다. 회원가입·결제·상품 관리 전반을 포함하며 개발·마케팅·디자인 3개 팀이 참여한다.",
     tag: "GOODS",
     color: "#7C3AED",
     departments: ["개발팀", "마케팅팀", "디자인팀"],
@@ -22,6 +24,8 @@ export const TOP_LEVEL_PROJECTS: ProjectListItem[] = [
   {
     id: "p-brand",
     name: "3분기 마케팅 브랜드 리뉴얼",
+    description:
+      "3분기 브랜드 아이덴티티를 리뉴얼한다. 로고·가이드라인 개편과 캠페인 자산 제작을 마케팅·디자인팀이 함께 진행한다.",
     tag: "BRAND",
     color: "#DB2777",
     departments: ["마케팅팀", "디자인팀"],
@@ -33,6 +37,8 @@ export const TOP_LEVEL_PROJECTS: ProjectListItem[] = [
   {
     id: "p-collab",
     name: "사내 협업툴 리뉴얼",
+    description:
+      "사내에서 쓰는 협업 도구를 재정비한다. 회의·문서·일정 흐름을 하나로 잇는 개편을 개발·전략기획팀이 담당한다.",
     tag: "COLLAB",
     color: "#2563EB",
     departments: ["개발팀", "전략기획팀"],

--- a/src/features/project/server.ts
+++ b/src/features/project/server.ts
@@ -1,0 +1,19 @@
+import type { ProjectStatus } from "@/constants/domain";
+import { isMock } from "@/mocks/config";
+
+import { TOP_LEVEL_PROJECTS } from "./mock/projects";
+import type { ProjectListItem } from "./types";
+
+/**
+ * 프로젝트 전체 조회 — 상태 탭으로 거르고 **마감 임박순(오름차순)** 정렬.
+ * ⚠️ 실연동 시 이 분기와 매퍼만 고친다(격리막). 페이지네이션은 BE가 페이지 단위로 주면 그때 얹는다.
+ */
+export async function getProjectList(status: ProjectStatus): Promise<ProjectListItem[]> {
+  if (isMock) {
+    return TOP_LEVEL_PROJECTS.filter((project) => project.status === status).sort((a, b) =>
+      a.dueDate.localeCompare(b.dueDate),
+    );
+  }
+
+  throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
+}

--- a/src/features/project/server.ts
+++ b/src/features/project/server.ts
@@ -1,7 +1,7 @@
-import type { ProjectStatus } from "@/constants/domain";
+import { DEFAULT_PROJECT_SORT, type ProjectSort, type ProjectStatus } from "@/constants/domain";
 import { isMock } from "@/mocks/config";
 
-import { DEFAULT_PROJECT_SORT, type ProjectSort, sortProjects } from "./lib";
+import { sortProjects } from "./lib";
 import { TOP_LEVEL_PROJECTS } from "./mock/projects";
 import type { ProjectListItem } from "./types";
 

--- a/src/features/project/server.ts
+++ b/src/features/project/server.ts
@@ -1,18 +1,54 @@
 import type { ProjectStatus } from "@/constants/domain";
 import { isMock } from "@/mocks/config";
 
+import { DEFAULT_PROJECT_SORT, type ProjectSort, sortProjects } from "./lib";
 import { TOP_LEVEL_PROJECTS } from "./mock/projects";
 import type { ProjectListItem } from "./types";
 
+/** 이름에 검색어가 들어가는지(대소문자·공백 무시). 검색어가 없으면 항상 통과. */
+function matchesKeyword(project: ProjectListItem, keyword?: string): boolean {
+  const q = keyword?.trim().toLowerCase();
+  if (!q) return true;
+  return project.name.toLowerCase().includes(q);
+}
+
+export interface ProjectListQuery {
+  status: ProjectStatus;
+  keyword?: string;
+  sort?: ProjectSort;
+}
+
 /**
- * 프로젝트 전체 조회 — 상태 탭으로 거르고 **마감 임박순(오름차순)** 정렬.
+ * 프로젝트 전체 조회 — 상태 탭·검색어로 거르고 정렬(기본 마감 임박순).
  * ⚠️ 실연동 시 이 분기와 매퍼만 고친다(격리막). 페이지네이션은 BE가 페이지 단위로 주면 그때 얹는다.
  */
-export async function getProjectList(status: ProjectStatus): Promise<ProjectListItem[]> {
+export async function getProjectList({
+  status,
+  keyword,
+  sort = DEFAULT_PROJECT_SORT,
+}: ProjectListQuery): Promise<ProjectListItem[]> {
   if (isMock) {
-    return TOP_LEVEL_PROJECTS.filter((project) => project.status === status).sort((a, b) =>
-      a.dueDate.localeCompare(b.dueDate),
+    const filtered = TOP_LEVEL_PROJECTS.filter(
+      (project) => project.status === status && matchesKeyword(project, keyword),
     );
+    return sortProjects(filtered, sort);
+  }
+
+  throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
+}
+
+/**
+ * 상태별 프로젝트 수 — 필터 탭에 붙는 배지. 검색어가 있으면 그 결과 안에서 센다(탭·목록이 같은 기준).
+ */
+export async function getProjectStatusCounts(
+  keyword?: string,
+): Promise<Record<ProjectStatus, number>> {
+  if (isMock) {
+    const counts: Record<ProjectStatus, number> = { TODO: 0, IN_PROGRESS: 0, DONE: 0 };
+    for (const project of TOP_LEVEL_PROJECTS) {
+      if (matchesKeyword(project, keyword)) counts[project.status] += 1;
+    }
+    return counts;
   }
 
   throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");

--- a/src/features/project/types.ts
+++ b/src/features/project/types.ts
@@ -1,0 +1,23 @@
+import type { ProjectStatus } from "@/constants/domain";
+
+/**
+ * 프로젝트 전체 조회(`/app/projects`)의 한 행. UI 계약(Mock → Live 격리막) — 컴포넌트는 이 타입만 안다.
+ * ⚠️ 프로젝트는 전부 Owner가 개설하므로 개설자 라벨은 항상 "Owner"라 필드로 두지 않는다(상수 표시).
+ */
+export interface ProjectListItem {
+  id: string;
+  name: string;
+  /** 프로젝트 태그(프로젝트당 1개 고정) */
+  tag: string;
+  /** 자유 HEX(프로젝트 태그 색) */
+  color: string;
+  /** 참여 부서명들 — 2개까지 노출 후 `+N` */
+  departments: string[];
+  /** 이 태그가 달린 전체 액션 수 */
+  actionTotal: number;
+  /** 그중 완료 액션 수 — 진척율 = done/total */
+  actionDone: number;
+  /** 마감일 `YYYY-MM-DD` */
+  dueDate: string;
+  status: ProjectStatus;
+}

--- a/src/features/project/types.ts
+++ b/src/features/project/types.ts
@@ -12,10 +12,12 @@ export interface ProjectListItem {
    * ⚠️ 목록 카드에는 요약이 아니라 원문을 그대로 내려보내고, 자르기는 화면이 `line-clamp`로 한다.
    */
   description: string;
-  /** 프로젝트 태그(프로젝트당 1개 고정) */
+  /**
+   * 프로젝트 태그(프로젝트당 1개 고정). 태그 칩·스트립 색은 이 값으로 고정 팔레트에서 뽑는다
+   * (`lib/palette` → `globals.css --tag-*`). 별도 색 필드를 두지 않는다 — 자유 HEX는 다크모드에
+   * 안 맞고, BE에 색 필드가 없어 프론트가 이름으로 일관되게 배정한다.
+   */
   tag: string;
-  /** 자유 HEX(프로젝트 태그 색) */
-  color: string;
   /** 참여 부서명들 — 2개까지 노출 후 `+N` */
   departments: string[];
   /** 이 태그가 달린 전체 액션 수 */

--- a/src/features/project/types.ts
+++ b/src/features/project/types.ts
@@ -7,6 +7,11 @@ import type { ProjectStatus } from "@/constants/domain";
 export interface ProjectListItem {
   id: string;
   name: string;
+  /**
+   * 세부 설명(기획). 실제로는 Owner가 길게 쓸 수 있는 본문이라 목록에선 **첫 줄만** 잘라 보여준다.
+   * ⚠️ 목록 카드에는 요약이 아니라 원문을 그대로 내려보내고, 자르기는 화면이 `line-clamp`로 한다.
+   */
+  description: string;
   /** 프로젝트 태그(프로젝트당 1개 고정) */
   tag: string;
   /** 자유 HEX(프로젝트 태그 색) */

--- a/src/features/shell/nav-config.test.ts
+++ b/src/features/shell/nav-config.test.ts
@@ -178,6 +178,7 @@ describe("화면이 있으면 자동으로 이어진다", () => {
     ["/owner", "대시보드"],
     ["/team", "대시보드"],
     ["/my", "대시보드"],
+    ["/app/projects", "프로젝트"],
     ["/app/calendar", "캘린더"],
     ["/app/notice", "공지"],
     ["/app/me", "마이페이지"],
@@ -191,7 +192,6 @@ describe("화면이 있으면 자동으로 이어진다", () => {
   });
 
   it.each([
-    ["/app/projects", "프로젝트"],
     ["/app/meeting", "회의"],
     ["/manage/members", "사원 관리"],
     ["/owner/setting", "기업 설정"],

--- a/src/lib/date.test.ts
+++ b/src/lib/date.test.ts
@@ -1,4 +1,4 @@
-import { formatElapsed } from "./date";
+import { formatElapsed, formatMonthDayWeekday } from "./date";
 
 /**
  * ⚠️ `todayIso()`는 테스트하지 않는다 — 실제 시계를 읽는 함수라 시각을 고정하지 않으면
@@ -45,5 +45,21 @@ describe("formatElapsed", () => {
   it("형식이 아니면 null이다", () => {
     expect(formatElapsed("", TODAY)).toBeNull();
     expect(formatElapsed("어제", TODAY)).toBeNull();
+  });
+});
+
+describe("formatMonthDayWeekday", () => {
+  it("월·일·요일을 조립한다 — 2026-09-05는 토요일", () => {
+    expect(formatMonthDayWeekday("2026-09-05")).toBe("9월 5일(토)");
+    expect(formatMonthDayWeekday("2026-08-05")).toBe("8월 5일(수)");
+  });
+
+  it("앞자리 0을 붙이지 않는다", () => {
+    expect(formatMonthDayWeekday("2026-01-03")).toBe("1월 3일(토)");
+  });
+
+  it("형식이 아니면 null이다", () => {
+    expect(formatMonthDayWeekday("2026/09/05")).toBeNull();
+    expect(formatMonthDayWeekday("")).toBeNull();
   });
 });

--- a/src/lib/date.test.ts
+++ b/src/lib/date.test.ts
@@ -62,4 +62,9 @@ describe("formatMonthDayWeekday", () => {
     expect(formatMonthDayWeekday("2026/09/05")).toBeNull();
     expect(formatMonthDayWeekday("")).toBeNull();
   });
+
+  it("형식은 맞지만 실재하지 않는 날짜는 null이다", () => {
+    expect(formatMonthDayWeekday("2026-02-30")).toBeNull();
+    expect(formatMonthDayWeekday("2026-02-29")).toBeNull(); // 2026은 평년
+  });
 });

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -98,6 +98,16 @@ export function formatMonthDayWeekday(iso: string): string | null {
   const d = parseIsoDate(iso);
   if (!d) return null;
 
-  const weekday = WEEKDAY_LABEL[new Date(Date.UTC(d.y, d.m - 1, d.d)).getUTCDay()] ?? "";
+  const date = new Date(Date.UTC(d.y, d.m - 1, d.d));
+  // `2026-02-30`처럼 형식은 맞지만 없는 날짜는 Date가 다음 달로 굴러간다 — 되돌려 확인해 걸러낸다
+  if (
+    date.getUTCFullYear() !== d.y ||
+    date.getUTCMonth() !== d.m - 1 ||
+    date.getUTCDate() !== d.d
+  ) {
+    return null;
+  }
+
+  const weekday = WEEKDAY_LABEL[date.getUTCDay()] ?? "";
   return `${d.m}월 ${d.d}일(${weekday})`;
 }

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -84,3 +84,20 @@ export function formatElapsed(iso: string, today: string): string | null {
 
   return `${Math.floor(months / 12)}년 전`;
 }
+
+/** 요일 라벨 — `Date.getUTCDay()` 인덱스(0=일)와 짝. */
+const WEEKDAY_LABEL = ["일", "월", "화", "수", "목", "금", "토"] as const;
+
+/**
+ * `2026-09-05` → `9월 5일(토)`. 형식이 아니면 `null`.
+ *
+ * ⚠️ 요일도 `toLocaleDateString` 대신 `Date.UTC`로 구한다 — 로케일·시간대에 흔들리지 않게
+ *    (§렌더링: 서버·클라 표기가 갈리면 하이드레이션이 어긋난다). 카피 규칙 `8월 5일(수)`.
+ */
+export function formatMonthDayWeekday(iso: string): string | null {
+  const d = parseIsoDate(iso);
+  if (!d) return null;
+
+  const weekday = WEEKDAY_LABEL[new Date(Date.UTC(d.y, d.m - 1, d.d)).getUTCDay()] ?? "";
+  return `${d.m}월 ${d.d}일(${weekday})`;
+}


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가
- [x] test — 테스트 코드

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

- 공용 워크벤치 프로젝트 전체 조회 `/app/projects`를 피그마 기준으로 구현
- 상태 필터 탭(할일/진행중/완료) — `?status=` 서버우선(Link), 기본 진행중
- 행 = 회의 아이템 결 — 좌 태그·프로젝트명·Owner 라벨 / 우 진척 바 · 마감일 · **참여 팀(2개+`+N`, hover 시 전체)**
- 진척 바는 재사용 컴포넌트 `components/ui/progress.tsx`(base-ui) 신설, 길이는 고정 폭으로 짧게
- 마감 임박순 정렬, 전 구성원 조회. `새 프로젝트` 버튼은 Owner 전용(`canCreateProject`)
- 왼쪽 태그색 스트립. 카드 클릭 → `/app/projects/:tag`(상세는 후속)
- `features/project`(격리막): types·lib·mock(`TOP_LEVEL_PROJECTS` GOODS/BRAND/COLLAB)·server
- 공용 `lib/date.ts`에 `formatMonthDayWeekday`(`9월 5일(토)`) 추가

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [x] 🔐 권한 2축 검사 — `새 프로젝트` 버튼은 Owner 전용(`canCreateProject`)
- [ ] 🧬 zod — 해당 없음
- [x] 🕵️ 정직성 — BE 연동 전 목 기준임을 명시, 페이지네이션은 BE 페이지네이션 확정 후 연결
- [x] 🎨 디자인 토큰 사용 · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [x] ♿ a11y — 안내 툴팁 UI 포함
- [x] ♻️ 재사용 확인 — `components/ui/progress.tsx` 신설해 진척 바 공용화
- [x] 🧪 `loading` / `error(ScreenError)` / `empty` 3상태
- [ ] 브라우저 전용 API 미사용

---

## 🔗 연관 이슈

Closes #134

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

-

---

## 📝 추가 메모

순수 로직 유닛 테스트(진척율·부서 분할·상태 파싱·날짜 포맷) 포함.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 프로젝트 목록 페이지를 추가했습니다.
  - 상태별 필터, 프로젝트 검색 및 정렬 기능을 제공합니다.
  - 프로젝트별 태그, 설명, 담당 부서, 진행률, 마감일과 참여 팀을 확인할 수 있습니다.
  - 프로젝트 생성 권한이 있는 경우 새 프로젝트로 이동할 수 있습니다.
  - 로딩 중 스켈레톤 화면과 프로젝트 로드 실패 시 재시도 기능을 제공합니다.
  - 진행률 표시와 안내 툴팁 UI를 추가했습니다.

- **테스트**
  - 프로젝트 필터·정렬·진행률 계산 및 날짜 표시 동작을 검증했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
