### PR TITLE
[FEAT] 마이페이지 — 기본 정보 #142

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,15 @@
 import type { NextConfig } from "next";
 
+/*
+  ⚠️ 서버 프로세스의 시간대를 한국 시간(KST, UTC+9)으로 고정한다.
+     `new Date("2026-08-05T00:00:00")`처럼 오프셋 없는 문자열은 **프로세스의 로컬 시간대**로
+     해석된다(Mock 데이터·Server Action이 전부 이 방식이다, `src/features/calendar/mock/events.ts`
+     등). 배포 환경(컨테이너 등)이 기본값으로 UTC를 쓰면, 자정 근처 시각이 하루 앞뒤로 밀려
+     보인다 — 브라우저(사용자 KST)와 서버가 서로 다른 시간대로 같은 문자열을 해석해서 생기는
+     문제다. `next.config.ts`가 가장 먼저 로드되므로 여기서 프로세스 전체에 못 박는다.
+*/
+process.env.TZ = "Asia/Seoul";
+
 const nextConfig: NextConfig = {
   /*
     개발 서버 표시등(왼쪽 아래 동그란 `N` 배지)을 끈다.

--- a/src/app/(shell)/app/me/page.tsx
+++ b/src/app/(shell)/app/me/page.tsx
@@ -1,25 +1,36 @@
 import type { Metadata } from "next";
 
 import { ScreenScaleCard } from "@/features/appearance/components/screen-scale-card";
+import { ProfileHeader } from "@/features/profile/components/profile-header";
+import { ProfileInfoCard } from "@/features/profile/components/profile-info-card";
+import { getMyProfile } from "@/features/profile/server";
 
 export const metadata: Metadata = {
   title: "마이페이지",
 };
 
 /**
- * 마이페이지 — 지금은 **화면 배율 하나뿐**이다.
+ * 마이페이지 — 프로필(읽기 전용)과 화면 배율.
  *
- * ⚠️ **명세가 아직 없다.** 라우트 트리에는 `/app/me`가 있지만 `docs/WORKFLOW.md`에 화면
- *    내용이 없다 — 프로필·알림·비밀번호 같은 걸 지금 지어내면 명세가 나올 때 갈아엎어야 한다.
- *    배율만 먼저 두고 그 위에 얹는다(§명세에 없는 화면·기능은 안 만든다).
- * ⚠️ 배율은 **기기 설정**이라 서버에 저장하지 않는다. 여기서는 조회할 것도 없어서
- *    Server Component가 하는 일이 없다.
+ * ⚠️ **편집·연차 등은 명세가 없어 만들지 않는다**(§명세에 없는 화면·기능은 안 만든다).
+ *    "기본 정보"는 팀 디자인(피그마)을 그대로 반영했지만, 이 화면에서 값을 고칠 수 있다는
+ *    뜻은 아니다 — 편집 API·정책이 확정되면 그때 붙인다.
+ * ⚠️ 배율은 **기기 설정**이라 서버에 저장하지 않는다(`ScreenScaleCard` 그대로 유지).
  */
-export default function AppMePage() {
+export default async function AppMePage() {
+  const profile = await getMyProfile();
+
   return (
     <div className="flex-1 overflow-y-auto px-8 py-7">
       <div className="mx-auto w-full max-w-[1440px]">
-        <ScreenScaleCard />
+        <div className="mx-auto flex w-full max-w-[600px] flex-col gap-7">
+          <div className="flex flex-col gap-5">
+            <ProfileHeader profile={profile} />
+            <ProfileInfoCard profile={profile} />
+          </div>
+
+          <ScreenScaleCard />
+        </div>
       </div>
     </div>
   );

--- a/src/constants/profile.ts
+++ b/src/constants/profile.ts
@@ -1,0 +1,10 @@
+/** 마이페이지 "기본 정보" 카드 라벨 — 화면 문구는 상수에서만 가져온다(§도메인 상수: 라벨 하드코딩 금지). */
+export const PROFILE_INFO_CARD_TITLE = "기본 정보";
+
+export const PROFILE_INFO_ROW_LABEL = {
+  NAME: "이름",
+  EMAIL: "이메일",
+  TEAM: "부서",
+  POSITION: "직급",
+  JOINED_AT: "입사일",
+} as const;

--- a/src/features/profile/components/profile-header.test.tsx
+++ b/src/features/profile/components/profile-header.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+
+import { ROLE_LABEL } from "@/constants/role";
+
+import { MY_PROFILE_MOCK } from "../mock/profile";
+import { ProfileHeader } from "./profile-header";
+
+describe("ProfileHeader", () => {
+  it("이름·이메일·역할 라벨·소속을 보여준다", () => {
+    render(<ProfileHeader profile={MY_PROFILE_MOCK} />);
+
+    expect(screen.getByText(MY_PROFILE_MOCK.name)).toBeInTheDocument();
+    expect(screen.getByText(MY_PROFILE_MOCK.email)).toBeInTheDocument();
+    expect(screen.getByText(ROLE_LABEL[MY_PROFILE_MOCK.role])).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        `${MY_PROFILE_MOCK.companyName} · ${MY_PROFILE_MOCK.teamName} · ${MY_PROFILE_MOCK.position}`,
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/features/profile/components/profile-header.tsx
+++ b/src/features/profile/components/profile-header.tsx
@@ -3,8 +3,12 @@ import { cn } from "@/lib/utils";
 
 import type { MyProfile } from "../types";
 
+interface ProfileHeaderProps {
+  profile: MyProfile;
+}
+
 /** 마이페이지 맨 위 — 아바타·이름·이메일·역할 배지·소속. 편집 불가(읽기 전용, §명세 없음). */
-export function ProfileHeader({ profile }: { profile: MyProfile }) {
+export function ProfileHeader({ profile }: ProfileHeaderProps) {
   return (
     <div className="border-border flex items-center gap-3.5 border-b pb-5">
       <div className="bg-foreground text-background flex size-14 shrink-0 items-center justify-center rounded-full text-[22px] font-medium">

--- a/src/features/profile/components/profile-header.tsx
+++ b/src/features/profile/components/profile-header.tsx
@@ -1,0 +1,34 @@
+import { ROLE_BADGE_CLASS, ROLE_LABEL } from "@/constants/role";
+import { cn } from "@/lib/utils";
+
+import type { MyProfile } from "../types";
+
+/** 마이페이지 맨 위 — 아바타·이름·이메일·역할 배지·소속. 편집 불가(읽기 전용, §명세 없음). */
+export function ProfileHeader({ profile }: { profile: MyProfile }) {
+  return (
+    <div className="border-border flex items-center gap-3.5 border-b pb-5">
+      <div className="bg-foreground text-background flex size-14 shrink-0 items-center justify-center rounded-full text-[22px] font-medium">
+        {profile.name.charAt(0)}
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <p className="text-[17px] leading-[26px] font-semibold">{profile.name}</p>
+        <p className="text-muted-foreground text-xs">{profile.email}</p>
+
+        <div className="flex items-center gap-1.5 pt-0.5">
+          <span
+            className={cn(
+              "inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-[11px] leading-none",
+              ROLE_BADGE_CLASS[profile.role],
+            )}
+          >
+            {ROLE_LABEL[profile.role]}
+          </span>
+          <span className="text-muted-foreground/70 text-[11px]">
+            {profile.companyName} · {profile.teamName} · {profile.position}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/profile/components/profile-info-card.test.tsx
+++ b/src/features/profile/components/profile-info-card.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+
+import { PROFILE_INFO_CARD_TITLE, PROFILE_INFO_ROW_LABEL } from "@/constants/profile";
+
+import { MY_PROFILE_MOCK } from "../mock/profile";
+import { ProfileInfoCard } from "./profile-info-card";
+
+describe("ProfileInfoCard", () => {
+  it("기본 정보 제목과 각 행의 라벨·값을 정해진 순서대로 보여준다", () => {
+    render(<ProfileInfoCard profile={MY_PROFILE_MOCK} />);
+
+    expect(screen.getByText(PROFILE_INFO_CARD_TITLE)).toBeInTheDocument();
+
+    const expectedRows: [string, string][] = [
+      [PROFILE_INFO_ROW_LABEL.NAME, MY_PROFILE_MOCK.name],
+      [PROFILE_INFO_ROW_LABEL.EMAIL, MY_PROFILE_MOCK.email],
+      [PROFILE_INFO_ROW_LABEL.TEAM, MY_PROFILE_MOCK.teamName],
+      [PROFILE_INFO_ROW_LABEL.POSITION, MY_PROFILE_MOCK.position],
+      [PROFILE_INFO_ROW_LABEL.JOINED_AT, MY_PROFILE_MOCK.joinedAt],
+    ];
+
+    expectedRows.forEach(([label, value]) => {
+      const row = screen.getByText(label).closest("div");
+      expect(row).toHaveTextContent(value);
+    });
+
+    const renderedLabels = expectedRows.map(([label]) => screen.getByText(label));
+    const documentOrder: Element[] = [...document.body.querySelectorAll("p")];
+    const indices = renderedLabels.map((node) => documentOrder.indexOf(node));
+    expect(indices).toEqual([...indices].sort((a, b) => a - b));
+  });
+});

--- a/src/features/profile/components/profile-info-card.tsx
+++ b/src/features/profile/components/profile-info-card.tsx
@@ -1,3 +1,5 @@
+import { PROFILE_INFO_CARD_TITLE, PROFILE_INFO_ROW_LABEL } from "@/constants/profile";
+
 import type { MyProfile } from "../types";
 
 interface InfoRow {
@@ -5,25 +7,29 @@ interface InfoRow {
   value: string;
 }
 
+interface ProfileInfoCardProps {
+  profile: MyProfile;
+}
+
 /** 기본 정보 표시용 필드 — 편집 기능은 명세가 없어 만들지 않는다(§명세에 없는 화면·기능은 안 만든다). */
 function toRows(profile: MyProfile): InfoRow[] {
   return [
-    { label: "이름", value: profile.name },
-    { label: "이메일", value: profile.email },
-    { label: "부서", value: profile.teamName },
-    { label: "직급", value: profile.position },
-    { label: "입사일", value: profile.joinedAt },
+    { label: PROFILE_INFO_ROW_LABEL.NAME, value: profile.name },
+    { label: PROFILE_INFO_ROW_LABEL.EMAIL, value: profile.email },
+    { label: PROFILE_INFO_ROW_LABEL.TEAM, value: profile.teamName },
+    { label: PROFILE_INFO_ROW_LABEL.POSITION, value: profile.position },
+    { label: PROFILE_INFO_ROW_LABEL.JOINED_AT, value: profile.joinedAt },
   ];
 }
 
 /** 마이페이지 "기본 정보" 카드 — 읽기 전용. */
-export function ProfileInfoCard({ profile }: { profile: MyProfile }) {
+export function ProfileInfoCard({ profile }: ProfileInfoCardProps) {
   const rows = toRows(profile);
 
   return (
     <div className="border-border rounded-[10px] border">
       <div className="border-border border-b px-4 py-3">
-        <p className="text-sm font-medium">기본 정보</p>
+        <p className="text-sm font-medium">{PROFILE_INFO_CARD_TITLE}</p>
       </div>
 
       {rows.map((row, index) => (

--- a/src/features/profile/components/profile-info-card.tsx
+++ b/src/features/profile/components/profile-info-card.tsx
@@ -1,0 +1,44 @@
+import type { MyProfile } from "../types";
+
+interface InfoRow {
+  label: string;
+  value: string;
+}
+
+/** 기본 정보 표시용 필드 — 편집 기능은 명세가 없어 만들지 않는다(§명세에 없는 화면·기능은 안 만든다). */
+function toRows(profile: MyProfile): InfoRow[] {
+  return [
+    { label: "이름", value: profile.name },
+    { label: "이메일", value: profile.email },
+    { label: "부서", value: profile.teamName },
+    { label: "직급", value: profile.position },
+    { label: "입사일", value: profile.joinedAt },
+  ];
+}
+
+/** 마이페이지 "기본 정보" 카드 — 읽기 전용. */
+export function ProfileInfoCard({ profile }: { profile: MyProfile }) {
+  const rows = toRows(profile);
+
+  return (
+    <div className="border-border rounded-[10px] border">
+      <div className="border-border border-b px-4 py-3">
+        <p className="text-sm font-medium">기본 정보</p>
+      </div>
+
+      {rows.map((row, index) => (
+        <div
+          key={row.label}
+          className={
+            index === 0
+              ? "flex items-center gap-3.5 px-4 py-3"
+              : "border-border flex items-center gap-3.5 border-t px-4 py-3"
+          }
+        >
+          <p className="text-muted-foreground w-16 shrink-0 text-xs">{row.label}</p>
+          <p className="text-sm">{row.value}</p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/features/profile/mock/profile.ts
+++ b/src/features/profile/mock/profile.ts
@@ -1,0 +1,14 @@
+import { ROLE } from "@/constants/role";
+
+import type { MyProfile } from "../types";
+
+/** ⚠️ 목 데이터 — BE 연동 전. `getViewer()`(셸)와 별개로, 마이페이지 표시용 필드만 담는다. */
+export const MY_PROFILE_MOCK: MyProfile = {
+  name: "김서준",
+  email: "seojun@techstart.kr",
+  role: ROLE.OWNER,
+  companyName: "(주)테크스타트",
+  teamName: "제품개발팀",
+  position: "수석",
+  joinedAt: "2021-03-02",
+};

--- a/src/features/profile/server.ts
+++ b/src/features/profile/server.ts
@@ -1,0 +1,14 @@
+import "server-only";
+
+import { isMock } from "@/mocks/config";
+
+import { MY_PROFILE_MOCK } from "./mock/profile";
+import type { MyProfile } from "./types";
+
+/** 마이페이지 기본 정보 — 격리막(CLAUDE.md). 연동할 때 고칠 곳은 이 파일과 매퍼뿐이다. */
+export async function getMyProfile(): Promise<MyProfile> {
+  if (isMock) return MY_PROFILE_MOCK;
+
+  // ⚠️ 미구현 — API 스펙 확정 후 `GET /me` 경로로 fetch하고 매퍼로 UI 계약에 맞춘다.
+  throw new Error("마이페이지 조회 API가 아직 연결되지 않았습니다.");
+}

--- a/src/features/profile/types.ts
+++ b/src/features/profile/types.ts
@@ -1,0 +1,18 @@
+import type { Role } from "@/constants/role";
+
+/**
+ * 마이페이지 — 격리막의 UI 계약(CLAUDE.md §Mock 격리막).
+ * ⚠️ 명세 미확정(CLAUDE.md §⚠️[팀확정]) — 지금은 "기본 정보(읽기 전용)"만 다룬다.
+ *    편집·연차 등은 명세가 없어 만들지 않는다(§명세에 없는 화면·기능은 안 만든다).
+ */
+export interface MyProfile {
+  name: string;
+  email: string;
+  role: Role;
+  companyName: string;
+  teamName: string;
+  /** 직급 라벨 — 영문 워딩 규칙(§카피)과 별개로, 직급은 팀에서 한글로 쓴다(예: "수석"). */
+  position: string;
+  /** "YYYY-MM-DD" */
+  joinedAt: string;
+}


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가

---

## 🗂 작업 영역

- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

- `src/app/(shell)/app/me/page.tsx`: 폭 1440으로 변경, `ProfileHeader`/`ProfileInfoCard` 연결
- `src/features/profile/types.ts`, `mock/profile.ts`, `server.ts`: 마이페이지 프로필 조회 격리막
- `src/features/profile/components/profile-header.tsx`: 아바타·이름·이메일·역할 배지·소속 라인
- `src/features/profile/components/profile-info-card.tsx`: 기본 정보 읽기 전용 카드

---

## ✅ 작업 체크리스트

**기본**

- [ ] 브랜치 명명 규칙 준수 (`feature/profile-mypage#{이슈번호}` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [ ] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [x] 🔐 권한 2축 검사 — 본인 정보만 조회(추후 세션 붙을 때 서버 재검사)
- [ ] 🧬 zod — 해당 없음(조회만, 폼 없음)
- [x] 🕵️ 정직성 — 편집 불가능한 필드라는 걸 명확히 하려고 편집 버튼 자체를 빼둠(명세 없음 명시)
- [x] 🎨 디자인 토큰 사용 — `--role-owner` 등 기존 토큰 재사용, 새 hex 없음

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [x] ♿ a11y — 시맨틱 텍스트 위주, 별도 인터랙션 없음
- [x] ♻️ 재사용 확인 — 역할 배지는 `constants/role.ts`의 `ROLE_BADGE_CLASS`/`ROLE_LABEL` 재사용
- [ ] 🧪 `loading`/`error`/`empty` 3상태 — 해당 없음(항상 존재하는 본인 정보)
- [ ] 브라우저 전용 API — 해당 없음

---

## 🔗 연관 이슈

Closes #142

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- 편집 버튼·연차 섹션을 명세 미확정으로 빼고 "기본 정보"만 반영한 게 맞는 방향인지

---

## 📝 추가 메모

없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 마이페이지에서 이름, 이메일, 역할, 회사·팀, 직책, 입사일 등 기본 프로필 정보를 확인할 수 있습니다.
  * 이름 첫 글자 아바타와 역할에 맞는 배지를 제공합니다.
  * 프로필 정보는 읽기 전용으로 표시됩니다.
  * 화면 배율 설정은 기존과 같이 유지됩니다.

* **개선 사항**
  * 마이페이지의 콘텐츠 폭과 요소 간격을 조정해 가독성과 화면 구성을 개선했습니다.
  * 서버 시간대를 한국 시간(Asia/Seoul)으로 일관되게 처리합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
