### PR TITLE
[FEAT] 회의실 예약 도메인 스캐폴딩(목업) #145

### DIFF
--- a/src/app/(shell)/app/rooms/error.tsx
+++ b/src/app/(shell)/app/rooms/error.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { ScreenError } from "@/components/common/screen-error";
+
+interface RoomsErrorProps {
+  reset: () => void;
+}
+
+export default function Error({ reset }: RoomsErrorProps) {
+  return <ScreenError title="회의실 정보를 불러오지 못했어요" reset={reset} />;
+}

--- a/src/app/(shell)/app/rooms/layout.tsx
+++ b/src/app/(shell)/app/rooms/layout.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+
+import { PageHeader } from "@/features/shell/components/page-header";
+
+interface RoomsLayoutProps {
+  children: ReactNode;
+}
+
+/** 사이드바에서 바로 닿는 화면이라 뒤로가기를 두지 않는다(`calendar`·`notice` 목록과 같은 규칙). */
+export default function RoomsLayout({ children }: RoomsLayoutProps) {
+  return (
+    <>
+      <PageHeader title="회의실" />
+      {children}
+    </>
+  );
+}

--- a/src/app/(shell)/app/rooms/loading.tsx
+++ b/src/app/(shell)/app/rooms/loading.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { WEEKLY_CALENDAR_HEIGHT_PX } from "@/features/rooms/calendar-height";
+
+export default function Loading() {
+  return (
+    <main className="min-h-0 flex-1 overflow-y-auto p-6">
+      <div className="mx-auto flex max-w-[1440px] flex-col gap-6">
+        <Skeleton className="w-full rounded-lg" style={{ height: WEEKLY_CALENDAR_HEIGHT_PX }} />
+        <Skeleton className="h-64 w-full rounded-lg" />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/app/rooms/page.tsx
+++ b/src/app/(shell)/app/rooms/page.tsx
@@ -1,0 +1,52 @@
+import { format } from "date-fns";
+import type { Metadata } from "next";
+
+import { RoomsBoard } from "@/features/rooms/components/rooms-board";
+import {
+  getMeetingRooms,
+  getReservableMembers,
+  getWeekReservations,
+} from "@/features/rooms/server";
+
+export const metadata: Metadata = {
+  title: "회의실",
+};
+
+const DATE_PARAM_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+function parseWeekParam(raw: string | undefined): Date {
+  if (raw && DATE_PARAM_PATTERN.test(raw)) {
+    const parsed = new Date(`${raw}T00:00:00`);
+    if (!Number.isNaN(parsed.getTime())) return parsed;
+  }
+  return new Date();
+}
+
+interface RoomsPageProps {
+  searchParams: Promise<{ week?: string }>;
+}
+
+export default async function RoomsPage({ searchParams }: RoomsPageProps) {
+  const { week: weekParam } = await searchParams;
+  const week = parseWeekParam(weekParam);
+
+  const [reservations, rooms, members] = await Promise.all([
+    getWeekReservations(week),
+    getMeetingRooms(),
+    getReservableMembers(),
+  ]);
+
+  return (
+    <main className="min-h-0 flex-1 overflow-y-auto p-6">
+      <div className="mx-auto flex max-w-[1440px] flex-col gap-6">
+        <RoomsBoard
+          key={format(week, "yyyy-MM-dd")}
+          initialReservations={reservations}
+          rooms={rooms}
+          members={members}
+          week={format(week, "yyyy-MM-dd")}
+        />
+      </div>
+    </main>
+  );
+}

--- a/src/constants/meeting.ts
+++ b/src/constants/meeting.ts
@@ -59,3 +59,47 @@ export const MEETING_INVITE_STATUS_LABEL: Record<MeetingInviteStatus, string> = 
   ACCEPTED: "참석",
   DECLINED: "불참",
 };
+
+/**
+ * 회의 주제 대분류 — 회의실 예약 폼의 "회의 주제"(대주제→소주제) 선택에 쓴다.
+ * ⚠️ 미확정 목업이다 — 회의 도메인 담당자 문서를 받으면 이 파일부터 맞춘다(CLAUDE.md §연동 검증).
+ */
+export const MEETING_TOPIC_MAIN = {
+  PRODUCT: "PRODUCT",
+  MARKETING: "MARKETING",
+  INFRA: "INFRA",
+  TEAM: "TEAM",
+} as const;
+export type MeetingTopicMain = (typeof MEETING_TOPIC_MAIN)[keyof typeof MEETING_TOPIC_MAIN];
+
+export const MEETING_TOPIC_MAIN_LABEL: Record<MeetingTopicMain, string> = {
+  PRODUCT: "제품",
+  MARKETING: "마케팅",
+  INFRA: "인프라",
+  TEAM: "팀 운영",
+};
+
+export interface MeetingTopicSub {
+  value: string;
+  label: string;
+}
+
+/** 대주제별 소주제 목록 — 대주제를 고르면 이 목록으로 소주제 select가 갈린다. */
+export const MEETING_TOPIC_SUB: Record<MeetingTopicMain, MeetingTopicSub[]> = {
+  PRODUCT: [
+    { value: "ROADMAP_REVIEW", label: "로드맵 검토" },
+    { value: "FEATURE_PLANNING", label: "기능 기획" },
+  ],
+  MARKETING: [
+    { value: "CHANNEL_STRATEGY", label: "채널 전략" },
+    { value: "CAMPAIGN_REVIEW", label: "캠페인 리뷰" },
+  ],
+  INFRA: [
+    { value: "MIGRATION_REVIEW", label: "마이그레이션 리뷰" },
+    { value: "INCIDENT_RETRO", label: "장애 회고" },
+  ],
+  TEAM: [
+    { value: "WEEKLY_SYNC", label: "위클리 싱크" },
+    { value: "ONE_ON_ONE", label: "1:1" },
+  ],
+};

--- a/src/features/rooms/accent-color.ts
+++ b/src/features/rooms/accent-color.ts
@@ -1,0 +1,19 @@
+import { type PaletteColor, pickPaletteColor } from "@/lib/palette";
+
+/** 프로젝트에 안 묶인 예약(예: 팀 위클리 싱크)의 중립색 — `RoomReservationEvent`의 기본값으로도 쓴다. */
+export const NEUTRAL_ACCENT_COLOR: PaletteColor = {
+  bgColor: "var(--secondary)",
+  textColor: "var(--muted-foreground)",
+  solidColor: "var(--muted-foreground)",
+};
+
+/**
+ * 예약 막대 색 — 지금은 프로젝트 태그를 해시해 임의로 고른다(`pickPaletteColor`, 프로젝트
+ * 칩과 같은 팔레트).
+ * ⚠️ **컴포넌트(`RoomReservationEvent`)는 이 값을 prop으로만 받고 스스로 계산하지 않는다** —
+ *    나중에 프로젝트 API가 색 필드를 내려주면 이 함수 안만 그 값을 쓰도록 바꾸면 되고,
+ *    화면 쪽은 손댈 곳이 없다(CLAUDE.md §Mock 격리막).
+ */
+export function getReservationAccentColor(projectTag?: string): PaletteColor {
+  return projectTag ? pickPaletteColor(projectTag) : NEUTRAL_ACCENT_COLOR;
+}

--- a/src/features/rooms/actions.test.ts
+++ b/src/features/rooms/actions.test.ts
@@ -1,0 +1,82 @@
+// 서버 액션은 next 런타임 함수를 부른다 — jsdom엔 없으니 목으로 대체하고 호출만 검증한다.
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+
+import { revalidatePath } from "next/cache";
+
+import { createRoomReservationAction } from "./actions";
+
+const revalidatePathMock = revalidatePath as unknown as jest.Mock;
+
+const VALID_ENTRIES: Record<string, string> = {
+  title: "새 회의",
+  roomId: "room-small-b",
+  date: "2026-08-11",
+  startTime: "13:00",
+  projectId: "p-goods",
+  topicMain: "PRODUCT",
+  topicSub: "ROADMAP_REVIEW",
+};
+
+const form = (entries: Record<string, string>, attendeeIds: number[] = [1]) => {
+  const data = new FormData();
+  for (const [key, value] of Object.entries(entries)) data.append(key, value);
+  for (const id of attendeeIds) data.append("attendeeIds", String(id));
+  return data;
+};
+
+beforeEach(() => {
+  revalidatePathMock.mockClear();
+});
+
+describe("회의실 예약 생성", () => {
+  it("필수값이 다 있으면 성공하고 생성값을 돌려준다", async () => {
+    const result = await createRoomReservationAction({ errors: {} }, form(VALID_ENTRIES));
+
+    expect(result.errors).toEqual({});
+    expect(result.created?.title).toBe("새 회의");
+    expect(result.created?.roomName).toBe("소회의실 B");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/app/rooms");
+  });
+
+  it("제목이 비면 막고 revalidatePath를 안 부른다", async () => {
+    const result = await createRoomReservationAction(
+      { errors: {} },
+      form({ ...VALID_ENTRIES, title: "" }),
+    );
+
+    expect(result.errors.title).toBeDefined();
+    expect(result.created).toBeUndefined();
+    expect(revalidatePathMock).not.toHaveBeenCalled();
+  });
+
+  it("같은 회의실·겹치는 시간대는 막는다", async () => {
+    const first = await createRoomReservationAction(
+      { errors: {} },
+      form({ ...VALID_ENTRIES, roomId: "room-video", date: "2026-08-12", startTime: "10:00" }),
+    );
+    expect(first.errors).toEqual({});
+
+    const second = await createRoomReservationAction(
+      { errors: {} },
+      form({ ...VALID_ENTRIES, roomId: "room-video", date: "2026-08-12", startTime: "10:00" }),
+    );
+
+    expect(second.errors.roomId).toBe("그 시간에는 이미 예약된 회의실이에요");
+    expect(second.created).toBeUndefined();
+  });
+
+  it("겹치지 않는 시간대는 같은 회의실이어도 통과한다", async () => {
+    await createRoomReservationAction(
+      { errors: {} },
+      form({ ...VALID_ENTRIES, roomId: "room-video", date: "2026-08-13", startTime: "10:00" }),
+    );
+
+    const result = await createRoomReservationAction(
+      { errors: {} },
+      form({ ...VALID_ENTRIES, roomId: "room-video", date: "2026-08-13", startTime: "10:30" }),
+    );
+
+    expect(result.errors).toEqual({});
+    expect(result.created).toBeDefined();
+  });
+});

--- a/src/features/rooms/actions.test.ts
+++ b/src/features/rooms/actions.test.ts
@@ -79,4 +79,73 @@ describe("회의실 예약 생성", () => {
     expect(result.errors).toEqual({});
     expect(result.created).toBeDefined();
   });
+
+  it("프로젝트 없이도 생성된다(예: 팀 위클리 싱크 같은 예약)", async () => {
+    const result = await createRoomReservationAction(
+      { errors: {} },
+      form({ ...VALID_ENTRIES, projectId: "", date: "2026-08-14" }),
+    );
+
+    expect(result.errors).toEqual({});
+    expect(result.created?.projectId).toBeUndefined();
+    expect(result.created?.projectTag).toBeUndefined();
+  });
+
+  it("폼이 조작돼 존재하지 않는 회의실 id가 오면 막는다", async () => {
+    const result = await createRoomReservationAction(
+      { errors: {} },
+      form({ ...VALID_ENTRIES, roomId: "room-does-not-exist", date: "2026-08-15" }),
+    );
+
+    expect(result.errors.roomId).toBe("존재하지 않는 회의실이에요");
+    expect(result.created).toBeUndefined();
+  });
+
+  it("폼이 조작돼 존재하지 않는 프로젝트 id가 오면 막는다", async () => {
+    const result = await createRoomReservationAction(
+      { errors: {} },
+      form({ ...VALID_ENTRIES, projectId: "p-does-not-exist", date: "2026-08-15" }),
+    );
+
+    expect(result.errors.projectId).toBe("존재하지 않는 프로젝트예요");
+    expect(result.created).toBeUndefined();
+  });
+
+  it("폼이 조작돼 존재하지 않는 참석자 id가 오면 막는다", async () => {
+    const result = await createRoomReservationAction(
+      { errors: {} },
+      form({ ...VALID_ENTRIES, date: "2026-08-15" }, [9999]),
+    );
+
+    expect(result.errors.attendeeIds).toBe("존재하지 않는 참석자가 있어요");
+    expect(result.created).toBeUndefined();
+  });
+
+  it("폼이 조작돼 대주제·소주제 조합이 안 맞으면 막는다", async () => {
+    const result = await createRoomReservationAction(
+      { errors: {} },
+      form({
+        ...VALID_ENTRIES,
+        date: "2026-08-15",
+        topicMain: "PRODUCT",
+        topicSub: "CHANNEL_STRATEGY",
+      }),
+    );
+
+    expect(result.errors.topicSub).toBe("대주제와 맞지 않는 소주제예요");
+    expect(result.created).toBeUndefined();
+  });
+
+  it("폼이 조작돼 참석자 값이 숫자가 아니면 막는다", async () => {
+    const data = new FormData();
+    for (const [key, value] of Object.entries({ ...VALID_ENTRIES, date: "2026-08-15" })) {
+      data.append(key, value);
+    }
+    data.append("attendeeIds", "not-a-number");
+
+    const result = await createRoomReservationAction({ errors: {} }, data);
+
+    expect(result.errors.attendeeIds).toBe("참석자 값이 올바르지 않아요");
+    expect(result.created).toBeUndefined();
+  });
 });

--- a/src/features/rooms/actions.ts
+++ b/src/features/rooms/actions.ts
@@ -2,10 +2,13 @@
 
 import { revalidatePath } from "next/cache";
 
+import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
 import { getMockActor } from "@/lib/mock-actor";
 import { isMock } from "@/mocks/config";
 
+import { findMockMember } from "./mock/members";
 import { addMockReservation, listMockReservationsByRoom } from "./mock/reservations";
+import { findMockRoom } from "./mock/rooms";
 import type { RoomReservation, RoomReservationDraft, RoomReservationFormErrors } from "./types";
 import { RESERVATION_DURATION_MINUTES, validateRoomReservationDraft } from "./validate";
 
@@ -58,6 +61,18 @@ export async function createRoomReservationAction(
   if (!isMock) {
     // ⚠️ 미구현 — API 스펙 확정 후 BFF 경로로 예약 생성 요청을 보낸다.
     throw new Error("회의실 예약 API가 아직 연결되지 않았습니다.");
+  }
+
+  // ⚠️ 화면 select·피커가 이미 실제 목록에서만 고르게 해도, 폼은 조작될 수 있다
+  //    (§권한: 화면 숨김은 UX일 뿐 보안이 아니다) — 참조값이 실제로 존재하는지 서버에서 다시 본다.
+  if (!findMockRoom(draft.roomId)) {
+    return { errors: { roomId: "존재하지 않는 회의실이에요" } };
+  }
+  if (draft.projectId && !TOP_LEVEL_PROJECTS.some((project) => project.id === draft.projectId)) {
+    return { errors: { projectId: "존재하지 않는 프로젝트예요" } };
+  }
+  if (draft.attendeeIds.some((id) => !findMockMember(id))) {
+    return { errors: { attendeeIds: "존재하지 않는 참석자가 있어요" } };
   }
 
   const { start, end } = toReservedRange(draft);

--- a/src/features/rooms/actions.ts
+++ b/src/features/rooms/actions.ts
@@ -1,0 +1,75 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { getMockActor } from "@/lib/mock-actor";
+import { isMock } from "@/mocks/config";
+
+import { addMockReservation, listMockReservationsByRoom } from "./mock/reservations";
+import type { RoomReservation, RoomReservationDraft, RoomReservationFormErrors } from "./types";
+import { RESERVATION_DURATION_MINUTES, validateRoomReservationDraft } from "./validate";
+
+const ROOMS_PATH = "/app/rooms";
+
+/** 예약 폼 결과 — `useActionState`가 그대로 들고 있는 모양. */
+export interface RoomReservationFormState {
+  errors: RoomReservationFormErrors;
+  /** 성공 시 서버 확정값 — 화면은 재조회 없이 이 값을 바로 반영한다(비관적 갱신, §토스트). */
+  created?: RoomReservation;
+}
+
+function readDraft(formData: FormData): RoomReservationDraft {
+  const projectId = formData.get("projectId");
+  return {
+    title: String(formData.get("title") ?? ""),
+    roomId: String(formData.get("roomId") ?? ""),
+    date: String(formData.get("date") ?? ""),
+    startTime: String(formData.get("startTime") ?? ""),
+    projectId: projectId ? String(projectId) : undefined,
+    topicMain: String(formData.get("topicMain") ?? ""),
+    topicSub: String(formData.get("topicSub") ?? ""),
+    attendeeIds: formData.getAll("attendeeIds").map(Number),
+  };
+}
+
+function toReservedRange(draft: RoomReservationDraft): { start: Date; end: Date } {
+  const start = new Date(`${draft.date}T${draft.startTime}:00`);
+  const end = new Date(start.getTime() + RESERVATION_DURATION_MINUTES * 60_000);
+  return { start, end };
+}
+
+/**
+ * 회의실 예약 생성 — 격리막(CLAUDE.md §Mock 격리막).
+ * ⚠️ **비관적 갱신**이다 — 화면은 이 액션이 성공(created 반환)한 뒤에만 캘린더에 반영한다.
+ *    드래그로 즉시 그려지는 예약이 아니라 모달 확인을 거치는 흐름이라 낙관적으로 먼저
+ *    그릴 이유가 없다(요구사항: 선택→모달 확인→서버 성공 후에만 반영).
+ * ⚠️ 같은 회의실·겹치는 시간대 예약은 여기서 막는다(도메인 정책: 동시간대 회의실 중복 불가) —
+ *    화면에서 빈 슬롯만 눌러도 그 사이 다른 사람이 먼저 예약했을 수 있어 **서버에서 다시
+ *    확인**해야 한다(§권한: 화면 숨김은 UX일 뿐 보안이 아니다).
+ */
+export async function createRoomReservationAction(
+  _prev: RoomReservationFormState,
+  formData: FormData,
+): Promise<RoomReservationFormState> {
+  const draft = readDraft(formData);
+  const errors = validateRoomReservationDraft(draft);
+  if (Object.keys(errors).length > 0) return { errors };
+
+  if (!isMock) {
+    // ⚠️ 미구현 — API 스펙 확정 후 BFF 경로로 예약 생성 요청을 보낸다.
+    throw new Error("회의실 예약 API가 아직 연결되지 않았습니다.");
+  }
+
+  const { start, end } = toReservedRange(draft);
+  const overlapping = listMockReservationsByRoom(draft.roomId).some(
+    (reservation) => reservation.start < end && reservation.end > start,
+  );
+  if (overlapping) {
+    return { errors: { roomId: "그 시간에는 이미 예약된 회의실이에요" } };
+  }
+
+  const actor = getMockActor();
+  const created = addMockReservation(draft, actor.id);
+  revalidatePath(ROOMS_PATH);
+  return { errors: {}, created };
+}

--- a/src/features/rooms/calendar-height.ts
+++ b/src/features/rooms/calendar-height.ts
@@ -1,0 +1,22 @@
+const START_HOUR = 8;
+const END_HOUR = 18;
+const HOURS_VISIBLE = END_HOUR - START_HOUR;
+/**
+ * 요일 헤더 높이 — `weekly-room-calendar.css`의 `.rbc-time-header-content` 기준.
+ * ⚠️ `.rbc-allday-cell`을 숨겨서 헤더는 이제 요일 행 하나뿐이다(예전엔 그 행까지 감안해 더 컸다).
+ */
+const HEADER_HEIGHT_PX = 32;
+/**
+ * 30분 칸 높이 — 너무 크면 화면이 늘어지고, 너무 작으면 제목·시간·참석자가 잘린다.
+ * ⚠️ 40px는 너무 빡빡해서(팀 피드백) 1.3배(약 52px)로 키웠다 — 컴팩트함은 유지하되 읽히게.
+ */
+export const HALF_HOUR_SLOT_HEIGHT_PX = 52;
+
+/**
+ * 주간 캘린더 전체 높이(px, 고정값) — 뷰포트 비율(`calc(100vh - …)`)로 두면 RBC가 남는 높이를
+ * 반칸에 나눠 담아 칸이 다시 얇아진다. 30분 한 칸 높이를 **먼저 정하고** 그 배수로 전체 높이를
+ * 거꾸로 계산해야, 회의 내용(제목·시간·참석자)이 항상 들어갈 자리가 보장된다.
+ * ⚠️ 그래서 화면 자체가 길어질 수 있다 — `<main>`이 이미 `overflow-y-auto`라 페이지 스크롤로 받는다.
+ */
+export const WEEKLY_CALENDAR_HEIGHT_PX =
+  HEADER_HEIGHT_PX + HOURS_VISIBLE * 2 * HALF_HOUR_SLOT_HEIGHT_PX;

--- a/src/features/rooms/components/attendee-avatar-stack.tsx
+++ b/src/features/rooms/components/attendee-avatar-stack.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useProfileAvatar } from "@/hooks/use-profile-avatar";
+
+import type { RoomMember } from "../types";
+
+const AVATAR_SIZE = 12;
+const OVERLAP_PX = 3;
+
+interface AttendeeAvatarProps {
+  memberId: number;
+  name: string;
+  offset: number;
+}
+
+/**
+ * 아바타 하나 — `useProfileAvatar`는 훅이라 배열 순회 안에서 직접 못 부른다
+ * (호출 개수가 참석자 수만큼 달라져 rules-of-hooks 위반). 그래서 참석자 한 명당
+ * 이 컴포넌트를 하나씩 마운트해 각자 자기 훅을 한 번만 부르게 한다.
+ */
+function AttendeeAvatar({ memberId, name, offset }: AttendeeAvatarProps) {
+  const avatar = useProfileAvatar(memberId, AVATAR_SIZE);
+
+  return (
+    <span
+      title={name}
+      aria-hidden
+      style={{ marginLeft: offset === 0 ? 0 : -OVERLAP_PX }}
+      className="block shrink-0"
+    >
+      {avatar}
+    </span>
+  );
+}
+
+interface AttendeeAvatarStackProps {
+  memberIds: number[];
+  members: RoomMember[];
+  max?: number;
+}
+
+/** 참석자 아바타를 살짝 겹쳐 보여준다(+N은 마지막에 붙는다). 이름은 스크린리더용으로만 남긴다. */
+export function AttendeeAvatarStack({ memberIds, members, max = 3 }: AttendeeAvatarStackProps) {
+  const visible = memberIds.slice(0, max);
+  const overflow = memberIds.length - visible.length;
+
+  return (
+    <span className="flex items-center">
+      {visible.map((memberId, index) => (
+        <AttendeeAvatar
+          key={memberId}
+          memberId={memberId}
+          name={members.find((member) => member.id === memberId)?.name ?? `#${memberId}`}
+          offset={index}
+        />
+      ))}
+      {overflow > 0 && (
+        <span
+          style={{ marginLeft: -OVERLAP_PX }}
+          className="text-muted-foreground flex size-3 shrink-0 items-center justify-center text-[8px] font-medium"
+        >
+          +{overflow}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/src/features/rooms/components/room-list-panel.tsx
+++ b/src/features/rooms/components/room-list-panel.tsx
@@ -1,0 +1,36 @@
+import type { MeetingRoom } from "../types";
+
+interface RoomListPanelProps {
+  rooms: MeetingRoom[];
+}
+
+/** 하단 회의실 목록 — 예약은 위 캘린더에서 하고, 여기는 운영 시간만 빠르게 확인하는 자리. */
+export function RoomListPanel({ rooms }: RoomListPanelProps) {
+  return (
+    <section className="border-border bg-card rounded-lg border">
+      <header className="flex items-center justify-between px-5 py-4">
+        <div>
+          <h2 className="text-foreground text-base font-semibold">회의실 목록</h2>
+          <p className="text-muted-foreground mt-0.5 text-xs">
+            예약 가능 시간을 빠르게 확인하세요. 예약은 캘린더에서 진행합니다.
+          </p>
+        </div>
+        <span className="text-muted-foreground text-xs">{rooms.length}개</span>
+      </header>
+
+      <ul>
+        {rooms.map((room) => (
+          <li
+            key={room.id}
+            className="border-border flex items-center justify-between border-t px-5 py-3"
+          >
+            <span className="text-foreground text-sm">{room.name}</span>
+            <span className="text-muted-foreground text-xs tabular-nums">
+              {room.openTime} - {room.closeTime}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/features/rooms/components/room-reservation-event.tsx
+++ b/src/features/rooms/components/room-reservation-event.tsx
@@ -1,0 +1,50 @@
+import { format } from "date-fns";
+
+import type { PaletteColor } from "@/lib/palette";
+
+import { NEUTRAL_ACCENT_COLOR } from "../accent-color";
+import type { RoomMember, RoomReservation } from "../types";
+import { AttendeeAvatarStack } from "./attendee-avatar-stack";
+
+interface RoomReservationEventProps {
+  event: RoomReservation;
+  members: RoomMember[];
+  /**
+   * 막대 색 — 이 컴포넌트는 계산하지 않고 그대로 받아 그린다(호출부 `weekly-room-calendar.tsx`가
+   * `accent-color.ts`로 정한다). 나중에 프로젝트 API가 색을 내려주게 되면 그 호출부만 바뀐다.
+   */
+  accentColor: PaletteColor;
+}
+
+/**
+ * 예약 막대 — 옅은 tint 배경(`bgColor`) + 왼쪽 액센트 보더(`solidColor`) + 색 글자(`textColor`).
+ * 회의는 항상 30분 고정이라 칸 하나에 제목·시간·참석자가 다 들어가야 한다(칸 높이는
+ * `weekly-room-calendar.tsx`의 `WEEKLY_CALENDAR_HEIGHT_PX`가 넉넉히 잡아준다).
+ * ⚠️ `accentColor`에 방어적 기본값을 둔다 — react-big-calendar의 `event` 렌더 컴포넌트는
+ *    라이브러리 내부에서도 호출되는데, dev 환경(Turbopack HMR)에서 prop이 비어 오는 순간이
+ *    관측돼 화면 전체가 죽는 것보다 중립색으로라도 그리는 쪽을 택한다.
+ */
+export function RoomReservationEvent({
+  event,
+  members,
+  accentColor = NEUTRAL_ACCENT_COLOR,
+}: RoomReservationEventProps) {
+  return (
+    <div
+      style={{
+        backgroundColor: accentColor.bgColor,
+        borderLeftColor: accentColor.solidColor,
+        color: accentColor.textColor,
+      }}
+      className="flex h-full flex-col justify-between gap-0.5 overflow-hidden rounded-[5px] border-l-2 px-1.5 py-0.5 text-left leading-tight"
+    >
+      <span className="flex flex-col overflow-hidden">
+        <span className="truncate text-[11px] font-medium">{event.title}</span>
+        <span className="text-muted-foreground truncate text-[10px] tabular-nums">
+          {format(event.start, "HH:mm")}–{format(event.end, "HH:mm")}
+        </span>
+      </span>
+      <AttendeeAvatarStack memberIds={event.attendeeIds} members={members} />
+    </div>
+  );
+}

--- a/src/features/rooms/components/rooms-board.tsx
+++ b/src/features/rooms/components/rooms-board.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import type { MeetingRoom, RoomMember, RoomReservation } from "../types";
+import { RoomListPanel } from "./room-list-panel";
+import { WeeklyRoomCalendarLoader } from "./weekly-room-calendar-loader";
+
+interface RoomsBoardProps {
+  initialReservations: RoomReservation[];
+  rooms: MeetingRoom[];
+  members: RoomMember[];
+  /** "YYYY-MM-DD" — 이 주의 월요일. 서버 컴포넌트가 이 주 기준으로 `initialReservations`를 내려준다. */
+  week: string;
+}
+
+/**
+ * 회의실 화면 본체(client).
+ * ⚠️ 다음 단계(예약 모달·비관적 갱신)에서 `initialReservations`를 로컬 state로 바꾸고
+ *    생성 성공 시 재조회 없이 바로 얹는다(`calendar-board.tsx`와 같은 패턴) — 지금은 읽기전용이라
+ *    서버가 내려준 값을 그대로 그린다.
+ * ⚠️ 주를 옮기면(`?week=`) 서버가 새 `initialReservations`를 내려주는데, 이 컴포넌트는 그때마다
+ *    호출부에서 `key={week}`로 다시 마운트된다(개인 캘린더와 같은 이유).
+ */
+export function RoomsBoard({ initialReservations, rooms, members, week }: RoomsBoardProps) {
+  // ⚠️ 다음 단계(예약 모달)에서 채운다 — 지금은 30분 칸을 눌러도 아직 아무 일도 안 일어난다.
+  function handleSelectSlot(start: Date) {
+    void start;
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <WeeklyRoomCalendarLoader
+        reservations={initialReservations}
+        members={members}
+        week={week}
+        onSelectSlot={handleSelectSlot}
+      />
+      <RoomListPanel rooms={rooms} />
+    </div>
+  );
+}

--- a/src/features/rooms/components/rooms-calendar-toolbar.tsx
+++ b/src/features/rooms/components/rooms-calendar-toolbar.tsx
@@ -1,0 +1,55 @@
+import { addDays, format, startOfWeek } from "date-fns";
+import { ko } from "date-fns/locale";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import type { ToolbarProps } from "react-big-calendar";
+
+import { Button } from "@/components/ui/button";
+
+import type { RoomReservation } from "../types";
+
+/**
+ * 커스텀 툴바 — 왼쪽에 `<` 이번 주 구간(월~금) `>`을 그린다.
+ * ⚠️ RBC가 주는 `label`(로케일이 안 먹어 영문으로 나온다) 대신 `date`로 직접 만든다
+ *    (`calendar-toolbar.tsx`와 같은 이유, CLAUDE.md §카피: 날짜는 한글로).
+ * ⚠️ 구간 라벨에 **고정 너비**를 준다 — 월이 걸치면 자릿수가 달라져 다음 주 버튼 위치가 흔들린다.
+ */
+export function RoomsCalendarToolbar({ date, onNavigate }: ToolbarProps<RoomReservation>) {
+  const weekStart = startOfWeek(date, { weekStartsOn: 1 });
+  const weekEnd = addDays(weekStart, 4);
+  const rangeLabel =
+    weekStart.getMonth() === weekEnd.getMonth()
+      ? `${format(weekStart, "M월 d일", { locale: ko })} - ${format(weekEnd, "d일", { locale: ko })}`
+      : `${format(weekStart, "M월 d일", { locale: ko })} - ${format(weekEnd, "M월 d일", { locale: ko })}`;
+
+  return (
+    <div className="mb-3 flex items-center justify-between">
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="icon-sm"
+          aria-label="지난 주"
+          onClick={() => onNavigate("PREV")}
+        >
+          <ChevronLeft />
+        </Button>
+        <p className="w-40 shrink-0 text-center text-base font-semibold tabular-nums">
+          {rangeLabel}
+        </p>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon-sm"
+          aria-label="다음 주"
+          onClick={() => onNavigate("NEXT")}
+        >
+          <ChevronRight />
+        </Button>
+      </div>
+
+      <Button type="button" variant="outline" size="sm" onClick={() => onNavigate("TODAY")}>
+        오늘
+      </Button>
+    </div>
+  );
+}

--- a/src/features/rooms/components/weekly-room-calendar-loader.tsx
+++ b/src/features/rooms/components/weekly-room-calendar-loader.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+import { Skeleton } from "@/components/ui/skeleton";
+
+import { WEEKLY_CALENDAR_HEIGHT_PX } from "../calendar-height";
+import type { RoomMember, RoomReservation } from "../types";
+
+/** `react-big-calendar`는 무겁다 — 첫 로드 번들에서 뺀다(CLAUDE.md §최적화). */
+const WeeklyRoomCalendar = dynamic(
+  () => import("./weekly-room-calendar").then((m) => m.WeeklyRoomCalendar),
+  {
+    ssr: false,
+    loading: () => (
+      <Skeleton className="w-full rounded-lg" style={{ height: WEEKLY_CALENDAR_HEIGHT_PX }} />
+    ),
+  },
+);
+
+interface WeeklyRoomCalendarLoaderProps {
+  reservations: RoomReservation[];
+  members: RoomMember[];
+  week: string;
+  onSelectSlot: (start: Date) => void;
+}
+
+export function WeeklyRoomCalendarLoader(props: WeeklyRoomCalendarLoaderProps) {
+  return <WeeklyRoomCalendar {...props} />;
+}

--- a/src/features/rooms/components/weekly-room-calendar.css
+++ b/src/features/rooms/components/weekly-room-calendar.css
@@ -1,0 +1,128 @@
+/**
+ * react-big-calendar 기본 CSS(`rbc-*`)를 Z 디자인 토큰(CSS 변수)에 맞춘 오버라이드.
+ * `personal-calendar.css`(월간 뷰)와 짝이지만, 이 화면은 `work_week`(시간대) 뷰라 다른 클래스를 쓴다.
+ */
+
+.rbc-calendar {
+  color: var(--foreground);
+  font-family: var(--font-sans);
+}
+
+.rbc-time-view {
+  border-color: var(--border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+/*
+  ⚠️ 헤더(`.rbc-time-header-content`)엔 세로 스크롤바가 없고 본문(`.rbc-time-content`)엔
+  있을 수 있어서, 스크롤바 폭(브라우저·배율마다 다르다)만큼 두 영역의 실제 칸 너비가
+  서로 달라져 세로 구분선이 어긋나 보였다("화면 배율을 바꾸면" 흔들리는 것도 그래서다).
+  이 화면의 전체 높이(`calendar-height.ts`)는 이미 "시간 슬롯 수 × 칸 높이"로 딱 맞춰
+  계산해 두므로 본문이 넘칠 일이 없다 — 스크롤 자체를 없애 스크롤바 폭 변수를 지운다.
+  (RBC가 인라인으로 `overflow-y`를 얹으므로 `!important`로 이긴다.)
+*/
+.rbc-time-content {
+  overflow-y: hidden !important;
+}
+
+.rbc-header,
+.rbc-time-header-content,
+.rbc-time-content,
+.rbc-time-gutter {
+  border-color: var(--border) !important;
+}
+
+.rbc-header {
+  background-color: var(--secondary);
+  color: var(--muted-foreground);
+  padding: 6px 0;
+  font-weight: 500;
+}
+
+/*
+  ⚠️ RBC는 `.rbc-time-header-content` 안에 요일 행(`.rbc-row.rbc-time-header-cell`) 말고도
+  종일(all-day) 이벤트용 행(`.rbc-allday-cell`)을 항상 하나 더 만든다. 이 화면엔 종일 예약이
+  없는데도 그 빈 행이 계속 자리를 차지해서 "8/3" 같은 날짜가 요일 행 + 빈 행 두 줄로
+  갈라진 것처럼 보였다 — 아예 감춰서 요일 행 하나만 남긴다(라이브러리 코드는 안 건드리고
+  스타일로만 없앤다).
+*/
+.rbc-allday-cell {
+  display: none;
+}
+
+/*
+  RBC는 커스텀 `event` 컴포넌트를 써도 그 앞에 자체 시간 라벨(`.rbc-event-label`)을 항상 하나
+  더 그린다 — `RoomReservationEvent`가 이미 자기 시간을 표시하므로 이 라벨은 중복이라 감춘다.
+*/
+.rbc-event-label {
+  display: none;
+}
+
+/*
+  ⚠️ 정시(그룹)와 반시(슬롯) 경계선을 **다르게** 그린다 — `step=30, timeslots=2`라
+  `.rbc-timeslot-group` 하나가 정시 1시간, 그 안의 `.rbc-time-slot` 2개가 각각 30분이다.
+  전에는 슬롯 보더를 통째로 지워서 시간 눈금(왼쪽 거터)과 칸 사이가 안 맞아 보였다 —
+  30분 눈금도 옅은 점선으로 남겨야 왼쪽 숫자와 오른쪽 칸이 줄이 맞아떨어진다.
+*/
+.rbc-timeslot-group {
+  border-bottom: 1px solid var(--border) !important;
+}
+
+.rbc-time-slot {
+  color: var(--muted-foreground);
+  border-top: none;
+}
+
+.rbc-day-slot .rbc-time-slot {
+  border-top: 1px dashed color-mix(in srgb, var(--border) 60%, transparent);
+}
+
+.rbc-day-slot .rbc-timeslot-group > .rbc-time-slot:first-child {
+  border-top: none;
+}
+
+/* 셀 배경이 투명이면 뒤의 점 그리드가 비쳐 보인다 — 카드처럼 떠 있는 면으로 채운다. */
+.rbc-time-content > .rbc-day-slot {
+  background-color: var(--card);
+}
+
+.rbc-today {
+  background-color: var(--card);
+}
+
+/*
+  예약 막대는 안쪽 컴포넌트(`RoomReservationEvent`)가 색·패딩·글자를 전부 그린다 —
+  RBC 기본 배경·테두리는 지워서 우리 색만 보이게 한다(개인 캘린더는 반대로 글자를 지웠다,
+  거긴 오른쪽 상세조회 패널이 있어서고 여긴 없어서 막대 안에서 바로 읽혀야 한다).
+  ⚠️ `!important` — RBC가 `.rbc-event`에 인라인 스타일(테두리·배경)을 직접 얹어서 일반
+     클래스 규칙보다 우선순위가 높다. 그대로 두면 RBC 기본 테두리 + `RoomReservationEvent`의
+     `border-l-2` 액센트 테두리가 겹쳐 이중 테두리로 보인다 — 바깥(RBC) 쪽을 지우고
+     안쪽(우리) 테두리 하나만 남긴다.
+*/
+.rbc-event {
+  background: none !important;
+  border: none !important;
+  padding: 0 !important;
+}
+
+/*
+  ⚠️ RBC 기본 CSS는 `.rbc-day-slot .rbc-events-container`에 `margin-right: 10px`를 고정으로
+  건다(라이브러리 자체 스타일, 인라인 아님) — 그만큼 이벤트 막대가 칸 오른쪽 테두리에 못 닿고
+  항상 10px 틈이 남는다. 배율(줌)에 따라 칸 너비가 달라지면서 그 틈이 더 도드라져 보인
+  "줄이 안 맞는" 현상의 실제 원인이 이거다 — 컨테이너를 칸 전체 폭으로 채워서 막대 오른쪽
+  끝이 세로 구분선과 겹치게 한다.
+*/
+.rbc-day-slot .rbc-events-container {
+  right: 0;
+  margin-right: 0;
+}
+
+.rbc-event.rbc-selected {
+  outline: 2px solid var(--ring);
+  outline-offset: 1px;
+}
+
+.rbc-current-time-indicator {
+  background-color: var(--destructive);
+}

--- a/src/features/rooms/components/weekly-room-calendar.tsx
+++ b/src/features/rooms/components/weekly-room-calendar.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import "react-big-calendar/lib/css/react-big-calendar.css";
+import "./weekly-room-calendar.css";
+
+import { format, getDay, parse, startOfWeek } from "date-fns";
+import { ko } from "date-fns/locale";
+import { useRouter } from "next/navigation";
+import { useCallback, useMemo } from "react";
+import { Calendar, dateFnsLocalizer, type SlotInfo, type ToolbarProps } from "react-big-calendar";
+
+import { getReservationAccentColor } from "../accent-color";
+import { WEEKLY_CALENDAR_HEIGHT_PX } from "../calendar-height";
+import type { RoomMember, RoomReservation } from "../types";
+import { RoomReservationEvent } from "./room-reservation-event";
+import { RoomsCalendarToolbar } from "./rooms-calendar-toolbar";
+
+const localizer = dateFnsLocalizer({
+  format,
+  parse,
+  startOfWeek: (date: Date) => startOfWeek(date, { weekStartsOn: 1 }),
+  getDay,
+  locales: { ko },
+});
+
+function toWeekParam(date: Date): string {
+  return format(startOfWeek(date, { weekStartsOn: 1 }), "yyyy-MM-dd");
+}
+
+interface WeeklyRoomCalendarProps {
+  reservations: RoomReservation[];
+  members: RoomMember[];
+  /** "YYYY-MM-DD" — 이 주의 월요일. 서버 컴포넌트가 이 값 기준으로 예약을 걸러 내려준다. */
+  week: string;
+  /** 빈 슬롯을 선택하면(30분 칸 클릭) 그 시작 시각을 올려보낸다 — 예약 모달이 이 값으로 연다. */
+  onSelectSlot: (start: Date) => void;
+}
+
+/**
+ * 회의실 주간 캘린더(react-big-calendar `work_week` 뷰 — 평일 5일만, 팀 화면 목업과 동일).
+ * ⚠️ 개인 캘린더(`personal-calendar.tsx`)와 달리 이벤트 막대에 **글자를 그대로 보여준다** —
+ *    회의실 화면엔 오른쪽 상세조회 패널이 따로 없어서, 셀 안에서 제목·시간·참석자를 바로 봐야 한다.
+ * ⚠️ 예약은 **30분 한 타임 고정**이다(CLAUDE.md §브라우저 API, 팀 확정) — 시드 데이터도 예외
+ *    없이 30분이다. `step=30, timeslots=2`로 "정시(그룹, 실선)/반시(슬롯, 점선)" 두 겹 그리드를
+ *    만들고, 칸 높이는 `calendar-height.ts`가 30분 콘텐츠(제목·시간·참석자)가 항상 들어갈 만큼
+ *    먼저 정한 값을 그대로 쓴다(뷰포트 비율로 두면 칸이 다시 얇아진다).
+ */
+export function WeeklyRoomCalendar({
+  reservations,
+  members,
+  week,
+  onSelectSlot,
+}: WeeklyRoomCalendarProps) {
+  const router = useRouter();
+
+  const currentDate = useMemo(() => parse(week, "yyyy-MM-dd", new Date()), [week]);
+
+  const handleNavigate = useCallback(
+    (nextDate: Date) => {
+      router.push(`/app/rooms?week=${toWeekParam(nextDate)}`);
+    },
+    [router],
+  );
+
+  const handleSelectSlot = useCallback(
+    (slotInfo: SlotInfo) => onSelectSlot(slotInfo.start),
+    [onSelectSlot],
+  );
+
+  const EventComponent = useCallback(
+    ({ event }: { event: RoomReservation }) => (
+      <RoomReservationEvent
+        event={event}
+        members={members}
+        accentColor={getReservationAccentColor(event.projectTag)}
+      />
+    ),
+    [members],
+  );
+
+  const ToolbarComponent = useCallback(
+    (toolbarProps: ToolbarProps<RoomReservation>) => <RoomsCalendarToolbar {...toolbarProps} />,
+    [],
+  );
+
+  return (
+    <Calendar
+      localizer={localizer}
+      events={reservations}
+      views={["work_week"]}
+      defaultView="work_week"
+      date={currentDate}
+      onNavigate={handleNavigate}
+      components={{ toolbar: ToolbarComponent, event: EventComponent }}
+      step={30}
+      timeslots={2}
+      min={new Date(0, 0, 0, 8, 0, 0)}
+      max={new Date(0, 0, 0, 18, 0, 0)}
+      selectable
+      onSelectSlot={handleSelectSlot}
+      style={{ height: WEEKLY_CALENDAR_HEIGHT_PX }}
+      formats={{
+        dayFormat: (date: Date) => format(date, "EEE M/d", { locale: ko }),
+        timeGutterFormat: (date: Date) => format(date, "H:mm"),
+      }}
+      messages={{
+        today: "오늘",
+        previous: "이전",
+        next: "다음",
+        noEventsInRange: "이번 주엔 예약된 회의가 없어요",
+      }}
+    />
+  );
+}

--- a/src/features/rooms/mock/members.ts
+++ b/src/features/rooms/mock/members.ts
@@ -1,0 +1,27 @@
+import type { RoomMember } from "../types";
+
+/**
+ * ⚠️ 목 데이터 — BE 연동 전. 참석자 검색 대상이 되는 사원 목록(전사 공용, 부서 무관).
+ * 사원 도메인(`/manage/members`)과 별도로 이 화면 전용 경량 목록만 둔다 — 필요한 필드가
+ * id·이름뿐이라 사원 도메인 전체 타입을 끌어오지 않는다.
+ */
+export const MEETING_MEMBERS: RoomMember[] = [
+  { id: 1, name: "박대표" },
+  { id: 2, name: "김서준" },
+  { id: 3, name: "이하윤" },
+  { id: 4, name: "박도현" },
+  { id: 5, name: "최유진" },
+  { id: 6, name: "정민석" },
+  { id: 7, name: "강서연" },
+  { id: 8, name: "임지안" },
+  { id: 9, name: "오현우" },
+  { id: 10, name: "한소율" },
+];
+
+export function listMockMembers(): RoomMember[] {
+  return MEETING_MEMBERS;
+}
+
+export function findMockMember(id: number): RoomMember | null {
+  return MEETING_MEMBERS.find((member) => member.id === id) ?? null;
+}

--- a/src/features/rooms/mock/reservations.test.ts
+++ b/src/features/rooms/mock/reservations.test.ts
@@ -1,0 +1,49 @@
+import {
+  addMockReservation,
+  findMockReservation,
+  listMockReservations,
+  listMockReservationsByRoom,
+} from "./reservations";
+
+const DRAFT = {
+  title: "  신규 회의  ",
+  roomId: "room-small-b",
+  date: "2026-08-10",
+  startTime: "10:30",
+  projectId: "p-goods",
+  topicMain: "PRODUCT",
+  topicSub: "ROADMAP_REVIEW",
+  attendeeIds: [1, 2],
+};
+
+describe("회의실 예약 mock 스토어", () => {
+  it("시드 데이터가 회의실별로 최소 한 건씩 있다", () => {
+    expect(listMockReservationsByRoom("room-large").length).toBeGreaterThan(0);
+  });
+
+  it("예약을 추가하면 앞뒤 공백을 지우고 회의실 이름·소주제 라벨·프로젝트 태그를 채운다", () => {
+    const before = listMockReservations().length;
+
+    const created = addMockReservation(DRAFT, 3);
+
+    expect(created.title).toBe("신규 회의");
+    expect(created.roomName).toBe("소회의실 B");
+    expect(created.topicSub).toBe("로드맵 검토");
+    expect(created.projectTag).toBe("GOODS");
+    expect(created.ownerId).toBe(3);
+    // 시작 10:30 + 고정 30분 = 종료 11:00
+    expect(created.end.getTime() - created.start.getTime()).toBe(30 * 60_000);
+    expect(listMockReservations()).toHaveLength(before + 1);
+    expect(findMockReservation(created.id)).toEqual(created);
+  });
+
+  it("프로젝트에 안 묶인 예약은 projectTag 없이 만들어진다", () => {
+    const created = addMockReservation({ ...DRAFT, projectId: undefined }, 3);
+    expect(created.projectId).toBeUndefined();
+    expect(created.projectTag).toBeUndefined();
+  });
+
+  it("없는 id는 조회 시 null을 돌려준다", () => {
+    expect(findMockReservation("존재하지-않음")).toBeNull();
+  });
+});

--- a/src/features/rooms/mock/reservations.ts
+++ b/src/features/rooms/mock/reservations.ts
@@ -1,0 +1,128 @@
+import { MEETING_TOPIC_SUB, type MeetingTopicMain } from "@/constants/meeting";
+import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
+
+import type { RoomReservation, RoomReservationDraft } from "../types";
+import { RESERVATION_DURATION_MINUTES } from "../validate";
+import { findMockRoom } from "./rooms";
+
+/**
+ * ⚠️ 목 데이터 — BE 연동 전. **서버 프로세스 메모리에만 있다**(재시작하면 초기값으로 되돌아간다).
+ * 예약 생성 Server Action이 이 배열을 직접 바꾼다 — 실제 DB 흉내다.
+ * ⚠️ 상태를 `globalThis`에 매단다 — dev의 HMR로 `let`이 초기화되면 방금 만든 예약이 사라진다
+ *    (개인 캘린더 목과 같은 트릭, `calendar/mock/events.ts`).
+ */
+interface ReservationStore {
+  reservations: RoomReservation[];
+  sequence: number;
+}
+
+/** 오늘(2026-08-06)이 속한 주(월 8/3~금 8/7) 기준 시드. */
+const INITIAL: RoomReservation[] = [
+  {
+    id: "reservation-1",
+    title: "마케팅 채널 전략 논의",
+    start: new Date("2026-08-03T10:00:00"),
+    end: new Date("2026-08-03T11:30:00"),
+    roomId: "room-large",
+    roomName: "대회의실",
+    projectId: "p-brand",
+    projectTag: "BRAND",
+    topicMain: "MARKETING",
+    topicSub: "채널 전략",
+    attendeeIds: [1, 2, 3],
+    ownerId: 2,
+  },
+  {
+    id: "reservation-2",
+    title: "8월 제품 로드맵 검토",
+    start: new Date("2026-08-03T14:00:00"),
+    end: new Date("2026-08-03T16:00:00"),
+    roomId: "room-large",
+    roomName: "대회의실",
+    projectId: "p-goods",
+    projectTag: "GOODS",
+    topicMain: "PRODUCT",
+    topicSub: "로드맵 검토",
+    attendeeIds: [1, 2, 3, 4],
+    ownerId: 1,
+  },
+  {
+    id: "reservation-3",
+    title: "인프라 마이그레이션 리뷰",
+    start: new Date("2026-08-05T15:30:00"),
+    end: new Date("2026-08-05T17:00:00"),
+    roomId: "room-small-a",
+    roomName: "소회의실 A",
+    projectId: "p-collab",
+    projectTag: "COLLAB",
+    topicMain: "INFRA",
+    topicSub: "마이그레이션 리뷰",
+    attendeeIds: [4, 5, 6],
+    ownerId: 4,
+  },
+  {
+    id: "reservation-4",
+    title: "팀 위클리 싱크",
+    start: new Date("2026-08-06T11:00:00"),
+    end: new Date("2026-08-06T12:00:00"),
+    roomId: "room-video",
+    roomName: "화상회의실",
+    topicMain: "TEAM",
+    topicSub: "위클리 싱크",
+    attendeeIds: [2, 3, 7],
+    ownerId: 2,
+  },
+];
+
+const globalStore = globalThis as typeof globalThis & {
+  __roomReservationStore?: ReservationStore;
+};
+const store: ReservationStore = (globalStore.__roomReservationStore ??= {
+  reservations: INITIAL,
+  sequence: INITIAL.length,
+});
+
+export function listMockReservations(): RoomReservation[] {
+  return store.reservations;
+}
+
+export function listMockReservationsByRoom(roomId: string): RoomReservation[] {
+  return store.reservations.filter((reservation) => reservation.roomId === roomId);
+}
+
+export function findMockReservation(id: string): RoomReservation | null {
+  return store.reservations.find((reservation) => reservation.id === id) ?? null;
+}
+
+/**
+ * 예약 생성 — 시작 시각 + 고정 30분으로 종료 시각을 계산하고, roomId/projectId/topicSub
+ * 코드값을 표시용 이름·태그·라벨로 채워 넣는다(컴포넌트는 코드값을 모른다, §Mock 격리막).
+ * ⚠️ 같은 회의실·시간대 중복 여부는 여기서 보지 않는다 — 호출부(`actions.ts`)가 먼저 확인한다.
+ */
+export function addMockReservation(draft: RoomReservationDraft, ownerId: number): RoomReservation {
+  const room = findMockRoom(draft.roomId);
+  const start = new Date(`${draft.date}T${draft.startTime}:00`);
+  const end = new Date(start.getTime() + RESERVATION_DURATION_MINUTES * 60_000);
+  const topicMain = draft.topicMain as MeetingTopicMain;
+  const topicSub =
+    MEETING_TOPIC_SUB[topicMain]?.find((sub) => sub.value === draft.topicSub)?.label ??
+    draft.topicSub;
+  const project = TOP_LEVEL_PROJECTS.find((item) => item.id === draft.projectId);
+
+  const reservation: RoomReservation = {
+    id: `reservation-${++store.sequence}`,
+    title: draft.title.trim(),
+    start,
+    end,
+    roomId: draft.roomId,
+    roomName: room?.name ?? draft.roomId,
+    projectId: draft.projectId,
+    projectTag: project?.tag,
+    topicMain,
+    topicSub,
+    attendeeIds: draft.attendeeIds,
+    ownerId,
+  };
+  store.reservations = [...store.reservations, reservation];
+  return reservation;
+}

--- a/src/features/rooms/mock/reservations.ts
+++ b/src/features/rooms/mock/reservations.ts
@@ -16,13 +16,29 @@ interface ReservationStore {
   sequence: number;
 }
 
-/** 오늘(2026-08-06)이 속한 주(월 8/3~금 8/7) 기준 시드. */
+/**
+ * 오늘(2026-08-06)이 속한 주(월 8/3~금 8/7) 기준 시드.
+ * ⚠️ **회의는 예외 없이 30분 고정이다**(팀 확정, CLAUDE.md §브라우저 API) — 목 데이터도 이
+ *    규칙을 그대로 지킨다. 90분·2시간짜리 목업을 두면 "30분 고정"이 화면에서부터 거짓말이 된다.
+ */
 const INITIAL: RoomReservation[] = [
   {
     id: "reservation-1",
+    title: "Q3 OKR 중간 점검",
+    start: new Date("2026-08-03T09:00:00"),
+    end: new Date("2026-08-03T09:30:00"),
+    roomId: "room-small-b",
+    roomName: "소회의실 B",
+    topicMain: "TEAM",
+    topicSub: "위클리 싱크",
+    attendeeIds: [1, 2, 3],
+    ownerId: 1,
+  },
+  {
+    id: "reservation-2",
     title: "마케팅 채널 전략 논의",
     start: new Date("2026-08-03T10:00:00"),
-    end: new Date("2026-08-03T11:30:00"),
+    end: new Date("2026-08-03T10:30:00"),
     roomId: "room-large",
     roomName: "대회의실",
     projectId: "p-brand",
@@ -33,10 +49,10 @@ const INITIAL: RoomReservation[] = [
     ownerId: 2,
   },
   {
-    id: "reservation-2",
+    id: "reservation-3",
     title: "8월 제품 로드맵 검토",
     start: new Date("2026-08-03T14:00:00"),
-    end: new Date("2026-08-03T16:00:00"),
+    end: new Date("2026-08-03T14:30:00"),
     roomId: "room-large",
     roomName: "대회의실",
     projectId: "p-goods",
@@ -47,10 +63,10 @@ const INITIAL: RoomReservation[] = [
     ownerId: 1,
   },
   {
-    id: "reservation-3",
+    id: "reservation-4",
     title: "인프라 마이그레이션 리뷰",
     start: new Date("2026-08-05T15:30:00"),
-    end: new Date("2026-08-05T17:00:00"),
+    end: new Date("2026-08-05T16:00:00"),
     roomId: "room-small-a",
     roomName: "소회의실 A",
     projectId: "p-collab",
@@ -61,10 +77,10 @@ const INITIAL: RoomReservation[] = [
     ownerId: 4,
   },
   {
-    id: "reservation-4",
+    id: "reservation-5",
     title: "팀 위클리 싱크",
     start: new Date("2026-08-06T11:00:00"),
-    end: new Date("2026-08-06T12:00:00"),
+    end: new Date("2026-08-06T11:30:00"),
     roomId: "room-video",
     roomName: "화상회의실",
     topicMain: "TEAM",

--- a/src/features/rooms/mock/rooms.ts
+++ b/src/features/rooms/mock/rooms.ts
@@ -1,0 +1,20 @@
+import type { MeetingRoom } from "../types";
+
+/**
+ * ⚠️ 목 데이터 — BE 연동 전(ERD·API 스펙 미확정, DECISIONS.md).
+ * 회의실 CUD는 이 화면 소관이 아니다(`/manage/rooms`) — 여기서는 목록만 읽는다.
+ */
+export const MEETING_ROOMS: MeetingRoom[] = [
+  { id: "room-large", name: "대회의실", capacity: 8, openTime: "09:00", closeTime: "18:00" },
+  { id: "room-small-a", name: "소회의실 A", capacity: 4, openTime: "09:00", closeTime: "18:00" },
+  { id: "room-small-b", name: "소회의실 B", capacity: 4, openTime: "09:00", closeTime: "18:00" },
+  { id: "room-video", name: "화상회의실", capacity: 6, openTime: "09:00", closeTime: "18:00" },
+];
+
+export function listMockRooms(): MeetingRoom[] {
+  return MEETING_ROOMS;
+}
+
+export function findMockRoom(id: string): MeetingRoom | null {
+  return MEETING_ROOMS.find((room) => room.id === id) ?? null;
+}

--- a/src/features/rooms/server.ts
+++ b/src/features/rooms/server.ts
@@ -1,0 +1,38 @@
+import "server-only";
+
+import { endOfWeek, startOfWeek } from "date-fns";
+
+import { isMock } from "@/mocks/config";
+
+import { listMockMembers } from "./mock/members";
+import { listMockReservations } from "./mock/reservations";
+import { listMockRooms } from "./mock/rooms";
+import type { MeetingRoom, RoomMember, RoomReservation } from "./types";
+
+/**
+ * 그 주(월요일 시작)와 겹치는 예약만 걸러 내려준다. 격리막(CLAUDE.md §Mock 격리막).
+ * ⚠️ 예약 시작일 기준이 아니라 **그 주와 겹치는지**(start~end 구간)로 본다 — 지금은 예약이
+ *    전부 하루 안에서 끝나 차이가 없지만, 개인 캘린더 월 필터와 같은 이유로 구간 비교로 둔다.
+ */
+export async function getWeekReservations(weekOf: Date): Promise<RoomReservation[]> {
+  if (isMock) {
+    const weekStart = startOfWeek(weekOf, { weekStartsOn: 1 });
+    const weekEnd = endOfWeek(weekOf, { weekStartsOn: 1 });
+    return listMockReservations().filter(
+      (reservation) => reservation.start <= weekEnd && reservation.end >= weekStart,
+    );
+  }
+
+  // ⚠️ 미구현 — API 스펙 확정 후 회의실 예약 조회 경로를 매퍼로 UI 계약에 맞춘다.
+  throw new Error("회의실 예약 조회 API가 아직 연결되지 않았습니다.");
+}
+
+export async function getMeetingRooms(): Promise<MeetingRoom[]> {
+  if (isMock) return listMockRooms();
+  throw new Error("회의실 목록 조회 API가 아직 연결되지 않았습니다.");
+}
+
+export async function getReservableMembers(): Promise<RoomMember[]> {
+  if (isMock) return listMockMembers();
+  throw new Error("사원 목록 조회 API가 아직 연결되지 않았습니다.");
+}

--- a/src/features/rooms/types.ts
+++ b/src/features/rooms/types.ts
@@ -1,0 +1,69 @@
+/**
+ * 회의실 예약(주간 캘린더) — 격리막의 UI 계약(CLAUDE.md §Mock 격리막).
+ * 컴포넌트는 이 타입만 알고, 목/실서버 분기는 `server.ts`가 끝낸다.
+ */
+
+import type { MeetingTopicMain } from "@/constants/meeting";
+
+/** 회의실 한 곳. 운영시간은 전 회의실 09:00~18:00 동일(팀 워크플로우 목업). */
+export interface MeetingRoom {
+  id: string;
+  name: string;
+  /** 수용 인원 */
+  capacity: number;
+  /** "HH:mm" */
+  openTime: string;
+  /** "HH:mm" */
+  closeTime: string;
+}
+
+/** 참석자 검색 대상 — 예약 폼의 "참석자" 피커가 쓴다. */
+export interface RoomMember {
+  id: number;
+  name: string;
+}
+
+/**
+ * 주간 캘린더 한 칸에 그려지는 예약 건. react-big-calendar의 start/end 접근자가 이 필드명을 그대로 쓴다.
+ * ⚠️ 막대 색은 여기 없다 — `projectTag`를 화면에서 `pickPaletteColor`에 넘겨 그때 뽑는다
+ *    (프로젝트 태그·아바타와 같은 팔레트, CLAUDE.md §디자인 토큰: 하드코딩 금지).
+ */
+export interface RoomReservation {
+  id: string;
+  title: string;
+  start: Date;
+  end: Date;
+  roomId: string;
+  roomName: string;
+  /** 프로젝트에 안 묶인 예약도 있다(예: 팀 위클리 싱크) — 그럴 땐 중립색을 쓴다. */
+  projectId?: string;
+  projectTag?: string;
+  topicMain: MeetingTopicMain;
+  /** 소주제 라벨(한글) — 목록·상세 표시용으로 이미 라벨을 들고 있다. */
+  topicSub: string;
+  attendeeIds: number[];
+  /** 담당자 — 이 예약의 시간을 바꿀 수 있는 유일한 사람(권한 ②축, CLAUDE.md §권한). */
+  ownerId: number;
+}
+
+/**
+ * 회의실 예약 폼 입력 — 화면과 서버가 같은 스키마(`validate.ts`)로 검증한다.
+ * ⚠️ 종료 시각은 입력받지 않는다 — 예약은 **30분 한 타임 고정**이라(팀 확정,
+ *    CLAUDE.md §브라우저 API) 시작 시각만 받고 길이는 서버가 계산한다.
+ */
+export interface RoomReservationDraft {
+  title: string;
+  roomId: string;
+  /** "YYYY-MM-DD" */
+  date: string;
+  /** "HH:mm" — 30분 단위 슬롯의 시작 시각 */
+  startTime: string;
+  projectId?: string;
+  /** MEETING_TOPIC_MAIN 코드값 */
+  topicMain: string;
+  /** MEETING_TOPIC_SUB[topicMain]의 value 코드값 */
+  topicSub: string;
+  attendeeIds: number[];
+}
+
+export type RoomReservationFormErrors = Partial<Record<keyof RoomReservationDraft, string>>;

--- a/src/features/rooms/validate.test.ts
+++ b/src/features/rooms/validate.test.ts
@@ -56,9 +56,9 @@ describe("회의실 예약 검증", () => {
     expect(errors.startTime).toBeUndefined();
   });
 
-  it("프로젝트를 안 고르면 막는다", () => {
+  it("프로젝트 없이도 통과한다(예: 팀 위클리 싱크)", () => {
     const errors = validateRoomReservationDraft({ ...VALID_DRAFT, projectId: undefined });
-    expect(errors.projectId).toBe("프로젝트를 선택해 주세요");
+    expect(errors.projectId).toBeUndefined();
   });
 
   it("대주제를 안 고르면 막는다", () => {
@@ -71,8 +71,22 @@ describe("회의실 예약 검증", () => {
     expect(errors.topicSub).toBeDefined();
   });
 
+  it("대주제와 안 맞는 소주제 조합은 막는다", () => {
+    const errors = validateRoomReservationDraft({
+      ...VALID_DRAFT,
+      topicMain: "PRODUCT",
+      topicSub: "CHANNEL_STRATEGY",
+    });
+    expect(errors.topicSub).toBe("대주제와 맞지 않는 소주제예요");
+  });
+
   it("참석자가 한 명도 없으면 막는다", () => {
     const errors = validateRoomReservationDraft({ ...VALID_DRAFT, attendeeIds: [] });
     expect(errors.attendeeIds).toBe("참석자를 한 명 이상 선택해 주세요");
+  });
+
+  it("참석자 값이 정수가 아니면 막는다", () => {
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, attendeeIds: [Number.NaN] });
+    expect(errors.attendeeIds).toBe("참석자 값이 올바르지 않아요");
   });
 });

--- a/src/features/rooms/validate.test.ts
+++ b/src/features/rooms/validate.test.ts
@@ -1,0 +1,78 @@
+import { validateRoomReservationDraft } from "./validate";
+
+const VALID_DRAFT = {
+  title: "주간 싱크",
+  roomId: "room-large",
+  date: "2026-08-10",
+  startTime: "10:00",
+  projectId: "p-goods",
+  topicMain: "PRODUCT",
+  topicSub: "ROADMAP_REVIEW",
+  attendeeIds: [1],
+};
+
+describe("회의실 예약 검증", () => {
+  it("전부 채우면 통과한다", () => {
+    expect(validateRoomReservationDraft(VALID_DRAFT)).toEqual({});
+  });
+
+  it("제목이 비면 막는다", () => {
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, title: "   " });
+    expect(errors.title).toBe("회의 제목을 입력해 주세요");
+  });
+
+  it("회의실을 안 고르면 막는다", () => {
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, roomId: "" });
+    expect(errors.roomId).toBeDefined();
+  });
+
+  it("날짜 형식이 아니면 막는다", () => {
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, date: "2026/08/10" });
+    expect(errors.date).toBe("올바른 날짜가 아니에요");
+  });
+
+  it("존재하지 않는 날짜는 막는다", () => {
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, date: "2026-02-30" });
+    expect(errors.date).toBe("올바른 날짜가 아니에요");
+  });
+
+  it("30분 단위가 아닌 시작 시각은 막는다", () => {
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, startTime: "10:15" });
+    expect(errors.startTime).toBe("예약은 30분 단위로만 가능해요");
+  });
+
+  it("운영 시작(09:00) 이전은 막는다", () => {
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, startTime: "08:30" });
+    expect(errors.startTime).toBe("회의실 운영 시간(09:00~18:00) 안에서 선택해 주세요");
+  });
+
+  it("30분을 더하면 운영 종료(18:00)를 넘는 시작 시각은 막는다", () => {
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, startTime: "17:45" });
+    expect(errors.startTime).toBeDefined();
+  });
+
+  it("운영 종료 딱 맞춰 끝나는 17:30 시작은 통과한다", () => {
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, startTime: "17:30" });
+    expect(errors.startTime).toBeUndefined();
+  });
+
+  it("프로젝트를 안 고르면 막는다", () => {
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, projectId: undefined });
+    expect(errors.projectId).toBe("프로젝트를 선택해 주세요");
+  });
+
+  it("대주제를 안 고르면 막는다", () => {
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, topicMain: "" });
+    expect(errors.topicMain).toBeDefined();
+  });
+
+  it("소주제를 안 고르면 막는다", () => {
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, topicSub: "" });
+    expect(errors.topicSub).toBeDefined();
+  });
+
+  it("참석자가 한 명도 없으면 막는다", () => {
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, attendeeIds: [] });
+    expect(errors.attendeeIds).toBe("참석자를 한 명 이상 선택해 주세요");
+  });
+});

--- a/src/features/rooms/validate.ts
+++ b/src/features/rooms/validate.ts
@@ -1,0 +1,60 @@
+import { isValid, parse } from "date-fns";
+
+import type { RoomReservationDraft, RoomReservationFormErrors } from "./types";
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const TIME_PATTERN = /^([01]\d|2[0-3]):(00|30)$/;
+
+/** 예약 길이 — 팀 확정: 30분 한 타임, 연장하지 않는다(CLAUDE.md §브라우저 API). */
+export const RESERVATION_DURATION_MINUTES = 30;
+
+const OPERATING_START_MINUTES = 9 * 60;
+const OPERATING_END_MINUTES = 18 * 60;
+
+function isValidCalendarDate(value: string): boolean {
+  if (!DATE_PATTERN.test(value)) return false;
+  return isValid(parse(value, "yyyy-MM-dd", new Date()));
+}
+
+function toMinutes(time: string): number {
+  const [hour, minute] = time.split(":");
+  return Number(hour) * 60 + Number(minute);
+}
+
+/**
+ * 회의실 예약 폼 검증 — 화면(모달)과 서버(Server Action)가 **이 함수 하나**로 본다.
+ * ⚠️ 같은 회의실·시간대 중복 여부는 여기서 보지 않는다 — 그건 기존 예약 목록이 있어야 판단할 수
+ *    있어 `actions.ts`가 목/실서버 조회 뒤에 따로 확인한다.
+ */
+export function validateRoomReservationDraft(
+  draft: RoomReservationDraft,
+): RoomReservationFormErrors {
+  const errors: RoomReservationFormErrors = {};
+
+  if (!draft.title.trim()) errors.title = "회의 제목을 입력해 주세요";
+  if (!draft.roomId.trim()) errors.roomId = "회의실을 선택해 주세요";
+
+  if (!draft.date.trim()) errors.date = "날짜를 선택해 주세요";
+  else if (!isValidCalendarDate(draft.date)) errors.date = "올바른 날짜가 아니에요";
+
+  if (!draft.startTime.trim()) {
+    errors.startTime = "시작 시간을 선택해 주세요";
+  } else if (!TIME_PATTERN.test(draft.startTime)) {
+    errors.startTime = "예약은 30분 단위로만 가능해요";
+  } else {
+    const startMinutes = toMinutes(draft.startTime);
+    if (
+      startMinutes < OPERATING_START_MINUTES ||
+      startMinutes + RESERVATION_DURATION_MINUTES > OPERATING_END_MINUTES
+    ) {
+      errors.startTime = "회의실 운영 시간(09:00~18:00) 안에서 선택해 주세요";
+    }
+  }
+
+  if (!draft.projectId?.trim()) errors.projectId = "프로젝트를 선택해 주세요";
+  if (!draft.topicMain.trim()) errors.topicMain = "대주제를 선택해 주세요";
+  if (!draft.topicSub.trim()) errors.topicSub = "소주제를 선택해 주세요";
+  if (draft.attendeeIds.length === 0) errors.attendeeIds = "참석자를 한 명 이상 선택해 주세요";
+
+  return errors;
+}

--- a/src/features/rooms/validate.ts
+++ b/src/features/rooms/validate.ts
@@ -1,5 +1,7 @@
 import { isValid, parse } from "date-fns";
 
+import { MEETING_TOPIC_SUB, type MeetingTopicMain } from "@/constants/meeting";
+
 import type { RoomReservationDraft, RoomReservationFormErrors } from "./types";
 
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
@@ -51,10 +53,22 @@ export function validateRoomReservationDraft(
     }
   }
 
-  if (!draft.projectId?.trim()) errors.projectId = "프로젝트를 선택해 주세요";
+  // ⚠️ 프로젝트는 선택값이다 — "팀 위클리 싱크"처럼 프로젝트에 안 묶인 예약도 있다
+  //    (types.ts의 RoomReservation.projectId, mock/reservations.ts 시드가 이미 그렇다).
   if (!draft.topicMain.trim()) errors.topicMain = "대주제를 선택해 주세요";
   if (!draft.topicSub.trim()) errors.topicSub = "소주제를 선택해 주세요";
-  if (draft.attendeeIds.length === 0) errors.attendeeIds = "참석자를 한 명 이상 선택해 주세요";
+  else if (draft.topicMain.trim()) {
+    const validSubs = MEETING_TOPIC_SUB[draft.topicMain as MeetingTopicMain];
+    if (!validSubs?.some((sub) => sub.value === draft.topicSub)) {
+      errors.topicSub = "대주제와 맞지 않는 소주제예요";
+    }
+  }
+
+  if (draft.attendeeIds.length === 0) {
+    errors.attendeeIds = "참석자를 한 명 이상 선택해 주세요";
+  } else if (draft.attendeeIds.some((id) => !Number.isInteger(id))) {
+    errors.attendeeIds = "참석자 값이 올바르지 않아요";
+  }
 
   return errors;
 }


### PR DESCRIPTION
## 📋 PR 타입
- [x] feature

---

## 🗂 작업 영역
- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실

---

## 🙋 관련 역할
- [x] 공통

---

## 📝 작업 내용
- 회의실 예약 Mock 격리막(types/mock/server/actions/validate) 추가
- 회의 주제(대주제/소주제) 상수 추가(constants/meeting.ts) — 미확정 목업
- 예약 생성 액션에 회의실·시간대 중복 방지 서버 재검증 추가

---

## ✅ 작업 체크리스트
- [x] 🔐 권한 2축 검사 — 역할 조건 없음, 예약 생성자=담당자(ownerId) 부여까지만(시간 변경 검증은 다음 단계)
- [ ] 🧬 zod — **미적용**: 기존 calendar/notice validate.ts와 동일하게 순수 함수 검증 컨벤션을 따름(리포 전체가 zod 미사용, 의도된 일관성)
- [x] 🕵️ 정직성 — 회의 주제 상수·실서버 미연동 부분에 주석으로 명시
- [x] 🎨 디자인 토큰 — UI 없음(스캐폴딩 단계)
- [x] 🧪 loading/error/empty — UI 없음, 다음 단계에서 적용

---

## 🔗 연관 이슈
Closes #145

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

-

---

## 📝 추가 메모

-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 회의실 목록과 평일 주간 예약 현황을 조회할 수 있습니다.
  - 이전 주·다음 주·오늘로 이동할 수 있습니다.
  - 예약 생성 시 제목, 회의실, 날짜·시간, 프로젝트, 주제, 참석자 정보를 입력하고 검증합니다.
  - 운영 시간(09:00~18:00)과 30분 단위 예약을 지원합니다.
  - 예약 시간 중복을 확인하고, 프로젝트별 색상과 참석자 정보를 표시합니다.
  - 회의 주제의 대분류 및 소주제 선택 항목을 제공합니다.

- **테스트**
  - 예약 생성, 입력 검증, 중복 시간 처리 및 예약 조회 시나리오를 검증했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
