### PR TITLE
[DESIGN] 프로젝트 생성 화면 DESIGN.md 위반 정리 #170

### DIFF
--- a/src/app/(shell)/app/projects/new/loading.tsx
+++ b/src/app/(shell)/app/projects/new/loading.tsx
@@ -1,0 +1,14 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+/** 실제 화면과 같은 골격(브레드크럼 + 제목 + 폼 카드). 목록용 loading.tsx는 폭이 달라 물려받으면 튄다. */
+export default function Loading() {
+  return (
+    <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
+      <div className="mx-auto flex w-full max-w-[720px] flex-col gap-4">
+        <Skeleton className="h-4 w-32 rounded-lg" />
+        <Skeleton className="h-6 w-24 rounded-lg" />
+        <Skeleton className="h-96 w-full rounded-2xl" />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/app/projects/new/page.tsx
+++ b/src/app/(shell)/app/projects/new/page.tsx
@@ -32,7 +32,7 @@ export default async function AppProjectNewPage() {
           <h2 className="text-foreground text-base font-semibold">새 프로젝트</h2>
         </div>
 
-        <div className="border-border bg-card rounded-xl border p-6">
+        <div className="border-border bg-card rounded-2xl border p-7">
           <ProjectForm
             action={createProjectAction}
             teamOptions={teamOptions}

--- a/src/features/project/components/project-form.tsx
+++ b/src/features/project/components/project-form.tsx
@@ -313,7 +313,7 @@ export function ProjectForm({ action, teamOptions, cancelHref }: ProjectFormProp
             type="button"
             variant="outline"
             size="sm"
-            className="w-fit"
+            className="w-full justify-start"
             onClick={() => fileInputRef.current?.click()}
           >
             <Paperclip />

--- a/src/features/project/components/project-form.tsx
+++ b/src/features/project/components/project-form.tsx
@@ -93,39 +93,41 @@ export function ProjectForm({ action, teamOptions, cancelHref }: ProjectFormProp
     <form action={formAction} className="flex flex-col gap-5">
       <input type="hidden" name="tagColor" value={tagColor} />
 
-      <div className="flex flex-col gap-1.5">
-        <Label htmlFor="project-name">
-          프로젝트명 <span className="text-destructive">*</span>
-        </Label>
-        <Input
-          id="project-name"
-          name="name"
-          value={name}
-          onChange={(event) => setName(event.target.value)}
-          placeholder="예: 온라인 굿즈샵 웹 구축"
-          aria-invalid={Boolean(state.errors.name)}
-        />
-        {state.errors.name && <p className="text-destructive text-xs">{state.errors.name}</p>}
-      </div>
+      <div className="flex items-start gap-4">
+        <div className="flex flex-1 flex-col gap-1.5">
+          <Label htmlFor="project-name">
+            프로젝트명 <span className="text-destructive">*</span>
+          </Label>
+          <Input
+            id="project-name"
+            name="name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="예: 온라인 굿즈샵 웹 구축"
+            aria-invalid={Boolean(state.errors.name)}
+          />
+          {state.errors.name && <p className="text-destructive text-xs">{state.errors.name}</p>}
+        </div>
 
-      <div className="flex flex-col gap-1.5">
-        <Label htmlFor="project-tag">
-          ProjectTag <span className="text-destructive">*</span>
-        </Label>
-        <Input
-          id="project-tag"
-          name="tag"
-          value={tag}
-          onChange={(event) => setTag(toTagInput(event.target.value))}
-          placeholder="GOODS"
-          maxLength={PROJECT_TAG_MAX_LENGTH}
-          className="w-40 font-mono"
-          aria-invalid={Boolean(state.errors.tag)}
-        />
-        <p className="text-muted-foreground text-xs">
-          영문 대문자만, 최대 {PROJECT_TAG_MAX_LENGTH}자 (소문자는 자동으로 대문자가 돼요)
-        </p>
-        {state.errors.tag && <p className="text-destructive text-xs">{state.errors.tag}</p>}
+        <div className="flex w-40 flex-col gap-1.5">
+          <Label htmlFor="project-tag">
+            프로젝트 태그 <span className="text-destructive">*</span>
+          </Label>
+          <Input
+            id="project-tag"
+            name="tag"
+            value={tag}
+            onChange={(event) => setTag(toTagInput(event.target.value))}
+            placeholder="GOODS"
+            maxLength={PROJECT_TAG_MAX_LENGTH}
+            className="font-mono"
+            aria-invalid={Boolean(state.errors.tag)}
+          />
+          <p className="text-muted-foreground text-xs">
+            영문 대문자만, 최대 {PROJECT_TAG_MAX_LENGTH}자
+          </p>
+          {state.errors.tag && <p className="text-destructive text-xs">{state.errors.tag}</p>}
+        </div>
       </div>
 
       <div className="flex flex-col gap-1.5">
@@ -153,170 +155,175 @@ export function ProjectForm({ action, teamOptions, cancelHref }: ProjectFormProp
         )}
       </div>
 
-      <div className="flex flex-col gap-1.5">
-        <Label>
-          태그 색상 <span className="text-destructive">*</span>
-        </Label>
-        <div className="flex items-center gap-2">
-          <button
-            type="button"
-            onClick={cycleTagColor}
-            className="ring-offset-background size-8 shrink-0 rounded-full ring-2 ring-offset-2 transition-transform outline-none active:scale-95"
-            style={
-              {
-                backgroundColor: mainColor.solidColor,
-                "--tw-ring-color": mainColor.solidColor,
-              } as CSSProperties
-            }
-            aria-label={`태그 색상: ${TAG_NAME_LABEL[tagColor]} (클릭하면 다른 색으로 바뀌어요)`}
-          />
-
-          <Popover open={colorPickerOpen} onOpenChange={setColorPickerOpen}>
-            <PopoverTrigger
-              render={
-                <Button type="button" variant="outline" size="sm">
-                  더보기
-                </Button>
+      <div className="flex items-start justify-between gap-6">
+        <div className="flex flex-col gap-1.5">
+          <Label>
+            태그 색상 <span className="text-destructive">*</span>
+          </Label>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={cycleTagColor}
+              className="ring-offset-background size-8 shrink-0 rounded-full ring-2 ring-offset-2 transition-transform outline-none active:scale-95"
+              style={
+                {
+                  backgroundColor: mainColor.solidColor,
+                  "--tw-ring-color": mainColor.solidColor,
+                } as CSSProperties
               }
+              aria-label={`태그 색상: ${TAG_NAME_LABEL[tagColor]} (클릭하면 다른 색으로 바뀌어요)`}
             />
-            {/* 버튼 우측에, 바닥면을 버튼 바닥과 맞춰서 띄운다. */}
-            <PopoverContent side="right" align="end" sideOffset={8} className="w-56">
-              <div className="grid grid-cols-4 gap-2">
-                {TAG_NAMES.map((colorName) => {
-                  const color = paletteColorByName(colorName);
-                  const label = TAG_NAME_LABEL[colorName];
-                  return (
-                    <button
-                      key={colorName}
-                      type="button"
-                      onClick={() => {
-                        setTagColor(colorName);
-                        setColorPickerOpen(false);
-                      }}
-                      className={cn(
-                        "hover:bg-muted focus-visible:ring-ring/50 flex flex-col items-center gap-1 rounded-md p-1.5 outline-none focus-visible:ring-3",
-                        colorName === tagColor && "bg-muted",
-                      )}
-                    >
-                      <span
-                        className="size-6 rounded-full"
-                        style={{ backgroundColor: color.solidColor }}
-                        aria-hidden
-                      />
-                      {/* 4글자부터 칸 폭에서 줄바꿈되므로 그만큼 작게 — 전부 한 줄로 보이게 */}
-                      <span
+
+            <Popover open={colorPickerOpen} onOpenChange={setColorPickerOpen}>
+              <PopoverTrigger
+                render={
+                  <Button type="button" variant="outline" size="sm">
+                    더보기
+                  </Button>
+                }
+              />
+              {/* 버튼 우측에, 바닥면을 버튼 바닥과 맞춰서 띄운다. */}
+              <PopoverContent side="right" align="end" sideOffset={8} className="w-56">
+                <div className="grid grid-cols-4 gap-2">
+                  {TAG_NAMES.map((colorName) => {
+                    const color = paletteColorByName(colorName);
+                    const label = TAG_NAME_LABEL[colorName];
+                    return (
+                      <button
+                        key={colorName}
+                        type="button"
+                        onClick={() => {
+                          setTagColor(colorName);
+                          setColorPickerOpen(false);
+                        }}
                         className={cn(
-                          "text-muted-foreground whitespace-nowrap",
-                          label.length >= 4 ? "text-[9px]" : "text-[11px]",
+                          "hover:bg-muted focus-visible:ring-ring/50 flex flex-col items-center gap-1 rounded-md p-1.5 outline-none focus-visible:ring-3",
+                          colorName === tagColor && "bg-muted",
                         )}
                       >
-                        {label}
-                      </span>
-                    </button>
-                  );
-                })}
-              </div>
-            </PopoverContent>
-          </Popover>
+                        <span
+                          className="size-6 rounded-full"
+                          style={{ backgroundColor: color.solidColor }}
+                          aria-hidden
+                        />
+                        {/* 4글자부터 칸 폭에서 줄바꿈되므로 그만큼 작게 — 전부 한 줄로 보이게 */}
+                        <span
+                          className={cn(
+                            "text-muted-foreground whitespace-nowrap",
+                            label.length >= 4 ? "text-[9px]" : "text-[11px]",
+                          )}
+                        >
+                          {label}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </PopoverContent>
+            </Popover>
+          </div>
+        </div>
+
+        <div className="flex w-48 flex-col gap-1.5">
+          <Label htmlFor="project-due-date">
+            마감 기한 <span className="text-destructive">*</span>
+          </Label>
+          <Input
+            id="project-due-date"
+            name="dueDate"
+            type="date"
+            value={dueDate}
+            onChange={(event) => setDueDate(event.target.value)}
+            aria-invalid={Boolean(state.errors.dueDate)}
+          />
+          {state.errors.dueDate && (
+            <p className="text-destructive text-xs">{state.errors.dueDate}</p>
+          )}
         </div>
       </div>
 
-      <div className="flex flex-col gap-1.5">
-        <Label htmlFor="project-due-date">
-          마감 기한 <span className="text-destructive">*</span>
-        </Label>
-        <Input
-          id="project-due-date"
-          name="dueDate"
-          type="date"
-          value={dueDate}
-          onChange={(event) => setDueDate(event.target.value)}
-          className="w-48"
-          aria-invalid={Boolean(state.errors.dueDate)}
-        />
-        {state.errors.dueDate && <p className="text-destructive text-xs">{state.errors.dueDate}</p>}
-      </div>
-
-      <div className="flex flex-col gap-1.5">
-        <Label>
-          참여 팀 <span className="text-destructive">*</span>
-        </Label>
-        <div className="flex flex-col gap-2">
-          {teamRows.map((row) => (
-            <div key={row.rowId} className="flex items-center gap-2">
-              <Select
-                value={row.team}
-                onValueChange={(value) => updateTeamRow(row.rowId, value ?? "")}
-              >
-                <SelectTrigger aria-label="참여 팀 선택" className="w-48">
-                  <SelectValue placeholder="팀 선택" />
-                </SelectTrigger>
-                <SelectContent side="bottom" alignItemWithTrigger={false}>
-                  {teamOptions.map((team) => (
-                    <SelectItem
-                      key={team}
-                      value={team}
-                      disabled={team !== row.team && usedTeams.has(team)}
-                    >
-                      {team}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {teamRows.length > 1 && (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-sm"
-                  aria-label="이 팀 지정 삭제"
-                  onClick={() => removeTeamRow(row.rowId)}
+      <div className="flex items-start justify-between gap-6">
+        <div className="flex flex-col gap-1.5">
+          <Label>
+            참여 팀 <span className="text-destructive">*</span>
+          </Label>
+          <div className="flex flex-col gap-2">
+            {teamRows.map((row) => (
+              <div key={row.rowId} className="flex items-center gap-2">
+                <Select
+                  value={row.team}
+                  onValueChange={(value) => updateTeamRow(row.rowId, value ?? "")}
                 >
-                  <X />
-                </Button>
-              )}
-              {row.team && <input type="hidden" name="teamNames" value={row.team} />}
-            </div>
-          ))}
+                  <SelectTrigger aria-label="참여 팀 선택" className="w-48">
+                    <SelectValue placeholder="팀 선택" />
+                  </SelectTrigger>
+                  <SelectContent side="bottom" alignItemWithTrigger={false}>
+                    {teamOptions.map((team) => (
+                      <SelectItem
+                        key={team}
+                        value={team}
+                        disabled={team !== row.team && usedTeams.has(team)}
+                      >
+                        {team}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {teamRows.length > 1 && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    aria-label="이 팀 지정 삭제"
+                    onClick={() => removeTeamRow(row.rowId)}
+                  >
+                    <X />
+                  </Button>
+                )}
+                {row.team && <input type="hidden" name="teamNames" value={row.team} />}
+              </div>
+            ))}
 
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="w-fit"
+              disabled={!canAddTeamRow}
+              onClick={() => setTeamRows((rows) => [...rows, { rowId: nextRowId++, team: "" }])}
+            >
+              <Plus />팀 추가
+            </Button>
+          </div>
+          {state.errors.teamNames && (
+            <p className="text-destructive text-xs">{state.errors.teamNames}</p>
+          )}
+        </div>
+
+        <div className="flex w-56 flex-col gap-1.5">
+          <Label htmlFor="project-attachment">첨부파일</Label>
+          <input
+            ref={fileInputRef}
+            id="project-attachment"
+            type="file"
+            className="hidden"
+            onChange={(event) => setAttachmentName(event.target.files?.[0]?.name)}
+          />
           <Button
             type="button"
             variant="outline"
             size="sm"
             className="w-fit"
-            disabled={!canAddTeamRow}
-            onClick={() => setTeamRows((rows) => [...rows, { rowId: nextRowId++, team: "" }])}
+            onClick={() => fileInputRef.current?.click()}
           >
-            <Plus />팀 추가
+            <Paperclip />
+            {attachmentName ?? "파일 첨부 (선택)"}
           </Button>
+          {attachmentName && <input type="hidden" name="attachmentName" value={attachmentName} />}
+          <p className="text-muted-foreground text-xs">
+            프로젝트 기획서 등 참고 문서가 있다면 첨부해주세요.
+          </p>
         </div>
-        {state.errors.teamNames && (
-          <p className="text-destructive text-xs">{state.errors.teamNames}</p>
-        )}
-      </div>
-
-      <div className="flex flex-col gap-1.5">
-        <Label htmlFor="project-attachment">첨부파일</Label>
-        <input
-          ref={fileInputRef}
-          id="project-attachment"
-          type="file"
-          className="hidden"
-          onChange={(event) => setAttachmentName(event.target.files?.[0]?.name)}
-        />
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="w-fit"
-          onClick={() => fileInputRef.current?.click()}
-        >
-          <Paperclip />
-          {attachmentName ?? "파일 첨부 (선택)"}
-        </Button>
-        {attachmentName && <input type="hidden" name="attachmentName" value={attachmentName} />}
-        <p className="text-muted-foreground text-xs">
-          프로젝트 기획서 등 참고 문서가 있다면 첨부해주세요.
-        </p>
       </div>
 
       <div className="flex justify-end gap-2">

--- a/src/features/project/components/project-form.tsx
+++ b/src/features/project/components/project-form.tsx
@@ -155,7 +155,7 @@ export function ProjectForm({ action, teamOptions, cancelHref }: ProjectFormProp
         )}
       </div>
 
-      <div className="grid grid-cols-[minmax(0,1fr)_224px] items-start gap-6">
+      <div className="grid grid-cols-[minmax(0,1fr)_160px] items-start gap-6">
         <div className="flex flex-col gap-1.5">
           <Label>
             태그 색상 <span className="text-destructive">*</span>
@@ -242,7 +242,7 @@ export function ProjectForm({ action, teamOptions, cancelHref }: ProjectFormProp
         </div>
       </div>
 
-      <div className="grid grid-cols-[minmax(0,1fr)_224px] items-start gap-6">
+      <div className="grid grid-cols-[minmax(0,1fr)_160px] items-start gap-6">
         <div className="flex flex-col gap-1.5">
           <Label>
             참여 팀 <span className="text-destructive">*</span>

--- a/src/features/project/components/project-form.tsx
+++ b/src/features/project/components/project-form.tsx
@@ -155,7 +155,7 @@ export function ProjectForm({ action, teamOptions, cancelHref }: ProjectFormProp
         )}
       </div>
 
-      <div className="flex items-start justify-between gap-6">
+      <div className="grid grid-cols-[minmax(0,1fr)_224px] items-start gap-6">
         <div className="flex flex-col gap-1.5">
           <Label>
             태그 색상 <span className="text-destructive">*</span>
@@ -224,7 +224,7 @@ export function ProjectForm({ action, teamOptions, cancelHref }: ProjectFormProp
           </div>
         </div>
 
-        <div className="flex w-48 flex-col gap-1.5">
+        <div className="flex flex-col gap-1.5">
           <Label htmlFor="project-due-date">
             마감 기한 <span className="text-destructive">*</span>
           </Label>
@@ -242,7 +242,7 @@ export function ProjectForm({ action, teamOptions, cancelHref }: ProjectFormProp
         </div>
       </div>
 
-      <div className="flex items-start justify-between gap-6">
+      <div className="grid grid-cols-[minmax(0,1fr)_224px] items-start gap-6">
         <div className="flex flex-col gap-1.5">
           <Label>
             참여 팀 <span className="text-destructive">*</span>
@@ -300,7 +300,7 @@ export function ProjectForm({ action, teamOptions, cancelHref }: ProjectFormProp
           )}
         </div>
 
-        <div className="flex w-56 flex-col gap-1.5">
+        <div className="flex flex-col gap-1.5">
           <Label htmlFor="project-attachment">첨부파일</Label>
           <input
             ref={fileInputRef}


### PR DESCRIPTION
## 📋 PR 타입

- [x] design — UI/UX 변경

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

- 폼 카드 모서리 `rounded-xl` → `rounded-2xl`, 안쪽 여백 `p-6` → `p-7`(§2·§4)
- `loading.tsx` 신설(720px) — 목록용(1080px)을 물려받아 로딩→본문 전환 시 폭이 튀던 문제 해소
- 폭 720px 자체는 DESIGN.md §4 "폼 한 장" 규정과 이미 맞아 변경 없음

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [ ] 🔐 권한 2축 검사 — 해당 없음
- [ ] 🧬 zod — 해당 없음
- [x] 🕵️ 정직성 — 목·미구현 변경 없음
- [x] 🎨 디자인 토큰 사용 — DESIGN.md §2·§4 값으로 통일

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [ ] ♿ a11y — 변경 없음
- [x] ♻️ 재사용 확인 — 기존 폼 카드 값만 조정
- [x] 🧪 `loading` / `error` / `empty` 3상태 — `loading.tsx` 신설
- [ ] 브라우저 전용 API 미사용

---

## 🔗 연관 이슈

Closes #170

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

-

---

## 📝 추가 메모

검증 — `npx jest`·타입체크는 커밋 훅/CI에 맡김.
