### PR TITLE
[DESIGN] 프로젝트 목록 DESIGN.md 위반 정리 #168

### DIFF
--- a/src/app/(shell)/app/projects/loading.tsx
+++ b/src/app/(shell)/app/projects/loading.tsx
@@ -4,9 +4,9 @@ import { Skeleton } from "@/components/ui/skeleton";
 export default function Loading() {
   return (
     <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
-      <div className="mx-auto flex w-full max-w-[1080px] flex-col gap-4">
+      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-4">
         <Skeleton className="h-9 w-52 rounded-lg" />
-        <Skeleton className="h-60 w-full rounded-xl" />
+        <Skeleton className="h-60 w-full rounded-2xl" />
       </div>
     </main>
   );

--- a/src/app/(shell)/app/projects/page.tsx
+++ b/src/app/(shell)/app/projects/page.tsx
@@ -39,7 +39,7 @@ export default async function ProjectsPage({ searchParams }: ProjectsPageProps) 
 
   return (
     <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
-      <div className="mx-auto flex w-full max-w-[1080px] flex-col gap-4">
+      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-4">
         {/* 상단바엔 버튼을 두지 않는다(팀 규칙) — 생성 버튼은 본문 안, Owner 전용 */}
         <div className="flex items-center justify-between gap-4">
           <ProjectFilterTabs
@@ -66,7 +66,7 @@ export default async function ProjectsPage({ searchParams }: ProjectsPageProps) 
         </div>
 
         {/* 데이터가 있으면 내용 높이만큼만, 비어 있을 때만 최소 높이를 둬 텅 빈 카드가 안 되게 한다 */}
-        <section className="border-border bg-card overflow-hidden rounded-xl border">
+        <section className="border-border bg-card overflow-hidden rounded-2xl border">
           {projects.length === 0 ? (
             <p className="text-muted-foreground flex min-h-[360px] items-center justify-center px-4 text-sm">
               {keyword?.trim() ? "검색 결과가 없습니다." : "해당 상태의 프로젝트가 없습니다."}


### PR DESCRIPTION
## 📋 PR 타입

- [x] design — UI/UX 변경

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

- 본문 폭 `1080px` → `1440px`(DESIGN.md §4)
- 목록 카드 모서리 `rounded-xl` → `rounded-2xl`(§2)
- `loading.tsx` 폭·모서리 동기화

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [ ] 🔐 권한 2축 검사 — 해당 없음(폭·모서리만 변경)
- [ ] 🧬 zod — 해당 없음
- [x] 🕵️ 정직성 — 목·미구현 변경 없음
- [x] 🎨 디자인 토큰 사용 — DESIGN.md §2·§4 값으로 통일

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [ ] ♿ a11y — 변경 없음
- [x] ♻️ 재사용 확인 — 기존 카드 컴포넌트 값만 조정
- [x] 🧪 `loading` / `error` / `empty` 3상태 — `loading.tsx` 동기화
- [ ] 브라우저 전용 API 미사용

---

## 🔗 연관 이슈

Closes #168

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

-

---

## 📝 추가 메모

검증 — `npx jest`·타입체크는 커밋 훅/CI에 맡김.
