### PR TITLE
[FEAT] Actor teamName 확장 + 회의(Meeting) 최소 스캐폴딩 #210

### DIFF
--- a/src/features/meeting/mock/meetings.test.ts
+++ b/src/features/meeting/mock/meetings.test.ts
@@ -1,0 +1,49 @@
+import { AUTHORITY } from "@/constants/authority";
+
+import type { MeetingDraft } from "../types";
+import { addMockMeeting, findMockMeeting, listMockMeetings } from "./meetings";
+
+const DRAFT: MeetingDraft = {
+  title: "8월 킥오프 미팅",
+  start: new Date("2026-08-11T13:00:00"),
+  end: new Date("2026-08-11T13:30:00"),
+  roomId: "room-large",
+  roomName: "대회의실",
+  projectId: 1,
+  projectTag: "GOODS",
+  topics: [{ main: "제품", sub: "킥오프" }],
+  attendeeIds: [1, 2, 3],
+  hostId: 1,
+  hostAuthority: AUTHORITY.OWNER,
+  roomReservationId: "reservation-1",
+};
+
+describe("회의 mock 스토어", () => {
+  it("회의를 추가하면 id·생성시각을 채워 목록에 반영된다", () => {
+    const before = listMockMeetings().length;
+
+    const created = addMockMeeting(DRAFT);
+
+    expect(created.id).toBeDefined();
+    expect(created.createdAt).toBeDefined();
+    expect(created.title).toBe("8월 킥오프 미팅");
+    expect(listMockMeetings()).toHaveLength(before + 1);
+    expect(findMockMeeting(created.id)).toEqual(created);
+  });
+
+  it("팀 액션 회의는 parentTeamActionId·hostTeamId를 그대로 담는다", () => {
+    const created = addMockMeeting({
+      ...DRAFT,
+      hostAuthority: AUTHORITY.LEADER,
+      hostTeamId: 7,
+      parentTeamActionId: 2,
+    });
+
+    expect(created.parentTeamActionId).toBe(2);
+    expect(created.hostTeamId).toBe(7);
+  });
+
+  it("없는 id는 조회 시 null을 돌려준다", () => {
+    expect(findMockMeeting("존재하지-않음")).toBeNull();
+  });
+});

--- a/src/features/meeting/mock/meetings.ts
+++ b/src/features/meeting/mock/meetings.ts
@@ -1,0 +1,42 @@
+import type { Meeting, MeetingDraft } from "../types";
+
+/**
+ * ⚠️ 목 데이터 — BE 연동 전. 지금은 `/app/rooms` 예약 액션이 이 스토어를 직접 채운다
+ * (`rooms/actions.ts`가 `TOP_LEVEL_PROJECTS`를 직접 참조하는 것과 같은 이유 — 아직
+ * `/app/meeting` 쪽 서버·액션 레이어가 없어서 격리막을 통째로 만들 소비자가 없다.
+ * `/app/meeting`이 생기면 그때 `meeting/server.ts`가 이 스토어 앞을 막는다).
+ * ⚠️ 상태를 `globalThis`에 매단다 — dev의 HMR로 `let`이 초기화되면 방금 만든 회의가 사라진다
+ *    (`rooms/mock/reservations.ts`와 같은 트릭).
+ */
+interface MeetingStore {
+  meetings: Meeting[];
+  sequence: number;
+}
+
+const globalStore = globalThis as typeof globalThis & {
+  __meetingStore?: MeetingStore;
+};
+const store: MeetingStore = (globalStore.__meetingStore ??= { meetings: [], sequence: 0 });
+
+export function listMockMeetings(): Meeting[] {
+  return store.meetings;
+}
+
+export function findMockMeeting(id: string): Meeting | null {
+  return store.meetings.find((meeting) => meeting.id === id) ?? null;
+}
+
+/**
+ * 회의 생성 — 회의실 예약과 짝지어 항상 같이 만들어진다(WORKFLOW.md §3-1).
+ * ⚠️ 여기서 참조 무결성(roomId·projectId·attendeeIds 존재 여부)을 다시 보지 않는다 —
+ *    호출부(`rooms/actions.ts`)가 예약을 검증할 때 이미 확인했다.
+ */
+export function addMockMeeting(draft: MeetingDraft): Meeting {
+  const meeting: Meeting = {
+    ...draft,
+    id: `meeting-${++store.sequence}`,
+    createdAt: new Date().toISOString(),
+  };
+  store.meetings = [...store.meetings, meeting];
+  return meeting;
+}

--- a/src/features/meeting/types.ts
+++ b/src/features/meeting/types.ts
@@ -1,0 +1,47 @@
+/**
+ * 회의(Meeting) — 격리막의 UI 계약(CLAUDE.md §Mock 격리막).
+ * ⚠️ **최소 스캐폴딩이다.** `/app/meeting`(목록·상세·캡처·AI 리뷰)은 별도 이슈다 — 지금은
+ *    회의실 예약이 만드는 레코드 하나만 담는다(WORKFLOW.md §3-1: "회의실 예약 = 회의 개설"이
+ *    하나의 동작이라, 예약만 저장하고 회의를 안 만들면 스펙과 어긋난다).
+ */
+
+import type { Authority } from "@/constants/authority";
+
+/** 회의 안건 대주제/소주제 한 쌍 — 자유 입력 텍스트다(고정 enum 아님, WORKFLOW.md §3-1). */
+export interface MeetingTopic {
+  main: string;
+  sub: string;
+}
+
+/**
+ * 회의 한 건.
+ * ⚠️ **프로젝트 태그는 항상 필수다**(WORKFLOW.md §3-1) — 프로젝트에 안 묶인 회의는 없다.
+ * ⚠️ `parentTeamActionId`는 **Host가 Owner가 아닐 때만** 있다(= 팀 액션 회의). Host가
+ *    Owner면 프로젝트 회의라 이 필드가 없다(WORKFLOW.md §3-1 "상위 팀 액션 노출 조건").
+ */
+export interface Meeting {
+  id: string;
+  title: string;
+  start: Date;
+  end: Date;
+  roomId: string;
+  roomName: string;
+  projectId: number;
+  projectTag: string;
+  /** 최소 1쌍(대주제+소주제) — 나머지는 "추가/삭제"로 늘고 준다. */
+  topics: MeetingTopic[];
+  attendeeIds: number[];
+  /** 개설자 — 회의 조작 권한의 기준(권한 ②축, `lib/permission.ts`의 `canOperateMeeting`). */
+  hostId: number;
+  hostAuthority: Authority;
+  /** Host의 소속 팀 — 팀 액션 회의의 상세 열람 범위 판정(`lib/permission.ts`의 `hostTeamId`)에 쓴다. */
+  hostTeamId?: number;
+  parentTeamActionId?: number;
+  /** 이 회의를 만든 예약 — 같은 동작이라 항상 있다(WORKFLOW.md §3-1). */
+  roomReservationId: string;
+  /** ISO datetime — 서버 기준 생성 시각. */
+  createdAt: string;
+}
+
+/** 회의 생성 입력 — id·createdAt은 서버(mock 스토어)가 채운다. */
+export type MeetingDraft = Omit<Meeting, "id" | "createdAt">;

--- a/src/lib/permission.ts
+++ b/src/lib/permission.ts
@@ -31,6 +31,15 @@ export interface Actor {
    *    이 권한 판정에는 쓰지 않는다 — 범위 판정은 teamId 하나로 끝난다.
    */
   teamId?: number;
+  /**
+   * 소속 팀 이름 — `teamId`와 별개다. **팀 registry(id↔이름 매핑)가 아직 없어서** 둘이
+   * 같은 값을 가리키는지 이 파일은 보장하지 않는다.
+   * ⚠️ `teamId`는 권한 범위 비교(`isWithinTeamScope`)에만 쓰고, 이 필드는 프로젝트
+   *    도메인이 팀을 **이름 문자열**로만 다루는 곳(`ProjectTeamAction.team` 등)과 매칭할 때만
+   *    쓴다(예: 회의실 예약의 "상위 팀 액션" select — 그 프로젝트 내 자기 팀에 하달된 팀
+   *    액션만 골라야 하는데, 그 목록이 이름으로만 저장돼 있다). OWNER는 `undefined`.
+   */
+  teamName?: string;
 }
 
 /* ───────── ① 권한 축 ───────── */


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가
- [x] test — 테스트 코드
- [ ] fix / style / refactor / docs / design / chore / merge

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 / 조직 / 공유 셸 · 디자인 시스템
- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

- `Actor`(`lib/permission.ts`)에 `teamName?: string` 추가 — "상위 팀 액션" select가 그 프로젝트
  내 **자기 팀**에 하달된 팀 액션만 걸러야 하는데, 팀 액션 데이터(`ProjectTeamAction.team`)가
  이름 문자열로만 저장돼 있어서 기존 숫자 `teamId`(권한 범위 비교 전용)와는 별개로 필요했음
- `src/features/meeting/` 신규 — `Meeting` 엔티티 타입 + mock 스토어만. `/app/meeting` UI는
  범위 밖이라 server.ts/actions.ts는 만들지 않음(소비자 없는 레이어 미리 안 만듦)
- `getMockActor()`/`getViewer()`는 안 건드림 — 계속 OWNER 고정, Leader/Member 분기는 다음
  PR에서 실제 로직 + 단위테스트로 검증

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수
- [x] `Closes #` 기입
- [x] console·주석코드 없음
- [x] 민감 정보 없음

**Z 필수**

- [x] 🔐 권한 2축 — 화면·액션 없는 순수 타입/데이터 모델 작업이라 해당 없음(다음 PR에서 실제 검사 붙음)
- [ ] 🧬 zod — 미사용(기존 rooms 패턴과 동일하게 순수 함수/타입 검증)
- [x] 🕵️ 정직성 — Meeting mock이 "BE 연동 전"임을 주석에 명시
- [x] 🎨 디자인 토큰 — 해당 없음(화면 없음)

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [ ] ♿ a11y — 해당 없음(화면 없음)
- [x] ♻️ 재사용 확인 — `mock/reservations.ts`의 globalThis 스토어 트릭 재사용
- [ ] 🧪 loading/error/empty — 해당 없음(화면 없음)
- [ ] 브라우저 전용 API — 해당 없음

---

## 🔗 연관 이슈

Closes #210 

---

## 📸 스크린샷 (선택)

해당 없음 — 화면 변경 없음

---

## 💬 리뷰 포인트

- `Meeting`에 `server.ts`/`actions.ts` 없이 타입+mock만 두는 게 맞는 판단인지(다음 PR에서
  rooms의 `actions.ts`가 `addMockMeeting`을 직접 부르는 방식, 기존 `TOP_LEVEL_PROJECTS` 직접
  참조 패턴과 동일)
- `teamName`과 기존 `teamId`가 같은 개념처럼 보이는데 실제로는 매핑이 없다는 점 — 팀
  registry가 나중에 생기면 이 필드를 어떻게 정리할지

---

## 📝 추가 메모

`npx jest`(전체 65개 스위트, 727개) · `npx tsc --noEmit` · `npx eslint` 전부 통과 확인함.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 회의 정보를 생성하고 목록에서 확인할 수 있는 기능을 추가했습니다.
  * 회의 안건, 프로젝트, 회의실, 참석자, 주최 권한 및 예약 정보를 관리할 수 있습니다.
  * 팀 액션과 연결된 회의 정보를 보존하고 조회할 수 있습니다.
  * 회의 생성 시 식별자와 생성 시간이 자동으로 기록됩니다.
  * 팀 이름을 활용한 권한 및 도메인 매칭 정보를 지원합니다.

* **테스트**
  * 회의 생성, 조회, 목록 반영 및 잘못된 식별자 처리에 대한 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->