### PR TITLE
[FEAT] 프로젝트 생성 화면 /app/projects/new #149

### DIFF
--- a/src/app/(shell)/app/projects/new/page.tsx
+++ b/src/app/(shell)/app/projects/new/page.tsx
@@ -1,0 +1,45 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { createProjectAction } from "@/features/project/actions";
+import { ProjectForm } from "@/features/project/components/project-form";
+import { getCompanyTeamOptions } from "@/features/project/server";
+import { getViewer } from "@/features/shell/viewer";
+import { canCreateProject } from "@/lib/permission";
+
+export const metadata: Metadata = {
+  title: "새 프로젝트",
+};
+
+export default async function AppProjectNewPage() {
+  const viewer = await getViewer();
+  // 권한 없는 사람은 화면 자체를 숨긴다(404) — 서버 재검사는 액션에서도 한 번 더(§권한).
+  if (!canCreateProject(viewer)) notFound();
+
+  const teamOptions = await getCompanyTeamOptions();
+
+  return (
+    <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
+      <div className="mx-auto flex w-full max-w-[720px] flex-col gap-4">
+        <div className="flex flex-col gap-1">
+          <p className="text-muted-foreground text-xs">
+            <Link href="/app/projects" className="hover:text-foreground">
+              프로젝트
+            </Link>{" "}
+            &gt; 새 프로젝트
+          </p>
+          <h2 className="text-foreground text-base font-semibold">새 프로젝트</h2>
+        </div>
+
+        <div className="border-border bg-card rounded-xl border p-6">
+          <ProjectForm
+            action={createProjectAction}
+            teamOptions={teamOptions}
+            cancelHref="/app/projects"
+          />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/constants/project.ts
+++ b/src/constants/project.ts
@@ -36,3 +36,15 @@ export const PROJECT_SORT_LABEL: Record<ProjectSort, string> = {
 
 /** 기본 정렬 — 마감 임박순(스펙). */
 export const DEFAULT_PROJECT_SORT: ProjectSort = PROJECT_SORT.DUE_ASC;
+
+/** ProjectTag 최대 길이(백엔드 협의 확정) — 영문 대문자만 허용. */
+export const PROJECT_TAG_MAX_LENGTH = 6;
+
+/** 세부 설명 최대 길이 — 백엔드 `varchar(255)` 제한을 프론트에서도 그대로 지킨다. */
+export const PROJECT_DESCRIPTION_MAX_LENGTH = 255;
+
+/**
+ * ⚠️ 목 데이터 — BE 연동 전. 회사 팀 목록(팀·역할·권한 스키마의 `Team`).
+ * 실제로는 `GET /companies/me/teams` 같은 API로 내려받는다.
+ */
+export const COMPANY_TEAM_NAMES = ["개발팀", "마케팅팀", "디자인팀", "전략기획팀"] as const;

--- a/src/features/project/actions.ts
+++ b/src/features/project/actions.ts
@@ -1,0 +1,60 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { getViewer } from "@/features/shell/viewer";
+import { canCreateProject } from "@/lib/permission";
+import { isMock } from "@/mocks/config";
+
+import { addMockProject } from "./mock/projects";
+import type { ProjectDraft, ProjectFormErrors } from "./types";
+import { validateProjectDraft } from "./validate";
+
+const LIST_PATH = "/app/projects";
+
+/** 생성 폼 결과 — `useActionState`가 그대로 들고 있는 모양. */
+export interface ProjectFormState {
+  errors: ProjectFormErrors;
+}
+
+function readDraft(formData: FormData): ProjectDraft {
+  return {
+    name: String(formData.get("name") ?? ""),
+    // ⚠️ 화면이 이미 대문자로 바꿔 보내지만, 서버는 그 처리를 신뢰하지 않고 다시 올린다.
+    tag: String(formData.get("tag") ?? "").toUpperCase(),
+    description: String(formData.get("description") ?? ""),
+    tagColor: String(formData.get("tagColor") ?? "slate") as ProjectDraft["tagColor"],
+    dueDate: String(formData.get("dueDate") ?? ""),
+    teamNames: formData.getAll("teamNames").map(String),
+    attachmentName: String(formData.get("attachmentName") ?? "") || undefined,
+  };
+}
+
+/**
+ * 프로젝트 생성 — 격리막(CLAUDE.md §Mock 격리막).
+ * ⚠️ **권한을 서버에서 다시 본다** — 화면 숨김은 UX일 뿐 보안이 아니다(§권한).
+ * ⚠️ 화면과 **같은 함수**(`validateProjectDraft`)로 다시 검증한다.
+ */
+export async function createProjectAction(
+  _prev: ProjectFormState,
+  formData: FormData,
+): Promise<ProjectFormState> {
+  const viewer = await getViewer();
+  if (!canCreateProject(viewer)) return { errors: { name: "프로젝트를 생성할 권한이 없어요" } };
+
+  const draft = readDraft(formData);
+  const errors = validateProjectDraft(draft);
+  if (Object.keys(errors).length > 0) return { errors };
+
+  if (!isMock) {
+    // ⚠️ 미구현 — API 스펙 확정 후 BFF 경로로 생성 요청을 보낸다(첨부파일 업로드 포함).
+    throw new Error("프로젝트 생성 API가 아직 연결되지 않았습니다.");
+  }
+
+  addMockProject(draft);
+
+  revalidatePath(LIST_PATH);
+  // ⚠️ `redirect`는 내부적으로 예외를 던진다 — try/catch 밖에 둔다(§렌더링·데이터)
+  redirect(LIST_PATH);
+}

--- a/src/features/project/components/project-form.tsx
+++ b/src/features/project/components/project-form.tsx
@@ -102,7 +102,7 @@ export function ProjectForm({ action, teamOptions, cancelHref }: ProjectFormProp
           name="name"
           value={name}
           onChange={(event) => setName(event.target.value)}
-          placeholder="예: 제품 v3.0"
+          placeholder="예: 온라인 굿즈샵 웹 구축"
           aria-invalid={Boolean(state.errors.name)}
         />
         {state.errors.name && <p className="text-destructive text-xs">{state.errors.name}</p>}
@@ -117,7 +117,7 @@ export function ProjectForm({ action, teamOptions, cancelHref }: ProjectFormProp
           name="tag"
           value={tag}
           onChange={(event) => setTag(toTagInput(event.target.value))}
-          placeholder="PROJ"
+          placeholder="GOODS"
           maxLength={PROJECT_TAG_MAX_LENGTH}
           className="w-40 font-mono"
           aria-invalid={Boolean(state.errors.tag)}
@@ -140,7 +140,7 @@ export function ProjectForm({ action, teamOptions, cancelHref }: ProjectFormProp
           onChange={(event) =>
             setDescription(event.target.value.slice(0, PROJECT_DESCRIPTION_MAX_LENGTH))
           }
-          placeholder="프로젝트 목표나 배경을 간략히 적어주세요"
+          placeholder="예: 아티스트 공식 굿즈를 판매하는 온라인 커머스 웹을 신규 구축합니다."
           maxLength={PROJECT_DESCRIPTION_MAX_LENGTH}
           aria-invalid={Boolean(state.errors.description)}
           className="border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive dark:bg-input/30 w-full resize-none rounded-lg border bg-transparent px-2.5 py-2 text-sm transition-colors outline-none focus-visible:ring-3"

--- a/src/features/project/components/project-form.tsx
+++ b/src/features/project/components/project-form.tsx
@@ -154,7 +154,9 @@ export function ProjectForm({ action, teamOptions, cancelHref }: ProjectFormProp
       </div>
 
       <div className="flex flex-col gap-1.5">
-        <Label>태그 색상</Label>
+        <Label>
+          태그 색상 <span className="text-destructive">*</span>
+        </Label>
         <div className="flex items-center gap-2">
           <button
             type="button"

--- a/src/features/project/components/project-form.tsx
+++ b/src/features/project/components/project-form.tsx
@@ -1,0 +1,335 @@
+"use client";
+
+import { Paperclip, Plus, X } from "lucide-react";
+import Link from "next/link";
+import type { CSSProperties } from "react";
+import { useActionState, useRef, useState } from "react";
+
+import { Button, buttonVariants } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { PROJECT_DESCRIPTION_MAX_LENGTH, PROJECT_TAG_MAX_LENGTH } from "@/constants/project";
+import { paletteColorByName, TAG_NAME_LABEL, TAG_NAMES, type TagColorName } from "@/lib/palette";
+import { cn } from "@/lib/utils";
+
+import type { ProjectFormState } from "../actions";
+
+interface TeamRow {
+  /** React key용 — 팀명이 아니라 행 자체의 정체성(같은 팀을 지웠다 다시 골라도 행은 별개). */
+  rowId: number;
+  team: string;
+}
+
+interface ProjectFormProps {
+  action: (prev: ProjectFormState, formData: FormData) => Promise<ProjectFormState>;
+  /** 참여 팀 드롭다운 선택지 — 회사 전체 팀 목록. */
+  teamOptions: string[];
+  cancelHref: string;
+}
+
+/** 대문자 A-Z가 아닌 문자를 전부 걷어낸다 — 소문자는 버리지 않고 대문자로 살린다. */
+function toTagInput(raw: string): string {
+  return raw
+    .toUpperCase()
+    .replace(/[^A-Z]/g, "")
+    .slice(0, PROJECT_TAG_MAX_LENGTH);
+}
+
+let nextRowId = 1;
+
+/**
+ * 프로젝트 생성 폼.
+ * ⚠️ 참여 팀은 **드롭다운 하나가 아니라 다중 지정**이다 — 프로젝트 하나에 여러 팀이 참여할 수 있어
+ *    행을 늘려가며 고른다(팀당 한 행, 중복 선택 불가).
+ * ⚠️ 태그 색상은 고정 팔레트(`lib/palette`)에서만 고른다 — 자유 HEX는 다크모드에 안 맞는다.
+ */
+export function ProjectForm({ action, teamOptions, cancelHref }: ProjectFormProps) {
+  const [state, formAction, isPending] = useActionState(action, { errors: {} });
+
+  const [name, setName] = useState("");
+  const [tag, setTag] = useState("");
+  const [description, setDescription] = useState("");
+  const [dueDate, setDueDate] = useState("");
+  const [tagColor, setTagColor] = useState<TagColorName>(TAG_NAMES[0]);
+  const [colorPickerOpen, setColorPickerOpen] = useState(false);
+  const [teamRows, setTeamRows] = useState<TeamRow[]>([{ rowId: nextRowId++, team: "" }]);
+  const [attachmentName, setAttachmentName] = useState<string | undefined>(undefined);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const canSubmit =
+    name.trim().length > 0 &&
+    tag.length > 0 &&
+    description.trim().length > 0 &&
+    dueDate.trim().length > 0 &&
+    teamRows.length > 0 &&
+    teamRows.every((row) => row.team.trim().length > 0);
+  const mainColor = paletteColorByName(tagColor);
+  const usedTeams = new Set(teamRows.map((row) => row.team).filter(Boolean));
+  const canAddTeamRow = teamRows.length < teamOptions.length;
+
+  function cycleTagColor() {
+    const rest = TAG_NAMES.filter((candidate) => candidate !== tagColor);
+    const next = rest[Math.floor(Math.random() * rest.length)] ?? tagColor;
+    setTagColor(next);
+  }
+
+  function updateTeamRow(rowId: number, team: string) {
+    setTeamRows((rows) => rows.map((row) => (row.rowId === rowId ? { ...row, team } : row)));
+  }
+
+  function removeTeamRow(rowId: number) {
+    setTeamRows((rows) => rows.filter((row) => row.rowId !== rowId));
+  }
+
+  return (
+    <form action={formAction} className="flex flex-col gap-5">
+      <input type="hidden" name="tagColor" value={tagColor} />
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="project-name">
+          프로젝트명 <span className="text-destructive">*</span>
+        </Label>
+        <Input
+          id="project-name"
+          name="name"
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          placeholder="예: 제품 v3.0"
+          aria-invalid={Boolean(state.errors.name)}
+        />
+        {state.errors.name && <p className="text-destructive text-xs">{state.errors.name}</p>}
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="project-tag">
+          ProjectTag <span className="text-destructive">*</span>
+        </Label>
+        <Input
+          id="project-tag"
+          name="tag"
+          value={tag}
+          onChange={(event) => setTag(toTagInput(event.target.value))}
+          placeholder="PROJ"
+          maxLength={PROJECT_TAG_MAX_LENGTH}
+          className="w-40 font-mono"
+          aria-invalid={Boolean(state.errors.tag)}
+        />
+        <p className="text-muted-foreground text-xs">
+          영문 대문자만, 최대 {PROJECT_TAG_MAX_LENGTH}자 (소문자는 자동으로 대문자가 돼요)
+        </p>
+        {state.errors.tag && <p className="text-destructive text-xs">{state.errors.tag}</p>}
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="project-description">
+          세부 설명 <span className="text-destructive">*</span>
+        </Label>
+        <textarea
+          id="project-description"
+          name="description"
+          rows={4}
+          value={description}
+          onChange={(event) =>
+            setDescription(event.target.value.slice(0, PROJECT_DESCRIPTION_MAX_LENGTH))
+          }
+          placeholder="프로젝트 목표나 배경을 간략히 적어주세요"
+          maxLength={PROJECT_DESCRIPTION_MAX_LENGTH}
+          aria-invalid={Boolean(state.errors.description)}
+          className="border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive dark:bg-input/30 w-full resize-none rounded-lg border bg-transparent px-2.5 py-2 text-sm transition-colors outline-none focus-visible:ring-3"
+        />
+        <p className="text-muted-foreground text-right text-xs tabular-nums">
+          {description.length}/{PROJECT_DESCRIPTION_MAX_LENGTH}
+        </p>
+        {state.errors.description && (
+          <p className="text-destructive text-xs">{state.errors.description}</p>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label>태그 색상</Label>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={cycleTagColor}
+            className="ring-offset-background size-8 shrink-0 rounded-full ring-2 ring-offset-2 transition-transform outline-none active:scale-95"
+            style={
+              {
+                backgroundColor: mainColor.solidColor,
+                "--tw-ring-color": mainColor.solidColor,
+              } as CSSProperties
+            }
+            aria-label={`태그 색상: ${TAG_NAME_LABEL[tagColor]} (클릭하면 다른 색으로 바뀌어요)`}
+          />
+
+          <Popover open={colorPickerOpen} onOpenChange={setColorPickerOpen}>
+            <PopoverTrigger
+              render={
+                <Button type="button" variant="outline" size="sm">
+                  더보기
+                </Button>
+              }
+            />
+            {/* 버튼 우측에, 바닥면을 버튼 바닥과 맞춰서 띄운다. */}
+            <PopoverContent side="right" align="end" sideOffset={8} className="w-56">
+              <div className="grid grid-cols-4 gap-2">
+                {TAG_NAMES.map((colorName) => {
+                  const color = paletteColorByName(colorName);
+                  const label = TAG_NAME_LABEL[colorName];
+                  return (
+                    <button
+                      key={colorName}
+                      type="button"
+                      onClick={() => {
+                        setTagColor(colorName);
+                        setColorPickerOpen(false);
+                      }}
+                      className={cn(
+                        "hover:bg-muted focus-visible:ring-ring/50 flex flex-col items-center gap-1 rounded-md p-1.5 outline-none focus-visible:ring-3",
+                        colorName === tagColor && "bg-muted",
+                      )}
+                    >
+                      <span
+                        className="size-6 rounded-full"
+                        style={{ backgroundColor: color.solidColor }}
+                        aria-hidden
+                      />
+                      {/* 4글자부터 칸 폭에서 줄바꿈되므로 그만큼 작게 — 전부 한 줄로 보이게 */}
+                      <span
+                        className={cn(
+                          "text-muted-foreground whitespace-nowrap",
+                          label.length >= 4 ? "text-[9px]" : "text-[11px]",
+                        )}
+                      >
+                        {label}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            </PopoverContent>
+          </Popover>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="project-due-date">
+          마감 기한 <span className="text-destructive">*</span>
+        </Label>
+        <Input
+          id="project-due-date"
+          name="dueDate"
+          type="date"
+          value={dueDate}
+          onChange={(event) => setDueDate(event.target.value)}
+          className="w-48"
+          aria-invalid={Boolean(state.errors.dueDate)}
+        />
+        {state.errors.dueDate && <p className="text-destructive text-xs">{state.errors.dueDate}</p>}
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label>
+          참여 팀 <span className="text-destructive">*</span>
+        </Label>
+        <div className="flex flex-col gap-2">
+          {teamRows.map((row) => (
+            <div key={row.rowId} className="flex items-center gap-2">
+              <Select
+                value={row.team}
+                onValueChange={(value) => updateTeamRow(row.rowId, value ?? "")}
+              >
+                <SelectTrigger aria-label="참여 팀 선택" className="w-48">
+                  <SelectValue placeholder="팀 선택" />
+                </SelectTrigger>
+                <SelectContent side="bottom" alignItemWithTrigger={false}>
+                  {teamOptions.map((team) => (
+                    <SelectItem
+                      key={team}
+                      value={team}
+                      disabled={team !== row.team && usedTeams.has(team)}
+                    >
+                      {team}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {teamRows.length > 1 && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label="이 팀 지정 삭제"
+                  onClick={() => removeTeamRow(row.rowId)}
+                >
+                  <X />
+                </Button>
+              )}
+              {row.team && <input type="hidden" name="teamNames" value={row.team} />}
+            </div>
+          ))}
+
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="w-fit"
+            disabled={!canAddTeamRow}
+            onClick={() => setTeamRows((rows) => [...rows, { rowId: nextRowId++, team: "" }])}
+          >
+            <Plus />팀 추가
+          </Button>
+        </div>
+        {state.errors.teamNames && (
+          <p className="text-destructive text-xs">{state.errors.teamNames}</p>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="project-attachment">첨부파일</Label>
+        <input
+          ref={fileInputRef}
+          id="project-attachment"
+          type="file"
+          className="hidden"
+          onChange={(event) => setAttachmentName(event.target.files?.[0]?.name)}
+        />
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="w-fit"
+          onClick={() => fileInputRef.current?.click()}
+        >
+          <Paperclip />
+          {attachmentName ?? "파일 첨부 (선택)"}
+        </Button>
+        {attachmentName && <input type="hidden" name="attachmentName" value={attachmentName} />}
+        <p className="text-muted-foreground text-xs">
+          프로젝트 기획서 등 참고 문서가 있다면 첨부해주세요.
+        </p>
+      </div>
+
+      <div className="flex justify-end gap-2">
+        <Link href={cancelHref} className={buttonVariants({ variant: "outline", size: "sm" })}>
+          취소
+        </Link>
+        <Button
+          type="submit"
+          size="sm"
+          disabled={isPending || !canSubmit}
+          className="bg-foreground text-background hover:bg-foreground/90"
+        >
+          {isPending ? "생성 중…" : "프로젝트 생성"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/features/project/mock/projects.ts
+++ b/src/features/project/mock/projects.ts
@@ -1,6 +1,6 @@
 import { PROJECT_STATUS } from "@/constants/domain";
 
-import type { ProjectListItem } from "../types";
+import type { ProjectDraft, ProjectListItem } from "../types";
 
 /**
  * ⚠️ 목 데이터 — BE 연동 전(ERD·API 스펙 미확정, DECISIONS.md).
@@ -45,3 +45,25 @@ export const TOP_LEVEL_PROJECTS: ProjectListItem[] = [
     status: PROJECT_STATUS.IN_PROGRESS,
   },
 ];
+
+/**
+ * 프로젝트 생성 — 격리막(CLAUDE.md §Mock 격리막). 새 프로젝트는 착수 직후라 진척 0%·할일 상태로 만든다.
+ * ⚠️ 태그 색상(`tagColor`)은 지금 이 목 배열에 저장할 자리가 없다 — `ProjectListItem`엔
+ *    색 필드가 없고 목록은 태그명을 해시해 색을 뽑는다(`pickPaletteColor`). 사용자가 고른 색은
+ *    BE에 색 필드가 생기면 그때 같이 흘려보낸다(지금은 생성 폼에서만 쓰고 버려진다).
+ */
+export function addMockProject(draft: ProjectDraft): ProjectListItem {
+  const project: ProjectListItem = {
+    id: `p-${draft.tag.toLowerCase()}`,
+    name: draft.name,
+    description: draft.description,
+    tag: draft.tag,
+    departments: draft.teamNames,
+    actionTotal: 0,
+    actionDone: 0,
+    dueDate: draft.dueDate,
+    status: PROJECT_STATUS.TODO,
+  };
+  TOP_LEVEL_PROJECTS.push(project);
+  return project;
+}

--- a/src/features/project/server.ts
+++ b/src/features/project/server.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_PROJECT_SORT, type ProjectSort, type ProjectStatus } from "@/constants/domain";
+import { COMPANY_TEAM_NAMES } from "@/constants/project";
 import { isMock } from "@/mocks/config";
 
 import { sortProjects } from "./lib";
@@ -33,6 +34,13 @@ export async function getProjectList({
     );
     return sortProjects(filtered, sort);
   }
+
+  throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
+}
+
+/** 프로젝트 생성 폼의 "참여 팀" 선택지 — 회사 전체 팀 목록. */
+export async function getCompanyTeamOptions(): Promise<string[]> {
+  if (isMock) return [...COMPANY_TEAM_NAMES];
 
   throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
 }

--- a/src/features/project/types.ts
+++ b/src/features/project/types.ts
@@ -1,4 +1,5 @@
 import type { ProjectStatus } from "@/constants/domain";
+import type { TagColorName } from "@/lib/palette";
 
 /**
  * 프로젝트 전체 조회(`/app/projects`)의 한 행. UI 계약(Mock → Live 격리막) — 컴포넌트는 이 타입만 안다.
@@ -28,3 +29,25 @@ export interface ProjectListItem {
   dueDate: string;
   status: ProjectStatus;
 }
+
+/**
+ * 프로젝트 생성 폼 입력 — 화면과 서버 액션이 **같은 스키마**로 검증한다(규칙이 두 벌이면 어긋난다).
+ * ⚠️ `attachmentName`은 목 단계라 파일명만 들고 있는다 — 실제 업로드는 API 스펙 확정 후.
+ */
+export interface ProjectDraft {
+  name: string;
+  tag: string;
+  description: string;
+  tagColor: TagColorName;
+  dueDate: string;
+  /** 참여 팀 — 최소 1개. 순서 무관, 빈 값은 제출 전 걸러낸다. */
+  teamNames: string[];
+  attachmentName?: string;
+}
+
+/** 칸별 검증 오류 — 비어 있으면 통과. `teamNames`는 배열이라 한 문구로 받는다. */
+export type ProjectFormErrors = Partial<
+  Record<keyof Omit<ProjectDraft, "teamNames" | "attachmentName">, string> & {
+    teamNames: string;
+  }
+>;

--- a/src/features/project/validate.ts
+++ b/src/features/project/validate.ts
@@ -1,0 +1,35 @@
+import { PROJECT_DESCRIPTION_MAX_LENGTH, PROJECT_TAG_MAX_LENGTH } from "@/constants/project";
+
+import type { ProjectDraft, ProjectFormErrors } from "./types";
+
+const TAG_PATTERN = /^[A-Z]+$/;
+
+/**
+ * 프로젝트 생성 검증 — 화면(폼)과 서버(Server Action)가 **이 함수 하나**로 본다.
+ * ⚠️ 태그는 화면에서 이미 대문자로 강제 변환하지만, 서버 액션은 그 변환을 신뢰하지 않고 다시 본다
+ *    (CLAUDE.md §권한: 화면 처리는 UX일 뿐 검증이 아니다).
+ */
+export function validateProjectDraft(draft: ProjectDraft): ProjectFormErrors {
+  const errors: ProjectFormErrors = {};
+
+  if (!draft.name.trim()) errors.name = "프로젝트명을 입력해 주세요";
+
+  const tag = draft.tag.trim();
+  if (!tag) errors.tag = "ProjectTag를 입력해 주세요";
+  else if (tag.length > PROJECT_TAG_MAX_LENGTH)
+    errors.tag = `ProjectTag는 영문 대문자 ${PROJECT_TAG_MAX_LENGTH}자 이내로 입력해 주세요`;
+  else if (!TAG_PATTERN.test(tag)) errors.tag = "ProjectTag는 영문 대문자만 입력할 수 있어요";
+
+  if (!draft.description.trim()) errors.description = "세부 설명을 입력해 주세요";
+  else if (draft.description.length > PROJECT_DESCRIPTION_MAX_LENGTH) {
+    errors.description = `세부 설명은 ${PROJECT_DESCRIPTION_MAX_LENGTH}자를 넘을 수 없어요`;
+  }
+
+  if (!draft.dueDate.trim()) errors.dueDate = "마감 기한을 선택해 주세요";
+
+  if (draft.teamNames.filter((team) => team.trim()).length === 0) {
+    errors.teamNames = "참여 팀을 1개 이상 지정해 주세요";
+  }
+
+  return errors;
+}

--- a/src/lib/palette.ts
+++ b/src/lib/palette.ts
@@ -16,7 +16,7 @@
  *    자동 배정인 지금은 겹치는 게 정상이다. 색으로 프로젝트를 **식별하지 않는다** —
  *    식별은 이름과 태그가 한다.
  */
-const TAG_NAMES = [
+export const TAG_NAMES = [
   "slate",
   "yellow",
   "lime",
@@ -29,6 +29,32 @@ const TAG_NAMES = [
   "fuchsia",
   "pink",
 ] as const;
+
+export type TagColorName = (typeof TAG_NAMES)[number];
+
+/** 팔레트 이름의 화면 표시용 한글 라벨 — 사용자가 직접 색을 고르는 화면(프로젝트 생성 등)에서 쓴다. */
+export const TAG_NAME_LABEL: Record<TagColorName, string> = {
+  slate: "슬레이트",
+  yellow: "옐로우",
+  lime: "라임",
+  emerald: "에메랄드",
+  teal: "틸",
+  cyan: "시안",
+  sky: "스카이",
+  indigo: "인디고",
+  purple: "퍼플",
+  fuchsia: "푸시아",
+  pink: "핑크",
+};
+
+/** 팔레트 이름으로 바로 색을 뽑는다 — 사용자가 명시적으로 고른 이름을 그대로 쓸 때(해시를 거치지 않는다). */
+export function paletteColorByName(name: TagColorName): PaletteColor {
+  return {
+    bgColor: `var(--tag-${name}-bg)`,
+    textColor: `var(--tag-${name}-fg)`,
+    solidColor: `var(--tag-${name}-solid)`,
+  };
+}
 
 export interface PaletteColor {
   /** 칩 배경 — `var(--tag-teal-bg)`. 테마 전환은 CSS가 한다 */


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [x] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

Figma 목업 기준으로 프로젝트 생성 폼(`/app/projects/new`)을 구현했다. 프로젝트 전체 조회(#134)에 이어 생성 진입점이 없어서, `docs/WORKFLOW.md`의 생성 정책(§생성)을 화면으로 옮겼다.

- ProjectTag — 영문 대문자만, 최대 6자. 소문자 입력 시 자동 대문자 변환(화면), 서버 액션도 동일 검증 재수행
- 세부 설명 — BE `varchar(255)` 제한 반영 + 글자수 카운터, 필수 항목
- 태그 색상 — 다크모드 대응 고정 팔레트(`lib/palette`)에서만 선택. 기본 원 클릭 시 랜덤 순환, "더보기"로 4열 팔레트 그리드
- 참여 팀 — 드롭다운 다중 지정(추가 버튼으로 행 증가, 팀당 한 행·중복 선택 불가), 필수
- 첨부파일 — 선택 사항 + 안내 문구
- Owner 전용(`canCreateProject`), 서버 액션에서 권한·검증 재검사
- 목 데이터 생성(`addMockProject`) — 생성 후 `/app/projects` 목록에 즉시 반영

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [x] 🔐 권한 2축 검사 — Owner 전용(`canCreateProject`), 서버 액션에서 재검사
- [ ] 🧬 zod — 해당 없음
- [x] 🕵️ 정직성 — 목 데이터 생성임을 명시
- [x] 🎨 디자인 토큰 사용 — 다크모드 대응 고정 팔레트만 사용

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [x] ♿ a11y — 필수 항목 다 채워야 생성 버튼 활성화, 인라인 오류
- [x] ♻️ 재사용 확인 — `lib/palette` 고정 팔레트 재사용
- [ ] 🧪 3상태 — 해당 없음(폼 화면)
- [ ] 브라우저 전용 API 미사용

---

## 🔗 연관 이슈

Closes #149

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

-

---

## 📝 추가 메모

확인법 — `/app/projects/new` 접근 시 Owner만 접근 가능(다른 권한은 404). ProjectTag에 소문자/숫자 섞어 입력 → 대문자만 남고 6자 제한. 참여 팀 추가 버튼으로 여러 팀 지정, 이미 고른 팀은 다른 행에서 비활성화. 생성 후 `/app/projects` 목록에서 새 프로젝트 확인(할일 탭).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 새 프로젝트 생성 페이지를 추가했습니다.
  * 프로젝트명, 태그, 설명, 색상, 마감일, 참여 팀 및 첨부파일을 입력할 수 있습니다.
  * 여러 참여 팀을 선택하고 행을 추가하거나 삭제할 수 있습니다.
  * 입력값 검증과 필드별 오류 안내를 제공합니다.
  * 태그를 대문자로 입력하고 글자 수 제한을 적용합니다.
  * 태그 색상 팔레트와 한글 색상 라벨을 지원합니다.
  * 프로젝트 생성 후 프로젝트 목록으로 이동합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
