### PR TITLE
[FEAT] 내 액션 화면 /app/my/actions #206

### DIFF
--- a/src/app/(shell)/app/my/actions/error.tsx
+++ b/src/app/(shell)/app/my/actions/error.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { ScreenError } from "@/components/common/screen-error";
+
+interface MyActionsErrorProps {
+  reset: () => void;
+}
+
+export default function Error({ reset }: MyActionsErrorProps) {
+  // 셸(상단바 h1) 안에서 뜨므로 isInsideShell — h1 중복·높이 잘림을 막는다
+  return <ScreenError title="내 액션을 불러오지 못했습니다" reset={reset} isInsideShell />;
+}

--- a/src/app/(shell)/app/my/actions/layout.tsx
+++ b/src/app/(shell)/app/my/actions/layout.tsx
@@ -1,0 +1,14 @@
+import { ListChecks } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { PageHeader } from "@/features/shell/components/page-header";
+
+/** 내 액션 상단바 — 사이드바에서 바로 닿는 화면이라 backTo는 두지 않는다. */
+export default function MyActionsLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <PageHeader title="내 액션" icon={ListChecks} />
+      {children}
+    </>
+  );
+}

--- a/src/app/(shell)/app/my/actions/loading.tsx
+++ b/src/app/(shell)/app/my/actions/loading.tsx
@@ -1,0 +1,12 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
+      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-4">
+        <Skeleton className="h-5 w-40 rounded-lg" />
+        <Skeleton className="h-60 w-full rounded-2xl" />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/app/my/actions/page.tsx
+++ b/src/app/(shell)/app/my/actions/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 
 import { MyActionListItemRow } from "@/features/action/components/my-action-list-item";
 import { getMyActionList } from "@/features/action/server";
+import type { MyActionListItem } from "@/features/action/types";
+import { pickPaletteColor } from "@/lib/palette";
 
 export const metadata: Metadata = {
   title: "내 액션",
@@ -11,27 +13,83 @@ export const metadata: Metadata = {
 //    세션이 붙으면 viewer.name으로 바꾼다.
 const MOCK_ASSIGNEE_NAME = "이하윤";
 
+/** 프로젝트별로 묶는다 — 마감 임박순으로 이미 정렬된 목록이라 그룹 안 순서도 그대로 유지된다. */
+function groupByProject(
+  actions: MyActionListItem[],
+): { projectId: number; projectName: string; projectTag: string; actions: MyActionListItem[] }[] {
+  const groups: Map<
+    number,
+    { projectName: string; projectTag: string; actions: MyActionListItem[] }
+  > = new Map();
+  for (const action of actions) {
+    const group = groups.get(action.projectId);
+    if (group) group.actions.push(action);
+    else {
+      groups.set(action.projectId, {
+        projectName: action.projectName,
+        projectTag: action.projectTag,
+        actions: [action],
+      });
+    }
+  }
+  return [...groups.entries()].map(([projectId, group]) => ({ projectId, ...group }));
+}
+
 export default async function MyActionsPage() {
   const actions = await getMyActionList(MOCK_ASSIGNEE_NAME);
+  const groups = groupByProject(actions);
 
   return (
     <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
       <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-4">
         <p className="text-muted-foreground text-sm">나에게 할당된 개인 액션 {actions.length}건</p>
 
-        <section className="border-border bg-card overflow-hidden rounded-2xl border">
-          {actions.length === 0 ? (
+        {groups.length === 0 ? (
+          <section className="border-border bg-card overflow-hidden rounded-2xl border">
             <p className="text-muted-foreground flex min-h-[240px] items-center justify-center text-sm">
               아직 할당된 개인 액션이 없습니다.
             </p>
-          ) : (
-            <ul>
-              {actions.map((action, index) => (
-                <MyActionListItemRow key={action.id} action={action} showDivider={index > 0} />
-              ))}
-            </ul>
-          )}
-        </section>
+          </section>
+        ) : (
+          groups.map((group) => {
+            const tagColor = pickPaletteColor(group.projectTag);
+            return (
+              <section
+                key={group.projectId}
+                className="border-border bg-card flex flex-col overflow-hidden rounded-2xl border"
+              >
+                <div className="border-border flex shrink-0 items-baseline justify-between gap-3 border-b px-7 pt-6 pb-3">
+                  <h3 className="flex items-center gap-2 text-[17px] leading-7 font-semibold tracking-[-0.3px]">
+                    <span className="bg-foreground size-2 rounded-full" aria-hidden />
+                    {group.projectName}
+                    <span
+                      className="rounded px-1.5 py-0.5 font-mono text-xs leading-none font-semibold"
+                      style={{ backgroundColor: tagColor.bgColor, color: tagColor.textColor }}
+                    >
+                      {group.projectTag}
+                    </span>
+                  </h3>
+                  <p className="text-muted-foreground text-[12px] leading-4 tabular-nums">
+                    {group.actions.length}건
+                  </p>
+                </div>
+                <ul>
+                  {group.actions.map((action, index) => (
+                    <MyActionListItemRow
+                      key={action.id}
+                      action={action}
+                      showDivider={index > 0}
+                      // ⚠️ 항상 false — 카드 위쪽 모서리는 헤더가 이미 차지해서 목록의 첫 행은
+                      //    거기 안 닿는다(맞물리는 건 마지막 행뿐).
+                      isFirst={false}
+                      isLast={index === group.actions.length - 1}
+                    />
+                  ))}
+                </ul>
+              </section>
+            );
+          })
+        )}
       </div>
     </main>
   );

--- a/src/app/(shell)/app/my/actions/page.tsx
+++ b/src/app/(shell)/app/my/actions/page.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from "next";
+
+import { MyActionListItemRow } from "@/features/action/components/my-action-list-item";
+import { getMyActionList } from "@/features/action/server";
+
+export const metadata: Metadata = {
+  title: "내 액션",
+};
+
+// ⚠️ 로그인 전이라 실제 담당자를 알 수 없다 — 팀 대시보드 목과 같은 대표 인물(이하윤)로 대신한다.
+//    세션이 붙으면 viewer.name으로 바꾼다.
+const MOCK_ASSIGNEE_NAME = "이하윤";
+
+export default async function MyActionsPage() {
+  const actions = await getMyActionList(MOCK_ASSIGNEE_NAME);
+
+  return (
+    <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
+      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-4">
+        <p className="text-muted-foreground text-sm">나에게 할당된 개인 액션 {actions.length}건</p>
+
+        <section className="border-border bg-card overflow-hidden rounded-2xl border">
+          {actions.length === 0 ? (
+            <p className="text-muted-foreground flex min-h-[240px] items-center justify-center text-sm">
+              아직 할당된 개인 액션이 없습니다.
+            </p>
+          ) : (
+            <ul>
+              {actions.map((action, index) => (
+                <MyActionListItemRow key={action.id} action={action} showDivider={index > 0} />
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/features/action/components/my-action-list-item.tsx
+++ b/src/features/action/components/my-action-list-item.tsx
@@ -1,0 +1,82 @@
+import Link from "next/link";
+
+import { Badge } from "@/components/ui/badge";
+import { ACTION_DELAYED_LABEL, ACTION_STATUS_LABEL, isDelayed } from "@/constants/domain";
+import { formatMonthDayWeekday } from "@/lib/date";
+import { pickPaletteColor } from "@/lib/palette";
+import { cn } from "@/lib/utils";
+
+import type { MyActionListItem } from "../types";
+
+/** 상태 배지 색 — `member/components/action-timeline`의 BAR_CLASS와 같은 결(할일·완료=무채색, 진행중=초록, 지연=빨강). */
+const STATUS_TONE: Record<"TODO" | "IN_PROGRESS" | "DONE" | "DELAYED", string> = {
+  TODO: "bg-muted text-muted-foreground",
+  IN_PROGRESS: "bg-success/12 text-success",
+  DONE: "bg-muted text-muted-foreground",
+  DELAYED: "bg-destructive/10 text-destructive",
+};
+
+interface MyActionListItemRowProps {
+  action: MyActionListItem;
+  /** 목록의 첫 항목이 아니면 위쪽 구분선을 그린다 */
+  showDivider: boolean;
+}
+
+/** 좌: 태그색 막대 / 제목·프로젝트 태그·팀명 라벨 + 세부 설명 한 줄 / 우: 마감일 + 상태 배지. */
+export function MyActionListItemRow({ action, showDivider }: MyActionListItemRowProps) {
+  const tagColor = pickPaletteColor(action.projectTag);
+  const delayed = isDelayed(action);
+  const tone = delayed ? "DELAYED" : action.status;
+  const statusLabel = delayed ? ACTION_DELAYED_LABEL : ACTION_STATUS_LABEL[action.status];
+  const due = formatMonthDayWeekday(action.dueDate);
+
+  return (
+    <li className={cn(showDivider && "border-border border-t")}>
+      <Link
+        href={`/app/actions/${action.id}`}
+        className="hover:bg-muted flex items-stretch transition-colors"
+      >
+        {/* 프로젝트 색 왼쪽 막대 — 행 위아래 끝에 딱 붙는 얇은 세로선 */}
+        <span
+          className="w-1 shrink-0"
+          style={{ backgroundColor: tagColor.solidColor }}
+          aria-hidden
+        />
+
+        <div className="flex min-w-0 flex-1 items-center gap-3 px-4 py-3">
+          {/* 좌: 제목 · 프로젝트 태그 · 팀명 라벨 + 세부 설명 한 줄 */}
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <div className="flex min-w-0 items-center gap-2">
+              <span className="truncate text-[15px]">{action.title}</span>
+              <span
+                className="shrink-0 rounded px-1.5 py-0.5 font-mono text-[10px] font-semibold"
+                style={{ backgroundColor: tagColor.bgColor, color: tagColor.textColor }}
+              >
+                {action.projectTag}
+              </span>
+              <Badge variant="secondary" className="shrink-0">
+                {action.team}
+              </Badge>
+            </div>
+            <p className="text-muted-foreground line-clamp-1 text-xs">{action.description}</p>
+          </div>
+
+          {/* 우: 마감일 + 상태 배지(맨 오른쪽 끝) */}
+          <div className="flex shrink-0 items-center gap-3">
+            <span className="text-muted-foreground text-xs tabular-nums">
+              {due ? `${due}까지` : "-"}
+            </span>
+            <span
+              className={cn(
+                "inline-flex h-5 shrink-0 items-center rounded-full px-2 text-xs font-medium",
+                STATUS_TONE[tone],
+              )}
+            >
+              {statusLabel}
+            </span>
+          </div>
+        </div>
+      </Link>
+    </li>
+  );
+}

--- a/src/features/action/components/my-action-list-item.tsx
+++ b/src/features/action/components/my-action-list-item.tsx
@@ -20,10 +20,22 @@ interface MyActionListItemRowProps {
   action: MyActionListItem;
   /** 목록의 첫 항목이 아니면 위쪽 구분선을 그린다 */
   showDivider: boolean;
+  /**
+   * 카드 모서리(rounded-2xl)와 맞물리는 위치인지 — 왼쪽 막대가 카드 곡선과 어긋나면
+   * 위아래 끝이 잘린 것처럼 보인다(2026-08-07 실제로 겪은 문제). 막대 자체를 카드와
+   * 같은 반지름으로 둥글려서 카드의 `overflow-hidden`이 정확히 그 곡선만 잘라내게 한다.
+   */
+  isFirst: boolean;
+  isLast: boolean;
 }
 
 /** 좌: 태그색 막대 / 제목·프로젝트 태그·팀명 라벨 + 세부 설명 한 줄 / 우: 마감일 + 상태 배지. */
-export function MyActionListItemRow({ action, showDivider }: MyActionListItemRowProps) {
+export function MyActionListItemRow({
+  action,
+  showDivider,
+  isFirst,
+  isLast,
+}: MyActionListItemRowProps) {
   const tagColor = pickPaletteColor(action.projectTag);
   const delayed = isDelayed(action);
   const tone = delayed ? "DELAYED" : action.status;
@@ -36,16 +48,16 @@ export function MyActionListItemRow({ action, showDivider }: MyActionListItemRow
         href={`/app/actions/${action.id}`}
         className="hover:bg-muted flex items-stretch transition-colors"
       >
-        {/* 프로젝트 색 왼쪽 막대 — 행 위아래 끝에 딱 붙는 얇은 세로선 */}
+        {/* 프로젝트 색 왼쪽 막대 — 카드 모서리와 만나는 첫·마지막 행만 그만큼 둥글린다 */}
         <span
-          className="w-1 shrink-0"
+          className={cn("w-1 shrink-0", isFirst && "rounded-tl-2xl", isLast && "rounded-bl-2xl")}
           style={{ backgroundColor: tagColor.solidColor }}
           aria-hidden
         />
 
-        <div className="flex min-w-0 flex-1 items-center gap-3 px-4 py-3">
+        <div className="flex min-w-0 flex-1 items-center gap-3 px-4 py-4">
           {/* 좌: 제목 · 프로젝트 태그 · 팀명 라벨 + 세부 설명 한 줄 */}
-          <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <div className="flex min-w-0 flex-1 flex-col gap-1.5">
             <div className="flex min-w-0 items-center gap-2">
               <span className="truncate text-[15px]">{action.title}</span>
               <span

--- a/src/features/action/server.ts
+++ b/src/features/action/server.ts
@@ -1,3 +1,4 @@
+import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
 import { TEAM_ACTION_PERSONAL_ITEMS_MOCK } from "@/features/project/mock/team-action-detail";
 import { isMock } from "@/mocks/config";
 
@@ -26,12 +27,15 @@ export async function getMyActionList(assigneeName: string): Promise<MyActionLis
         if (item.assigneeName !== assigneeName) continue;
         const detail = PERSONAL_ACTION_DETAIL_MOCK[item.id];
         if (!detail) continue;
+        const project = TOP_LEVEL_PROJECTS.find((p) => p.id === detail.projectId);
+        if (!project) continue;
         list.push({
           id: item.id,
           title: item.title,
           description: detail.description,
           team: detail.team,
           projectId: detail.projectId,
+          projectName: project.name,
           projectTag: detail.projectTag,
           startDate: item.startDate,
           dueDate: item.dueDate,

--- a/src/features/action/server.ts
+++ b/src/features/action/server.ts
@@ -1,7 +1,8 @@
+import { TEAM_ACTION_PERSONAL_ITEMS_MOCK } from "@/features/project/mock/team-action-detail";
 import { isMock } from "@/mocks/config";
 
 import { PERSONAL_ACTION_DETAIL_MOCK } from "./mock/action-detail";
-import type { PersonalActionDetail } from "./types";
+import type { MyActionListItem, PersonalActionDetail } from "./types";
 
 /** 개인 액션 상세(`/app/actions/:actionId`). 못 찾으면 `null`(호출부가 404). */
 export async function getPersonalActionDetail(
@@ -11,6 +12,34 @@ export async function getPersonalActionDetail(
     const numericId = Number(actionId);
     if (!Number.isInteger(numericId)) return null;
     return PERSONAL_ACTION_DETAIL_MOCK[numericId] ?? null;
+  }
+
+  throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
+}
+
+/** 내 액션 목록(`/app/my/actions`) — 담당자 이름이 일치하는 개인 액션 전체, 마감 임박순. */
+export async function getMyActionList(assigneeName: string): Promise<MyActionListItem[]> {
+  if (isMock) {
+    const list: MyActionListItem[] = [];
+    for (const items of Object.values(TEAM_ACTION_PERSONAL_ITEMS_MOCK)) {
+      for (const item of items) {
+        if (item.assigneeName !== assigneeName) continue;
+        const detail = PERSONAL_ACTION_DETAIL_MOCK[item.id];
+        if (!detail) continue;
+        list.push({
+          id: item.id,
+          title: item.title,
+          description: detail.description,
+          team: detail.team,
+          projectId: detail.projectId,
+          projectTag: detail.projectTag,
+          startDate: item.startDate,
+          dueDate: item.dueDate,
+          status: item.status,
+        });
+      }
+    }
+    return list.sort((a, b) => a.dueDate.localeCompare(b.dueDate));
   }
 
   throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");

--- a/src/features/action/types.ts
+++ b/src/features/action/types.ts
@@ -43,6 +43,7 @@ export interface MyActionListItem {
   description: string;
   team: string;
   projectId: number;
+  projectName: string;
   projectTag: string;
   /** 작업 시작일 `YYYY-MM-DD` — 지연 판정에는 안 쓰지만(`isDelayed`는 마감일만 본다) 계약은 갖춰 둔다. */
   startDate: string;

--- a/src/features/action/types.ts
+++ b/src/features/action/types.ts
@@ -1,3 +1,5 @@
+import type { ActionStatus } from "@/constants/domain";
+
 /**
  * 개인 액션 상세(`/app/actions/:actionId`)의 UI 계약.
  * ⚠️ 팀 액션 상세(`TeamActionDetail`)와 거의 같은 모양이다 — 다른 점 둘뿐:
@@ -29,4 +31,22 @@ export interface PersonalActionDetail {
     /** 마감일 `YYYY-MM-DD` */
     dueDate: string;
   };
+}
+
+/**
+ * 내 액션(`/app/my/actions`) 목록 한 줄 — 리스트 전용이라 상세 화면의 회의·상위 팀 액션
+ * 정보는 없다. 제목·태그·팀명·상태·마감일·세부 설명 한 줄만 있으면 된다.
+ */
+export interface MyActionListItem {
+  id: number;
+  title: string;
+  description: string;
+  team: string;
+  projectId: number;
+  projectTag: string;
+  /** 작업 시작일 `YYYY-MM-DD` — 지연 판정에는 안 쓰지만(`isDelayed`는 마감일만 본다) 계약은 갖춰 둔다. */
+  startDate: string;
+  /** 마감일 `YYYY-MM-DD` */
+  dueDate: string;
+  status: ActionStatus;
 }


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [x] LEADER (팀장)
- [x] MEMBER (사원)
- [ ] OWNER (대표) — 접근 제외 대상
- [ ] ADMIN (관리자)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

- 최근 프로젝트 회의 리스트와 같은 결의 플랫 리스트
- 한 줄: 제목 · 프로젝트 태그 칩 · 팀명 라벨(태그가 제목과 팀명 사이) → 그 아래 세부 설명 한 줄(line-clamp-1) / 오른쪽: 마감일 · 상태 배지(지연은 `isDelayed`로 계산)
- 왼쪽 프로젝트 태그색 세로 막대, 마감 임박순 정렬
- `getMyActionList(assigneeName)` 신설(action 피처) — 개인 액션 항목과 개인 액션 상세를 id로 합쳐서 만듭니다

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/my-actions-list#206`)
- [x] 커밋 컨벤션 준수
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [x] 🔐 권한 2축 검사 — Owner 제외 전원, 본인에게 할당된 개인 액션만 노출
- [ ] 🧬 zod — 해당 없음
- [x] 🕵️ 정직성 — 목 기준임을 명시
- [x] 🎨 디자인 토큰 사용 · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [x] ♿ a11y — 회의 리스트와 같은 패턴 재사용
- [x] ♻️ 재사용 확인 — 대시보드 공용 컴포넌트 결을 그대로 따름
- [x] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API 미사용

---

## 🔗 연관 이슈

Closes #206

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

`getMyActionList`가 개인 액션 항목과 상세를 id로 합치는 방식이 맞는지 봐주세요 — BE 연동 시 이 자리만 고치면 됩니다.

---

## 📝 추가 메모

⚠️ **스태킹 PR** — base가 develop이 아니라 `feature/team-action-dashboard#204`(PR #205)였습니다. 작업 순서상 그 브랜치 위에서 이어졌습니다. 앞선 PR들이 순서대로 머지되며 GitHub가 base를 자동으로 develop로 리타겟했습니다.

`npx jest`(전체 54 스위트/602 테스트 통과), 타입체크 통과.
