### PR TITLE
[FEAT] 팀 액션 대시보드 /team/action #204

### DIFF
--- a/src/app/(shell)/(authority)/team/action/error.tsx
+++ b/src/app/(shell)/(authority)/team/action/error.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { ScreenError } from "@/components/common/screen-error";
+
+interface TeamActionErrorProps {
+  reset: () => void;
+}
+
+export default function Error({ reset }: TeamActionErrorProps) {
+  // 셸(상단바 h1) 안에서 뜨므로 isInsideShell — h1 중복·높이 잘림을 막는다
+  return <ScreenError title="팀 액션을 불러오지 못했습니다" reset={reset} isInsideShell />;
+}

--- a/src/app/(shell)/(authority)/team/action/layout.tsx
+++ b/src/app/(shell)/(authority)/team/action/layout.tsx
@@ -1,0 +1,14 @@
+import { Columns3 } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { PageHeader } from "@/features/shell/components/page-header";
+
+/** 팀 액션 상단바 — 사이드바에서 바로 닿는 화면이라 backTo는 두지 않는다. */
+export default function TeamActionLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <PageHeader title="팀 액션" icon={Columns3} />
+      {children}
+    </>
+  );
+}

--- a/src/app/(shell)/(authority)/team/action/loading.tsx
+++ b/src/app/(shell)/(authority)/team/action/loading.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
+      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-4">
+        <Skeleton className="h-7 w-40 rounded-lg" />
+        <Skeleton className="h-60 w-full rounded-2xl" />
+        <Skeleton className="h-40 w-full rounded-2xl" />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/(authority)/team/action/page.tsx
+++ b/src/app/(shell)/(authority)/team/action/page.tsx
@@ -1,0 +1,90 @@
+import type { Metadata } from "next";
+
+import { isDelayed } from "@/constants/domain";
+import type { TimelineActionInput } from "@/features/member/action-timeline";
+import { ActionTimeline, ActionTimelineLegend } from "@/features/member/components/action-timeline";
+import { getProgressPercent } from "@/features/project/lib";
+import { getTeamActionsByTeam } from "@/features/project/server";
+import type { ProjectListItem, ProjectTeamActionWithProgress } from "@/features/project/types";
+import { getTeamDashboardOverview } from "@/features/team/server";
+import { pickPaletteColor } from "@/lib/palette";
+
+export const metadata: Metadata = {
+  title: "팀 액션",
+};
+
+/** 이 프로젝트의 팀 액션들을 타임라인 입력으로 — 프로젝트 상세 타임라인 탭과 같은 모양(§디자인). */
+function toTimelineItems(
+  project: ProjectListItem,
+  teamActions: ProjectTeamActionWithProgress[],
+): TimelineActionInput[] {
+  const tagColor = pickPaletteColor(project.tag);
+  return teamActions.map((action) => ({
+    id: String(action.id),
+    title: action.name,
+    tag: project.tag,
+    tagBgColor: tagColor.bgColor,
+    tagTextColor: tagColor.textColor,
+    startDate: action.startDate,
+    dueDate: action.dueDate,
+    tone: isDelayed(action) ? "DELAYED" : action.status,
+    href: `/app/projects/${project.id}/team/${action.id}`,
+    progressPercent: getProgressPercent(action.actionDone, action.actionTotal),
+  }));
+}
+
+export default async function TeamActionPage() {
+  const { teamName } = await getTeamDashboardOverview();
+  const groups = await getTeamActionsByTeam(teamName);
+  const totalTeamActions = groups.reduce((sum, group) => sum + group.teamActions.length, 0);
+
+  return (
+    <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
+      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-4">
+        <div className="flex items-baseline justify-between gap-3">
+          <h2 className="text-foreground text-xl leading-7 font-semibold tracking-[-0.4px]">
+            {teamName}
+          </h2>
+          <p className="text-muted-foreground text-xs tabular-nums">
+            {groups.length}개 프로젝트 · 총 {totalTeamActions}개 팀 액션
+          </p>
+        </div>
+
+        {groups.length === 0 ? (
+          <p className="text-muted-foreground flex min-h-[240px] items-center justify-center text-sm">
+            아직 하달된 팀 액션이 없습니다.
+          </p>
+        ) : (
+          groups.map(({ project, teamActions }) => {
+            const tagColor = pickPaletteColor(project.tag);
+            return (
+              <section
+                key={project.id}
+                className="border-border bg-card flex flex-col overflow-hidden rounded-2xl border"
+              >
+                <div className="border-border flex shrink-0 items-baseline justify-between gap-3 border-b px-7 pt-6 pb-3">
+                  <h3 className="flex items-center gap-2 text-[17px] leading-7 font-semibold tracking-[-0.3px]">
+                    <span className="bg-foreground size-2 rounded-full" aria-hidden />
+                    {project.name}
+                    <span
+                      className="rounded px-1.5 py-0.5 font-mono text-xs leading-none font-semibold"
+                      style={{ backgroundColor: tagColor.bgColor, color: tagColor.textColor }}
+                    >
+                      {project.tag}
+                    </span>
+                  </h3>
+                  <p className="text-muted-foreground text-[12px] leading-4 tabular-nums">
+                    {teamActions.length}개 팀 액션
+                  </p>
+                </div>
+                <ActionTimeline items={toTimelineItems(project, teamActions)} today={new Date()} />
+              </section>
+            );
+          })
+        )}
+
+        <ActionTimelineLegend />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/(authority)/team/action/page.tsx
+++ b/src/app/(shell)/(authority)/team/action/page.tsx
@@ -41,14 +41,9 @@ export default async function TeamActionPage() {
   return (
     <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
       <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-4">
-        <div className="flex items-baseline justify-between gap-3">
-          <h2 className="text-foreground text-xl leading-7 font-semibold tracking-[-0.4px]">
-            {teamName}
-          </h2>
-          <p className="text-muted-foreground text-xs tabular-nums">
-            {groups.length}개 프로젝트 · 총 {totalTeamActions}개 팀 액션
-          </p>
-        </div>
+        <p className="text-muted-foreground self-end text-xs tabular-nums">
+          {groups.length}개 프로젝트 · 총 {totalTeamActions}개 팀 액션
+        </p>
 
         {groups.length === 0 ? (
           <p className="text-muted-foreground flex min-h-[240px] items-center justify-center text-sm">

--- a/src/app/(shell)/app/projects/[projectId]/page.tsx
+++ b/src/app/(shell)/app/projects/[projectId]/page.tsx
@@ -9,6 +9,7 @@ import { isDelayed } from "@/constants/domain";
 import type { TimelineActionInput } from "@/features/member/action-timeline";
 import { ActionTimeline, ActionTimelineLegend } from "@/features/member/components/action-timeline";
 import {
+  getProgressPercent,
   parseProjectDetailTab,
   PROJECT_DETAIL_TABS,
   PROJECT_TIMELINE_BOX_HEIGHT,
@@ -62,6 +63,7 @@ export default async function ProjectDetailPage({ params, searchParams }: Projec
       // ⚠️ 식별자는 action.id(팀 액션 ID)를 쓴다 — action.team(팀명)으로 경로를 만들면
       //    같은 팀에 팀 액션이 여러 개일 때 서로 구분이 안 된다.
       href: `/app/projects/${project.id}/team/${action.id}`,
+      progressPercent: getProgressPercent(action.actionDone, action.actionTotal),
     };
   });
 

--- a/src/features/member/action-timeline.ts
+++ b/src/features/member/action-timeline.ts
@@ -35,6 +35,11 @@ export interface TimelineActionInput {
   tone: StatusTone;
   /** 클릭 시 이동할 상세 경로. 상세 라우트가 아직 없으면 비워서 클릭 불가로 둔다. */
   href?: string;
+  /**
+   * 진척율(%, 0~100) — **팀 액션처럼 하위 항목이 있는 행에만** 넘긴다(개인 액션은 더 쪼갤
+   * 하위가 없어 넘기지 않는다). 있으면 행이 살짝 높아지고 제목 아래에 진척 바가 붙는다.
+   */
+  progressPercent?: number;
 }
 
 /** 축의 하루 칸. */

--- a/src/features/member/components/action-timeline.tsx
+++ b/src/features/member/components/action-timeline.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import type { StatusTone } from "@/components/common/status-dot";
+import { Progress } from "@/components/ui/progress";
 import { ACTION_DELAYED_LABEL, ACTION_STATUS, ACTION_STATUS_LABEL } from "@/constants/domain";
 import {
   buildActionTimeline,
@@ -90,6 +91,8 @@ const LABEL_COL_PX = 200;
 const LABEL_COL_STYLE = { width: LABEL_COL_PX, minWidth: LABEL_COL_PX };
 /** 행 높이(px) — 그리드 오버레이 높이 계산에 쓴다(행 수 × 이 값). */
 const ROW_HEIGHT_PX = 44;
+/** 진척 바가 붙는 행 높이 — 제목 아래 한 줄이 더 필요하다(팀 액션처럼 하위 항목이 있을 때만). */
+const ROW_HEIGHT_WITH_PROGRESS_PX = 60;
 
 interface ActionTimelineProps {
   items: TimelineActionInput[];
@@ -115,7 +118,11 @@ export function ActionTimeline({
   }
 
   const { days, bars, todayLeftPx, totalWidthPx, monthLabel } = model;
-  const gridHeightPx = bars.length * ROW_HEIGHT_PX;
+  // ⚠️ 한 인스턴스 안에서는 전부 팀 액션이거나 전부 개인 액션이라 섞이지 않는다 — 행 높이는
+  //    균일해야 그리드·오늘선 계산이 맞으므로, 하나라도 진척 바가 있으면 전체를 키운다.
+  const hasProgress = bars.some((bar) => bar.progressPercent !== undefined);
+  const rowHeightPx = hasProgress ? ROW_HEIGHT_WITH_PROGRESS_PX : ROW_HEIGHT_PX;
+  const gridHeightPx = bars.length * rowHeightPx;
 
   return (
     <div className="scrollbar-hidden min-h-0 flex-1 overflow-auto">
@@ -173,22 +180,32 @@ export function ActionTimeline({
             //    막대만 눌리면 클릭 영역이 좁고, 좌측을 눌렀을 때 반응이 없어 헷갈린다.
             const rowContent = (
               <>
-                {/* 좌: 상태점 · 액션명 · 칩(호출부마다 뜻 다름 — 태그 또는 팀명) */}
+                {/* 좌: 상태점 · 액션명 · 칩(호출부마다 뜻 다름 — 태그 또는 팀명) · (있으면) 진척 바 */}
                 <div
-                  className="bg-card sticky left-0 z-10 flex min-w-0 shrink-0 items-center gap-2 px-3"
+                  className="bg-card sticky left-0 z-10 flex min-w-0 shrink-0 flex-col justify-center gap-1 px-3"
                   style={LABEL_COL_STYLE}
                 >
-                  <span
-                    className={cn("size-1.5 shrink-0 rounded-full", DOT_CLASS[bar.tone])}
-                    aria-hidden
-                  />
-                  <span className="min-w-0 truncate text-[13px]">{bar.title}</span>
-                  <span
-                    className="shrink-0 rounded px-1.5 py-0.5 font-mono text-[10px] font-semibold"
-                    style={{ backgroundColor: bar.tagBgColor, color: bar.tagTextColor }}
-                  >
-                    {bar.tag}
-                  </span>
+                  <div className="flex min-w-0 items-center gap-2">
+                    <span
+                      className={cn("size-1.5 shrink-0 rounded-full", DOT_CLASS[bar.tone])}
+                      aria-hidden
+                    />
+                    <span className="min-w-0 truncate text-[13px]">{bar.title}</span>
+                    <span
+                      className="shrink-0 rounded px-1.5 py-0.5 font-mono text-[10px] font-semibold"
+                      style={{ backgroundColor: bar.tagBgColor, color: bar.tagTextColor }}
+                    >
+                      {bar.tag}
+                    </span>
+                  </div>
+                  {bar.progressPercent !== undefined && (
+                    <div className="flex items-center gap-1.5 pl-3.5">
+                      <Progress value={bar.progressPercent} />
+                      <span className="text-muted-foreground shrink-0 text-[10px] tabular-nums">
+                        {bar.progressPercent}%
+                      </span>
+                    </div>
+                  )}
                 </div>
 
                 {/* 우: 기간 바 */}
@@ -218,7 +235,7 @@ export function ActionTimeline({
                 href={bar.href}
                 aria-label={barAriaLabel(bar)}
                 className={rowClassName}
-                style={{ height: ROW_HEIGHT_PX }}
+                style={{ height: rowHeightPx }}
               >
                 {rowContent}
               </Link>
@@ -227,7 +244,7 @@ export function ActionTimeline({
                 key={bar.id}
                 aria-label={barAriaLabel(bar)}
                 className={rowClassName}
-                style={{ height: ROW_HEIGHT_PX }}
+                style={{ height: rowHeightPx }}
               >
                 {rowContent}
               </div>
@@ -245,6 +262,7 @@ export function ActionTimelineLegend() {
     { tone: "DELAYED", label: TONE_LABEL.DELAYED },
     { tone: "IN_PROGRESS", label: TONE_LABEL.IN_PROGRESS },
     { tone: "TODO", label: TONE_LABEL.TODO },
+    { tone: "DONE", label: TONE_LABEL.DONE },
   ];
 
   return (

--- a/src/features/project/server.ts
+++ b/src/features/project/server.ts
@@ -1,4 +1,9 @@
-import { DEFAULT_PROJECT_SORT, type ProjectSort, type ProjectStatus } from "@/constants/domain";
+import {
+  ACTION_STATUS,
+  DEFAULT_PROJECT_SORT,
+  type ProjectSort,
+  type ProjectStatus,
+} from "@/constants/domain";
 import { COMPANY_TEAM_NAMES } from "@/constants/project";
 import { isMock } from "@/mocks/config";
 
@@ -12,7 +17,7 @@ import { PROJECT_ATTACHMENT_MOCK, PROJECT_TEAM_ACTIONS_MOCK } from "./mock/team-
 import type {
   ProjectDetail,
   ProjectListItem,
-  ProjectTeamAction,
+  ProjectTeamActionWithProgress,
   TeamActionDetail,
   TeamActionPersonalItem,
 } from "./types";
@@ -79,11 +84,42 @@ export async function getProjectDetail(id: string): Promise<ProjectDetail | null
   throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
 }
 
+/** 팀 액션 id로 개인 액션 진척(전체·완료)을 센다 — 진척 바(§타임라인 진척 바)에 쓴다. */
+function countActionProgress(teamActionId: number): { actionTotal: number; actionDone: number } {
+  const items = TEAM_ACTION_PERSONAL_ITEMS_MOCK[teamActionId] ?? [];
+  return {
+    actionTotal: items.length,
+    actionDone: items.filter((item) => item.status === ACTION_STATUS.DONE).length,
+  };
+}
+
 /** 프로젝트 상세의 타임라인 탭 — 이 프로젝트에 속한 팀 액션 전체(여러 팀이 하나의 축에 함께). */
-export async function getProjectTeamActions(id: string): Promise<ProjectTeamAction[]> {
+export async function getProjectTeamActions(id: string): Promise<ProjectTeamActionWithProgress[]> {
   if (isMock) {
     const project = findProjectById(id);
-    return project ? (PROJECT_TEAM_ACTIONS_MOCK[project.tag] ?? []) : [];
+    const teamActions = project ? (PROJECT_TEAM_ACTIONS_MOCK[project.tag] ?? []) : [];
+    return teamActions.map((action) => ({ ...action, ...countActionProgress(action.id) }));
+  }
+
+  throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
+}
+
+/**
+ * 팀 액션 대시보드(`/team/action`)용 — 이 팀이 받은 팀 액션 전체를 프로젝트별로 묶어서 준다.
+ * ⚠️ Leader 개인화: 로그인한 사람의 소속 팀 것만(WORKFLOW.md §4).
+ */
+export async function getTeamActionsByTeam(
+  teamName: string,
+): Promise<{ project: ProjectListItem; teamActions: ProjectTeamActionWithProgress[] }[]> {
+  if (isMock) {
+    const groups: { project: ProjectListItem; teamActions: ProjectTeamActionWithProgress[] }[] = [];
+    for (const project of TOP_LEVEL_PROJECTS) {
+      const teamActions = (PROJECT_TEAM_ACTIONS_MOCK[project.tag] ?? [])
+        .filter((action) => action.team === teamName)
+        .map((action) => ({ ...action, ...countActionProgress(action.id) }));
+      if (teamActions.length > 0) groups.push({ project, teamActions });
+    }
+    return groups;
   }
 
   throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");

--- a/src/features/project/types.ts
+++ b/src/features/project/types.ts
@@ -95,6 +95,17 @@ export interface ProjectTeamAction {
 }
 
 /**
+ * `ProjectTeamAction` + 진척(done/total) — 조회 시점에 개인 액션을 세서 채운다(저장 안 함).
+ * 타임라인 진척 바에 쓴다(프로젝트 상세 타임라인 탭·팀 액션 대시보드).
+ */
+export interface ProjectTeamActionWithProgress extends ProjectTeamAction {
+  /** 이 팀 액션에 속한 개인 액션 수. */
+  actionTotal: number;
+  /** 그중 완료된 개인 액션 수. */
+  actionDone: number;
+}
+
+/**
  * 팀 액션 상세(`/app/projects/:projectId/team/:teamActionId`)의 상세 탭.
  * ⚠️ 담당자는 이 팀 액션을 받은 팀의 **팀장**이다(`assigneeRoleLabel`은 항상 "팀장") —
  *    개인 액션 상세를 만들 때는 같은 필드에 그 사람 본인 역할이 들어간다.


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [x] LEADER (팀장)
- [ ] OWNER (대표)
- [ ] MEMBER (사원)
- [ ] ADMIN (관리자)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

팀장의 소속 팀 팀 액션 전체를 **프로젝트별 카드**로 묶어 표시합니다(WORKFLOW.md §4).

- 카드 헤더 = 머리 표식+프로젝트명+태그+팀 액션 수, 본문은 프로젝트 상세 타임라인 탭과 **완전히 같은 `ActionTimeline`** 재사용
- `ActionTimeline`에 선택적 `progressPercent`를 추가 — 있으면 행 높이를 늘리고 제목 아래에 진척 바를 붙입니다(하위 개인 액션 done/total). 같은 컴포넌트를 쓰는 **프로젝트 상세 타임라인 탭에도 자동 반영**됩니다
- 범례에 빠져 있던 '완료' 항목도 추가
- `ProjectTeamActionWithProgress` 타입 신설(조회 시점에 진척 계산, 저장 안 함) — `ProjectTeamAction` 자체는 안 건드립니다
- `getTeamActionsByTeam(teamName)` 신설

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/team-action-dashboard#204`)
- [x] 커밋 컨벤션 준수
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [x] 🔐 권한 2축 검사 — LEADER 본인 팀 스코프. 리소스 소유권은 해당 없음(팀장이 자기 팀 전체를 봄)
- [ ] 🧬 zod — 해당 없음
- [x] 🕵️ 정직성 — 목 기준임을 명시
- [x] 🎨 디자인 토큰 사용 · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [x] ♿ a11y — 기존 `ActionTimeline` 접근성 그대로 유지
- [x] ♻️ 재사용 확인 — `ActionTimeline`을 새로 안 만들고 `progressPercent`만 얹었습니다
- [x] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API 미사용

---

## 🔗 연관 이슈

Closes #204

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

`ActionTimeline`에 얹은 `progressPercent`가 **프로젝트 상세 타임라인 탭에도 그대로 반영됩니다** — 같은 컴포넌트라서입니다. 의도한 동작인지 봐주세요.

---

## 📝 추가 메모

⚠️ **스태킹 PR** — base가 develop이 아니라 `feature/board-page#202`(PR #203)였습니다. 순서상 이 브랜치 위에서 작업해 자연히 쌓였습니다. #203(그 위로 #201)이 머지되며 GitHub가 이 PR의 base를 자동으로 develop로 리타겟했습니다.

`npx jest`(전체 54 스위트/602 테스트 통과), 타입체크 통과.
