### PR TITLE
[DESIGN] 팀장 대시보드 DESIGN.md 위반 정리 #176

### DIFF
--- a/src/app/(shell)/(authority)/team/(dashboard)/loading.tsx
+++ b/src/app/(shell)/(authority)/team/(dashboard)/loading.tsx
@@ -5,15 +5,15 @@ import { MEETING_BOX_HEIGHT, MEMBER_BOX_HEIGHT } from "@/features/team/lib";
 export default function Loading() {
   return (
     <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
-      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-4">
+      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-7">
         <div className="grid grid-cols-4 gap-3">
           {Array.from({ length: 4 }, (_, index) => (
-            <Skeleton key={index} className="h-[104px] rounded-xl" />
+            <Skeleton key={index} className="h-[104px] rounded-2xl" />
           ))}
         </div>
 
-        <Skeleton className="rounded-xl" style={{ height: MEMBER_BOX_HEIGHT }} />
-        <Skeleton className="rounded-xl" style={{ height: MEETING_BOX_HEIGHT }} />
+        <Skeleton className="rounded-2xl" style={{ height: MEMBER_BOX_HEIGHT }} />
+        <Skeleton className="rounded-2xl" style={{ height: MEETING_BOX_HEIGHT }} />
       </div>
     </main>
   );

--- a/src/app/(shell)/(authority)/team/(dashboard)/page.tsx
+++ b/src/app/(shell)/(authority)/team/(dashboard)/page.tsx
@@ -36,7 +36,7 @@ export default async function TeamDashboardPage() {
 
   return (
     <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
-      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-4">
+      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-7">
         <div className="grid grid-cols-4 gap-3">
           {kpis.map((kpi) => (
             <KpiCard key={kpi.label} {...kpi} />
@@ -44,12 +44,15 @@ export default async function TeamDashboardPage() {
         </div>
 
         <section
-          className="border-border bg-card flex flex-col overflow-hidden rounded-xl border"
+          className="border-border bg-card flex flex-col overflow-hidden rounded-2xl border"
           style={{ height: MEMBER_BOX_HEIGHT }}
         >
-          <div className="border-border flex shrink-0 items-center justify-between border-b px-4 py-3">
-            <h2 className="text-sm font-semibold">팀원 현황</h2>
-            <span className="text-muted-foreground text-xs">
+          <div className="border-border flex shrink-0 items-baseline justify-between gap-3 border-b px-7 pt-6 pb-3">
+            <h2 className="flex items-center gap-2 text-[17px] leading-7 font-semibold tracking-[-0.3px]">
+              <span className="bg-foreground size-2 rounded-full" aria-hidden />
+              팀원 현황
+            </h2>
+            <span className="text-muted-foreground text-[12px] leading-4">
               {teamName} · {members.length}명
             </span>
           </div>
@@ -88,12 +91,15 @@ export default async function TeamDashboardPage() {
         </section>
 
         <section
-          className="border-border bg-card flex flex-col overflow-hidden rounded-xl border"
+          className="border-border bg-card flex flex-col overflow-hidden rounded-2xl border"
           style={{ height: MEETING_BOX_HEIGHT }}
         >
-          <div className="border-border flex shrink-0 items-center justify-between border-b px-4 py-3">
-            <h2 className="text-sm font-semibold">최근 팀 회의</h2>
-            <span className="text-muted-foreground text-xs">최신 5건</span>
+          <div className="border-border flex shrink-0 items-baseline justify-between gap-3 border-b px-7 pt-6 pb-3">
+            <h2 className="flex items-center gap-2 text-[17px] leading-7 font-semibold tracking-[-0.3px]">
+              <span className="bg-foreground size-2 rounded-full" aria-hidden />
+              최근 팀 회의
+            </h2>
+            <span className="text-muted-foreground text-[12px] leading-4">최신 5건</span>
           </div>
           {meetings.length === 0 ? (
             <p className="text-muted-foreground flex flex-1 items-center justify-center text-sm">

--- a/src/features/team/components/kpi-card.tsx
+++ b/src/features/team/components/kpi-card.tsx
@@ -11,7 +11,7 @@ interface KpiCardProps {
 /** 대시보드 상단 KPI 4카드가 공유하는 한 칸. */
 export function KpiCard({ label, value, sub, tone }: KpiCardProps) {
   return (
-    <div className="border-border bg-card flex flex-col gap-1.5 rounded-xl border p-4">
+    <div className="border-border bg-card flex flex-col gap-1.5 rounded-2xl border p-4">
       <p className="text-muted-foreground text-xs leading-4">{label}</p>
       <p
         className={cn(


### PR DESCRIPTION
## 📋 PR 타입

- [x] design — UI/UX 변경

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [x] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

- 섹션 카드·KPI 타일 모서리 `rounded-xl` → `rounded-2xl`(§2)
- 카드 헤더 패딩 `px-4 py-3` → `px-7 pt-6 pb-3`, 제목에 머리 표식 추가(§2)
- 카드 사이 간격 `gap-4` → `gap-7`(§1)
- `loading.tsx` 동기화
- 폭 1440px는 이미 맞아 변경 없음

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [ ] 🔐 권한 2축 검사 — 해당 없음
- [ ] 🧬 zod — 해당 없음
- [x] 🕵️ 정직성 — 목·미구현 변경 없음
- [x] 🎨 디자인 토큰 사용 — DESIGN.md §1·§2 값으로 통일

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [ ] ♿ a11y — 변경 없음
- [x] ♻️ 재사용 확인 — 기존 카드 컴포넌트 값만 조정
- [x] 🧪 `loading` / `error` / `empty` 3상태 — `loading.tsx` 동기화
- [ ] 브라우저 전용 API 미사용

---

## 🔗 연관 이슈

Closes #176

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

-

---

## 📝 추가 메모

검증 — `npx jest`·타입체크는 커밋 훅/CI에 맡김.
