### PR TITLE
[FEAT] 회의실 관리 화면 /manage/rooms + 회의실 필드 정리 #194

### DIFF
--- a/src/app/(shell)/(authority)/manage/rooms/error.tsx
+++ b/src/app/(shell)/(authority)/manage/rooms/error.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { ScreenError } from "@/components/common/screen-error";
+
+/** 화면 전체가 실패하면 토스트가 아니라 여기서 알린다(DECISIONS §토스트). */
+export default function ManageRoomsError({ reset }: { error: Error; reset: () => void }) {
+  return <ScreenError title="회의실 목록을 불러오지 못했습니다" reset={reset} isInsideShell />;
+}

--- a/src/app/(shell)/(authority)/manage/rooms/layout.tsx
+++ b/src/app/(shell)/(authority)/manage/rooms/layout.tsx
@@ -1,0 +1,14 @@
+import { CalendarRange } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { PageHeader } from "@/features/shell/components/page-header";
+
+/** ⚠️ 상단바에 "추가" 버튼을 두지 않는다 — 카드 위 액션 자리에 둔다(DESIGN.md §1). */
+export default function ManageRoomsLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <PageHeader title="회의실 관리" icon={CalendarRange} />
+      {children}
+    </>
+  );
+}

--- a/src/app/(shell)/(authority)/manage/rooms/loading.tsx
+++ b/src/app/(shell)/(authority)/manage/rooms/loading.tsx
@@ -1,0 +1,17 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+/** 뼈대는 실제 배치와 같은 자리 — 추가 버튼 줄 + 목록 카드 하나(`manage/storage/loading.tsx`와 같은 이유). */
+export default function ManageRoomsLoading() {
+  return (
+    <div className="flex-1 overflow-y-auto px-8 py-7">
+      <div className="mx-auto w-full max-w-[1440px]">
+        <div className="flex flex-col gap-4">
+          <div className="flex justify-end">
+            <Skeleton className="h-8 w-24 rounded-md" />
+          </div>
+          <Skeleton className="h-[320px] w-full rounded-2xl" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(shell)/(authority)/manage/rooms/page.tsx
+++ b/src/app/(shell)/(authority)/manage/rooms/page.tsx
@@ -1,0 +1,35 @@
+import type { Metadata } from "next";
+
+import { RoomCreateDialog } from "@/features/rooms/components/room-create-dialog";
+import { RoomsManageTable } from "@/features/rooms/components/rooms-manage-table";
+import { getMeetingRooms } from "@/features/rooms/server";
+import { getViewer } from "@/features/shell/viewer";
+import { canManageRooms } from "@/lib/permission";
+
+export const metadata: Metadata = {
+  title: "회의실 관리",
+};
+
+/**
+ * 회의실 관리(`/manage/rooms`, is_admin 전용, WORKFLOW.md §10-A) — 목록 + 추가/수정 모달.
+ * 예약 승인 절차가 없다 — 저장 즉시 `/app/rooms` 예약 모달의 회의실 select에 나타난다.
+ * ⚠️ 화면 가드는 UX일 뿐이다 — 추가·수정 Server Action이 `canManageRooms`로 다시 본다(§권한).
+ */
+export default async function ManageRoomsPage() {
+  const [rooms, viewer] = await Promise.all([getMeetingRooms(), getViewer()]);
+  const canManage = canManageRooms(viewer);
+
+  return (
+    <main className="min-h-0 flex-1 overflow-y-auto px-8 py-7">
+      <div className="mx-auto flex max-w-[1440px] flex-col gap-4">
+        {canManage && (
+          <div className="flex justify-end">
+            <RoomCreateDialog />
+          </div>
+        )}
+
+        <RoomsManageTable rooms={rooms} canManage={canManage} />
+      </div>
+    </main>
+  );
+}

--- a/src/features/rooms/actions.test.ts
+++ b/src/features/rooms/actions.test.ts
@@ -2,12 +2,24 @@
 jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
 // isMock은 NEXT_PUBLIC_USE_MOCK 환경변수로 정해진다 — 테스트가 환경에 휘둘리지 않게 고정한다.
 jest.mock("@/mocks/config", () => ({ isMock: true }));
+// 기본은 실제 getMockActor()와 같은 값(OWNER, Admin 아님) — 회의실 관리 권한 테스트에서만
+// Admin 겸직 액터로 덮어쓴다(`canManageRooms`는 Admin 겸직자 전용이라 OWNER로는 절대 못 지나간다).
+jest.mock("@/lib/mock-actor", () => ({
+  getMockActor: jest.fn(() => ({ id: 1, role: "OWNER" })),
+}));
 
 import { revalidatePath } from "next/cache";
 
-import { createRoomReservationAction } from "./actions";
+import { getMockActor } from "@/lib/mock-actor";
+
+import {
+  createMeetingRoomAction,
+  createRoomReservationAction,
+  updateMeetingRoomAction,
+} from "./actions";
 
 const revalidatePathMock = revalidatePath as unknown as jest.Mock;
+const getMockActorMock = getMockActor as unknown as jest.Mock;
 
 const VALID_ENTRIES: Record<string, string> = {
   title: "새 회의",
@@ -28,6 +40,70 @@ const form = (entries: Record<string, string>, attendeeIds: number[] = [1]) => {
 
 beforeEach(() => {
   revalidatePathMock.mockClear();
+  getMockActorMock.mockReturnValue({ id: 1, role: "OWNER" });
+});
+
+const roomForm = (entries: Record<string, string>) => {
+  const data = new FormData();
+  for (const [key, value] of Object.entries(entries)) data.append(key, value);
+  return data;
+};
+
+const VALID_ROOM_ENTRIES: Record<string, string> = {
+  name: "신관 세미나실",
+  location: "4층 C동",
+  openTime: "10:00",
+  closeTime: "17:00",
+};
+
+describe("회의실 추가·수정", () => {
+  it("Admin이 아니면 추가를 막는다(OWNER도 예외 없음)", async () => {
+    const result = await createMeetingRoomAction({ errors: {} }, roomForm(VALID_ROOM_ENTRIES));
+
+    expect(result.errors.name).toBe("회의실을 추가할 권한이 없어요");
+    expect(result.room).toBeUndefined();
+  });
+
+  it("Admin 겸직자면 추가할 수 있다", async () => {
+    getMockActorMock.mockReturnValue({ id: 2, role: "MEMBER", isAdmin: true });
+
+    const result = await createMeetingRoomAction({ errors: {} }, roomForm(VALID_ROOM_ENTRIES));
+
+    expect(result.errors).toEqual({});
+    expect(result.room?.name).toBe("신관 세미나실");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/manage/rooms");
+  });
+
+  it("Admin이어도 필수값이 비면 막는다", async () => {
+    getMockActorMock.mockReturnValue({ id: 2, role: "MEMBER", isAdmin: true });
+
+    const result = await createMeetingRoomAction(
+      { errors: {} },
+      roomForm({ ...VALID_ROOM_ENTRIES, name: "" }),
+    );
+
+    expect(result.errors.name).toBe("회의실 이름을 입력해 주세요");
+  });
+
+  it("Admin이 아니면 수정도 막는다", async () => {
+    const result = await updateMeetingRoomAction(
+      { errors: {} },
+      roomForm({ ...VALID_ROOM_ENTRIES, id: "room-large" }),
+    );
+
+    expect(result.errors.name).toBe("회의실을 수정할 권한이 없어요");
+  });
+
+  it("없는 id를 수정하려 하면 오류를 돌려준다", async () => {
+    getMockActorMock.mockReturnValue({ id: 2, role: "MEMBER", isAdmin: true });
+
+    const result = await updateMeetingRoomAction(
+      { errors: {} },
+      roomForm({ ...VALID_ROOM_ENTRIES, id: "존재하지-않음" }),
+    );
+
+    expect(result.errors.name).toBe("수정할 회의실을 찾을 수 없어요");
+  });
 });
 
 describe("회의실 예약 생성", () => {

--- a/src/features/rooms/actions.ts
+++ b/src/features/rooms/actions.ts
@@ -4,15 +4,28 @@ import { revalidatePath } from "next/cache";
 
 import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
 import { getMockActor } from "@/lib/mock-actor";
+import { canManageRooms } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
 import { findMockMember } from "./mock/members";
 import { addMockReservation, listMockReservationsByRoom } from "./mock/reservations";
-import { findMockRoom } from "./mock/rooms";
-import type { RoomReservation, RoomReservationDraft, RoomReservationFormErrors } from "./types";
-import { RESERVATION_DURATION_MINUTES, validateRoomReservationDraft } from "./validate";
+import { addMockRoom, findMockRoom, updateMockRoom } from "./mock/rooms";
+import type {
+  MeetingRoom,
+  MeetingRoomDraft,
+  MeetingRoomFormErrors,
+  RoomReservation,
+  RoomReservationDraft,
+  RoomReservationFormErrors,
+} from "./types";
+import {
+  RESERVATION_DURATION_MINUTES,
+  validateMeetingRoomDraft,
+  validateRoomReservationDraft,
+} from "./validate";
 
 const ROOMS_PATH = "/app/rooms";
+const MANAGE_ROOMS_PATH = "/manage/rooms";
 
 /** 예약 폼 결과 — `useActionState`가 그대로 들고 있는 모양. */
 export interface RoomReservationFormState {
@@ -90,4 +103,75 @@ export async function createRoomReservationAction(
   const created = addMockReservation(draft, actor.id);
   revalidatePath(ROOMS_PATH);
   return { errors: {}, created };
+}
+
+/** 회의실 추가·수정 폼 결과 — `useActionState`가 그대로 들고 있는 모양. */
+export interface MeetingRoomFormState {
+  errors: MeetingRoomFormErrors;
+  room?: MeetingRoom;
+}
+
+function readRoomDraft(formData: FormData): MeetingRoomDraft {
+  return {
+    name: String(formData.get("name") ?? ""),
+    location: String(formData.get("location") ?? ""),
+    openTime: String(formData.get("openTime") ?? ""),
+    closeTime: String(formData.get("closeTime") ?? ""),
+  };
+}
+
+/**
+ * 회의실 추가(`/manage/rooms`, is_admin 전용) — 격리막(CLAUDE.md §Mock 격리막).
+ * ⚠️ 예약 승인 절차가 없다(WORKFLOW.md §10-A) — 저장되는 즉시 `/app/rooms` 예약 모달의
+ *    회의실 select에 나타난다.
+ * ⚠️ **권한을 서버에서 다시 본다** — 화면 가드는 UX일 뿐 보안이 아니다(§권한).
+ */
+export async function createMeetingRoomAction(
+  _prev: MeetingRoomFormState,
+  formData: FormData,
+): Promise<MeetingRoomFormState> {
+  if (!canManageRooms(getMockActor())) {
+    return { errors: { name: "회의실을 추가할 권한이 없어요" } };
+  }
+
+  const draft = readRoomDraft(formData);
+  const errors = validateMeetingRoomDraft(draft);
+  if (Object.keys(errors).length > 0) return { errors };
+
+  if (!isMock) {
+    // ⚠️ 미구현 — API 스펙 확정 후 BFF 경로로 회의실 추가 요청을 보낸다.
+    throw new Error("회의실 추가 API가 아직 연결되지 않았습니다.");
+  }
+
+  const room = addMockRoom(draft);
+  revalidatePath(MANAGE_ROOMS_PATH);
+  revalidatePath(ROOMS_PATH);
+  return { errors: {}, room };
+}
+
+/** 회의실 수정 — 추가와 같은 규칙(권한·검증). */
+export async function updateMeetingRoomAction(
+  _prev: MeetingRoomFormState,
+  formData: FormData,
+): Promise<MeetingRoomFormState> {
+  if (!canManageRooms(getMockActor())) {
+    return { errors: { name: "회의실을 수정할 권한이 없어요" } };
+  }
+
+  const id = String(formData.get("id") ?? "");
+  const draft = readRoomDraft(formData);
+  const errors = validateMeetingRoomDraft(draft);
+  if (Object.keys(errors).length > 0) return { errors };
+
+  if (!isMock) {
+    // ⚠️ 미구현 — API 스펙 확정 후 BFF 경로로 회의실 수정 요청을 보낸다.
+    throw new Error("회의실 수정 API가 아직 연결되지 않았습니다.");
+  }
+
+  const room = updateMockRoom(id, draft);
+  if (!room) return { errors: { name: "수정할 회의실을 찾을 수 없어요" } };
+
+  revalidatePath(MANAGE_ROOMS_PATH);
+  revalidatePath(ROOMS_PATH);
+  return { errors: {}, room };
 }

--- a/src/features/rooms/components/room-create-dialog.tsx
+++ b/src/features/rooms/components/room-create-dialog.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Plus } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+import { createMeetingRoomAction } from "../actions";
+import { RoomForm } from "./room-form";
+
+/**
+ * "회의실 추가" 트리거 + 추가 모달 — 전용 라우트 대신 모달로 연다(`notice-create-dialog.tsx`와 같은 패턴).
+ * ⚠️ 목록(`rooms-manage-table.tsx`)은 서버 컴포넌트라 성공 뒤 `router.refresh()`로 다시 받아온다
+ *    (`revalidatePath`가 이미 캐시를 무효화해 뒀다).
+ */
+export function RoomCreateDialog() {
+  const [open, setOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const router = useRouter();
+
+  return (
+    <>
+      <Button type="button" size="sm" variant="ink" onClick={() => setOpen(true)}>
+        <Plus aria-hidden />
+        회의실 추가
+      </Button>
+
+      <Dialog
+        open={open}
+        onOpenChange={(next) => {
+          // ⚠️ 제출 중엔 Esc·바깥 클릭으로 안 닫는다 — 요청은 계속 가는데 화면만 사라지면 결과를 못 본다.
+          if (!next && isSubmitting) return;
+          setOpen(next);
+        }}
+      >
+        <DialogContent className="sm:max-w-[420px]">
+          <DialogHeader>
+            <DialogTitle>회의실을 추가할까요?</DialogTitle>
+          </DialogHeader>
+
+          <RoomForm
+            action={createMeetingRoomAction}
+            submitLabel="추가"
+            onCancel={() => setOpen(false)}
+            onPendingChange={setIsSubmitting}
+            onSuccess={(room) => {
+              setOpen(false);
+              router.refresh();
+              toast.success(`'${room.name}' 회의실을 추가했습니다`);
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/features/rooms/components/room-edit-dialog.tsx
+++ b/src/features/rooms/components/room-edit-dialog.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Pencil } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+import { updateMeetingRoomAction } from "../actions";
+import type { MeetingRoom } from "../types";
+import { RoomForm } from "./room-form";
+
+interface RoomEditDialogProps {
+  /** 목록(서버 컴포넌트)이 이미 받아 온 값 — 모달을 위해 다시 조회하지 않는다 */
+  room: MeetingRoom;
+}
+
+/** "수정" 트리거 + 수정 모달 — `notice-edit-dialog.tsx`와 같은 패턴. */
+export function RoomEditDialog({ room }: RoomEditDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const router = useRouter();
+
+  return (
+    <>
+      <Button type="button" variant="outline" size="xs" onClick={() => setOpen(true)}>
+        <Pencil aria-hidden />
+        수정
+      </Button>
+
+      <Dialog
+        open={open}
+        onOpenChange={(next) => {
+          if (!next && isSubmitting) return;
+          setOpen(next);
+        }}
+      >
+        <DialogContent className="sm:max-w-[420px]">
+          <DialogHeader>
+            <DialogTitle>회의실 정보를 수정할까요?</DialogTitle>
+          </DialogHeader>
+
+          <RoomForm
+            action={updateMeetingRoomAction}
+            room={room}
+            submitLabel="저장"
+            onCancel={() => setOpen(false)}
+            onPendingChange={setIsSubmitting}
+            onSuccess={(updated) => {
+              setOpen(false);
+              router.refresh();
+              toast.success(`'${updated.name}' 정보를 수정했습니다`);
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/features/rooms/components/room-form.tsx
+++ b/src/features/rooms/components/room-form.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useActionState, useEffect, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+import type { MeetingRoomFormState } from "../actions";
+import type { MeetingRoom } from "../types";
+
+interface RoomFormProps {
+  /** 추가면 `createMeetingRoomAction`, 수정이면 `updateMeetingRoomAction` */
+  action: (prev: MeetingRoomFormState, formData: FormData) => Promise<MeetingRoomFormState>;
+  /** 수정일 때만 — 기존 값 채우기 + id 전달 */
+  room?: MeetingRoom;
+  submitLabel: string;
+  onCancel: () => void;
+  onSuccess: (room: MeetingRoom) => void;
+  onPendingChange?: (isPending: boolean) => void;
+}
+
+/**
+ * 회의실 추가·수정 폼 — `notice-form.tsx`와 같은 골격(실제 `<form action={formAction}>`,
+ * 필드가 전부 plain input이라 shadcn `Select` 우회 없이 그대로 쓴다).
+ */
+export function RoomForm({
+  action,
+  room,
+  submitLabel,
+  onCancel,
+  onSuccess,
+  onPendingChange,
+}: RoomFormProps) {
+  const [state, formAction, isPending] = useActionState(action, { errors: {} });
+  const [name, setName] = useState(room?.name ?? "");
+  const [location, setLocation] = useState(room?.location ?? "");
+  const [openTime, setOpenTime] = useState(room?.openTime ?? "");
+  const [closeTime, setCloseTime] = useState(room?.closeTime ?? "");
+  const canSubmit =
+    name.trim().length > 0 &&
+    location.trim().length > 0 &&
+    openTime.length > 0 &&
+    closeTime.length > 0;
+  const handledRoomId = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (state.room && state.room.id !== handledRoomId.current) {
+      handledRoomId.current = state.room.id;
+      onSuccess(state.room);
+    }
+  }, [state.room, onSuccess]);
+
+  useEffect(() => {
+    onPendingChange?.(isPending);
+  }, [isPending, onPendingChange]);
+
+  return (
+    <form action={formAction} className="flex flex-col gap-4">
+      {room && <input type="hidden" name="id" value={room.id} />}
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="room-name">이름</Label>
+        <Input
+          id="room-name"
+          name="name"
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          placeholder="예: 대회의실"
+          aria-invalid={Boolean(state.errors.name)}
+        />
+        {state.errors.name && <p className="text-destructive text-xs">{state.errors.name}</p>}
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="room-location">위치</Label>
+        <Input
+          id="room-location"
+          name="location"
+          value={location}
+          onChange={(event) => setLocation(event.target.value)}
+          placeholder="예: 3층 A동"
+          aria-invalid={Boolean(state.errors.location)}
+        />
+        {state.errors.location && (
+          <p className="text-destructive text-xs">{state.errors.location}</p>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="room-open-time">이용 시작</Label>
+          <Input
+            id="room-open-time"
+            name="openTime"
+            type="time"
+            value={openTime}
+            onChange={(event) => setOpenTime(event.target.value)}
+            aria-invalid={Boolean(state.errors.openTime)}
+          />
+          {state.errors.openTime && (
+            <p className="text-destructive text-xs">{state.errors.openTime}</p>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="room-close-time">이용 종료</Label>
+          <Input
+            id="room-close-time"
+            name="closeTime"
+            type="time"
+            value={closeTime}
+            onChange={(event) => setCloseTime(event.target.value)}
+            aria-invalid={Boolean(state.errors.closeTime)}
+          />
+          {state.errors.closeTime && (
+            <p className="text-destructive text-xs">{state.errors.closeTime}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex justify-end gap-2">
+        <Button type="button" variant="outline" size="sm" disabled={isPending} onClick={onCancel}>
+          취소
+        </Button>
+        <Button type="submit" size="sm" variant="ink" disabled={isPending || !canSubmit}>
+          {isPending ? "저장 중…" : submitLabel}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/features/rooms/components/room-reservation-dialog.test.tsx
+++ b/src/features/rooms/components/room-reservation-dialog.test.tsx
@@ -7,7 +7,13 @@ import type { MeetingRoom, RoomMember, RoomProjectOption } from "../types";
 import { RoomReservationDialog } from "./room-reservation-dialog";
 
 const ROOMS: MeetingRoom[] = [
-  { id: "room-large", name: "대회의실", capacity: 8, openTime: "09:00", closeTime: "18:00" },
+  {
+    id: "room-large",
+    name: "대회의실",
+    location: "3층 A동",
+    openTime: "09:00",
+    closeTime: "18:00",
+  },
 ];
 const MEMBERS: RoomMember[] = [{ id: 1, name: "박대표" }];
 const PROJECTS: RoomProjectOption[] = [{ id: "p-goods", name: "굿즈 프로젝트", tag: "GOODS" }];

--- a/src/features/rooms/components/rooms-manage-table.tsx
+++ b/src/features/rooms/components/rooms-manage-table.tsx
@@ -1,0 +1,71 @@
+import type { MeetingRoom } from "../types";
+import { RoomEditDialog } from "./room-edit-dialog";
+
+interface RoomsManageTableProps {
+  rooms: MeetingRoom[];
+  /** false면 "수정" 열 자체를 안 그린다 — 화면 가드는 UX일 뿐이고, 진짜 검사는 Server Action이 한다. */
+  canManage: boolean;
+}
+
+/**
+ * 회의실 목록(관리) — 카드 anatomy는 DESIGN.md §2, 표는 §3을 따른다.
+ * ⚠️ `/app/rooms`의 읽기전용 `room-list-panel.tsx`와 다르다 — 여기는 관리자가 고치는 표라
+ *    "위치"·"수정" 열이 더 있다.
+ */
+export function RoomsManageTable({ rooms, canManage }: RoomsManageTableProps) {
+  return (
+    <div className="border-border bg-card overflow-hidden rounded-2xl border">
+      <div className="flex items-baseline justify-between gap-3 px-7 pt-6 pb-3">
+        <h2 className="flex items-center gap-2 text-[17px] leading-7 font-semibold tracking-[-0.3px]">
+          <span className="bg-foreground size-2 rounded-full" aria-hidden />
+          회의실 목록
+        </h2>
+        <p className="text-muted-foreground text-xs">전체 {rooms.length}개</p>
+      </div>
+
+      {rooms.length === 0 ? (
+        <div className="flex items-center justify-center p-10 text-center">
+          <p className="text-muted-foreground text-sm">등록된 회의실이 없어요</p>
+        </div>
+      ) : (
+        <div className="border-border overflow-x-auto border-t">
+          <table className="w-full min-w-[560px] table-fixed text-[13px]">
+            <colgroup>
+              <col className="w-[30%]" />
+              <col className="w-[28%]" />
+              <col className="w-[26%]" />
+              <col className="w-[16%]" />
+            </colgroup>
+            <thead>
+              <tr className="text-muted-foreground bg-secondary/50 border-border border-b text-[12px] leading-4">
+                <th className="px-6 py-3 text-left font-normal">이름</th>
+                <th className="px-4 py-3 text-center font-normal">위치</th>
+                <th className="px-4 py-3 text-center font-normal">이용 가능 시간</th>
+                <th className="px-4 py-3 text-center font-normal">
+                  <span className="sr-only">관리</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rooms.map((room) => (
+                <tr
+                  key={room.id}
+                  className="group border-border hover:bg-foreground/[0.04] transition-colors not-first:border-t"
+                >
+                  <td className="px-6 py-3.5 text-left">{room.name}</td>
+                  <td className="px-4 py-3.5 text-center">{room.location}</td>
+                  <td className="px-4 py-3.5 text-center tabular-nums">
+                    {room.openTime} - {room.closeTime}
+                  </td>
+                  <td className="px-4 py-3.5 text-center">
+                    {canManage && <RoomEditDialog room={room} />}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/rooms/mock/rooms.test.ts
+++ b/src/features/rooms/mock/rooms.test.ts
@@ -1,0 +1,43 @@
+import { addMockRoom, findMockRoom, listMockRooms, updateMockRoom } from "./rooms";
+
+const DRAFT = {
+  name: "  신관 세미나실  ",
+  location: "  4층 C동  ",
+  openTime: "10:00",
+  closeTime: "17:00",
+};
+
+describe("회의실 mock 스토어", () => {
+  it("시드 데이터가 최소 한 곳 있다", () => {
+    expect(listMockRooms().length).toBeGreaterThan(0);
+  });
+
+  it("회의실을 추가하면 앞뒤 공백을 지우고 목록에 반영된다", () => {
+    const before = listMockRooms().length;
+
+    const created = addMockRoom(DRAFT);
+
+    expect(created.name).toBe("신관 세미나실");
+    expect(created.location).toBe("4층 C동");
+    expect(listMockRooms()).toHaveLength(before + 1);
+    expect(findMockRoom(created.id)).toEqual(created);
+  });
+
+  it("회의실을 수정하면 그 id의 값만 바뀐다", () => {
+    const created = addMockRoom(DRAFT);
+
+    const updated = updateMockRoom(created.id, { ...DRAFT, name: "신관 세미나실(개편)" });
+
+    expect(updated?.id).toBe(created.id);
+    expect(updated?.name).toBe("신관 세미나실(개편)");
+    expect(findMockRoom(created.id)?.name).toBe("신관 세미나실(개편)");
+  });
+
+  it("없는 id를 수정하려 하면 null을 돌려준다", () => {
+    expect(updateMockRoom("존재하지-않음", DRAFT)).toBeNull();
+  });
+
+  it("없는 id는 조회 시 null을 돌려준다", () => {
+    expect(findMockRoom("존재하지-않음")).toBeNull();
+  });
+});

--- a/src/features/rooms/mock/rooms.ts
+++ b/src/features/rooms/mock/rooms.ts
@@ -1,20 +1,87 @@
-import type { MeetingRoom } from "../types";
+import type { MeetingRoom, MeetingRoomDraft } from "../types";
 
 /**
  * ⚠️ 목 데이터 — BE 연동 전(ERD·API 스펙 미확정, DECISIONS.md).
- * 회의실 CUD는 이 화면 소관이 아니다(`/manage/rooms`) — 여기서는 목록만 읽는다.
+ * ⚠️ 상태를 `globalThis`에 매단다 — dev의 HMR로 `let`이 초기화되면 방금 추가한 회의실이 사라진다
+ *    (`mock/reservations.ts`와 같은 트릭).
  */
-export const MEETING_ROOMS: MeetingRoom[] = [
-  { id: "room-large", name: "대회의실", capacity: 8, openTime: "09:00", closeTime: "18:00" },
-  { id: "room-small-a", name: "소회의실 A", capacity: 4, openTime: "09:00", closeTime: "18:00" },
-  { id: "room-small-b", name: "소회의실 B", capacity: 4, openTime: "09:00", closeTime: "18:00" },
-  { id: "room-video", name: "화상회의실", capacity: 6, openTime: "09:00", closeTime: "18:00" },
+interface RoomStore {
+  rooms: MeetingRoom[];
+  sequence: number;
+}
+
+const INITIAL: MeetingRoom[] = [
+  {
+    id: "room-large",
+    name: "대회의실",
+    location: "3층 A동",
+    openTime: "09:00",
+    closeTime: "18:00",
+  },
+  {
+    id: "room-small-a",
+    name: "소회의실 A",
+    location: "3층 A동",
+    openTime: "09:00",
+    closeTime: "18:00",
+  },
+  {
+    id: "room-small-b",
+    name: "소회의실 B",
+    location: "3층 B동",
+    openTime: "09:00",
+    closeTime: "18:00",
+  },
+  {
+    id: "room-video",
+    name: "화상회의실",
+    location: "본관 5층",
+    openTime: "09:00",
+    closeTime: "18:00",
+  },
 ];
 
+const globalStore = globalThis as typeof globalThis & {
+  __meetingRoomStore?: RoomStore;
+};
+const store: RoomStore = (globalStore.__meetingRoomStore ??= {
+  rooms: INITIAL,
+  sequence: INITIAL.length,
+});
+
 export function listMockRooms(): MeetingRoom[] {
-  return MEETING_ROOMS;
+  return store.rooms;
 }
 
 export function findMockRoom(id: string): MeetingRoom | null {
-  return MEETING_ROOMS.find((room) => room.id === id) ?? null;
+  return store.rooms.find((room) => room.id === id) ?? null;
+}
+
+/** 회의실 추가(`/manage/rooms`) — 예약 승인 절차가 없어 만들면 바로 예약 가능한 목록에 들어간다. */
+export function addMockRoom(draft: MeetingRoomDraft): MeetingRoom {
+  const room: MeetingRoom = {
+    id: `room-${++store.sequence}`,
+    name: draft.name.trim(),
+    location: draft.location.trim(),
+    openTime: draft.openTime,
+    closeTime: draft.closeTime,
+  };
+  store.rooms = [...store.rooms, room];
+  return room;
+}
+
+/** 회의실 수정 — 없는 id면 `null`(호출부가 "수정할 회의실을 찾을 수 없다" 오류로 바꾼다). */
+export function updateMockRoom(id: string, draft: MeetingRoomDraft): MeetingRoom | null {
+  const index = store.rooms.findIndex((room) => room.id === id);
+  if (index === -1) return null;
+
+  const updated: MeetingRoom = {
+    id,
+    name: draft.name.trim(),
+    location: draft.location.trim(),
+    openTime: draft.openTime,
+    closeTime: draft.closeTime,
+  };
+  store.rooms = [...store.rooms.slice(0, index), updated, ...store.rooms.slice(index + 1)];
+  return updated;
 }

--- a/src/features/rooms/types.ts
+++ b/src/features/rooms/types.ts
@@ -5,17 +5,36 @@
 
 import type { MeetingTopicMain } from "@/constants/meeting";
 
-/** 회의실 한 곳. 운영시간은 전 회의실 09:00~18:00 동일(팀 워크플로우 목업). */
+/**
+ * 회의실 한 곳.
+ * ⚠️ **"수용 인원" 필드는 없다**(WORKFLOW.md §10-A 확정 — 전면 폐기). 화면·모달·데이터 구조
+ *    어디에도 안 둔다. 대신 "위치"가 있다.
+ */
 export interface MeetingRoom {
   id: string;
   name: string;
-  /** 수용 인원 */
-  capacity: number;
+  /** 자유 텍스트 — "3층 A동"처럼(WORKFLOW.md §10-A) */
+  location: string;
   /** "HH:mm" */
   openTime: string;
   /** "HH:mm" */
   closeTime: string;
 }
+
+/**
+ * 회의실 추가·수정 폼 입력(`/manage/rooms`, is_admin 전용) — 화면과 서버가 같은 스키마로 검증한다.
+ * ⚠️ 예약 승인 절차가 없다(WORKFLOW.md §10-A) — 만들면 바로 예약 가능한 목록에 들어간다.
+ */
+export interface MeetingRoomDraft {
+  name: string;
+  location: string;
+  /** "HH:mm" */
+  openTime: string;
+  /** "HH:mm" */
+  closeTime: string;
+}
+
+export type MeetingRoomFormErrors = Partial<Record<keyof MeetingRoomDraft, string>>;
 
 /** 참석자 검색 대상 — 예약 폼의 "참석자" 피커가 쓴다. */
 export interface RoomMember {

--- a/src/features/rooms/validate.test.ts
+++ b/src/features/rooms/validate.test.ts
@@ -1,4 +1,4 @@
-import { validateRoomReservationDraft } from "./validate";
+import { validateMeetingRoomDraft, validateRoomReservationDraft } from "./validate";
 
 const VALID_DRAFT = {
   title: "주간 싱크",
@@ -88,5 +88,56 @@ describe("회의실 예약 검증", () => {
   it("참석자 값이 정수가 아니면 막는다", () => {
     const errors = validateRoomReservationDraft({ ...VALID_DRAFT, attendeeIds: [Number.NaN] });
     expect(errors.attendeeIds).toBe("참석자 값이 올바르지 않아요");
+  });
+});
+
+const VALID_ROOM_DRAFT = {
+  name: "대회의실",
+  location: "3층 A동",
+  openTime: "09:00",
+  closeTime: "18:00",
+};
+
+describe("회의실 추가·수정 검증", () => {
+  it("전부 채우면 통과한다", () => {
+    expect(validateMeetingRoomDraft(VALID_ROOM_DRAFT)).toEqual({});
+  });
+
+  it("이름이 비면 막는다", () => {
+    const errors = validateMeetingRoomDraft({ ...VALID_ROOM_DRAFT, name: "   " });
+    expect(errors.name).toBe("회의실 이름을 입력해 주세요");
+  });
+
+  it("위치가 비면 막는다", () => {
+    const errors = validateMeetingRoomDraft({ ...VALID_ROOM_DRAFT, location: "" });
+    expect(errors.location).toBe("위치를 입력해 주세요");
+  });
+
+  it("시간 형식이 아니면 막는다", () => {
+    const errors = validateMeetingRoomDraft({ ...VALID_ROOM_DRAFT, openTime: "9:00" });
+    expect(errors.openTime).toBe("올바른 시간 형식이 아니에요");
+  });
+
+  it("30분 단위가 아니어도 통과한다(예약 슬롯과 달리 제약 없음)", () => {
+    const errors = validateMeetingRoomDraft({ ...VALID_ROOM_DRAFT, openTime: "09:15" });
+    expect(errors.openTime).toBeUndefined();
+  });
+
+  it("종료 시간이 시작 시간보다 이르면 막는다", () => {
+    const errors = validateMeetingRoomDraft({
+      ...VALID_ROOM_DRAFT,
+      openTime: "18:00",
+      closeTime: "09:00",
+    });
+    expect(errors.closeTime).toBe("종료 시간은 시작 시간보다 늦어야 해요");
+  });
+
+  it("시작과 종료가 같으면 막는다", () => {
+    const errors = validateMeetingRoomDraft({
+      ...VALID_ROOM_DRAFT,
+      openTime: "09:00",
+      closeTime: "09:00",
+    });
+    expect(errors.closeTime).toBe("종료 시간은 시작 시간보다 늦어야 해요");
   });
 });

--- a/src/features/rooms/validate.ts
+++ b/src/features/rooms/validate.ts
@@ -2,10 +2,17 @@ import { isValid, parse } from "date-fns";
 
 import { MEETING_TOPIC_SUB, type MeetingTopicMain } from "@/constants/meeting";
 
-import type { RoomReservationDraft, RoomReservationFormErrors } from "./types";
+import type {
+  MeetingRoomDraft,
+  MeetingRoomFormErrors,
+  RoomReservationDraft,
+  RoomReservationFormErrors,
+} from "./types";
 
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 const TIME_PATTERN = /^([01]\d|2[0-3]):(00|30)$/;
+/** 회의실 운영 시작·종료 시각용 — 예약 슬롯(`TIME_PATTERN`)과 달리 30분 단위 제약이 없다. */
+const GENERAL_TIME_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/;
 
 /** 예약 길이 — 팀 확정: 30분 한 타임, 연장하지 않는다(CLAUDE.md §브라우저 API). */
 export const RESERVATION_DURATION_MINUTES = 30;
@@ -68,6 +75,40 @@ export function validateRoomReservationDraft(
     errors.attendeeIds = "참석자를 한 명 이상 선택해 주세요";
   } else if (draft.attendeeIds.some((id) => !Number.isInteger(id))) {
     errors.attendeeIds = "참석자 값이 올바르지 않아요";
+  }
+
+  return errors;
+}
+
+/**
+ * 회의실 추가·수정 폼 검증(`/manage/rooms`) — 화면과 서버(Server Action)가 이 함수 하나로 본다.
+ * ⚠️ 이용 가능 시간은 예약 슬롯과 달리 30분 단위 제약이 없다 — 회의실 자체의 운영시간일 뿐,
+ *    그 안에서 예약은 여전히 30분 단위로만 잡힌다(`validateRoomReservationDraft`가 맡는다).
+ */
+export function validateMeetingRoomDraft(draft: MeetingRoomDraft): MeetingRoomFormErrors {
+  const errors: MeetingRoomFormErrors = {};
+
+  if (!draft.name.trim()) errors.name = "회의실 이름을 입력해 주세요";
+  if (!draft.location.trim()) errors.location = "위치를 입력해 주세요";
+
+  if (!draft.openTime.trim()) {
+    errors.openTime = "이용 시작 시간을 입력해 주세요";
+  } else if (!GENERAL_TIME_PATTERN.test(draft.openTime)) {
+    errors.openTime = "올바른 시간 형식이 아니에요";
+  }
+
+  if (!draft.closeTime.trim()) {
+    errors.closeTime = "이용 종료 시간을 입력해 주세요";
+  } else if (!GENERAL_TIME_PATTERN.test(draft.closeTime)) {
+    errors.closeTime = "올바른 시간 형식이 아니에요";
+  }
+
+  if (
+    !errors.openTime &&
+    !errors.closeTime &&
+    toMinutes(draft.openTime) >= toMinutes(draft.closeTime)
+  ) {
+    errors.closeTime = "종료 시간은 시작 시간보다 늦어야 해요";
   }
 
   return errors;


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [x] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [x] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

- `MeetingRoom`에서 "수용 인원"(capacity) 필드를 전면 폐기하고 "위치"(location) 필드로 교체(WORKFLOW.md §10-A 확정 정책 반영)
- `/manage/rooms` 신규 — 회의실 목록 표 + 추가/수정 모달, `notice-form.tsx`/`notice-create-dialog.tsx` 패턴 그대로 재사용
- `createMeetingRoomAction`/`updateMeetingRoomAction` 추가, `canManageRooms`(Admin 겸직자 전용)로 서버 재검사
- mock 스토어에 `addMockRoom`/`updateMockRoom` 추가, RTL 없이 액션·검증·mock 단위테스트로 커버

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — `canManageRooms`(Admin 겸직자 전용, OWNER도 예외 없음), Server Action에서 재검사. 리소스 소유권 축은 해당 없음(회의실 자체엔 담당자 개념이 없음)
- [ ] 🧬 **zod** — 이 기능은 zod를 안 쓴다(rooms 기존 스캐폴딩부터 순수 함수 검증 패턴, `validate.ts`)
- [x] 🕵️ **정직성** — 목 데이터임을 주석에 명시, 미구현 API는 throw로 막음
- [x] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 — 해당 없음(이미지·폰트 없음)
- [x] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로 — DnD 없음
- [x] ♻️ 재사용 확인 — `notice-form.tsx`/`notice-create-dialog.tsx`/`notice-edit-dialog.tsx` 그대로 재사용
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 전부 구현
- [ ] 브라우저 전용 API(STT · 녹음) — 해당 없음

---

## 🔗 연관 이슈

Closes #194

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
| (`/manage/rooms` 없음) | (목록 + 추가/수정 모달) |

⚠️ **지금 mock 액터가 OWNER 고정(Admin 아님)이라 실제 데모 화면에선 "추가"/"수정" 버튼이 안 보입니다** — `canManageRooms`가 Admin 겸직자만 통과시키는 기존 정책이 그대로 지켜진 결과입니다(버그 아님). 스크린샷은 브라우저 검증이 막힌 상태라 못 붙였고, Admin 겸직 액터로 바꿔야 버튼이 보입니다.

---

## 💬 리뷰 포인트

- `canManageRooms`가 OWNER도 막는 게 의도대로 맞는지(다른 `/manage/*`는 대부분 `OWNER || isAdmin`인데 회의실만 Admin 전용)
- mock 액터가 OWNER 고정이라 이 화면을 실제로 눌러볼 방법이 없는 상태 — 다음 PR(Actor 확장)까지 감안하고 볼지, 이 PR에 임시 admin 페르소나라도 넣을지

---

## 📝 추가 메모

`npx jest src/features/rooms`(54개) · `npx tsc --noEmit` · `npx eslint` 전부 통과 확인함. 브라우저 실제 렌더링은 미검증(이전부터 이어진 dev 서버 이슈).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 회의실 관리 페이지를 추가했습니다.
  - 회의실 목록에서 이름, 위치, 이용 가능 시간을 확인할 수 있습니다.
  - 권한이 있는 관리자는 회의실을 추가하고 기존 정보를 수정할 수 있습니다.
  - 필수 항목, 시간 형식 및 이용 시간 순서를 자동으로 검증합니다.
  - 저장 중에는 중복 제출과 실수로 인한 창 닫기를 방지합니다.
  - 목록이 비어 있거나 로딩·오류가 발생한 경우 안내 화면을 제공합니다.
- **개선**
  - 회의실 정보에 위치가 표시되며, 변경 사항이 저장 후 목록에 즉시 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->