### PR TITLE
[DESIGN] 프로젝트 상세 화면 DESIGN.md 위반 정리 #172

### DIFF
--- a/src/app/(shell)/app/projects/[projectId]/loading.tsx
+++ b/src/app/(shell)/app/projects/[projectId]/loading.tsx
@@ -4,10 +4,10 @@ import { Skeleton } from "@/components/ui/skeleton";
 export default function Loading() {
   return (
     <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
-      <div className="mx-auto flex w-full max-w-[1080px] flex-col gap-4">
+      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-4">
         <Skeleton className="h-7 w-64 rounded-lg" />
         <Skeleton className="h-8 w-40 rounded-lg" />
-        <Skeleton className="h-60 w-full rounded-xl" />
+        <Skeleton className="h-60 w-full rounded-2xl" />
       </div>
     </main>
   );

--- a/src/app/(shell)/app/projects/[projectId]/page.tsx
+++ b/src/app/(shell)/app/projects/[projectId]/page.tsx
@@ -61,13 +61,15 @@ export default async function ProjectDetailPage({ params, searchParams }: Projec
     <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
       <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-4">
         <div className="flex flex-col gap-1">
-          <p className="text-muted-foreground text-xs">
+          <p className="text-muted-foreground text-[11px] leading-4">
             <Link href="/app/projects" className="hover:text-foreground">
               프로젝트
             </Link>{" "}
             &gt; {project.name}
           </p>
-          <h2 className="text-foreground text-base font-semibold">{project.name}</h2>
+          <h2 className="text-foreground text-xl leading-7 font-semibold tracking-[-0.4px]">
+            {project.name}
+          </h2>
         </div>
 
         <nav aria-label="프로젝트 상세 탭" className="border-border flex gap-4 border-b">

--- a/src/app/(shell)/app/projects/[projectId]/page.tsx
+++ b/src/app/(shell)/app/projects/[projectId]/page.tsx
@@ -59,7 +59,7 @@ export default async function ProjectDetailPage({ params, searchParams }: Projec
 
   return (
     <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
-      <div className="mx-auto flex w-full max-w-[1080px] flex-col gap-4">
+      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-4">
         <div className="flex flex-col gap-1">
           <p className="text-muted-foreground text-xs">
             <Link href="/app/projects" className="hover:text-foreground">
@@ -93,36 +93,45 @@ export default async function ProjectDetailPage({ params, searchParams }: Projec
         </nav>
 
         {activeTab === "plan" ? (
-          <section className="border-border bg-card flex flex-col gap-3 rounded-xl border p-6">
-            <div className="flex items-center gap-2 text-xs">
+          <section className="border-border bg-card flex flex-col rounded-2xl border">
+            <div className="flex items-baseline justify-between gap-3 px-7 pt-6 pb-3">
+              <h3 className="flex items-center gap-2 text-[17px] leading-7 font-semibold tracking-[-0.3px]">
+                <span className="bg-foreground size-2 rounded-full" aria-hidden />
+                {project.name}
+              </h3>
+              <p className="text-muted-foreground text-[12px] leading-4">
+                마감 {due ? `${due}까지` : "-"}
+              </p>
+            </div>
+            <div className="flex flex-col gap-3 px-7 pb-7">
               <span
-                className="rounded px-1.5 py-0.5 font-mono font-semibold"
+                className="w-fit rounded px-1.5 py-0.5 font-mono text-xs font-semibold"
                 style={{ backgroundColor: tagColor.bgColor, color: tagColor.textColor }}
               >
                 {project.tag}
               </span>
-              <span className="text-muted-foreground">마감 {due ? `${due}까지` : "-"}</span>
+              <p className="text-muted-foreground text-sm whitespace-pre-wrap">
+                {project.description}
+              </p>
+              {project.attachmentName && (
+                // ⚠️ 목 단계라 다운로드 URL이 없다(§9 화면은 사실만 말한다) — 죽은 링크(href="#") 대신
+                //    지금 있는 파일명만 정직하게 보여준다. API 스펙 확정 후 실제 다운로드 링크로 바꾼다.
+                <span className="text-muted-foreground inline-flex w-fit items-center gap-1.5 text-sm">
+                  <Paperclip className="size-3.5" />
+                  {project.attachmentName}
+                </span>
+              )}
             </div>
-            <h3 className="text-foreground text-lg font-semibold">{project.name}</h3>
-            <p className="text-muted-foreground text-sm whitespace-pre-wrap">
-              {project.description}
-            </p>
-            {project.attachmentName && (
-              // ⚠️ 목 단계라 다운로드 URL이 없다(§9 화면은 사실만 말한다) — 죽은 링크(href="#") 대신
-              //    지금 있는 파일명만 정직하게 보여준다. API 스펙 확정 후 실제 다운로드 링크로 바꾼다.
-              <span className="text-muted-foreground inline-flex w-fit items-center gap-1.5 text-sm">
-                <Paperclip className="size-3.5" />
-                {project.attachmentName}
-              </span>
-            )}
           </section>
         ) : (
           <section
-            className="border-border bg-card flex flex-col overflow-hidden rounded-xl border"
+            className="border-border bg-card flex flex-col overflow-hidden rounded-2xl border"
             style={{ height: PROJECT_TIMELINE_BOX_HEIGHT }}
           >
-            <div className="border-border flex shrink-0 items-center justify-between border-b px-4 py-3">
-              <h3 className="text-sm font-semibold">팀 액션 타임라인</h3>
+            <div className="border-border flex shrink-0 items-baseline justify-between gap-3 border-b px-7 pt-6 pb-3">
+              <h3 className="flex items-center gap-2 text-[17px] leading-7 font-semibold tracking-[-0.3px]">
+                <span className="bg-foreground size-2 rounded-full" aria-hidden />팀 액션 타임라인
+              </h3>
               <ActionTimelineLegend />
             </div>
             <ActionTimeline


### PR DESCRIPTION
## 📋 PR 타입

- [x] design — UI/UX 변경

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

- 본문 폭 `1080px` → `1440px`(§4)
- 기획 카드·타임라인 카드 모서리 `rounded-xl` → `rounded-2xl`(§2)
- 두 카드 헤더에 머리 표식(먹색 점) 추가, 헤더 패딩 `px-7 pt-6 pb-3`로 통일
- 기획 카드를 헤더(제목+마감일)/본문(태그·설명·첨부) 구조로 재편
- `loading.tsx` 폭·모서리 동기화

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [ ] 🔐 권한 2축 검사 — 해당 없음
- [ ] 🧬 zod — 해당 없음
- [x] 🕵️ 정직성 — 목·미구현 변경 없음
- [x] 🎨 디자인 토큰 사용 — DESIGN.md §2·§4 값으로 통일

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [ ] ♿ a11y — 변경 없음
- [x] ♻️ 재사용 확인 — 기존 카드 컴포넌트 재구성
- [x] 🧪 `loading` / `error` / `empty` 3상태 — `loading.tsx` 동기화
- [ ] 브라우저 전용 API 미사용

---

## 🔗 연관 이슈

Closes #172

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

⚠️ **스태킹 PR** — base가 develop이 아니라 `feature/project-new#149`(PR #165)다. 상세 라우트(`[projectId]`)가 아직 그 PR에만 있어 develop에는 없다. #165가 머지되면 GitHub가 이 PR의 base를 자동으로 develop로 리타겟한다.

---

## 📝 추가 메모

검증 — `npx jest`·타입체크는 커밋 훅/CI에 맡김.
