### PR TITLE
[FEAT] 회의실 예약 스펙 정합화 — 안건 자유입력·프로젝트 필수·상위 팀 액션·회의 동시 생성 #212

### DIFF
--- a/src/app/(shell)/app/rooms/page.tsx
+++ b/src/app/(shell)/app/rooms/page.tsx
@@ -6,8 +6,10 @@ import {
   getMeetingRooms,
   getReservableMembers,
   getReservableProjects,
+  getReservableTeamActions,
   getWeekReservations,
 } from "@/features/rooms/server";
+import { getViewer } from "@/features/shell/viewer";
 
 export const metadata: Metadata = {
   title: "회의실",
@@ -31,11 +33,15 @@ export default async function RoomsPage({ searchParams }: RoomsPageProps) {
   const { week: weekParam } = await searchParams;
   const week = parseWeekParam(weekParam);
 
-  const [reservations, rooms, members, projects] = await Promise.all([
+  // ⚠️ 팀 액션 목록은 지금 보고 있는 사람이 누구인지(권한·소속 팀)에 따라 달라져서 먼저 받는다.
+  const viewer = await getViewer();
+
+  const [reservations, rooms, members, projects, teamActions] = await Promise.all([
     getWeekReservations(week),
     getMeetingRooms(),
     getReservableMembers(),
     getReservableProjects(),
+    getReservableTeamActions(viewer),
   ]);
 
   return (
@@ -47,6 +53,8 @@ export default async function RoomsPage({ searchParams }: RoomsPageProps) {
           rooms={rooms}
           members={members}
           projects={projects}
+          hostAuthority={viewer.role}
+          teamActions={teamActions}
           week={format(week, "yyyy-MM-dd")}
         />
       </div>

--- a/src/constants/meeting.ts
+++ b/src/constants/meeting.ts
@@ -60,46 +60,8 @@ export const MEETING_INVITE_STATUS_LABEL: Record<MeetingInviteStatus, string> = 
   DECLINED: "불참",
 };
 
-/**
- * 회의 주제 대분류 — 회의실 예약 폼의 "회의 주제"(대주제→소주제) 선택에 쓴다.
- * ⚠️ 미확정 목업이다 — 회의 도메인 담당자 문서를 받으면 이 파일부터 맞춘다(CLAUDE.md §연동 검증).
- */
-export const MEETING_TOPIC_MAIN = {
-  PRODUCT: "PRODUCT",
-  MARKETING: "MARKETING",
-  INFRA: "INFRA",
-  TEAM: "TEAM",
-} as const;
-export type MeetingTopicMain = (typeof MEETING_TOPIC_MAIN)[keyof typeof MEETING_TOPIC_MAIN];
-
-export const MEETING_TOPIC_MAIN_LABEL: Record<MeetingTopicMain, string> = {
-  PRODUCT: "제품",
-  MARKETING: "마케팅",
-  INFRA: "인프라",
-  TEAM: "팀 운영",
-};
-
-export interface MeetingTopicSub {
-  value: string;
-  label: string;
-}
-
-/** 대주제별 소주제 목록 — 대주제를 고르면 이 목록으로 소주제 select가 갈린다. */
-export const MEETING_TOPIC_SUB: Record<MeetingTopicMain, MeetingTopicSub[]> = {
-  PRODUCT: [
-    { value: "ROADMAP_REVIEW", label: "로드맵 검토" },
-    { value: "FEATURE_PLANNING", label: "기능 기획" },
-  ],
-  MARKETING: [
-    { value: "CHANNEL_STRATEGY", label: "채널 전략" },
-    { value: "CAMPAIGN_REVIEW", label: "캠페인 리뷰" },
-  ],
-  INFRA: [
-    { value: "MIGRATION_REVIEW", label: "마이그레이션 리뷰" },
-    { value: "INCIDENT_RETRO", label: "장애 회고" },
-  ],
-  TEAM: [
-    { value: "WEEKLY_SYNC", label: "위클리 싱크" },
-    { value: "ONE_ON_ONE", label: "1:1" },
-  ],
-};
+/*
+  ⚠️ 회의 주제(대주제/소주제) 고정 enum은 여기 없다(2026-08-07 제거) — WORKFLOW.md §3-1
+     확정: "대주제 1개+소주제 1개 필수, 나머지는 추가/삭제 버튼으로 늘리고 줄이는" **자유 입력
+     텍스트**다. 타입은 `features/rooms/types.ts`의 `MeetingTopicInput`(자유 텍스트 쌍)을 본다.
+*/

--- a/src/features/meeting/mock/meetings.test.ts
+++ b/src/features/meeting/mock/meetings.test.ts
@@ -1,0 +1,49 @@
+import { AUTHORITY } from "@/constants/authority";
+
+import type { MeetingDraft } from "../types";
+import { addMockMeeting, findMockMeeting, listMockMeetings } from "./meetings";
+
+const DRAFT: MeetingDraft = {
+  title: "8월 킥오프 미팅",
+  start: new Date("2026-08-11T13:00:00"),
+  end: new Date("2026-08-11T13:30:00"),
+  roomId: "room-large",
+  roomName: "대회의실",
+  projectId: 1,
+  projectTag: "GOODS",
+  topics: [{ main: "제품", sub: "킥오프" }],
+  attendeeIds: [1, 2, 3],
+  hostId: 1,
+  hostAuthority: AUTHORITY.OWNER,
+  roomReservationId: "reservation-1",
+};
+
+describe("회의 mock 스토어", () => {
+  it("회의를 추가하면 id·생성시각을 채워 목록에 반영된다", () => {
+    const before = listMockMeetings().length;
+
+    const created = addMockMeeting(DRAFT);
+
+    expect(created.id).toBeDefined();
+    expect(created.createdAt).toBeDefined();
+    expect(created.title).toBe("8월 킥오프 미팅");
+    expect(listMockMeetings()).toHaveLength(before + 1);
+    expect(findMockMeeting(created.id)).toEqual(created);
+  });
+
+  it("팀 액션 회의는 parentTeamActionId·hostTeamId를 그대로 담는다", () => {
+    const created = addMockMeeting({
+      ...DRAFT,
+      hostAuthority: AUTHORITY.LEADER,
+      hostTeamId: 7,
+      parentTeamActionId: 2,
+    });
+
+    expect(created.parentTeamActionId).toBe(2);
+    expect(created.hostTeamId).toBe(7);
+  });
+
+  it("없는 id는 조회 시 null을 돌려준다", () => {
+    expect(findMockMeeting("존재하지-않음")).toBeNull();
+  });
+});

--- a/src/features/meeting/mock/meetings.ts
+++ b/src/features/meeting/mock/meetings.ts
@@ -1,0 +1,42 @@
+import type { Meeting, MeetingDraft } from "../types";
+
+/**
+ * ⚠️ 목 데이터 — BE 연동 전. 지금은 `/app/rooms` 예약 액션이 이 스토어를 직접 채운다
+ * (`rooms/actions.ts`가 `TOP_LEVEL_PROJECTS`를 직접 참조하는 것과 같은 이유 — 아직
+ * `/app/meeting` 쪽 서버·액션 레이어가 없어서 격리막을 통째로 만들 소비자가 없다.
+ * `/app/meeting`이 생기면 그때 `meeting/server.ts`가 이 스토어 앞을 막는다).
+ * ⚠️ 상태를 `globalThis`에 매단다 — dev의 HMR로 `let`이 초기화되면 방금 만든 회의가 사라진다
+ *    (`rooms/mock/reservations.ts`와 같은 트릭).
+ */
+interface MeetingStore {
+  meetings: Meeting[];
+  sequence: number;
+}
+
+const globalStore = globalThis as typeof globalThis & {
+  __meetingStore?: MeetingStore;
+};
+const store: MeetingStore = (globalStore.__meetingStore ??= { meetings: [], sequence: 0 });
+
+export function listMockMeetings(): Meeting[] {
+  return store.meetings;
+}
+
+export function findMockMeeting(id: string): Meeting | null {
+  return store.meetings.find((meeting) => meeting.id === id) ?? null;
+}
+
+/**
+ * 회의 생성 — 회의실 예약과 짝지어 항상 같이 만들어진다(WORKFLOW.md §3-1).
+ * ⚠️ 여기서 참조 무결성(roomId·projectId·attendeeIds 존재 여부)을 다시 보지 않는다 —
+ *    호출부(`rooms/actions.ts`)가 예약을 검증할 때 이미 확인했다.
+ */
+export function addMockMeeting(draft: MeetingDraft): Meeting {
+  const meeting: Meeting = {
+    ...draft,
+    id: `meeting-${++store.sequence}`,
+    createdAt: new Date().toISOString(),
+  };
+  store.meetings = [...store.meetings, meeting];
+  return meeting;
+}

--- a/src/features/meeting/types.ts
+++ b/src/features/meeting/types.ts
@@ -1,0 +1,47 @@
+/**
+ * 회의(Meeting) — 격리막의 UI 계약(CLAUDE.md §Mock 격리막).
+ * ⚠️ **최소 스캐폴딩이다.** `/app/meeting`(목록·상세·캡처·AI 리뷰)은 별도 이슈다 — 지금은
+ *    회의실 예약이 만드는 레코드 하나만 담는다(WORKFLOW.md §3-1: "회의실 예약 = 회의 개설"이
+ *    하나의 동작이라, 예약만 저장하고 회의를 안 만들면 스펙과 어긋난다).
+ */
+
+import type { Authority } from "@/constants/authority";
+
+/** 회의 안건 대주제/소주제 한 쌍 — 자유 입력 텍스트다(고정 enum 아님, WORKFLOW.md §3-1). */
+export interface MeetingTopic {
+  main: string;
+  sub: string;
+}
+
+/**
+ * 회의 한 건.
+ * ⚠️ **프로젝트 태그는 항상 필수다**(WORKFLOW.md §3-1) — 프로젝트에 안 묶인 회의는 없다.
+ * ⚠️ `parentTeamActionId`는 **Host가 Owner가 아닐 때만** 있다(= 팀 액션 회의). Host가
+ *    Owner면 프로젝트 회의라 이 필드가 없다(WORKFLOW.md §3-1 "상위 팀 액션 노출 조건").
+ */
+export interface Meeting {
+  id: string;
+  title: string;
+  start: Date;
+  end: Date;
+  roomId: string;
+  roomName: string;
+  projectId: number;
+  projectTag: string;
+  /** 최소 1쌍(대주제+소주제) — 나머지는 "추가/삭제"로 늘고 준다. */
+  topics: MeetingTopic[];
+  attendeeIds: number[];
+  /** 개설자 — 회의 조작 권한의 기준(권한 ②축, `lib/permission.ts`의 `canOperateMeeting`). */
+  hostId: number;
+  hostAuthority: Authority;
+  /** Host의 소속 팀 — 팀 액션 회의의 상세 열람 범위 판정(`lib/permission.ts`의 `hostTeamId`)에 쓴다. */
+  hostTeamId?: number;
+  parentTeamActionId?: number;
+  /** 이 회의를 만든 예약 — 같은 동작이라 항상 있다(WORKFLOW.md §3-1). */
+  roomReservationId: string;
+  /** ISO datetime — 서버 기준 생성 시각. */
+  createdAt: string;
+}
+
+/** 회의 생성 입력 — id·createdAt은 서버(mock 스토어)가 채운다. */
+export type MeetingDraft = Omit<Meeting, "id" | "createdAt">;

--- a/src/features/rooms/accent-color.ts
+++ b/src/features/rooms/accent-color.ts
@@ -1,6 +1,10 @@
 import { type PaletteColor, pickPaletteColor } from "@/lib/palette";
 
-/** 프로젝트에 안 묶인 예약(예: 팀 위클리 싱크)의 중립색 — `RoomReservationEvent`의 기본값으로도 쓴다. */
+/**
+ * `RoomReservationEvent`의 기본값 — prop이 비어 오는 순간(예: dev HMR)에도 화면 전체가
+ * 죽는 것보다 중립색으로라도 그리는 쪽을 택한다. 프로젝트 태그는 이제 항상 있어서
+ * (WORKFLOW.md §3-1) 정상 흐름에서는 이 색이 실제로 쓰일 일이 없다.
+ */
 export const NEUTRAL_ACCENT_COLOR: PaletteColor = {
   bgColor: "var(--secondary)",
   textColor: "var(--muted-foreground)",

--- a/src/features/rooms/actions.test.ts
+++ b/src/features/rooms/actions.test.ts
@@ -2,8 +2,8 @@
 jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
 // isMock은 NEXT_PUBLIC_USE_MOCK 환경변수로 정해진다 — 테스트가 환경에 휘둘리지 않게 고정한다.
 jest.mock("@/mocks/config", () => ({ isMock: true }));
-// 기본은 실제 getMockActor()와 같은 값(OWNER, Admin 아님) — 회의실 관리 권한 테스트에서만
-// Admin 겸직 액터로 덮어쓴다(`canManageRooms`는 Admin 겸직자 전용이라 OWNER로는 절대 못 지나간다).
+// 기본은 실제 getMockActor()와 같은 값(OWNER, Admin 아님) — 회의실 관리·상위 팀 액션 권한
+// 테스트에서만 다른 역할·팀의 액터로 덮어쓴다.
 jest.mock("@/lib/mock-actor", () => ({
   getMockActor: jest.fn(() => ({ id: 1, role: "OWNER" })),
 }));
@@ -27,14 +27,22 @@ const VALID_ENTRIES: Record<string, string> = {
   date: "2026-08-11",
   startTime: "13:00",
   projectId: "1", // TOP_LEVEL_PROJECTS의 GOODS(id=1) — 실존 프로젝트여야 통과한다
-  topicMain: "PRODUCT",
-  topicSub: "ROADMAP_REVIEW",
 };
 
-const form = (entries: Record<string, string>, attendeeIds: number[] = [1]) => {
+const DEFAULT_TOPICS = [{ main: "제품", sub: "로드맵 검토" }];
+
+const form = (
+  entries: Record<string, string>,
+  attendeeIds: number[] = [1],
+  topics: { main: string; sub: string }[] = DEFAULT_TOPICS,
+) => {
   const data = new FormData();
   for (const [key, value] of Object.entries(entries)) data.append(key, value);
   for (const id of attendeeIds) data.append("attendeeIds", String(id));
+  for (const topic of topics) {
+    data.append("topicMain", topic.main);
+    data.append("topicSub", topic.sub);
+  }
   return data;
 };
 
@@ -106,13 +114,14 @@ describe("회의실 추가·수정", () => {
   });
 });
 
-describe("회의실 예약 생성", () => {
+describe("회의실 예약 생성 (Owner 개설 = 프로젝트 회의)", () => {
   it("필수값이 다 있으면 성공하고 생성값을 돌려준다", async () => {
     const result = await createRoomReservationAction({ errors: {} }, form(VALID_ENTRIES));
 
     expect(result.errors).toEqual({});
     expect(result.created?.title).toBe("새 회의");
     expect(result.created?.roomName).toBe("소회의실 B");
+    expect(result.created?.projectTag).toBe("GOODS");
     expect(revalidatePathMock).toHaveBeenCalledWith("/app/rooms");
   });
 
@@ -158,15 +167,52 @@ describe("회의실 예약 생성", () => {
     expect(result.created).toBeDefined();
   });
 
-  it("프로젝트 없이도 생성된다(예: 팀 위클리 싱크 같은 예약)", async () => {
+  it("프로젝트를 안 넣으면 막는다(WORKFLOW.md §3-1: 항상 필수)", async () => {
     const result = await createRoomReservationAction(
       { errors: {} },
       form({ ...VALID_ENTRIES, projectId: "", date: "2026-08-14" }),
     );
 
+    expect(result.errors.projectId).toBe("프로젝트를 선택해 주세요");
+    expect(result.created).toBeUndefined();
+  });
+
+  it("안건을 안 넣으면 막는다", async () => {
+    const result = await createRoomReservationAction(
+      { errors: {} },
+      form({ ...VALID_ENTRIES, date: "2026-08-14" }, [1], []),
+    );
+
+    expect(result.errors.topics).toBeDefined();
+    expect(result.created).toBeUndefined();
+  });
+
+  it("안건을 여러 쌍 넣으면 전부 저장된다", async () => {
+    const result = await createRoomReservationAction(
+      { errors: {} },
+      form(
+        { ...VALID_ENTRIES, date: "2026-08-14" },
+        [1],
+        [
+          { main: "제품", sub: "로드맵 검토" },
+          { main: "마케팅", sub: "캠페인 리뷰" },
+        ],
+      ),
+    );
+
+    expect(result.created?.topics).toEqual([
+      { main: "제품", sub: "로드맵 검토" },
+      { main: "마케팅", sub: "캠페인 리뷰" },
+    ]);
+  });
+
+  it("Owner는 상위 팀 액션 없이도 통과한다", async () => {
+    const result = await createRoomReservationAction(
+      { errors: {} },
+      form({ ...VALID_ENTRIES, date: "2026-08-14", startTime: "09:00" }),
+    );
+
     expect(result.errors).toEqual({});
-    expect(result.created?.projectId).toBeUndefined();
-    expect(result.created?.projectTag).toBeUndefined();
   });
 
   it("폼이 조작돼 존재하지 않는 회의실 id가 오면 막는다", async () => {
@@ -182,7 +228,7 @@ describe("회의실 예약 생성", () => {
   it("폼이 조작돼 존재하지 않는 프로젝트 id가 오면 막는다", async () => {
     const result = await createRoomReservationAction(
       { errors: {} },
-      form({ ...VALID_ENTRIES, projectId: "p-does-not-exist", date: "2026-08-15" }),
+      form({ ...VALID_ENTRIES, projectId: "999", date: "2026-08-15" }),
     );
 
     expect(result.errors.projectId).toBe("존재하지 않는 프로젝트예요");
@@ -199,31 +245,69 @@ describe("회의실 예약 생성", () => {
     expect(result.created).toBeUndefined();
   });
 
-  it("폼이 조작돼 대주제·소주제 조합이 안 맞으면 막는다", async () => {
-    const result = await createRoomReservationAction(
-      { errors: {} },
-      form({
-        ...VALID_ENTRIES,
-        date: "2026-08-15",
-        topicMain: "PRODUCT",
-        topicSub: "CHANNEL_STRATEGY",
-      }),
-    );
-
-    expect(result.errors.topicSub).toBe("대주제와 맞지 않는 소주제예요");
-    expect(result.created).toBeUndefined();
-  });
-
   it("폼이 조작돼 참석자 값이 숫자가 아니면 막는다", async () => {
     const data = new FormData();
     for (const [key, value] of Object.entries({ ...VALID_ENTRIES, date: "2026-08-15" })) {
       data.append(key, value);
     }
     data.append("attendeeIds", "not-a-number");
+    data.append("topicMain", "제품");
+    data.append("topicSub", "로드맵 검토");
 
     const result = await createRoomReservationAction({ errors: {} }, data);
 
     expect(result.errors.attendeeIds).toBe("참석자 값이 올바르지 않아요");
+    expect(result.created).toBeUndefined();
+  });
+});
+
+describe("회의실 예약 생성 (Leader 개설 = 팀 액션 회의)", () => {
+  const LEADER = { id: 5, role: "LEADER", teamId: 7, teamName: "개발팀" };
+
+  beforeEach(() => {
+    getMockActorMock.mockReturnValue(LEADER);
+  });
+
+  it("상위 팀 액션 없이 제출하면 막는다", async () => {
+    const result = await createRoomReservationAction(
+      { errors: {} },
+      form({ ...VALID_ENTRIES, date: "2026-08-16" }),
+    );
+
+    expect(result.errors.parentTeamActionId).toBe("상위 팀 액션을 선택해 주세요");
+    expect(result.created).toBeUndefined();
+  });
+
+  it("자기 팀의 진짜 팀 액션이면 통과하고, 회의에도 그대로 담긴다", async () => {
+    // projectId=1(GOODS)의 팀 액션 id=1("앱 개발 착수")은 team-actions 목데이터상 "개발팀" 소속이다.
+    const result = await createRoomReservationAction(
+      { errors: {} },
+      form({ ...VALID_ENTRIES, date: "2026-08-16", parentTeamActionId: "1" }),
+    );
+
+    expect(result.errors).toEqual({});
+    expect(result.created).toBeDefined();
+  });
+
+  it("다른 팀 소속 팀 액션 id를 끼워 넣으면 막는다(폼 조작 방어)", async () => {
+    // id=3("TV 광고 계약 및 모델 섭외")은 GOODS 프로젝트 소속이지만 팀은 "마케팅팀"이다.
+    const result = await createRoomReservationAction(
+      { errors: {} },
+      form({ ...VALID_ENTRIES, date: "2026-08-16", parentTeamActionId: "3" }),
+    );
+
+    expect(result.errors.parentTeamActionId).toBe("존재하지 않는 상위 팀 액션이에요");
+    expect(result.created).toBeUndefined();
+  });
+
+  it("다른 프로젝트 소속 팀 액션 id를 끼워 넣으면 막는다", async () => {
+    // id=7("협업툴 리뉴얼 착수")은 "개발팀" 소속이지만 COLLAB 프로젝트다 — 지금 고른 프로젝트는 GOODS(1).
+    const result = await createRoomReservationAction(
+      { errors: {} },
+      form({ ...VALID_ENTRIES, date: "2026-08-16", parentTeamActionId: "7" }),
+    );
+
+    expect(result.errors.parentTeamActionId).toBe("존재하지 않는 상위 팀 액션이에요");
     expect(result.created).toBeUndefined();
   });
 });

--- a/src/features/rooms/actions.ts
+++ b/src/features/rooms/actions.ts
@@ -2,7 +2,9 @@
 
 import { revalidatePath } from "next/cache";
 
+import { AUTHORITY } from "@/constants/authority";
 import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
+import { PROJECT_TEAM_ACTIONS_MOCK } from "@/features/project/mock/team-actions";
 import { getMockActor } from "@/lib/mock-actor";
 import { canManageRooms } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
@@ -14,6 +16,7 @@ import type {
   MeetingRoom,
   MeetingRoomDraft,
   MeetingRoomFormErrors,
+  MeetingTopicInput,
   RoomReservation,
   RoomReservationDraft,
   RoomReservationFormErrors,
@@ -34,17 +37,23 @@ export interface RoomReservationFormState {
   created?: RoomReservation;
 }
 
+function readTopics(formData: FormData): MeetingTopicInput[] {
+  const mains = formData.getAll("topicMain");
+  const subs = formData.getAll("topicSub");
+  return mains.map((main, index) => ({ main: String(main), sub: String(subs[index] ?? "") }));
+}
+
 function readDraft(formData: FormData): RoomReservationDraft {
-  const projectId = formData.get("projectId");
+  const parentTeamActionId = formData.get("parentTeamActionId");
   return {
     title: String(formData.get("title") ?? ""),
     roomId: String(formData.get("roomId") ?? ""),
     date: String(formData.get("date") ?? ""),
     startTime: String(formData.get("startTime") ?? ""),
-    projectId: projectId ? String(projectId) : undefined,
-    topicMain: String(formData.get("topicMain") ?? ""),
-    topicSub: String(formData.get("topicSub") ?? ""),
+    projectId: String(formData.get("projectId") ?? ""),
+    topics: readTopics(formData),
     attendeeIds: formData.getAll("attendeeIds").map(Number),
+    parentTeamActionId: parentTeamActionId ? Number(parentTeamActionId) : undefined,
   };
 }
 
@@ -68,7 +77,8 @@ export async function createRoomReservationAction(
   formData: FormData,
 ): Promise<RoomReservationFormState> {
   const draft = readDraft(formData);
-  const errors = validateRoomReservationDraft(draft);
+  const actor = getMockActor();
+  const errors = validateRoomReservationDraft(draft, { authority: actor.role });
   if (Object.keys(errors).length > 0) return { errors };
 
   if (!isMock) {
@@ -81,14 +91,23 @@ export async function createRoomReservationAction(
   if (!findMockRoom(draft.roomId)) {
     return { errors: { roomId: "존재하지 않는 회의실이에요" } };
   }
-  if (
-    draft.projectId &&
-    !TOP_LEVEL_PROJECTS.some((project) => String(project.id) === draft.projectId)
-  ) {
+  const project = TOP_LEVEL_PROJECTS.find((item) => String(item.id) === draft.projectId);
+  if (!project) {
     return { errors: { projectId: "존재하지 않는 프로젝트예요" } };
   }
   if (draft.attendeeIds.some((id) => !findMockMember(id))) {
     return { errors: { attendeeIds: "존재하지 않는 참석자가 있어요" } };
+  }
+  // ⚠️ Owner가 아니면 "상위 팀 액션"이 필수인데, 그 값이 진짜 이 프로젝트 소속이고 **자기
+  //    팀**에 하달된 게 맞는지까지 다시 본다 — 화면이 이미 걸러 보여줘도, 폼은 조작될 수 있어서
+  //    다른 팀의 팀 액션 id를 끼워 넣으면 그 팀 몫으로 회의가 잡히는 걸 여기서 막는다.
+  if (actor.role !== AUTHORITY.OWNER && draft.parentTeamActionId !== undefined) {
+    const teamAction = PROJECT_TEAM_ACTIONS_MOCK[project.tag]?.find(
+      (item) => item.id === draft.parentTeamActionId,
+    );
+    if (!teamAction || teamAction.team !== actor.teamName) {
+      return { errors: { parentTeamActionId: "존재하지 않는 상위 팀 액션이에요" } };
+    }
   }
 
   const { start, end } = toReservedRange(draft);
@@ -99,8 +118,7 @@ export async function createRoomReservationAction(
     return { errors: { roomId: "그 시간에는 이미 예약된 회의실이에요" } };
   }
 
-  const actor = getMockActor();
-  const created = addMockReservation(draft, actor.id);
+  const created = addMockReservation(draft, actor);
   revalidatePath(ROOMS_PATH);
   return { errors: {}, created };
 }

--- a/src/features/rooms/components/meeting-topic-list.tsx
+++ b/src/features/rooms/components/meeting-topic-list.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { Plus, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+import type { MeetingTopicInput } from "../types";
+
+interface MeetingTopicListProps {
+  topics: MeetingTopicInput[];
+  onChange: (topics: MeetingTopicInput[]) => void;
+  error?: string;
+}
+
+const EMPTY_TOPIC: MeetingTopicInput = { main: "", sub: "" };
+
+/**
+ * 회의 안건(대주제/소주제) 입력 — **자유 텍스트**다, 고정 목록에서 고르지 않는다
+ * (WORKFLOW.md §3-1). 첫 쌍은 필수, "안건 추가"로 늘리고 각 줄의 X로 줄인다(첫 줄은 못 뺀다 —
+ * 최소 1쌍은 항상 있어야 한다).
+ */
+export function MeetingTopicList({ topics, onChange, error }: MeetingTopicListProps) {
+  function updateTopic(index: number, patch: Partial<MeetingTopicInput>) {
+    onChange(topics.map((topic, i) => (i === index ? { ...topic, ...patch } : topic)));
+  }
+
+  function removeTopic(index: number) {
+    onChange(topics.filter((_, i) => i !== index));
+  }
+
+  function addTopic() {
+    onChange([...topics, EMPTY_TOPIC]);
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label>회의 안건</Label>
+      <div className="flex flex-col gap-2">
+        {topics.map((topic, index) => (
+          // 안건 줄은 고유 id가 없고 순서만 의미가 있다 — index를 key로 쓴다.
+          <div key={index} className="flex items-center gap-2">
+            <Input
+              value={topic.main}
+              onChange={(event) => updateTopic(index, { main: event.target.value })}
+              placeholder="대주제"
+              aria-label={`안건 ${index + 1} 대주제`}
+              aria-invalid={Boolean(error)}
+              className="flex-1"
+            />
+            <Input
+              value={topic.sub}
+              onChange={(event) => updateTopic(index, { sub: event.target.value })}
+              placeholder="소주제"
+              aria-label={`안건 ${index + 1} 소주제`}
+              aria-invalid={Boolean(error)}
+              className="flex-1"
+            />
+            {topics.length > 1 && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                aria-label={`안건 ${index + 1} 삭제`}
+                onClick={() => removeTopic(index)}
+              >
+                <X aria-hidden />
+              </Button>
+            )}
+          </div>
+        ))}
+      </div>
+      {error && <p className="text-destructive text-xs">{error}</p>}
+      <Button type="button" variant="outline" size="xs" className="w-fit" onClick={addTopic}>
+        <Plus aria-hidden />
+        안건 추가
+      </Button>
+    </div>
+  );
+}

--- a/src/features/rooms/components/room-reservation-dialog.test.tsx
+++ b/src/features/rooms/components/room-reservation-dialog.test.tsx
@@ -1,9 +1,14 @@
 jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/lib/mock-actor", () => ({
+  getMockActor: jest.fn(() => ({ id: 1, role: "OWNER" })),
+}));
 
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import type { MeetingRoom, RoomMember, RoomProjectOption } from "../types";
+import { AUTHORITY } from "@/constants/authority";
+
+import type { MeetingRoom, RoomMember, RoomProjectOption, RoomTeamActionOption } from "../types";
 import { RoomReservationDialog } from "./room-reservation-dialog";
 
 const ROOMS: MeetingRoom[] = [
@@ -16,7 +21,8 @@ const ROOMS: MeetingRoom[] = [
   },
 ];
 const MEMBERS: RoomMember[] = [{ id: 1, name: "박대표" }];
-const PROJECTS: RoomProjectOption[] = [{ id: "p-goods", name: "굿즈 프로젝트", tag: "GOODS" }];
+const PROJECTS: RoomProjectOption[] = [{ id: "1", name: "굿즈 프로젝트", tag: "GOODS" }];
+const TEAM_ACTIONS: RoomTeamActionOption[] = [];
 
 const SLOT_START = new Date("2026-08-11T10:00:00");
 
@@ -30,6 +36,8 @@ function renderDialog(overrides: Partial<React.ComponentProps<typeof RoomReserva
       rooms={ROOMS}
       members={MEMBERS}
       projects={PROJECTS}
+      hostAuthority={AUTHORITY.OWNER}
+      teamActions={TEAM_ACTIONS}
       onCreated={onCreated}
       {...overrides}
     />,
@@ -46,6 +54,8 @@ describe("RoomReservationDialog", () => {
         rooms={ROOMS}
         members={MEMBERS}
         projects={PROJECTS}
+        hostAuthority={AUTHORITY.OWNER}
+        teamActions={TEAM_ACTIONS}
         onCreated={jest.fn()}
       />,
     );
@@ -68,6 +78,18 @@ describe("RoomReservationDialog", () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
+  it("Owner가 열면 상위 팀 액션 필드가 없다", () => {
+    renderDialog({ hostAuthority: AUTHORITY.OWNER });
+
+    expect(screen.queryByText("상위 팀 액션")).not.toBeInTheDocument();
+  });
+
+  it("Leader가 열면 상위 팀 액션 필드가 뜬다", () => {
+    renderDialog({ hostAuthority: AUTHORITY.LEADER });
+
+    expect(screen.getByText("상위 팀 액션")).toBeInTheDocument();
+  });
+
   it("필수값을 안 채우고 등록을 누르면 필드별 오류를 보여주고 onCreated는 안 부른다", async () => {
     const user = userEvent.setup();
     const { onCreated } = renderDialog();
@@ -82,7 +104,15 @@ describe("RoomReservationDialog", () => {
       );
       expect(roomError).toBeInTheDocument();
     });
-    expect(screen.getByText("대주제를 선택해 주세요")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        (_content, element) =>
+          element?.tagName === "P" && element.textContent === "프로젝트를 선택해 주세요",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("회의 안건(대주제·소주제)을 한 쌍 이상 입력해 주세요"),
+    ).toBeInTheDocument();
     expect(screen.getByText("참석자를 한 명 이상 선택해 주세요")).toBeInTheDocument();
     expect(onCreated).not.toHaveBeenCalled();
   });

--- a/src/features/rooms/components/room-reservation-dialog.tsx
+++ b/src/features/rooms/components/room-reservation-dialog.tsx
@@ -11,8 +11,15 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import type { Authority } from "@/constants/authority";
 
-import type { MeetingRoom, RoomMember, RoomProjectOption, RoomReservation } from "../types";
+import type {
+  MeetingRoom,
+  RoomMember,
+  RoomProjectOption,
+  RoomReservation,
+  RoomTeamActionOption,
+} from "../types";
 import { RoomReservationFields } from "./room-reservation-fields";
 import { useRoomReservationForm } from "./use-room-reservation-form";
 
@@ -24,6 +31,9 @@ interface RoomReservationDialogProps {
   rooms: MeetingRoom[];
   members: RoomMember[];
   projects: RoomProjectOption[];
+  /** 지금 모달을 여는 사람의 권한 — Owner가 아니면 "상위 팀 액션" 필드가 뜬다(WORKFLOW.md §3-1). */
+  hostAuthority: Authority;
+  teamActions: RoomTeamActionOption[];
   /** 생성 성공 시 호출 — 재조회 없이 부모 화면에 바로 얹는다(§최적화: action 리턴값 그대로 반영). */
   onCreated: (created: RoomReservation) => void;
 }
@@ -41,9 +51,11 @@ export function RoomReservationDialog({
   rooms,
   members,
   projects,
+  hostAuthority,
+  teamActions,
   onCreated,
 }: RoomReservationDialogProps) {
-  const { state, isPending, form, setForm, topicSubOptions, handleOpenChange, handleSubmit } =
+  const { state, isPending, form, setForm, handleOpenChange, handleSubmit } =
     useRoomReservationForm({ slotStart, onCreated, onOpenChange });
 
   return (
@@ -64,7 +76,8 @@ export function RoomReservationDialog({
           rooms={rooms}
           members={members}
           projects={projects}
-          topicSubOptions={topicSubOptions}
+          hostAuthority={hostAuthority}
+          teamActions={teamActions}
         />
 
         <div className="mt-2 flex justify-end gap-2">

--- a/src/features/rooms/components/room-reservation-fields.tsx
+++ b/src/features/rooms/components/room-reservation-fields.tsx
@@ -11,16 +11,18 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { MEETING_TOPIC_MAIN_LABEL, type MeetingTopicSub } from "@/constants/meeting";
+import { AUTHORITY, type Authority } from "@/constants/authority";
 
 import type {
   MeetingRoom,
   RoomMember,
   RoomProjectOption,
   RoomReservationFormErrors,
+  RoomTeamActionOption,
 } from "../types";
+import { MeetingTopicList } from "./meeting-topic-list";
 import { RoomAttendeePicker } from "./room-attendee-picker";
-import { NO_PROJECT_VALUE, type RoomReservationFormValues } from "./use-room-reservation-form";
+import type { RoomReservationFormValues } from "./use-room-reservation-form";
 
 interface RoomReservationFieldsProps {
   form: RoomReservationFormValues;
@@ -29,10 +31,13 @@ interface RoomReservationFieldsProps {
   rooms: MeetingRoom[];
   members: RoomMember[];
   projects: RoomProjectOption[];
-  topicSubOptions: MeetingTopicSub[];
+  /** 지금 예약 모달을 여는 사람의 권한 — Owner가 아니면 "상위 팀 액션"이 뜬다(WORKFLOW.md §3-1). */
+  hostAuthority: Authority;
+  /** Host의 팀에 하달된 팀 액션 전체(프로젝트 무관) — 지금 고른 프로젝트로 화면에서 다시 거른다. */
+  teamActions: RoomTeamActionOption[];
 }
 
-/** 예약 모달의 입력 필드 전부 — 제목·회의실·프로젝트·대주제/소주제·참석자(`room-reservation-dialog.tsx`에서 뺀 조각). */
+/** 예약 모달의 입력 필드 전부 — 제목·회의실·프로젝트·안건·상위 팀 액션·참석자(`room-reservation-dialog.tsx`에서 뺀 조각). */
 export function RoomReservationFields({
   form,
   setForm,
@@ -40,8 +45,14 @@ export function RoomReservationFields({
   rooms,
   members,
   projects,
-  topicSubOptions,
+  hostAuthority,
+  teamActions,
 }: RoomReservationFieldsProps) {
+  const selectedProjectTag = projects.find((project) => project.id === form.projectId)?.tag;
+  const availableTeamActions = teamActions.filter(
+    (teamAction) => teamAction.projectTag === selectedProjectTag,
+  );
+
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-1.5">
@@ -85,14 +96,18 @@ export function RoomReservationFields({
         <Select
           value={form.projectId}
           onValueChange={(value) =>
-            setForm((prev) => ({ ...prev, projectId: value ?? NO_PROJECT_VALUE }))
+            // 프로젝트를 바꾸면 그 프로젝트 소속이 아닌 상위 팀 액션 선택은 의미가 없어진다.
+            setForm((prev) => ({ ...prev, projectId: value ?? "", parentTeamActionId: "" }))
           }
         >
-          <SelectTrigger id="reservation-project" className="w-full">
+          <SelectTrigger
+            id="reservation-project"
+            aria-invalid={Boolean(errors.projectId)}
+            className="w-full"
+          >
             <SelectValue placeholder="프로젝트를 선택해 주세요" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value={NO_PROJECT_VALUE}>없음</SelectItem>
             {projects.map((project) => (
               <SelectItem key={project.id} value={project.id}>
                 {project.name}
@@ -103,58 +118,46 @@ export function RoomReservationFields({
         {errors.projectId && <p className="text-destructive text-xs">{errors.projectId}</p>}
       </div>
 
-      <div className="grid grid-cols-2 gap-3">
+      {hostAuthority !== AUTHORITY.OWNER && (
         <div className="flex flex-col gap-1.5">
-          <Label htmlFor="reservation-topic-main">대주제</Label>
+          <Label htmlFor="reservation-parent-team-action">상위 팀 액션</Label>
           <Select
-            value={form.topicMain}
+            value={form.parentTeamActionId}
             onValueChange={(value) =>
-              setForm((prev) => ({ ...prev, topicMain: value ?? "", topicSub: "" }))
+              setForm((prev) => ({ ...prev, parentTeamActionId: value ?? "" }))
             }
+            disabled={!form.projectId}
           >
             <SelectTrigger
-              id="reservation-topic-main"
-              aria-invalid={Boolean(errors.topicMain)}
+              id="reservation-parent-team-action"
+              aria-invalid={Boolean(errors.parentTeamActionId)}
               className="w-full"
             >
-              <SelectValue placeholder="대주제" />
+              <SelectValue
+                placeholder={
+                  form.projectId ? "상위 팀 액션을 선택해 주세요" : "프로젝트를 먼저 선택해 주세요"
+                }
+              />
             </SelectTrigger>
             <SelectContent>
-              {Object.entries(MEETING_TOPIC_MAIN_LABEL).map(([value, label]) => (
-                <SelectItem key={value} value={value}>
-                  {label}
+              {availableTeamActions.map((teamAction) => (
+                <SelectItem key={teamAction.id} value={String(teamAction.id)}>
+                  {teamAction.name}
                 </SelectItem>
               ))}
             </SelectContent>
           </Select>
-          {errors.topicMain && <p className="text-destructive text-xs">{errors.topicMain}</p>}
+          {errors.parentTeamActionId && (
+            <p className="text-destructive text-xs">{errors.parentTeamActionId}</p>
+          )}
         </div>
+      )}
 
-        <div className="flex flex-col gap-1.5">
-          <Label htmlFor="reservation-topic-sub">소주제</Label>
-          <Select
-            value={form.topicSub}
-            onValueChange={(value) => setForm((prev) => ({ ...prev, topicSub: value ?? "" }))}
-            disabled={!form.topicMain}
-          >
-            <SelectTrigger
-              id="reservation-topic-sub"
-              aria-invalid={Boolean(errors.topicSub)}
-              className="w-full"
-            >
-              <SelectValue placeholder="소주제" />
-            </SelectTrigger>
-            <SelectContent>
-              {topicSubOptions.map((sub) => (
-                <SelectItem key={sub.value} value={sub.value}>
-                  {sub.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          {errors.topicSub && <p className="text-destructive text-xs">{errors.topicSub}</p>}
-        </div>
-      </div>
+      <MeetingTopicList
+        topics={form.topics}
+        onChange={(topics) => setForm((prev) => ({ ...prev, topics }))}
+        error={errors.topics}
+      />
 
       <div className="flex flex-col gap-1.5">
         <Label>참석자</Label>

--- a/src/features/rooms/components/rooms-board.tsx
+++ b/src/features/rooms/components/rooms-board.tsx
@@ -2,7 +2,15 @@
 
 import { useState } from "react";
 
-import type { MeetingRoom, RoomMember, RoomProjectOption, RoomReservation } from "../types";
+import type { Authority } from "@/constants/authority";
+
+import type {
+  MeetingRoom,
+  RoomMember,
+  RoomProjectOption,
+  RoomReservation,
+  RoomTeamActionOption,
+} from "../types";
 import { RoomListPanel } from "./room-list-panel";
 import { RoomReservationDialog } from "./room-reservation-dialog";
 import { WeeklyRoomCalendarLoader } from "./weekly-room-calendar-loader";
@@ -12,6 +20,8 @@ interface RoomsBoardProps {
   rooms: MeetingRoom[];
   members: RoomMember[];
   projects: RoomProjectOption[];
+  hostAuthority: Authority;
+  teamActions: RoomTeamActionOption[];
   /** "YYYY-MM-DD" — 이 주의 월요일. 서버 컴포넌트가 이 주 기준으로 `initialReservations`를 내려준다. */
   week: string;
 }
@@ -29,6 +39,8 @@ export function RoomsBoard({
   rooms,
   members,
   projects,
+  hostAuthority,
+  teamActions,
   week,
 }: RoomsBoardProps) {
   const [reservations, setReservations] = useState(initialReservations);
@@ -50,6 +62,8 @@ export function RoomsBoard({
         rooms={rooms}
         members={members}
         projects={projects}
+        hostAuthority={hostAuthority}
+        teamActions={teamActions}
         onCreated={(created) => setReservations((prev) => [...prev, created])}
       />
     </div>

--- a/src/features/rooms/components/use-room-reservation-form.ts
+++ b/src/features/rooms/components/use-room-reservation-form.ts
@@ -4,22 +4,21 @@ import { format } from "date-fns";
 import { useActionState, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
-import { MEETING_TOPIC_SUB, type MeetingTopicMain } from "@/constants/meeting";
-
 import { createRoomReservationAction, type RoomReservationFormState } from "../actions";
-import type { RoomReservation } from "../types";
-
-export const NO_PROJECT_VALUE = "__none__";
+import type { MeetingTopicInput, RoomReservation } from "../types";
 
 const INITIAL_STATE: RoomReservationFormState = { errors: {} };
+
+const EMPTY_TOPIC: MeetingTopicInput = { main: "", sub: "" };
 
 const EMPTY_FORM = {
   title: "",
   roomId: "",
-  projectId: NO_PROJECT_VALUE,
-  topicMain: "",
-  topicSub: "",
+  projectId: "",
+  topics: [EMPTY_TOPIC] as MeetingTopicInput[],
   attendeeIds: [] as number[],
+  /** Select 값은 문자열이라 여기서도 문자열로 든다 — 없으면 빈 문자열("Owner 개설"이거나 아직 안 골랐을 때). */
+  parentTeamActionId: "",
 };
 
 export type RoomReservationFormValues = typeof EMPTY_FORM;
@@ -35,6 +34,8 @@ interface UseRoomReservationFormOptions {
  * (CLAUDE.md §폴더·네이밍: 로직=커스텀훅).
  * ⚠️ shadcn `Select`는 네이티브 `<select>`가 아니라 `FormData`에 자동으로 안 실린다 —
  *    `add-todo-dialog.tsx`와 같은 방식으로 상태를 들고 있다가 제출 시 직접 `FormData`를 만든다.
+ * ⚠️ 회의 안건(`topics`)은 (대주제, 소주제) 자유 텍스트 쌍의 배열이다 — `topicMain`/`topicSub`를
+ *    같은 순서로 반복 추가해서 넘기고, 서버(`readTopics`, `actions.ts`)가 인덱스로 다시 짝짓는다.
  */
 export function useRoomReservationForm({
   slotStart,
@@ -69,23 +70,21 @@ export function useRoomReservationForm({
     formData.set("roomId", form.roomId);
     formData.set("date", format(slotStart, "yyyy-MM-dd"));
     formData.set("startTime", format(slotStart, "HH:mm"));
-    if (form.projectId !== NO_PROJECT_VALUE) formData.set("projectId", form.projectId);
-    formData.set("topicMain", form.topicMain);
-    formData.set("topicSub", form.topicSub);
+    formData.set("projectId", form.projectId);
+    for (const topic of form.topics) {
+      formData.append("topicMain", topic.main);
+      formData.append("topicSub", topic.sub);
+    }
+    if (form.parentTeamActionId) formData.set("parentTeamActionId", form.parentTeamActionId);
     for (const id of form.attendeeIds) formData.append("attendeeIds", String(id));
     formAction(formData);
   }
-
-  const topicSubOptions = form.topicMain
-    ? (MEETING_TOPIC_SUB[form.topicMain as MeetingTopicMain] ?? [])
-    : [];
 
   return {
     state,
     isPending,
     form,
     setForm,
-    topicSubOptions,
     handleOpenChange,
     handleSubmit,
   };

--- a/src/features/rooms/mock/reservations.test.ts
+++ b/src/features/rooms/mock/reservations.test.ts
@@ -1,3 +1,7 @@
+import { AUTHORITY } from "@/constants/authority";
+import { listMockMeetings } from "@/features/meeting/mock/meetings";
+import type { Actor } from "@/lib/permission";
+
 import {
   addMockReservation,
   findMockReservation,
@@ -11,24 +15,25 @@ const DRAFT = {
   date: "2026-08-10",
   startTime: "10:30",
   projectId: "1", // TOP_LEVEL_PROJECTS의 GOODS(id=1)
-  topicMain: "PRODUCT",
-  topicSub: "ROADMAP_REVIEW",
+  topics: [{ main: "제품", sub: "로드맵 검토" }],
   attendeeIds: [1, 2],
 };
+
+const OWNER: Actor = { id: 3, role: AUTHORITY.OWNER };
+const LEADER: Actor = { id: 5, role: AUTHORITY.LEADER, teamId: 7, teamName: "개발팀" };
 
 describe("회의실 예약 mock 스토어", () => {
   it("시드 데이터가 회의실별로 최소 한 건씩 있다", () => {
     expect(listMockReservationsByRoom("room-large").length).toBeGreaterThan(0);
   });
 
-  it("예약을 추가하면 앞뒤 공백을 지우고 회의실 이름·소주제 라벨·프로젝트 태그를 채운다", () => {
+  it("예약을 추가하면 앞뒤 공백을 지우고 회의실 이름·프로젝트 태그를 채운다", () => {
     const before = listMockReservations().length;
 
-    const created = addMockReservation(DRAFT, 3);
+    const created = addMockReservation(DRAFT, OWNER);
 
     expect(created.title).toBe("신규 회의");
     expect(created.roomName).toBe("소회의실 B");
-    expect(created.topicSub).toBe("로드맵 검토");
     expect(created.projectTag).toBe("GOODS");
     expect(created.ownerId).toBe(3);
     // 시작 10:30 + 고정 30분 = 종료 11:00
@@ -37,10 +42,28 @@ describe("회의실 예약 mock 스토어", () => {
     expect(findMockReservation(created.id)).toEqual(created);
   });
 
-  it("프로젝트에 안 묶인 예약은 projectTag 없이 만들어진다", () => {
-    const created = addMockReservation({ ...DRAFT, projectId: undefined }, 3);
-    expect(created.projectId).toBeUndefined();
-    expect(created.projectTag).toBeUndefined();
+  it("예약과 같이 회의(Meeting)도 만들어진다(WORKFLOW.md §3-1: 예약=회의 개설)", () => {
+    const before = listMockMeetings().length;
+
+    const created = addMockReservation(DRAFT, OWNER);
+
+    const meetings = listMockMeetings();
+    expect(meetings).toHaveLength(before + 1);
+    const meeting = meetings[meetings.length - 1];
+    expect(meeting?.roomReservationId).toBe(created.id);
+    expect(meeting?.hostId).toBe(OWNER.id);
+    expect(meeting?.hostAuthority).toBe(AUTHORITY.OWNER);
+    expect(meeting?.hostTeamId).toBeUndefined();
+  });
+
+  it("Leader가 만들면 회의에 hostTeamId가 담긴다", () => {
+    addMockReservation({ ...DRAFT, parentTeamActionId: 1 }, LEADER);
+
+    const meetings = listMockMeetings();
+    const meeting = meetings[meetings.length - 1];
+    expect(meeting?.hostAuthority).toBe(AUTHORITY.LEADER);
+    expect(meeting?.hostTeamId).toBe(7);
+    expect(meeting?.parentTeamActionId).toBe(1);
   });
 
   it("없는 id는 조회 시 null을 돌려준다", () => {

--- a/src/features/rooms/mock/reservations.ts
+++ b/src/features/rooms/mock/reservations.ts
@@ -1,5 +1,7 @@
-import { MEETING_TOPIC_SUB, type MeetingTopicMain } from "@/constants/meeting";
+import { AUTHORITY } from "@/constants/authority";
+import { addMockMeeting } from "@/features/meeting/mock/meetings";
 import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
+import type { Actor } from "@/lib/permission";
 
 import type { RoomReservation, RoomReservationDraft } from "../types";
 import { RESERVATION_DURATION_MINUTES } from "../validate";
@@ -20,6 +22,7 @@ interface ReservationStore {
  * 오늘(2026-08-06)이 속한 주(월 8/3~금 8/7) 기준 시드.
  * ⚠️ **회의는 예외 없이 30분 고정이다**(팀 확정, CLAUDE.md §브라우저 API) — 목 데이터도 이
  *    규칙을 그대로 지킨다. 90분·2시간짜리 목업을 두면 "30분 고정"이 화면에서부터 거짓말이 된다.
+ * ⚠️ **프로젝트 태그는 전부 채워져 있다**(WORKFLOW.md §3-1 확정 — 프로젝트 없는 예약은 없다).
  */
 const INITIAL: RoomReservation[] = [
   {
@@ -29,8 +32,9 @@ const INITIAL: RoomReservation[] = [
     end: new Date("2026-08-03T09:30:00"),
     roomId: "room-small-b",
     roomName: "소회의실 B",
-    topicMain: "TEAM",
-    topicSub: "위클리 싱크",
+    projectId: "1",
+    projectTag: "GOODS",
+    topics: [{ main: "팀 운영", sub: "위클리 싱크" }],
     attendeeIds: [1, 2, 3],
     ownerId: 1,
   },
@@ -43,8 +47,7 @@ const INITIAL: RoomReservation[] = [
     roomName: "대회의실",
     projectId: "2",
     projectTag: "BRAND",
-    topicMain: "MARKETING",
-    topicSub: "채널 전략",
+    topics: [{ main: "마케팅", sub: "채널 전략" }],
     attendeeIds: [1, 2, 3],
     ownerId: 2,
   },
@@ -57,8 +60,7 @@ const INITIAL: RoomReservation[] = [
     roomName: "대회의실",
     projectId: "1",
     projectTag: "GOODS",
-    topicMain: "PRODUCT",
-    topicSub: "로드맵 검토",
+    topics: [{ main: "제품", sub: "로드맵 검토" }],
     attendeeIds: [1, 2, 3, 4],
     ownerId: 1,
   },
@@ -71,8 +73,7 @@ const INITIAL: RoomReservation[] = [
     roomName: "소회의실 A",
     projectId: "3",
     projectTag: "COLLAB",
-    topicMain: "INFRA",
-    topicSub: "마이그레이션 리뷰",
+    topics: [{ main: "인프라", sub: "마이그레이션 리뷰" }],
     attendeeIds: [4, 5, 6],
     ownerId: 4,
   },
@@ -83,8 +84,9 @@ const INITIAL: RoomReservation[] = [
     end: new Date("2026-08-06T11:30:00"),
     roomId: "room-video",
     roomName: "화상회의실",
-    topicMain: "TEAM",
-    topicSub: "위클리 싱크",
+    projectId: "3",
+    projectTag: "COLLAB",
+    topics: [{ main: "팀 운영", sub: "위클리 싱크" }],
     attendeeIds: [2, 3, 7],
     ownerId: 2,
   },
@@ -111,18 +113,19 @@ export function findMockReservation(id: string): RoomReservation | null {
 }
 
 /**
- * 예약 생성 — 시작 시각 + 고정 30분으로 종료 시각을 계산하고, roomId/projectId/topicSub
- * 코드값을 표시용 이름·태그·라벨로 채워 넣는다(컴포넌트는 코드값을 모른다, §Mock 격리막).
- * ⚠️ 같은 회의실·시간대 중복 여부는 여기서 보지 않는다 — 호출부(`actions.ts`)가 먼저 확인한다.
+ * 예약 생성 — 시작 시각 + 고정 30분으로 종료 시각을 계산하고, roomId/projectId를 표시용
+ * 이름·태그로 채워 넣는다(컴포넌트는 코드값을 모른다, §Mock 격리막).
+ * ⚠️ **회의(Meeting)도 같이 만든다**(WORKFLOW.md §3-1: "회의실 예약 = 회의 개설"은 한 동작) —
+ *    `features/meeting/mock/meetings.ts`를 직접 부른다(그 도메인엔 아직 소비할 화면이 없어
+ *    server.ts 격리막이 없다, `rooms/actions.ts`가 `TOP_LEVEL_PROJECTS`를 직접 참조하는 것과
+ *    같은 이유).
+ * ⚠️ 참조 무결성(roomId/projectId/attendeeIds/parentTeamActionId 존재 여부)은 여기서 다시
+ *    안 본다 — 호출부(`actions.ts`)가 먼저 확인한 뒤에만 이 함수를 부른다.
  */
-export function addMockReservation(draft: RoomReservationDraft, ownerId: number): RoomReservation {
+export function addMockReservation(draft: RoomReservationDraft, actor: Actor): RoomReservation {
   const room = findMockRoom(draft.roomId);
   const start = new Date(`${draft.date}T${draft.startTime}:00`);
   const end = new Date(start.getTime() + RESERVATION_DURATION_MINUTES * 60_000);
-  const topicMain = draft.topicMain as MeetingTopicMain;
-  const topicSub =
-    MEETING_TOPIC_SUB[topicMain]?.find((sub) => sub.value === draft.topicSub)?.label ??
-    draft.topicSub;
   const project = TOP_LEVEL_PROJECTS.find((item) => String(item.id) === draft.projectId);
 
   const reservation: RoomReservation = {
@@ -133,12 +136,29 @@ export function addMockReservation(draft: RoomReservationDraft, ownerId: number)
     roomId: draft.roomId,
     roomName: room?.name ?? draft.roomId,
     projectId: draft.projectId,
-    projectTag: project?.tag,
-    topicMain,
-    topicSub,
+    projectTag: project?.tag ?? "",
+    topics: draft.topics.map((topic) => ({ main: topic.main.trim(), sub: topic.sub.trim() })),
     attendeeIds: draft.attendeeIds,
-    ownerId,
+    ownerId: actor.id,
   };
   store.reservations = [...store.reservations, reservation];
+
+  addMockMeeting({
+    title: reservation.title,
+    start: reservation.start,
+    end: reservation.end,
+    roomId: reservation.roomId,
+    roomName: reservation.roomName,
+    projectId: project?.id ?? 0,
+    projectTag: reservation.projectTag,
+    topics: reservation.topics,
+    attendeeIds: reservation.attendeeIds,
+    hostId: actor.id,
+    hostAuthority: actor.role,
+    hostTeamId: actor.role === AUTHORITY.OWNER ? undefined : actor.teamId,
+    parentTeamActionId: draft.parentTeamActionId,
+    roomReservationId: reservation.id,
+  });
+
   return reservation;
 }

--- a/src/features/rooms/server.ts
+++ b/src/features/rooms/server.ts
@@ -2,13 +2,22 @@ import "server-only";
 
 import { endOfWeek, startOfWeek } from "date-fns";
 
+import { AUTHORITY } from "@/constants/authority";
 import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
+import { PROJECT_TEAM_ACTIONS_MOCK } from "@/features/project/mock/team-actions";
+import type { Actor } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
 import { listMockMembers } from "./mock/members";
 import { listMockReservations } from "./mock/reservations";
 import { listMockRooms } from "./mock/rooms";
-import type { MeetingRoom, RoomMember, RoomProjectOption, RoomReservation } from "./types";
+import type {
+  MeetingRoom,
+  RoomMember,
+  RoomProjectOption,
+  RoomReservation,
+  RoomTeamActionOption,
+} from "./types";
 
 /**
  * 그 주(월요일 시작)와 겹치는 예약만 걸러 내려준다. 격리막(CLAUDE.md §Mock 격리막).
@@ -48,4 +57,24 @@ export async function getReservableProjects(): Promise<RoomProjectOption[]> {
     }));
   }
   throw new Error("프로젝트 목록 조회 API가 아직 연결되지 않았습니다.");
+}
+
+/**
+ * 예약 폼의 "상위 팀 액션" select용 — Host가 Owner면 빈 배열(그 필드가 아예 안 뜬다,
+ * WORKFLOW.md §3-1). Leader/Member면 **자기 팀**에 하달된 팀 액션만, 어느 프로젝트 것인지
+ * `projectTag`로 같이 내려줘 화면이 지금 고른 프로젝트로 다시 거른다.
+ */
+export async function getReservableTeamActions(actor: Actor): Promise<RoomTeamActionOption[]> {
+  if (!isMock) throw new Error("팀 액션 목록 조회 API가 아직 연결되지 않았습니다.");
+  if (actor.role === AUTHORITY.OWNER || !actor.teamName) return [];
+
+  const options: RoomTeamActionOption[] = [];
+  for (const [projectTag, teamActions] of Object.entries(PROJECT_TEAM_ACTIONS_MOCK)) {
+    for (const teamAction of teamActions) {
+      if (teamAction.team === actor.teamName) {
+        options.push({ id: teamAction.id, name: teamAction.name, projectTag });
+      }
+    }
+  }
+  return options;
 }

--- a/src/features/rooms/types.ts
+++ b/src/features/rooms/types.ts
@@ -3,8 +3,6 @@
  * 컴포넌트는 이 타입만 알고, 목/실서버 분기는 `server.ts`가 끝낸다.
  */
 
-import type { MeetingTopicMain } from "@/constants/meeting";
-
 /**
  * 회의실 한 곳.
  * ⚠️ **"수용 인원" 필드는 없다**(WORKFLOW.md §10-A 확정 — 전면 폐기). 화면·모달·데이터 구조
@@ -50,9 +48,26 @@ export interface RoomProjectOption {
 }
 
 /**
+ * 예약 폼의 "상위 팀 액션" select가 쓰는 경량 항목 — Host가 Owner가 아닐 때만 뜬다
+ * (WORKFLOW.md §3-1). `projectTag`로 지금 고른 프로젝트에 속한 것만 걸러 보여준다.
+ */
+export interface RoomTeamActionOption {
+  id: number;
+  name: string;
+  projectTag: string;
+}
+
+/** 회의 안건 대주제/소주제 한 쌍 — 자유 입력 텍스트다(고정 enum 아님, WORKFLOW.md §3-1). */
+export interface MeetingTopicInput {
+  main: string;
+  sub: string;
+}
+
+/**
  * 주간 캘린더 한 칸에 그려지는 예약 건. react-big-calendar의 start/end 접근자가 이 필드명을 그대로 쓴다.
  * ⚠️ 막대 색은 여기 없다 — `projectTag`를 화면에서 `pickPaletteColor`에 넘겨 그때 뽑는다
  *    (프로젝트 태그·아바타와 같은 팔레트, CLAUDE.md §디자인 토큰: 하드코딩 금지).
+ * ⚠️ 프로젝트 태그는 **항상 있다**(WORKFLOW.md §3-1 확정 — 프로젝트 없는 회의는 없다).
  */
 export interface RoomReservation {
   id: string;
@@ -61,12 +76,10 @@ export interface RoomReservation {
   end: Date;
   roomId: string;
   roomName: string;
-  /** 프로젝트에 안 묶인 예약도 있다(예: 팀 위클리 싱크) — 그럴 땐 중립색을 쓴다. */
-  projectId?: string;
-  projectTag?: string;
-  topicMain: MeetingTopicMain;
-  /** 소주제 라벨(한글) — 목록·상세 표시용으로 이미 라벨을 들고 있다. */
-  topicSub: string;
+  projectId: string;
+  projectTag: string;
+  /** 최소 1쌍 — 나머지는 폼에서 "추가/삭제"로 늘고 준다. */
+  topics: MeetingTopicInput[];
   attendeeIds: number[];
   /** 담당자 — 이 예약의 시간을 바꿀 수 있는 유일한 사람(권한 ②축, CLAUDE.md §권한). */
   ownerId: number;
@@ -76,6 +89,8 @@ export interface RoomReservation {
  * 회의실 예약 폼 입력 — 화면과 서버가 같은 스키마(`validate.ts`)로 검증한다.
  * ⚠️ 종료 시각은 입력받지 않는다 — 예약은 **30분 한 타임 고정**이라(팀 확정,
  *    CLAUDE.md §브라우저 API) 시작 시각만 받고 길이는 서버가 계산한다.
+ * ⚠️ "회의실 예약 = 회의 개설"이 한 동작이라(WORKFLOW.md §3-1) 이 드래프트가 회의 쪽 입력도
+ *    같이 들고 있다 — `parentTeamActionId`는 Host가 Owner가 아닐 때만 필수다.
  */
 export interface RoomReservationDraft {
   title: string;
@@ -84,12 +99,12 @@ export interface RoomReservationDraft {
   date: string;
   /** "HH:mm" — 30분 단위 슬롯의 시작 시각 */
   startTime: string;
-  projectId?: string;
-  /** MEETING_TOPIC_MAIN 코드값 */
-  topicMain: string;
-  /** MEETING_TOPIC_SUB[topicMain]의 value 코드값 */
-  topicSub: string;
+  /** 항상 필수다(WORKFLOW.md §3-1) — "프로젝트에 안 묶인 예약"은 없다. */
+  projectId: string;
+  topics: MeetingTopicInput[];
   attendeeIds: number[];
+  /** Host가 Leader/Member일 때만 필수 — 그 프로젝트 내 자기 팀에 하달된 팀 액션 중 하나. */
+  parentTeamActionId?: number;
 }
 
 export type RoomReservationFormErrors = Partial<Record<keyof RoomReservationDraft, string>>;

--- a/src/features/rooms/validate.test.ts
+++ b/src/features/rooms/validate.test.ts
@@ -1,92 +1,142 @@
+import { AUTHORITY } from "@/constants/authority";
+
 import { validateMeetingRoomDraft, validateRoomReservationDraft } from "./validate";
+
+const OWNER_HOST = { authority: AUTHORITY.OWNER };
+const LEADER_HOST = { authority: AUTHORITY.LEADER };
 
 const VALID_DRAFT = {
   title: "주간 싱크",
   roomId: "room-large",
   date: "2026-08-10",
   startTime: "10:00",
-  projectId: "p-goods",
-  topicMain: "PRODUCT",
-  topicSub: "ROADMAP_REVIEW",
+  projectId: "1",
+  topics: [{ main: "제품", sub: "로드맵 검토" }],
   attendeeIds: [1],
 };
 
 describe("회의실 예약 검증", () => {
   it("전부 채우면 통과한다", () => {
-    expect(validateRoomReservationDraft(VALID_DRAFT)).toEqual({});
+    expect(validateRoomReservationDraft(VALID_DRAFT, OWNER_HOST)).toEqual({});
   });
 
   it("제목이 비면 막는다", () => {
-    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, title: "   " });
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, title: "   " }, OWNER_HOST);
     expect(errors.title).toBe("회의 제목을 입력해 주세요");
   });
 
   it("회의실을 안 고르면 막는다", () => {
-    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, roomId: "" });
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, roomId: "" }, OWNER_HOST);
     expect(errors.roomId).toBeDefined();
   });
 
   it("날짜 형식이 아니면 막는다", () => {
-    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, date: "2026/08/10" });
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, date: "2026/08/10" }, OWNER_HOST);
     expect(errors.date).toBe("올바른 날짜가 아니에요");
   });
 
   it("존재하지 않는 날짜는 막는다", () => {
-    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, date: "2026-02-30" });
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, date: "2026-02-30" }, OWNER_HOST);
     expect(errors.date).toBe("올바른 날짜가 아니에요");
   });
 
   it("30분 단위가 아닌 시작 시각은 막는다", () => {
-    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, startTime: "10:15" });
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, startTime: "10:15" }, OWNER_HOST);
     expect(errors.startTime).toBe("예약은 30분 단위로만 가능해요");
   });
 
   it("운영 시작(09:00) 이전은 막는다", () => {
-    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, startTime: "08:30" });
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, startTime: "08:30" }, OWNER_HOST);
     expect(errors.startTime).toBe("회의실 운영 시간(09:00~18:00) 안에서 선택해 주세요");
   });
 
   it("30분을 더하면 운영 종료(18:00)를 넘는 시작 시각은 막는다", () => {
-    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, startTime: "17:45" });
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, startTime: "17:45" }, OWNER_HOST);
     expect(errors.startTime).toBeDefined();
   });
 
   it("운영 종료 딱 맞춰 끝나는 17:30 시작은 통과한다", () => {
-    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, startTime: "17:30" });
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, startTime: "17:30" }, OWNER_HOST);
     expect(errors.startTime).toBeUndefined();
   });
 
-  it("프로젝트 없이도 통과한다(예: 팀 위클리 싱크)", () => {
-    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, projectId: undefined });
-    expect(errors.projectId).toBeUndefined();
+  it("프로젝트를 안 고르면 막는다(WORKFLOW.md §3-1: 항상 필수)", () => {
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, projectId: "" }, OWNER_HOST);
+    expect(errors.projectId).toBe("프로젝트를 선택해 주세요");
   });
 
-  it("대주제를 안 고르면 막는다", () => {
-    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, topicMain: "" });
-    expect(errors.topicMain).toBeDefined();
+  it("안건을 하나도 안 채우면 막는다", () => {
+    const errors = validateRoomReservationDraft(
+      { ...VALID_DRAFT, topics: [{ main: "", sub: "" }] },
+      OWNER_HOST,
+    );
+    expect(errors.topics).toBe("회의 안건(대주제·소주제)을 한 쌍 이상 입력해 주세요");
   });
 
-  it("소주제를 안 고르면 막는다", () => {
-    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, topicSub: "" });
-    expect(errors.topicSub).toBeDefined();
+  it("첫 안건의 소주제만 비어도 막는다", () => {
+    const errors = validateRoomReservationDraft(
+      { ...VALID_DRAFT, topics: [{ main: "제품", sub: "" }] },
+      OWNER_HOST,
+    );
+    expect(errors.topics).toBeDefined();
   });
 
-  it("대주제와 안 맞는 소주제 조합은 막는다", () => {
-    const errors = validateRoomReservationDraft({
-      ...VALID_DRAFT,
-      topicMain: "PRODUCT",
-      topicSub: "CHANNEL_STRATEGY",
-    });
-    expect(errors.topicSub).toBe("대주제와 맞지 않는 소주제예요");
+  it("둘째 안건부터는 비어 있으면 막는다(첫 쌍만 있어도 안 됨)", () => {
+    const errors = validateRoomReservationDraft(
+      {
+        ...VALID_DRAFT,
+        topics: [
+          { main: "제품", sub: "로드맵 검토" },
+          { main: "", sub: "" },
+        ],
+      },
+      OWNER_HOST,
+    );
+    expect(errors.topics).toBe("빈 안건 칸이 있어요 — 채우거나 삭제해 주세요");
+  });
+
+  it("안건을 여러 쌍 다 채우면 통과한다", () => {
+    const errors = validateRoomReservationDraft(
+      {
+        ...VALID_DRAFT,
+        topics: [
+          { main: "제품", sub: "로드맵 검토" },
+          { main: "마케팅", sub: "캠페인 리뷰" },
+        ],
+      },
+      OWNER_HOST,
+    );
+    expect(errors.topics).toBeUndefined();
+  });
+
+  it("Host가 Owner면 상위 팀 액션 없이도 통과한다", () => {
+    const errors = validateRoomReservationDraft(VALID_DRAFT, OWNER_HOST);
+    expect(errors.parentTeamActionId).toBeUndefined();
+  });
+
+  it("Host가 Leader면 상위 팀 액션이 없으면 막는다", () => {
+    const errors = validateRoomReservationDraft(VALID_DRAFT, LEADER_HOST);
+    expect(errors.parentTeamActionId).toBe("상위 팀 액션을 선택해 주세요");
+  });
+
+  it("Host가 Leader여도 상위 팀 액션을 채우면 통과한다", () => {
+    const errors = validateRoomReservationDraft(
+      { ...VALID_DRAFT, parentTeamActionId: 1 },
+      LEADER_HOST,
+    );
+    expect(errors.parentTeamActionId).toBeUndefined();
   });
 
   it("참석자가 한 명도 없으면 막는다", () => {
-    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, attendeeIds: [] });
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, attendeeIds: [] }, OWNER_HOST);
     expect(errors.attendeeIds).toBe("참석자를 한 명 이상 선택해 주세요");
   });
 
   it("참석자 값이 정수가 아니면 막는다", () => {
-    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, attendeeIds: [Number.NaN] });
+    const errors = validateRoomReservationDraft(
+      { ...VALID_DRAFT, attendeeIds: [Number.NaN] },
+      OWNER_HOST,
+    );
     expect(errors.attendeeIds).toBe("참석자 값이 올바르지 않아요");
   });
 });

--- a/src/features/rooms/validate.ts
+++ b/src/features/rooms/validate.ts
@@ -1,6 +1,6 @@
 import { isValid, parse } from "date-fns";
 
-import { MEETING_TOPIC_SUB, type MeetingTopicMain } from "@/constants/meeting";
+import { AUTHORITY, type Authority } from "@/constants/authority";
 
 import type {
   MeetingRoomDraft,
@@ -34,9 +34,15 @@ function toMinutes(time: string): number {
  * 회의실 예약 폼 검증 — 화면(모달)과 서버(Server Action)가 **이 함수 하나**로 본다.
  * ⚠️ 같은 회의실·시간대 중복 여부는 여기서 보지 않는다 — 그건 기존 예약 목록이 있어야 판단할 수
  *    있어 `actions.ts`가 목/실서버 조회 뒤에 따로 확인한다.
+ * ⚠️ **참조 무결성도 여기서 안 본다** — `roomId`·`projectId`가 실제로 존재하는지, 골라 낸
+ *    `parentTeamActionId`가 진짜 그 프로젝트·그 팀의 것인지는 `actions.ts`가 목/실서버 조회
+ *    뒤에 따로 확인한다(§권한: 화면 숨김은 UX일 뿐 보안이 아니다). 여기는 **형식**만 본다.
+ * @param host "상위 팀 액션" 필수 여부는 회의를 여는 사람의 권한에 달렸다(WORKFLOW.md §3-1) —
+ *   Owner면 이 필드가 없어도 되고, Leader/Member면 반드시 있어야 한다.
  */
 export function validateRoomReservationDraft(
   draft: RoomReservationDraft,
+  host: { authority: Authority },
 ): RoomReservationFormErrors {
   const errors: RoomReservationFormErrors = {};
 
@@ -60,15 +66,19 @@ export function validateRoomReservationDraft(
     }
   }
 
-  // ⚠️ 프로젝트는 선택값이다 — "팀 위클리 싱크"처럼 프로젝트에 안 묶인 예약도 있다
-  //    (types.ts의 RoomReservation.projectId, mock/reservations.ts 시드가 이미 그렇다).
-  if (!draft.topicMain.trim()) errors.topicMain = "대주제를 선택해 주세요";
-  if (!draft.topicSub.trim()) errors.topicSub = "소주제를 선택해 주세요";
-  else if (draft.topicMain.trim()) {
-    const validSubs = MEETING_TOPIC_SUB[draft.topicMain as MeetingTopicMain];
-    if (!validSubs?.some((sub) => sub.value === draft.topicSub)) {
-      errors.topicSub = "대주제와 맞지 않는 소주제예요";
-    }
+  // ⚠️ 프로젝트는 이제 항상 필수다(WORKFLOW.md §3-1 확정) — 프로젝트에 안 묶인 예약은 없다.
+  if (!draft.projectId.trim()) errors.projectId = "프로젝트를 선택해 주세요";
+
+  if (draft.topics.length === 0 || !draft.topics[0]?.main.trim() || !draft.topics[0]?.sub.trim()) {
+    errors.topics = "회의 안건(대주제·소주제)을 한 쌍 이상 입력해 주세요";
+  } else if (draft.topics.some((topic) => !topic.main.trim() || !topic.sub.trim())) {
+    errors.topics = "빈 안건 칸이 있어요 — 채우거나 삭제해 주세요";
+  }
+
+  // ⚠️ Owner가 개설하면 이 필드가 아예 없다(= 프로젝트 회의) — Leader/Member면 반드시 있어야
+  //    한다(= 팀 액션 회의, WORKFLOW.md §3-1 "상위 팀 액션 노출 조건").
+  if (host.authority !== AUTHORITY.OWNER && !draft.parentTeamActionId) {
+    errors.parentTeamActionId = "상위 팀 액션을 선택해 주세요";
   }
 
   if (draft.attendeeIds.length === 0) {

--- a/src/lib/permission.ts
+++ b/src/lib/permission.ts
@@ -31,6 +31,15 @@ export interface Actor {
    *    이 권한 판정에는 쓰지 않는다 — 범위 판정은 teamId 하나로 끝난다.
    */
   teamId?: number;
+  /**
+   * 소속 팀 이름 — `teamId`와 별개다. **팀 registry(id↔이름 매핑)가 아직 없어서** 둘이
+   * 같은 값을 가리키는지 이 파일은 보장하지 않는다.
+   * ⚠️ `teamId`는 권한 범위 비교(`isWithinTeamScope`)에만 쓰고, 이 필드는 프로젝트
+   *    도메인이 팀을 **이름 문자열**로만 다루는 곳(`ProjectTeamAction.team` 등)과 매칭할 때만
+   *    쓴다(예: 회의실 예약의 "상위 팀 액션" select — 그 프로젝트 내 자기 팀에 하달된 팀
+   *    액션만 골라야 하는데, 그 목록이 이름으로만 저장돼 있다). OWNER는 `undefined`.
+   */
+  teamName?: string;
 }
 
 /* ───────── ① 권한 축 ───────── */


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가
- [x] test — 테스트 코드
- [ ] fix / style / refactor / docs / design / chore / merge

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 / 조직 / 공유 셸 · 디자인 시스템
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [x] OWNER (대표)
- [x] LEADER (팀장)
- [x] MEMBER (사원)

---

## 📝 작업 내용

- 회의 안건을 고정 enum select에서 자유 입력 텍스트(대주제·소주제 쌍, 최소 1개, 추가/삭제
  가능)로 교체 — `MeetingTopicList` 신규, `MEETING_TOPIC_MAIN`/`MEETING_TOPIC_SUB` 삭제
- 프로젝트 태그를 다시 항상 필수로(WORKFLOW.md §3-1 확정), mock 시드 정합화
- Host가 Owner가 아니면 "상위 팀 액션" 필드가 뜨고 필수가 됨 — 프로젝트를 바꾸면 그 프로젝트
  소속 팀 액션만 다시 걸러 보여줌. 서버는 선택된 팀 액션이 실제로 그 프로젝트 소속이고
  **자기 팀** 것인지까지 재검증(다른 팀 것을 폼 조작으로 끼워 넣는 경우 방어)
- 예약 생성 성공 시 `addMockMeeting()`으로 회의(Meeting) 레코드를 동시에 생성

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수
- [x] `Closes #` 기입
- [x] console·주석코드 없음
- [x] 민감 정보 없음

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 역할(Host authority)에 따른 필드 노출/필수 여부 + 리소스 소유권(자기 팀 팀 액션만) 둘 다 서버에서 재검사
- [ ] 🧬 zod — 미사용(기존 rooms 패턴 유지, 순수 함수 검증)
- [x] 🕵️ 정직성 — mock 액터가 OWNER 고정이라 Leader/Member 분기는 데모에서 안 보인다는 점을 PR 본문·코드 주석에 명시
- [x] 🎨 디자인 토큰 — 하드코딩 없음

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [x] ♿ a11y — 안건 입력·삭제 버튼에 `aria-label` 부여
- [x] ♻️ 재사용 확인 — 기존 Select/Input/Button 컴포넌트 그대로 사용
- [x] 🧪 loading/error/empty — 기존 화면 그대로(이번 PR 범위 아님)
- [ ] 브라우저 전용 API — 해당 없음

---

## 🔗 연관 이슈

Closes #212

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
| (대주제/소주제 select, 프로젝트 선택) | (안건 자유입력 목록, 프로젝트 필수, 상위 팀 액션 조건부) |

⚠️ mock 액터가 OWNER 고정이라 "상위 팀 액션" 노출 화면은 스크린샷으로 못 보여줌 — 유닛테스트로 대체 검증.

---

## 💬 리뷰 포인트

- 서버가 `parentTeamActionId`를 "프로젝트 소속 + 자기 팀 소속" 이중으로 재검증하는 부분이 과한지 적절한지
- mock 액터가 OWNER 고정인 상태로 이 기능을 병합해도 되는지, 아니면 Actor 확장(#162)에 이어 mock-actor 자체에 역할 전환 방법을 붙여야 하는지

---

## 📝 추가 메모

`npx jest`(전체 65개 스위트, 740개) · `npx tsc --noEmit` · `npx eslint` 전부 통과 확인함.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 회의 주제의 대분류와 소분류를 자유롭게 입력하고, 여러 안건을 추가·삭제할 수 있습니다.
  * 예약 시 프로젝트 선택이 필수로 변경되었습니다.
  * 권한과 팀에 따라 선택 가능한 상위 팀 액션이 제공됩니다.
  * 예약한 회의가 회의 목록에 함께 생성됩니다.

* **버그 수정**
  * 프로젝트, 안건, 상위 팀 액션의 필수 입력 및 권한별 검증을 강화했습니다.
  * 프로젝트 변경 시 기존 팀 액션 선택이 초기화됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->