### PR TITLE
[DESIGN] 사원 대시보드 DESIGN.md 위반 정리 #178

### DIFF
--- a/src/app/(shell)/(authority)/my/(dashboard)/loading.tsx
+++ b/src/app/(shell)/(authority)/my/(dashboard)/loading.tsx
@@ -5,9 +5,9 @@ import { MEETING_BOX_HEIGHT } from "@/features/member/lib";
 export default function Loading() {
   return (
     <main className="scrollbar-hidden flex min-h-0 flex-1 flex-col overflow-y-auto px-8 py-7">
-      <div className="mx-auto flex min-h-0 w-full max-w-[1440px] flex-1 flex-col gap-4">
-        <Skeleton className="min-h-0 flex-1 rounded-xl" />
-        <Skeleton className="shrink-0 rounded-xl" style={{ height: MEETING_BOX_HEIGHT }} />
+      <div className="mx-auto flex min-h-0 w-full max-w-[1440px] flex-1 flex-col gap-7">
+        <Skeleton className="min-h-0 flex-1 rounded-2xl" />
+        <Skeleton className="shrink-0 rounded-2xl" style={{ height: MEETING_BOX_HEIGHT }} />
       </div>
     </main>
   );

--- a/src/app/(shell)/(authority)/my/(dashboard)/page.tsx
+++ b/src/app/(shell)/(authority)/my/(dashboard)/page.tsx
@@ -28,14 +28,17 @@ export default async function MemberDashboardPage() {
 
   return (
     <main className="scrollbar-hidden flex min-h-0 flex-1 flex-col overflow-y-auto px-8 py-7">
-      <div className="mx-auto flex min-h-0 w-full max-w-[1440px] flex-1 flex-col gap-4">
+      <div className="mx-auto flex min-h-0 w-full max-w-[1440px] flex-1 flex-col gap-7">
         {/* 처리할 액션 — 시작일→마감일 기간 타임라인. 남는 세로 공간을 채우고 넘치면 내부 스크롤 */}
         <section
-          className="border-border bg-card flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border"
+          className="border-border bg-card flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border"
           style={{ minHeight: DUE_SOON_BOX_MIN_HEIGHT }}
         >
-          <div className="border-border flex shrink-0 items-center justify-between border-b px-4 py-3">
-            <h2 className="text-sm font-semibold">처리할 액션</h2>
+          <div className="border-border flex shrink-0 items-baseline justify-between gap-3 border-b px-7 pt-6 pb-3">
+            <h2 className="flex items-center gap-2 text-[17px] leading-7 font-semibold tracking-[-0.3px]">
+              <span className="bg-foreground size-2 rounded-full" aria-hidden />
+              처리할 액션
+            </h2>
             <ActionTimelineLegend />
           </div>
           <ActionTimeline
@@ -47,12 +50,15 @@ export default async function MemberDashboardPage() {
 
         {/* 참석 회의 — 최신 5건 고정 */}
         <section
-          className="border-border bg-card flex shrink-0 flex-col overflow-hidden rounded-xl border"
+          className="border-border bg-card flex shrink-0 flex-col overflow-hidden rounded-2xl border"
           style={{ height: MEETING_BOX_HEIGHT }}
         >
-          <div className="border-border flex shrink-0 items-center justify-between border-b px-4 py-3">
-            <h2 className="text-sm font-semibold">참석 회의</h2>
-            <span className="text-muted-foreground text-xs">최신 5건</span>
+          <div className="border-border flex shrink-0 items-baseline justify-between gap-3 border-b px-7 pt-6 pb-3">
+            <h2 className="flex items-center gap-2 text-[17px] leading-7 font-semibold tracking-[-0.3px]">
+              <span className="bg-foreground size-2 rounded-full" aria-hidden />
+              참석 회의
+            </h2>
+            <span className="text-muted-foreground text-[12px] leading-4">최신 5건</span>
           </div>
           {attendedMeetings.length === 0 ? (
             <p className="text-muted-foreground flex flex-1 items-center justify-center text-sm">


### PR DESCRIPTION
## 📋 PR 타입

- [x] design — UI/UX 변경

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [x] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

- 섹션 카드 모서리 `rounded-xl` → `rounded-2xl`(§2)
- 카드 헤더 패딩 `px-4 py-3` → `px-7 pt-6 pb-3`, 제목에 머리 표식 추가(§2)
- 카드 사이 간격 `gap-4` → `gap-7`(§1)
- `loading.tsx` 동기화
- 폭 1440px는 이미 맞아 변경 없음

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [ ] 🔐 권한 2축 검사 — 해당 없음
- [ ] 🧬 zod — 해당 없음
- [x] 🕵️ 정직성 — 목·미구현 변경 없음
- [x] 🎨 디자인 토큰 사용 — DESIGN.md §1·§2 값으로 통일

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [ ] ♿ a11y — 변경 없음
- [x] ♻️ 재사용 확인 — 기존 카드 컴포넌트 값만 조정
- [x] 🧪 `loading` / `error` / `empty` 3상태 — `loading.tsx` 동기화
- [ ] 브라우저 전용 API 미사용

---

## 🔗 연관 이슈

Closes #178

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

-

---

## 📝 추가 메모

검증 — `npx jest`·타입체크는 커밋 훅/CI에 맡김.
