### PR TITLE
[FEAT] 회의실 예약 모달 UI #160

### DIFF
--- a/src/app/(shell)/app/rooms/page.tsx
+++ b/src/app/(shell)/app/rooms/page.tsx
@@ -5,6 +5,7 @@ import { RoomsBoard } from "@/features/rooms/components/rooms-board";
 import {
   getMeetingRooms,
   getReservableMembers,
+  getReservableProjects,
   getWeekReservations,
 } from "@/features/rooms/server";
 
@@ -30,10 +31,11 @@ export default async function RoomsPage({ searchParams }: RoomsPageProps) {
   const { week: weekParam } = await searchParams;
   const week = parseWeekParam(weekParam);
 
-  const [reservations, rooms, members] = await Promise.all([
+  const [reservations, rooms, members, projects] = await Promise.all([
     getWeekReservations(week),
     getMeetingRooms(),
     getReservableMembers(),
+    getReservableProjects(),
   ]);
 
   return (
@@ -44,6 +46,7 @@ export default async function RoomsPage({ searchParams }: RoomsPageProps) {
           initialReservations={reservations}
           rooms={rooms}
           members={members}
+          projects={projects}
           week={format(week, "yyyy-MM-dd")}
         />
       </div>

--- a/src/features/profile/components/profile-header.test.tsx
+++ b/src/features/profile/components/profile-header.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 
-import { ROLE_LABEL } from "@/constants/role";
+import { AUTHORITY_LABEL } from "@/constants/authority";
 
 import { MY_PROFILE_MOCK } from "../mock/profile";
 import { ProfileHeader } from "./profile-header";
@@ -11,7 +11,7 @@ describe("ProfileHeader", () => {
 
     expect(screen.getByText(MY_PROFILE_MOCK.name)).toBeInTheDocument();
     expect(screen.getByText(MY_PROFILE_MOCK.email)).toBeInTheDocument();
-    expect(screen.getByText(ROLE_LABEL[MY_PROFILE_MOCK.role])).toBeInTheDocument();
+    expect(screen.getByText(AUTHORITY_LABEL[MY_PROFILE_MOCK.role])).toBeInTheDocument();
     expect(
       screen.getByText(
         `${MY_PROFILE_MOCK.companyName} · ${MY_PROFILE_MOCK.teamName} · ${MY_PROFILE_MOCK.position}`,

--- a/src/features/profile/components/profile-header.tsx
+++ b/src/features/profile/components/profile-header.tsx
@@ -1,4 +1,4 @@
-import { ROLE_BADGE_CLASS, ROLE_LABEL } from "@/constants/role";
+import { AUTHORITY_BADGE_CLASS, AUTHORITY_LABEL } from "@/constants/authority";
 import { cn } from "@/lib/utils";
 
 import type { MyProfile } from "../types";
@@ -23,10 +23,10 @@ export function ProfileHeader({ profile }: ProfileHeaderProps) {
           <span
             className={cn(
               "inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-[11px] leading-none",
-              ROLE_BADGE_CLASS[profile.role],
+              AUTHORITY_BADGE_CLASS[profile.role],
             )}
           >
-            {ROLE_LABEL[profile.role]}
+            {AUTHORITY_LABEL[profile.role]}
           </span>
           <span className="text-muted-foreground/70 text-[11px]">
             {profile.companyName} · {profile.teamName} · {profile.position}

--- a/src/features/profile/mock/profile.ts
+++ b/src/features/profile/mock/profile.ts
@@ -1,4 +1,4 @@
-import { ROLE } from "@/constants/role";
+import { AUTHORITY } from "@/constants/authority";
 
 import type { MyProfile } from "../types";
 
@@ -6,7 +6,7 @@ import type { MyProfile } from "../types";
 export const MY_PROFILE_MOCK: MyProfile = {
   name: "김서준",
   email: "seojun@techstart.kr",
-  role: ROLE.OWNER,
+  role: AUTHORITY.OWNER,
   companyName: "(주)테크스타트",
   teamName: "제품개발팀",
   position: "수석",

--- a/src/features/profile/types.ts
+++ b/src/features/profile/types.ts
@@ -1,4 +1,4 @@
-import type { Role } from "@/constants/role";
+import type { Authority } from "@/constants/authority";
 
 /**
  * 마이페이지 — 격리막의 UI 계약(CLAUDE.md §Mock 격리막).
@@ -8,7 +8,7 @@ import type { Role } from "@/constants/role";
 export interface MyProfile {
   name: string;
   email: string;
-  role: Role;
+  role: Authority;
   companyName: string;
   teamName: string;
   /** 직급 라벨 — 영문 워딩 규칙(§카피)과 별개로, 직급은 팀에서 한글로 쓴다(예: "수석"). */

--- a/src/features/rooms/components/room-attendee-picker.test.tsx
+++ b/src/features/rooms/components/room-attendee-picker.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import type { RoomMember } from "../types";
+import { RoomAttendeePicker } from "./room-attendee-picker";
+
+const MEMBERS: RoomMember[] = [
+  { id: 1, name: "박대표" },
+  { id: 2, name: "김서준" },
+  { id: 3, name: "이하윤" },
+];
+
+describe("RoomAttendeePicker", () => {
+  it("이름을 검색하면 이미 선택된 사람은 빼고 결과를 보여준다", async () => {
+    const user = userEvent.setup();
+    render(<RoomAttendeePicker members={MEMBERS} selectedIds={[1]} onChange={jest.fn()} />);
+
+    await user.type(screen.getByRole("textbox", { name: "참석자 검색" }), "박");
+
+    // 이미 선택된 "박대표"는 칩으로만 남고, 검색 결과 버튼으로는 다시 뜨지 않는다.
+    expect(screen.queryByRole("button", { name: "박대표" })).not.toBeInTheDocument();
+  });
+
+  it("검색 결과를 누르면 선택 목록에 추가하고 검색어를 지운다", async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    render(<RoomAttendeePicker members={MEMBERS} selectedIds={[]} onChange={onChange} />);
+
+    await user.type(screen.getByRole("textbox", { name: "참석자 검색" }), "김서준");
+    await user.click(screen.getByRole("button", { name: "김서준" }));
+
+    expect(onChange).toHaveBeenCalledWith([2]);
+  });
+
+  it("선택된 사람의 X를 누르면 목록에서 뺀다", async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    render(<RoomAttendeePicker members={MEMBERS} selectedIds={[1, 2]} onChange={onChange} />);
+
+    await user.click(screen.getByRole("button", { name: "김서준 제외" }));
+
+    expect(onChange).toHaveBeenCalledWith([1]);
+  });
+
+  it("아무도 선택 안 하면 안내 문구를 보여준다", () => {
+    render(<RoomAttendeePicker members={MEMBERS} selectedIds={[]} onChange={jest.fn()} />);
+
+    expect(screen.getByText("참석자를 검색해 선택하세요")).toBeInTheDocument();
+  });
+});

--- a/src/features/rooms/components/room-attendee-picker.tsx
+++ b/src/features/rooms/components/room-attendee-picker.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { Search, X } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { Input } from "@/components/ui/input";
+
+import type { RoomMember } from "../types";
+
+interface RoomAttendeePickerProps {
+  members: RoomMember[];
+  selectedIds: number[];
+  onChange: (ids: number[]) => void;
+}
+
+/** 검색 결과로 한 번에 보여줄 최대 인원 — `notice-company-picker.tsx`와 같은 값. */
+const MAX_RESULTS = 6;
+
+/** 회의실 예약 "참석자" 선택 — 이름으로 검색해 여러 명을 골라 담는다(`notice-company-picker.tsx`와 같은 모양). */
+export function RoomAttendeePicker({ members, selectedIds, onChange }: RoomAttendeePickerProps) {
+  const [keyword, setKeyword] = useState("");
+
+  const selected = useMemo(
+    () => members.filter((member) => selectedIds.includes(member.id)),
+    [members, selectedIds],
+  );
+
+  const results = useMemo(() => {
+    const query = keyword.trim().toLowerCase();
+    if (!query) return [];
+    return members
+      .filter(
+        (member) => !selectedIds.includes(member.id) && member.name.toLowerCase().includes(query),
+      )
+      .slice(0, MAX_RESULTS);
+  }, [members, keyword, selectedIds]);
+
+  const add = (id: number) => {
+    onChange([...selectedIds, id]);
+    setKeyword("");
+  };
+  const remove = (id: number) => onChange(selectedIds.filter((value) => value !== id));
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="relative">
+        <Search
+          className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2"
+          aria-hidden
+        />
+        <Input
+          value={keyword}
+          onChange={(event) => setKeyword(event.target.value)}
+          placeholder="이름으로 검색"
+          aria-label="참석자 검색"
+          className="pl-8"
+        />
+      </div>
+
+      {keyword.trim().length > 0 && (
+        <div className="border-border overflow-hidden rounded-lg border">
+          {results.length === 0 ? (
+            <p className="text-muted-foreground px-3 py-3 text-xs">검색 결과가 없어요</p>
+          ) : (
+            <ul>
+              {results.map((member) => (
+                <li key={member.id}>
+                  <button
+                    type="button"
+                    onClick={() => add(member.id)}
+                    className="hover:bg-muted focus-visible:ring-ring flex w-full items-center px-3 py-2 text-left transition-colors focus-visible:ring-2 focus-visible:outline-none"
+                  >
+                    <span className="text-foreground truncate text-xs">{member.name}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+      {selected.length > 0 ? (
+        <div className="flex flex-wrap gap-1.5">
+          {selected.map((member) => (
+            <span
+              key={member.id}
+              className="bg-muted text-foreground inline-flex items-center gap-1 rounded-md py-1 pr-1 pl-2 text-xs"
+            >
+              {member.name}
+              <button
+                type="button"
+                onClick={() => remove(member.id)}
+                aria-label={`${member.name} 제외`}
+                className="hover:bg-foreground/10 focus-visible:ring-ring flex size-4 items-center justify-center rounded transition-colors focus-visible:ring-2 focus-visible:outline-none"
+              >
+                <X className="size-3" aria-hidden />
+              </button>
+            </span>
+          ))}
+        </div>
+      ) : (
+        <p className="text-muted-foreground text-[11px]">참석자를 검색해 선택하세요</p>
+      )}
+    </div>
+  );
+}

--- a/src/features/rooms/components/room-attendee-picker.tsx
+++ b/src/features/rooms/components/room-attendee-picker.tsx
@@ -35,11 +35,11 @@ export function RoomAttendeePicker({ members, selectedIds, onChange }: RoomAtten
       .slice(0, MAX_RESULTS);
   }, [members, keyword, selectedIds]);
 
-  const add = (id: number) => {
+  const handleAdd = (id: number) => {
     onChange([...selectedIds, id]);
     setKeyword("");
   };
-  const remove = (id: number) => onChange(selectedIds.filter((value) => value !== id));
+  const handleRemove = (id: number) => onChange(selectedIds.filter((value) => value !== id));
 
   return (
     <div className="flex flex-col gap-2">
@@ -67,7 +67,7 @@ export function RoomAttendeePicker({ members, selectedIds, onChange }: RoomAtten
                 <li key={member.id}>
                   <button
                     type="button"
-                    onClick={() => add(member.id)}
+                    onClick={() => handleAdd(member.id)}
                     className="hover:bg-muted focus-visible:ring-ring flex w-full items-center px-3 py-2 text-left transition-colors focus-visible:ring-2 focus-visible:outline-none"
                   >
                     <span className="text-foreground truncate text-xs">{member.name}</span>
@@ -89,7 +89,7 @@ export function RoomAttendeePicker({ members, selectedIds, onChange }: RoomAtten
               {member.name}
               <button
                 type="button"
-                onClick={() => remove(member.id)}
+                onClick={() => handleRemove(member.id)}
                 aria-label={`${member.name} 제외`}
                 className="hover:bg-foreground/10 focus-visible:ring-ring flex size-4 items-center justify-center rounded transition-colors focus-visible:ring-2 focus-visible:outline-none"
               >

--- a/src/features/rooms/components/room-reservation-dialog.test.tsx
+++ b/src/features/rooms/components/room-reservation-dialog.test.tsx
@@ -1,0 +1,83 @@
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import type { MeetingRoom, RoomMember, RoomProjectOption } from "../types";
+import { RoomReservationDialog } from "./room-reservation-dialog";
+
+const ROOMS: MeetingRoom[] = [
+  { id: "room-large", name: "대회의실", capacity: 8, openTime: "09:00", closeTime: "18:00" },
+];
+const MEMBERS: RoomMember[] = [{ id: 1, name: "박대표" }];
+const PROJECTS: RoomProjectOption[] = [{ id: "p-goods", name: "굿즈 프로젝트", tag: "GOODS" }];
+
+const SLOT_START = new Date("2026-08-11T10:00:00");
+
+function renderDialog(overrides: Partial<React.ComponentProps<typeof RoomReservationDialog>> = {}) {
+  const onOpenChange = jest.fn();
+  const onCreated = jest.fn();
+  render(
+    <RoomReservationDialog
+      slotStart={SLOT_START}
+      onOpenChange={onOpenChange}
+      rooms={ROOMS}
+      members={MEMBERS}
+      projects={PROJECTS}
+      onCreated={onCreated}
+      {...overrides}
+    />,
+  );
+  return { onOpenChange, onCreated };
+}
+
+describe("RoomReservationDialog", () => {
+  it("slotStart가 없으면 아무것도 그리지 않는다", () => {
+    render(
+      <RoomReservationDialog
+        slotStart={null}
+        onOpenChange={jest.fn()}
+        rooms={ROOMS}
+        members={MEMBERS}
+        projects={PROJECTS}
+        onCreated={jest.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("회의실을 예약할까요?")).not.toBeInTheDocument();
+  });
+
+  it("클릭한 슬롯의 날짜·시각을 안내한다", () => {
+    renderDialog();
+
+    expect(screen.getByText(/8월 11일\(화\) 10:00부터 30분간 진행됩니다\./)).toBeInTheDocument();
+  });
+
+  it("취소를 누르면 onOpenChange(false)를 부른다", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: "취소" }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("필수값을 안 채우고 등록을 누르면 필드별 오류를 보여주고 onCreated는 안 부른다", async () => {
+    const user = userEvent.setup();
+    const { onCreated } = renderDialog();
+
+    await user.type(screen.getByLabelText("회의 제목"), "새 회의");
+    await user.click(screen.getByRole("button", { name: "등록" }));
+
+    await waitFor(() => {
+      const roomError = screen.getByText(
+        (_content, element) =>
+          element?.tagName === "P" && element.textContent === "회의실을 선택해 주세요",
+      );
+      expect(roomError).toBeInTheDocument();
+    });
+    expect(screen.getByText("대주제를 선택해 주세요")).toBeInTheDocument();
+    expect(screen.getByText("참석자를 한 명 이상 선택해 주세요")).toBeInTheDocument();
+    expect(onCreated).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/rooms/components/room-reservation-dialog.tsx
+++ b/src/features/rooms/components/room-reservation-dialog.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import { format } from "date-fns";
+import { ko } from "date-fns/locale";
+import { useActionState, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  MEETING_TOPIC_MAIN_LABEL,
+  MEETING_TOPIC_SUB,
+  type MeetingTopicMain,
+} from "@/constants/meeting";
+
+import { createRoomReservationAction, type RoomReservationFormState } from "../actions";
+import type { MeetingRoom, RoomMember, RoomProjectOption, RoomReservation } from "../types";
+import { RoomAttendeePicker } from "./room-attendee-picker";
+
+interface RoomReservationDialogProps {
+  /** 클릭한 30분 슬롯의 시작 시각 — null이면 닫힌 상태다. 날짜·시작 시각은 이 값으로 고정된다
+   *  (30분 한 타임 고정, CLAUDE.md §브라우저 API — 모달에서 시간을 다시 고르지 않는다). */
+  slotStart: Date | null;
+  onOpenChange: (open: boolean) => void;
+  rooms: MeetingRoom[];
+  members: RoomMember[];
+  projects: RoomProjectOption[];
+  /** 생성 성공 시 호출 — 재조회 없이 부모 화면에 바로 얹는다(§최적화: action 리턴값 그대로 반영). */
+  onCreated: (created: RoomReservation) => void;
+}
+
+const NO_PROJECT_VALUE = "__none__";
+
+const INITIAL_STATE: RoomReservationFormState = { errors: {} };
+
+const EMPTY_FORM = {
+  title: "",
+  roomId: "",
+  projectId: NO_PROJECT_VALUE,
+  topicMain: "",
+  topicSub: "",
+  attendeeIds: [] as number[],
+};
+
+/**
+ * 회의실 예약 모달 — `/app/rooms` 예약이 유일한 회의 개설 진입점이다(CLAUDE.md §라우트 그룹).
+ * ⚠️ `ConfirmDialog`를 안 쓴다 — 필드가 여러 개라 두 버튼 동일폭 레이아웃이 안 맞는다. 대신
+ *    같은 표식 없는 순수 `Dialog`로 만들고, 제출 버튼은 하단 우측에 둔다(DESIGN.md §4 여백).
+ * ⚠️ shadcn `Select`는 네이티브 `<select>`가 아니라 `FormData`에 자동으로 안 실린다 —
+ *    `add-todo-dialog.tsx`와 같은 방식으로 상태를 들고 있다가 제출 시 직접 `FormData`를 만들어
+ *    `formAction`에 넘긴다.
+ */
+export function RoomReservationDialog({
+  slotStart,
+  onOpenChange,
+  rooms,
+  members,
+  projects,
+  onCreated,
+}: RoomReservationDialogProps) {
+  const [state, formAction, isPending] = useActionState(createRoomReservationAction, INITIAL_STATE);
+  const [form, setForm] = useState(EMPTY_FORM);
+  const handledCreatedId = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (state.created && state.created.id !== handledCreatedId.current) {
+      handledCreatedId.current = state.created.id;
+      onCreated(state.created);
+      onOpenChange(false);
+      setForm(EMPTY_FORM);
+      toast.success(`'${state.created.title}' 회의실을 예약했습니다`);
+    }
+  }, [state.created, onCreated, onOpenChange]);
+
+  function handleOpenChange(open: boolean) {
+    if (!open) setForm(EMPTY_FORM);
+    onOpenChange(open);
+  }
+
+  function handleSubmit() {
+    if (!slotStart) return;
+    const formData = new FormData();
+    formData.set("title", form.title);
+    formData.set("roomId", form.roomId);
+    formData.set("date", format(slotStart, "yyyy-MM-dd"));
+    formData.set("startTime", format(slotStart, "HH:mm"));
+    if (form.projectId !== NO_PROJECT_VALUE) formData.set("projectId", form.projectId);
+    formData.set("topicMain", form.topicMain);
+    formData.set("topicSub", form.topicSub);
+    for (const id of form.attendeeIds) formData.append("attendeeIds", String(id));
+    formAction(formData);
+  }
+
+  const topicSubOptions = form.topicMain
+    ? (MEETING_TOPIC_SUB[form.topicMain as MeetingTopicMain] ?? [])
+    : [];
+
+  return (
+    <Dialog open={slotStart !== null} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-[440px]">
+        <DialogHeader>
+          <DialogTitle>회의실을 예약할까요?</DialogTitle>
+          <DialogDescription>
+            {slotStart &&
+              `${format(slotStart, "M월 d일(EEE)", { locale: ko })} ${format(slotStart, "HH:mm")}부터 30분간 진행됩니다.`}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="reservation-title">회의 제목</Label>
+            <Input
+              id="reservation-title"
+              value={form.title}
+              onChange={(event) => setForm((prev) => ({ ...prev, title: event.target.value }))}
+              placeholder="회의 제목을 입력해 주세요"
+              aria-invalid={Boolean(state.errors.title)}
+            />
+            {state.errors.title && <p className="text-destructive text-xs">{state.errors.title}</p>}
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="reservation-room">회의실</Label>
+            <Select
+              value={form.roomId}
+              onValueChange={(value) => setForm((prev) => ({ ...prev, roomId: value ?? "" }))}
+            >
+              <SelectTrigger
+                id="reservation-room"
+                aria-invalid={Boolean(state.errors.roomId)}
+                className="w-full"
+              >
+                <SelectValue placeholder="회의실을 선택해 주세요" />
+              </SelectTrigger>
+              <SelectContent>
+                {rooms.map((room) => (
+                  <SelectItem key={room.id} value={room.id}>
+                    {room.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {state.errors.roomId && (
+              <p className="text-destructive text-xs">{state.errors.roomId}</p>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="reservation-project">프로젝트</Label>
+            <Select
+              value={form.projectId}
+              onValueChange={(value) =>
+                setForm((prev) => ({ ...prev, projectId: value ?? NO_PROJECT_VALUE }))
+              }
+            >
+              <SelectTrigger id="reservation-project" className="w-full">
+                <SelectValue placeholder="프로젝트를 선택해 주세요" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={NO_PROJECT_VALUE}>없음</SelectItem>
+                {projects.map((project) => (
+                  <SelectItem key={project.id} value={project.id}>
+                    {project.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {state.errors.projectId && (
+              <p className="text-destructive text-xs">{state.errors.projectId}</p>
+            )}
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="reservation-topic-main">대주제</Label>
+              <Select
+                value={form.topicMain}
+                onValueChange={(value) =>
+                  setForm((prev) => ({ ...prev, topicMain: value ?? "", topicSub: "" }))
+                }
+              >
+                <SelectTrigger
+                  id="reservation-topic-main"
+                  aria-invalid={Boolean(state.errors.topicMain)}
+                  className="w-full"
+                >
+                  <SelectValue placeholder="대주제" />
+                </SelectTrigger>
+                <SelectContent>
+                  {Object.entries(MEETING_TOPIC_MAIN_LABEL).map(([value, label]) => (
+                    <SelectItem key={value} value={value}>
+                      {label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {state.errors.topicMain && (
+                <p className="text-destructive text-xs">{state.errors.topicMain}</p>
+              )}
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="reservation-topic-sub">소주제</Label>
+              <Select
+                value={form.topicSub}
+                onValueChange={(value) => setForm((prev) => ({ ...prev, topicSub: value ?? "" }))}
+                disabled={!form.topicMain}
+              >
+                <SelectTrigger
+                  id="reservation-topic-sub"
+                  aria-invalid={Boolean(state.errors.topicSub)}
+                  className="w-full"
+                >
+                  <SelectValue placeholder="소주제" />
+                </SelectTrigger>
+                <SelectContent>
+                  {topicSubOptions.map((sub) => (
+                    <SelectItem key={sub.value} value={sub.value}>
+                      {sub.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {state.errors.topicSub && (
+                <p className="text-destructive text-xs">{state.errors.topicSub}</p>
+              )}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label>참석자</Label>
+            <RoomAttendeePicker
+              members={members}
+              selectedIds={form.attendeeIds}
+              onChange={(attendeeIds) => setForm((prev) => ({ ...prev, attendeeIds }))}
+            />
+            {state.errors.attendeeIds && (
+              <p className="text-destructive text-xs">{state.errors.attendeeIds}</p>
+            )}
+          </div>
+        </div>
+
+        <div className="mt-2 flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={isPending}
+            onClick={() => handleOpenChange(false)}
+          >
+            취소
+          </Button>
+          <Button type="button" variant="ink" disabled={isPending} onClick={handleSubmit}>
+            {isPending ? "등록 중" : "등록"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/rooms/components/room-reservation-dialog.tsx
+++ b/src/features/rooms/components/room-reservation-dialog.tsx
@@ -2,8 +2,6 @@
 
 import { format } from "date-fns";
 import { ko } from "date-fns/locale";
-import { useActionState, useEffect, useRef, useState } from "react";
-import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -13,24 +11,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
-  MEETING_TOPIC_MAIN_LABEL,
-  MEETING_TOPIC_SUB,
-  type MeetingTopicMain,
-} from "@/constants/meeting";
 
-import { createRoomReservationAction, type RoomReservationFormState } from "../actions";
 import type { MeetingRoom, RoomMember, RoomProjectOption, RoomReservation } from "../types";
-import { RoomAttendeePicker } from "./room-attendee-picker";
+import { RoomReservationFields } from "./room-reservation-fields";
+import { useRoomReservationForm } from "./use-room-reservation-form";
 
 interface RoomReservationDialogProps {
   /** 클릭한 30분 슬롯의 시작 시각 — null이면 닫힌 상태다. 날짜·시작 시각은 이 값으로 고정된다
@@ -44,26 +28,12 @@ interface RoomReservationDialogProps {
   onCreated: (created: RoomReservation) => void;
 }
 
-const NO_PROJECT_VALUE = "__none__";
-
-const INITIAL_STATE: RoomReservationFormState = { errors: {} };
-
-const EMPTY_FORM = {
-  title: "",
-  roomId: "",
-  projectId: NO_PROJECT_VALUE,
-  topicMain: "",
-  topicSub: "",
-  attendeeIds: [] as number[],
-};
-
 /**
  * 회의실 예약 모달 — `/app/rooms` 예약이 유일한 회의 개설 진입점이다(CLAUDE.md §라우트 그룹).
  * ⚠️ `ConfirmDialog`를 안 쓴다 — 필드가 여러 개라 두 버튼 동일폭 레이아웃이 안 맞는다. 대신
  *    같은 표식 없는 순수 `Dialog`로 만들고, 제출 버튼은 하단 우측에 둔다(DESIGN.md §4 여백).
- * ⚠️ shadcn `Select`는 네이티브 `<select>`가 아니라 `FormData`에 자동으로 안 실린다 —
- *    `add-todo-dialog.tsx`와 같은 방식으로 상태를 들고 있다가 제출 시 직접 `FormData`를 만들어
- *    `formAction`에 넘긴다.
+ * 폼 상태·제출 로직은 `useRoomReservationForm`, 입력 필드는 `RoomReservationFields`로 뺐다
+ * (CLAUDE.md §폴더·네이밍: 200줄↑ 분리·로직=커스텀훅) — 여기는 모달 뼈대만 조립한다.
  */
 export function RoomReservationDialog({
   slotStart,
@@ -73,42 +43,8 @@ export function RoomReservationDialog({
   projects,
   onCreated,
 }: RoomReservationDialogProps) {
-  const [state, formAction, isPending] = useActionState(createRoomReservationAction, INITIAL_STATE);
-  const [form, setForm] = useState(EMPTY_FORM);
-  const handledCreatedId = useRef<string | null>(null);
-
-  useEffect(() => {
-    if (state.created && state.created.id !== handledCreatedId.current) {
-      handledCreatedId.current = state.created.id;
-      onCreated(state.created);
-      onOpenChange(false);
-      setForm(EMPTY_FORM);
-      toast.success(`'${state.created.title}' 회의실을 예약했습니다`);
-    }
-  }, [state.created, onCreated, onOpenChange]);
-
-  function handleOpenChange(open: boolean) {
-    if (!open) setForm(EMPTY_FORM);
-    onOpenChange(open);
-  }
-
-  function handleSubmit() {
-    if (!slotStart) return;
-    const formData = new FormData();
-    formData.set("title", form.title);
-    formData.set("roomId", form.roomId);
-    formData.set("date", format(slotStart, "yyyy-MM-dd"));
-    formData.set("startTime", format(slotStart, "HH:mm"));
-    if (form.projectId !== NO_PROJECT_VALUE) formData.set("projectId", form.projectId);
-    formData.set("topicMain", form.topicMain);
-    formData.set("topicSub", form.topicSub);
-    for (const id of form.attendeeIds) formData.append("attendeeIds", String(id));
-    formAction(formData);
-  }
-
-  const topicSubOptions = form.topicMain
-    ? (MEETING_TOPIC_SUB[form.topicMain as MeetingTopicMain] ?? [])
-    : [];
+  const { state, isPending, form, setForm, topicSubOptions, handleOpenChange, handleSubmit } =
+    useRoomReservationForm({ slotStart, onCreated, onOpenChange });
 
   return (
     <Dialog open={slotStart !== null} onOpenChange={handleOpenChange}>
@@ -121,139 +57,15 @@ export function RoomReservationDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-col gap-1.5">
-            <Label htmlFor="reservation-title">회의 제목</Label>
-            <Input
-              id="reservation-title"
-              value={form.title}
-              onChange={(event) => setForm((prev) => ({ ...prev, title: event.target.value }))}
-              placeholder="회의 제목을 입력해 주세요"
-              aria-invalid={Boolean(state.errors.title)}
-            />
-            {state.errors.title && <p className="text-destructive text-xs">{state.errors.title}</p>}
-          </div>
-
-          <div className="flex flex-col gap-1.5">
-            <Label htmlFor="reservation-room">회의실</Label>
-            <Select
-              value={form.roomId}
-              onValueChange={(value) => setForm((prev) => ({ ...prev, roomId: value ?? "" }))}
-            >
-              <SelectTrigger
-                id="reservation-room"
-                aria-invalid={Boolean(state.errors.roomId)}
-                className="w-full"
-              >
-                <SelectValue placeholder="회의실을 선택해 주세요" />
-              </SelectTrigger>
-              <SelectContent>
-                {rooms.map((room) => (
-                  <SelectItem key={room.id} value={room.id}>
-                    {room.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {state.errors.roomId && (
-              <p className="text-destructive text-xs">{state.errors.roomId}</p>
-            )}
-          </div>
-
-          <div className="flex flex-col gap-1.5">
-            <Label htmlFor="reservation-project">프로젝트</Label>
-            <Select
-              value={form.projectId}
-              onValueChange={(value) =>
-                setForm((prev) => ({ ...prev, projectId: value ?? NO_PROJECT_VALUE }))
-              }
-            >
-              <SelectTrigger id="reservation-project" className="w-full">
-                <SelectValue placeholder="프로젝트를 선택해 주세요" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={NO_PROJECT_VALUE}>없음</SelectItem>
-                {projects.map((project) => (
-                  <SelectItem key={project.id} value={project.id}>
-                    {project.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {state.errors.projectId && (
-              <p className="text-destructive text-xs">{state.errors.projectId}</p>
-            )}
-          </div>
-
-          <div className="grid grid-cols-2 gap-3">
-            <div className="flex flex-col gap-1.5">
-              <Label htmlFor="reservation-topic-main">대주제</Label>
-              <Select
-                value={form.topicMain}
-                onValueChange={(value) =>
-                  setForm((prev) => ({ ...prev, topicMain: value ?? "", topicSub: "" }))
-                }
-              >
-                <SelectTrigger
-                  id="reservation-topic-main"
-                  aria-invalid={Boolean(state.errors.topicMain)}
-                  className="w-full"
-                >
-                  <SelectValue placeholder="대주제" />
-                </SelectTrigger>
-                <SelectContent>
-                  {Object.entries(MEETING_TOPIC_MAIN_LABEL).map(([value, label]) => (
-                    <SelectItem key={value} value={value}>
-                      {label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {state.errors.topicMain && (
-                <p className="text-destructive text-xs">{state.errors.topicMain}</p>
-              )}
-            </div>
-
-            <div className="flex flex-col gap-1.5">
-              <Label htmlFor="reservation-topic-sub">소주제</Label>
-              <Select
-                value={form.topicSub}
-                onValueChange={(value) => setForm((prev) => ({ ...prev, topicSub: value ?? "" }))}
-                disabled={!form.topicMain}
-              >
-                <SelectTrigger
-                  id="reservation-topic-sub"
-                  aria-invalid={Boolean(state.errors.topicSub)}
-                  className="w-full"
-                >
-                  <SelectValue placeholder="소주제" />
-                </SelectTrigger>
-                <SelectContent>
-                  {topicSubOptions.map((sub) => (
-                    <SelectItem key={sub.value} value={sub.value}>
-                      {sub.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {state.errors.topicSub && (
-                <p className="text-destructive text-xs">{state.errors.topicSub}</p>
-              )}
-            </div>
-          </div>
-
-          <div className="flex flex-col gap-1.5">
-            <Label>참석자</Label>
-            <RoomAttendeePicker
-              members={members}
-              selectedIds={form.attendeeIds}
-              onChange={(attendeeIds) => setForm((prev) => ({ ...prev, attendeeIds }))}
-            />
-            {state.errors.attendeeIds && (
-              <p className="text-destructive text-xs">{state.errors.attendeeIds}</p>
-            )}
-          </div>
-        </div>
+        <RoomReservationFields
+          form={form}
+          setForm={setForm}
+          errors={state.errors}
+          rooms={rooms}
+          members={members}
+          projects={projects}
+          topicSubOptions={topicSubOptions}
+        />
 
         <div className="mt-2 flex justify-end gap-2">
           <Button

--- a/src/features/rooms/components/room-reservation-fields.tsx
+++ b/src/features/rooms/components/room-reservation-fields.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import type { Dispatch, SetStateAction } from "react";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { MEETING_TOPIC_MAIN_LABEL, type MeetingTopicSub } from "@/constants/meeting";
+
+import type {
+  MeetingRoom,
+  RoomMember,
+  RoomProjectOption,
+  RoomReservationFormErrors,
+} from "../types";
+import { RoomAttendeePicker } from "./room-attendee-picker";
+import { NO_PROJECT_VALUE, type RoomReservationFormValues } from "./use-room-reservation-form";
+
+interface RoomReservationFieldsProps {
+  form: RoomReservationFormValues;
+  setForm: Dispatch<SetStateAction<RoomReservationFormValues>>;
+  errors: RoomReservationFormErrors;
+  rooms: MeetingRoom[];
+  members: RoomMember[];
+  projects: RoomProjectOption[];
+  topicSubOptions: MeetingTopicSub[];
+}
+
+/** 예약 모달의 입력 필드 전부 — 제목·회의실·프로젝트·대주제/소주제·참석자(`room-reservation-dialog.tsx`에서 뺀 조각). */
+export function RoomReservationFields({
+  form,
+  setForm,
+  errors,
+  rooms,
+  members,
+  projects,
+  topicSubOptions,
+}: RoomReservationFieldsProps) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="reservation-title">회의 제목</Label>
+        <Input
+          id="reservation-title"
+          value={form.title}
+          onChange={(event) => setForm((prev) => ({ ...prev, title: event.target.value }))}
+          placeholder="회의 제목을 입력해 주세요"
+          aria-invalid={Boolean(errors.title)}
+        />
+        {errors.title && <p className="text-destructive text-xs">{errors.title}</p>}
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="reservation-room">회의실</Label>
+        <Select
+          value={form.roomId}
+          onValueChange={(value) => setForm((prev) => ({ ...prev, roomId: value ?? "" }))}
+        >
+          <SelectTrigger
+            id="reservation-room"
+            aria-invalid={Boolean(errors.roomId)}
+            className="w-full"
+          >
+            <SelectValue placeholder="회의실을 선택해 주세요" />
+          </SelectTrigger>
+          <SelectContent>
+            {rooms.map((room) => (
+              <SelectItem key={room.id} value={room.id}>
+                {room.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {errors.roomId && <p className="text-destructive text-xs">{errors.roomId}</p>}
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="reservation-project">프로젝트</Label>
+        <Select
+          value={form.projectId}
+          onValueChange={(value) =>
+            setForm((prev) => ({ ...prev, projectId: value ?? NO_PROJECT_VALUE }))
+          }
+        >
+          <SelectTrigger id="reservation-project" className="w-full">
+            <SelectValue placeholder="프로젝트를 선택해 주세요" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={NO_PROJECT_VALUE}>없음</SelectItem>
+            {projects.map((project) => (
+              <SelectItem key={project.id} value={project.id}>
+                {project.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {errors.projectId && <p className="text-destructive text-xs">{errors.projectId}</p>}
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="reservation-topic-main">대주제</Label>
+          <Select
+            value={form.topicMain}
+            onValueChange={(value) =>
+              setForm((prev) => ({ ...prev, topicMain: value ?? "", topicSub: "" }))
+            }
+          >
+            <SelectTrigger
+              id="reservation-topic-main"
+              aria-invalid={Boolean(errors.topicMain)}
+              className="w-full"
+            >
+              <SelectValue placeholder="대주제" />
+            </SelectTrigger>
+            <SelectContent>
+              {Object.entries(MEETING_TOPIC_MAIN_LABEL).map(([value, label]) => (
+                <SelectItem key={value} value={value}>
+                  {label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {errors.topicMain && <p className="text-destructive text-xs">{errors.topicMain}</p>}
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="reservation-topic-sub">소주제</Label>
+          <Select
+            value={form.topicSub}
+            onValueChange={(value) => setForm((prev) => ({ ...prev, topicSub: value ?? "" }))}
+            disabled={!form.topicMain}
+          >
+            <SelectTrigger
+              id="reservation-topic-sub"
+              aria-invalid={Boolean(errors.topicSub)}
+              className="w-full"
+            >
+              <SelectValue placeholder="소주제" />
+            </SelectTrigger>
+            <SelectContent>
+              {topicSubOptions.map((sub) => (
+                <SelectItem key={sub.value} value={sub.value}>
+                  {sub.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {errors.topicSub && <p className="text-destructive text-xs">{errors.topicSub}</p>}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label>참석자</Label>
+        <RoomAttendeePicker
+          members={members}
+          selectedIds={form.attendeeIds}
+          onChange={(attendeeIds) => setForm((prev) => ({ ...prev, attendeeIds }))}
+        />
+        {errors.attendeeIds && <p className="text-destructive text-xs">{errors.attendeeIds}</p>}
+      </div>
+    </div>
+  );
+}

--- a/src/features/rooms/components/rooms-board.tsx
+++ b/src/features/rooms/components/rooms-board.tsx
@@ -1,40 +1,57 @@
 "use client";
 
-import type { MeetingRoom, RoomMember, RoomReservation } from "../types";
+import { useState } from "react";
+
+import type { MeetingRoom, RoomMember, RoomProjectOption, RoomReservation } from "../types";
 import { RoomListPanel } from "./room-list-panel";
+import { RoomReservationDialog } from "./room-reservation-dialog";
 import { WeeklyRoomCalendarLoader } from "./weekly-room-calendar-loader";
 
 interface RoomsBoardProps {
   initialReservations: RoomReservation[];
   rooms: MeetingRoom[];
   members: RoomMember[];
+  projects: RoomProjectOption[];
   /** "YYYY-MM-DD" — 이 주의 월요일. 서버 컴포넌트가 이 주 기준으로 `initialReservations`를 내려준다. */
   week: string;
 }
 
 /**
- * 회의실 화면 본체(client).
- * ⚠️ 다음 단계(예약 모달·비관적 갱신)에서 `initialReservations`를 로컬 state로 바꾸고
- *    생성 성공 시 재조회 없이 바로 얹는다(`calendar-board.tsx`와 같은 패턴) — 지금은 읽기전용이라
- *    서버가 내려준 값을 그대로 그린다.
+ * 회의실 화면 본체(client). 서버가 내려준 예약을 로컬 state로 들고 있다가, 예약 생성 성공 시
+ * 재조회 없이 바로 얹는다(`calendar-board.tsx`와 같은 패턴, §최적화: action 리턴값으로 화면 반영).
+ * ⚠️ 30분 칸을 클릭하면 그 시작 시각을 `slotStart`에 담아 예약 모달을 연다 — 모달이 열려 있는지는
+ *    `slotStart !== null`로만 판단한다(별도 `isOpen` state를 안 둔다).
  * ⚠️ 주를 옮기면(`?week=`) 서버가 새 `initialReservations`를 내려주는데, 이 컴포넌트는 그때마다
  *    호출부에서 `key={week}`로 다시 마운트된다(개인 캘린더와 같은 이유).
  */
-export function RoomsBoard({ initialReservations, rooms, members, week }: RoomsBoardProps) {
-  // ⚠️ 다음 단계(예약 모달)에서 채운다 — 지금은 30분 칸을 눌러도 아직 아무 일도 안 일어난다.
-  function handleSelectSlot(start: Date) {
-    void start;
-  }
+export function RoomsBoard({
+  initialReservations,
+  rooms,
+  members,
+  projects,
+  week,
+}: RoomsBoardProps) {
+  const [reservations, setReservations] = useState(initialReservations);
+  const [slotStart, setSlotStart] = useState<Date | null>(null);
 
   return (
     <div className="flex flex-col gap-6">
       <WeeklyRoomCalendarLoader
-        reservations={initialReservations}
+        reservations={reservations}
         members={members}
         week={week}
-        onSelectSlot={handleSelectSlot}
+        onSelectSlot={setSlotStart}
       />
       <RoomListPanel rooms={rooms} />
+
+      <RoomReservationDialog
+        slotStart={slotStart}
+        onOpenChange={(open) => !open && setSlotStart(null)}
+        rooms={rooms}
+        members={members}
+        projects={projects}
+        onCreated={(created) => setReservations((prev) => [...prev, created])}
+      />
     </div>
   );
 }

--- a/src/features/rooms/components/use-room-reservation-form.ts
+++ b/src/features/rooms/components/use-room-reservation-form.ts
@@ -1,0 +1,92 @@
+"use client";
+
+import { format } from "date-fns";
+import { useActionState, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+
+import { MEETING_TOPIC_SUB, type MeetingTopicMain } from "@/constants/meeting";
+
+import { createRoomReservationAction, type RoomReservationFormState } from "../actions";
+import type { RoomReservation } from "../types";
+
+export const NO_PROJECT_VALUE = "__none__";
+
+const INITIAL_STATE: RoomReservationFormState = { errors: {} };
+
+const EMPTY_FORM = {
+  title: "",
+  roomId: "",
+  projectId: NO_PROJECT_VALUE,
+  topicMain: "",
+  topicSub: "",
+  attendeeIds: [] as number[],
+};
+
+export type RoomReservationFormValues = typeof EMPTY_FORM;
+
+interface UseRoomReservationFormOptions {
+  slotStart: Date | null;
+  onCreated: (created: RoomReservation) => void;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * 예약 모달의 폼 상태·제출 흐름 — `RoomReservationDialog`를 200줄 아래로 유지하려고 뺐다
+ * (CLAUDE.md §폴더·네이밍: 로직=커스텀훅).
+ * ⚠️ shadcn `Select`는 네이티브 `<select>`가 아니라 `FormData`에 자동으로 안 실린다 —
+ *    `add-todo-dialog.tsx`와 같은 방식으로 상태를 들고 있다가 제출 시 직접 `FormData`를 만든다.
+ */
+export function useRoomReservationForm({
+  slotStart,
+  onCreated,
+  onOpenChange,
+}: UseRoomReservationFormOptions) {
+  const [state, formAction, isPending] = useActionState(createRoomReservationAction, INITIAL_STATE);
+  const [form, setForm] = useState<RoomReservationFormValues>(EMPTY_FORM);
+  const handledCreatedId = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (state.created && state.created.id !== handledCreatedId.current) {
+      handledCreatedId.current = state.created.id;
+      onCreated(state.created);
+      onOpenChange(false);
+      setForm(EMPTY_FORM);
+      toast.success(`'${state.created.title}' 회의실을 예약했습니다`);
+    }
+  }, [state.created, onCreated, onOpenChange]);
+
+  function handleOpenChange(open: boolean) {
+    if (!open) setForm(EMPTY_FORM);
+    onOpenChange(open);
+  }
+
+  function handleSubmit() {
+    // ⚠️ 버튼도 `disabled={isPending}`지만, 클릭과 그 disabled가 반영되는 렌더 사이의 좁은 틈에
+    //    두 번째 클릭이 끼어들면 예약이 두 번 생성될 수 있다 — 여기서도 같은 조건으로 막는다.
+    if (isPending || !slotStart) return;
+    const formData = new FormData();
+    formData.set("title", form.title);
+    formData.set("roomId", form.roomId);
+    formData.set("date", format(slotStart, "yyyy-MM-dd"));
+    formData.set("startTime", format(slotStart, "HH:mm"));
+    if (form.projectId !== NO_PROJECT_VALUE) formData.set("projectId", form.projectId);
+    formData.set("topicMain", form.topicMain);
+    formData.set("topicSub", form.topicSub);
+    for (const id of form.attendeeIds) formData.append("attendeeIds", String(id));
+    formAction(formData);
+  }
+
+  const topicSubOptions = form.topicMain
+    ? (MEETING_TOPIC_SUB[form.topicMain as MeetingTopicMain] ?? [])
+    : [];
+
+  return {
+    state,
+    isPending,
+    form,
+    setForm,
+    topicSubOptions,
+    handleOpenChange,
+    handleSubmit,
+  };
+}

--- a/src/features/rooms/server.ts
+++ b/src/features/rooms/server.ts
@@ -2,12 +2,13 @@ import "server-only";
 
 import { endOfWeek, startOfWeek } from "date-fns";
 
+import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
 import { isMock } from "@/mocks/config";
 
 import { listMockMembers } from "./mock/members";
 import { listMockReservations } from "./mock/reservations";
 import { listMockRooms } from "./mock/rooms";
-import type { MeetingRoom, RoomMember, RoomReservation } from "./types";
+import type { MeetingRoom, RoomMember, RoomProjectOption, RoomReservation } from "./types";
 
 /**
  * 그 주(월요일 시작)와 겹치는 예약만 걸러 내려준다. 격리막(CLAUDE.md §Mock 격리막).
@@ -35,4 +36,16 @@ export async function getMeetingRooms(): Promise<MeetingRoom[]> {
 export async function getReservableMembers(): Promise<RoomMember[]> {
   if (isMock) return listMockMembers();
   throw new Error("사원 목록 조회 API가 아직 연결되지 않았습니다.");
+}
+
+/** 예약 폼의 "프로젝트" select용 — 프로젝트 도메인의 전체 목록에서 경량 필드만 골라 낸다. */
+export async function getReservableProjects(): Promise<RoomProjectOption[]> {
+  if (isMock) {
+    return TOP_LEVEL_PROJECTS.map((project) => ({
+      id: project.id,
+      name: project.name,
+      tag: project.tag,
+    }));
+  }
+  throw new Error("프로젝트 목록 조회 API가 아직 연결되지 않았습니다.");
 }

--- a/src/features/rooms/types.ts
+++ b/src/features/rooms/types.ts
@@ -23,6 +23,13 @@ export interface RoomMember {
   name: string;
 }
 
+/** 예약 폼의 "프로젝트" select가 쓰는 경량 항목 — 프로젝트 도메인 전체 타입을 끌어오지 않는다. */
+export interface RoomProjectOption {
+  id: string;
+  name: string;
+  tag: string;
+}
+
 /**
  * 주간 캘린더 한 칸에 그려지는 예약 건. react-big-calendar의 start/end 접근자가 이 필드명을 그대로 쓴다.
  * ⚠️ 막대 색은 여기 없다 — `projectTag`를 화면에서 `pickPaletteColor`에 넘겨 그때 뽑는다


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [x] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

- 주간 캘린더 셀 오른쪽에 항상 남던 10px 여백 제거(`react-big-calendar` 기본 CSS `.rbc-events-container` margin-right 오버라이드) — 배율 바뀔 때 그리드 줄이 안 맞아 보이던 원인
- 예약 검증 보강 — 프로젝트 없는 예약 허용, roomId·projectId·attendeeIds 서버 측 참조 무결성 검사, 대주제/소주제 조합 검사, attendeeIds 정수 검사
- 예약 모달 UI(`RoomReservationDialog`, `RoomAttendeePicker`) + `useActionState` 연결, 성공 시 재조회 없이 캘린더 반영 + 토스트, RTL 테스트 추가

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 역할 가드 없음(전 사원 공통), **서버(Server Action)에서 roomId·projectId·attendeeIds 재검사**
- [ ] 🧬 **zod** — 이 기능은 zod를 안 쓴다(기존 rooms 스캐폴딩 때부터 순수 함수 검증, `validate.ts`). repo에 zod가 있긴 하지만(`auth` 도메인만 사용) rooms는 처음부터 이 패턴이 아니었음 — 리뷰 포인트에 남김
- [x] 🕵️ **정직성** — 목 데이터임을 주석·타입에 명시, 미구현 API는 throw로 명확히 막음
- [x] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그) — 해당 없음(이미지·폰트 없음)
- [x] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로 — DnD 없음
- [x] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인) — `notice-company-picker.tsx`, `add-todo-dialog.tsx` 패턴 재사용
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 기존 스캐폴딩에서 이미 구현됨(이번 PR 범위 아님)
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음 — 해당 없음

---

## 🔗 연관 이슈

Closes #160

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
| (조회 전용) | (모달로 예약 생성 가능) |

⚠️ 이번 세션에선 dev 서버 렌더링 검증이 막혀서 스크린샷을 못 붙였습니다 — 병합 전 로컬에서 한 번 직접 확인해 주세요.

---

## 💬 리뷰 포인트

- `validate.ts`가 zod를 안 쓰는 게 맞는지(기존 스캐폴딩 패턴 유지 vs 이번에 zod로 바꿀지)
- shadcn `Select`가 네이티브 폼 요소가 아니라서 `FormData`를 수동 구성하는 방식(`add-todo-dialog.tsx`와 동일 패턴)이 맞는 선택인지
- 브라우저 실제 렌더링 미검증 상태로 올라간 점

---

## 📝 추가 메모

`npx jest src/features/rooms`(37개) · `npx tsc --noEmit` · `npx eslint` 전부 통과 확인함.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 회의실 보드에서 시간대를 선택해 30분 예약을 생성할 수 있습니다.
  * 예약 제목, 회의실, 프로젝트, 주제와 참석자를 입력할 수 있습니다.
  * 참석자를 이름으로 검색하고 최대 6명까지 추가·제거할 수 있습니다.
  * 예약 가능한 프로젝트 목록이 예약 화면에 제공됩니다.
  * 예약 완료 후 캘린더에 즉시 반영되고 성공 안내가 표시됩니다.

* **개선 사항**
  * 필수 입력 누락 및 서버 검증 오류가 항목별로 표시됩니다.
  * 검색 결과 없음, 참석자 미선택 등 상황별 안내가 제공됩니다.
  * 프로필 역할 배지가 권한 기준으로 일관되게 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->