### PR TITLE
[FIX] develop 복구 — 마이페이지가 없어진 constants/role을 부른다 #157

### DIFF
--- a/src/features/profile/components/profile-header.test.tsx
+++ b/src/features/profile/components/profile-header.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 
-import { ROLE_LABEL } from "@/constants/role";
+import { AUTHORITY_LABEL } from "@/constants/authority";
 
 import { MY_PROFILE_MOCK } from "../mock/profile";
 import { ProfileHeader } from "./profile-header";
@@ -11,7 +11,7 @@ describe("ProfileHeader", () => {
 
     expect(screen.getByText(MY_PROFILE_MOCK.name)).toBeInTheDocument();
     expect(screen.getByText(MY_PROFILE_MOCK.email)).toBeInTheDocument();
-    expect(screen.getByText(ROLE_LABEL[MY_PROFILE_MOCK.role])).toBeInTheDocument();
+    expect(screen.getByText(AUTHORITY_LABEL[MY_PROFILE_MOCK.role])).toBeInTheDocument();
     expect(
       screen.getByText(
         `${MY_PROFILE_MOCK.companyName} · ${MY_PROFILE_MOCK.teamName} · ${MY_PROFILE_MOCK.position}`,

--- a/src/features/profile/components/profile-header.tsx
+++ b/src/features/profile/components/profile-header.tsx
@@ -1,4 +1,4 @@
-import { ROLE_BADGE_CLASS, ROLE_LABEL } from "@/constants/role";
+import { AUTHORITY_BADGE_CLASS, AUTHORITY_LABEL } from "@/constants/authority";
 import { cn } from "@/lib/utils";
 
 import type { MyProfile } from "../types";
@@ -23,10 +23,10 @@ export function ProfileHeader({ profile }: ProfileHeaderProps) {
           <span
             className={cn(
               "inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-[11px] leading-none",
-              ROLE_BADGE_CLASS[profile.role],
+              AUTHORITY_BADGE_CLASS[profile.role],
             )}
           >
-            {ROLE_LABEL[profile.role]}
+            {AUTHORITY_LABEL[profile.role]}
           </span>
           <span className="text-muted-foreground/70 text-[11px]">
             {profile.companyName} · {profile.teamName} · {profile.position}

--- a/src/features/profile/mock/profile.ts
+++ b/src/features/profile/mock/profile.ts
@@ -1,4 +1,4 @@
-import { ROLE } from "@/constants/role";
+import { AUTHORITY } from "@/constants/authority";
 
 import type { MyProfile } from "../types";
 
@@ -6,7 +6,7 @@ import type { MyProfile } from "../types";
 export const MY_PROFILE_MOCK: MyProfile = {
   name: "김서준",
   email: "seojun@techstart.kr",
-  role: ROLE.OWNER,
+  role: AUTHORITY.OWNER,
   companyName: "(주)테크스타트",
   teamName: "제품개발팀",
   position: "수석",

--- a/src/features/profile/types.ts
+++ b/src/features/profile/types.ts
@@ -1,4 +1,4 @@
-import type { Role } from "@/constants/role";
+import type { Authority } from "@/constants/authority";
 
 /**
  * 마이페이지 — 격리막의 UI 계약(CLAUDE.md §Mock 격리막).
@@ -8,7 +8,7 @@ import type { Role } from "@/constants/role";
 export interface MyProfile {
   name: string;
   email: string;
-  role: Role;
+  role: Authority;
   companyName: string;
   teamName: string;
   /** 직급 라벨 — 영문 워딩 규칙(§카피)과 별개로, 직급은 팀에서 한글로 쓴다(예: "수석"). */


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

- **develop이 깨져 있어 모든 PR의 CI가 실패하던 것**을 되살렸다
- 마이페이지(#142)가 먼저 들어오고 그 뒤 개명(#147)이 `constants/role.ts`→`constants/authority.ts`로 바꿨는데, 개명 브랜치에는 마이페이지가 없어 `features/profile`이 옛 경로를 그대로 부르고 있었다 — 머지 순서 문제, 각자 브랜치에서는 통과했다
- 타입·상수 이름만 바꿨다: `Role`→`Authority`, `ROLE`→`AUTHORITY`, `ROLE_LABEL`→`AUTHORITY_LABEL`, `ROLE_BADGE_CLASS`→`AUTHORITY_BADGE_CLASS`
- ⚠️ **필드명 `role`은 그대로 뒀다** — #147이 `Position.role`·`AssignableRole`의 필드명 리네임을 의도적으로 범위에서 뺐다(인계 문서 4절). 여기서 같이 바꾸면 같은 것을 두 이름으로 부르게 된다

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 권한 2축 검사 — 해당 없음(타입·상수 리네임)
- [ ] 🧬 zod — 해당 없음
- [x] 🕵️ 정직성 — 목·미구현 없음
- [ ] 🎨 디자인 토큰 사용 — 해당 없음
- [ ] (해당 시) 서버 재검사 — 해당 없음

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [ ] ♿ a11y — 해당 없음
- [x] ♻️ 재사용 확인 — 기존 `constants/authority.ts` 값을 그대로 참조
- [ ] 🧪 3상태 — 해당 없음
- [ ] 브라우저 전용 API 미사용

---

## 🔗 연관 이슈

Closes #157

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- 급합니다 — 머지될 때까지 **모든 PR의 CI가 빨간불**입니다
- `git grep "@/constants/role" -- src` 비어 있는지만 확인해도 충분합니다

---

## 📝 추가 메모

```
git checkout develop && git pull
npm run typecheck   # 이 브랜치 반영 전에는 TS2307 4건으로 죽음
```

이 브랜치에서는 typecheck·lint·빌드 통과, 테스트 519개 통과.
