### PR TITLE
[FIX] 회의실 예약 모달 디자인 수정 + 캘린더 hover 표시 #214

### DIFF
--- a/src/app/(shell)/app/rooms/page.tsx
+++ b/src/app/(shell)/app/rooms/page.tsx
@@ -10,6 +10,7 @@ import {
   getWeekReservations,
 } from "@/features/rooms/server";
 import { getViewer } from "@/features/shell/viewer";
+import { requiresParentTeamAction } from "@/lib/permission";
 
 export const metadata: Metadata = {
   title: "회의실",
@@ -53,7 +54,7 @@ export default async function RoomsPage({ searchParams }: RoomsPageProps) {
           rooms={rooms}
           members={members}
           projects={projects}
-          hostAuthority={viewer.role}
+          showParentTeamAction={requiresParentTeamAction(viewer)}
           teamActions={teamActions}
           week={format(week, "yyyy-MM-dd")}
         />

--- a/src/app/(shell)/app/rooms/page.tsx
+++ b/src/app/(shell)/app/rooms/page.tsx
@@ -6,8 +6,10 @@ import {
   getMeetingRooms,
   getReservableMembers,
   getReservableProjects,
+  getReservableTeamActions,
   getWeekReservations,
 } from "@/features/rooms/server";
+import { getViewer } from "@/features/shell/viewer";
 
 export const metadata: Metadata = {
   title: "회의실",
@@ -31,11 +33,15 @@ export default async function RoomsPage({ searchParams }: RoomsPageProps) {
   const { week: weekParam } = await searchParams;
   const week = parseWeekParam(weekParam);
 
-  const [reservations, rooms, members, projects] = await Promise.all([
+  // ⚠️ 팀 액션 목록은 지금 보고 있는 사람이 누구인지(권한·소속 팀)에 따라 달라져서 먼저 받는다.
+  const viewer = await getViewer();
+
+  const [reservations, rooms, members, projects, teamActions] = await Promise.all([
     getWeekReservations(week),
     getMeetingRooms(),
     getReservableMembers(),
     getReservableProjects(),
+    getReservableTeamActions(viewer),
   ]);
 
   return (
@@ -47,6 +53,8 @@ export default async function RoomsPage({ searchParams }: RoomsPageProps) {
           rooms={rooms}
           members={members}
           projects={projects}
+          hostAuthority={viewer.role}
+          teamActions={teamActions}
           week={format(week, "yyyy-MM-dd")}
         />
       </div>

--- a/src/constants/meeting.ts
+++ b/src/constants/meeting.ts
@@ -60,46 +60,8 @@ export const MEETING_INVITE_STATUS_LABEL: Record<MeetingInviteStatus, string> = 
   DECLINED: "불참",
 };
 
-/**
- * 회의 주제 대분류 — 회의실 예약 폼의 "회의 주제"(대주제→소주제) 선택에 쓴다.
- * ⚠️ 미확정 목업이다 — 회의 도메인 담당자 문서를 받으면 이 파일부터 맞춘다(CLAUDE.md §연동 검증).
- */
-export const MEETING_TOPIC_MAIN = {
-  PRODUCT: "PRODUCT",
-  MARKETING: "MARKETING",
-  INFRA: "INFRA",
-  TEAM: "TEAM",
-} as const;
-export type MeetingTopicMain = (typeof MEETING_TOPIC_MAIN)[keyof typeof MEETING_TOPIC_MAIN];
-
-export const MEETING_TOPIC_MAIN_LABEL: Record<MeetingTopicMain, string> = {
-  PRODUCT: "제품",
-  MARKETING: "마케팅",
-  INFRA: "인프라",
-  TEAM: "팀 운영",
-};
-
-export interface MeetingTopicSub {
-  value: string;
-  label: string;
-}
-
-/** 대주제별 소주제 목록 — 대주제를 고르면 이 목록으로 소주제 select가 갈린다. */
-export const MEETING_TOPIC_SUB: Record<MeetingTopicMain, MeetingTopicSub[]> = {
-  PRODUCT: [
-    { value: "ROADMAP_REVIEW", label: "로드맵 검토" },
-    { value: "FEATURE_PLANNING", label: "기능 기획" },
-  ],
-  MARKETING: [
-    { value: "CHANNEL_STRATEGY", label: "채널 전략" },
-    { value: "CAMPAIGN_REVIEW", label: "캠페인 리뷰" },
-  ],
-  INFRA: [
-    { value: "MIGRATION_REVIEW", label: "마이그레이션 리뷰" },
-    { value: "INCIDENT_RETRO", label: "장애 회고" },
-  ],
-  TEAM: [
-    { value: "WEEKLY_SYNC", label: "위클리 싱크" },
-    { value: "ONE_ON_ONE", label: "1:1" },
-  ],
-};
+/*
+  ⚠️ 회의 주제(대주제/소주제) 고정 enum은 여기 없다(2026-08-07 제거) — WORKFLOW.md §3-1
+     확정: "대주제 1개+소주제 1개 필수, 나머지는 추가/삭제 버튼으로 늘리고 줄이는" **자유 입력
+     텍스트**다. 타입은 `features/rooms/types.ts`의 `MeetingTopicInput`(자유 텍스트 쌍)을 본다.
+*/

--- a/src/features/meeting/mock/meetings.test.ts
+++ b/src/features/meeting/mock/meetings.test.ts
@@ -1,0 +1,49 @@
+import { AUTHORITY } from "@/constants/authority";
+
+import type { MeetingDraft } from "../types";
+import { addMockMeeting, findMockMeeting, listMockMeetings } from "./meetings";
+
+const DRAFT: MeetingDraft = {
+  title: "8월 킥오프 미팅",
+  start: new Date("2026-08-11T13:00:00"),
+  end: new Date("2026-08-11T13:30:00"),
+  roomId: "room-large",
+  roomName: "대회의실",
+  projectId: 1,
+  projectTag: "GOODS",
+  topics: [{ main: "제품", sub: "킥오프" }],
+  attendeeIds: [1, 2, 3],
+  hostId: 1,
+  hostAuthority: AUTHORITY.OWNER,
+  roomReservationId: "reservation-1",
+};
+
+describe("회의 mock 스토어", () => {
+  it("회의를 추가하면 id·생성시각을 채워 목록에 반영된다", () => {
+    const before = listMockMeetings().length;
+
+    const created = addMockMeeting(DRAFT);
+
+    expect(created.id).toBeDefined();
+    expect(created.createdAt).toBeDefined();
+    expect(created.title).toBe("8월 킥오프 미팅");
+    expect(listMockMeetings()).toHaveLength(before + 1);
+    expect(findMockMeeting(created.id)).toEqual(created);
+  });
+
+  it("팀 액션 회의는 parentTeamActionId·hostTeamId를 그대로 담는다", () => {
+    const created = addMockMeeting({
+      ...DRAFT,
+      hostAuthority: AUTHORITY.LEADER,
+      hostTeamId: 7,
+      parentTeamActionId: 2,
+    });
+
+    expect(created.parentTeamActionId).toBe(2);
+    expect(created.hostTeamId).toBe(7);
+  });
+
+  it("없는 id는 조회 시 null을 돌려준다", () => {
+    expect(findMockMeeting("존재하지-않음")).toBeNull();
+  });
+});

--- a/src/features/meeting/mock/meetings.test.ts
+++ b/src/features/meeting/mock/meetings.test.ts
@@ -24,11 +24,20 @@ describe("회의 mock 스토어", () => {
 
     const created = addMockMeeting(DRAFT);
 
-    expect(created.id).toBeDefined();
-    expect(created.createdAt).toBeDefined();
+    expect(created.id).toMatch(/^meeting-\d+$/);
+    expect(created.createdAt).toBe(new Date(created.createdAt).toISOString());
     expect(created.title).toBe("8월 킥오프 미팅");
     expect(listMockMeetings()).toHaveLength(before + 1);
     expect(findMockMeeting(created.id)).toEqual(created);
+  });
+
+  it("연달아 추가하면 id 뒷자리가 순서대로 늘어난다", () => {
+    const first = addMockMeeting(DRAFT);
+    const second = addMockMeeting(DRAFT);
+
+    const firstSeq = Number(first.id.replace("meeting-", ""));
+    const secondSeq = Number(second.id.replace("meeting-", ""));
+    expect(secondSeq).toBe(firstSeq + 1);
   });
 
   it("팀 액션 회의는 parentTeamActionId·hostTeamId를 그대로 담는다", () => {

--- a/src/features/meeting/mock/meetings.ts
+++ b/src/features/meeting/mock/meetings.ts
@@ -1,0 +1,42 @@
+import type { Meeting, MeetingDraft } from "../types";
+
+/**
+ * ⚠️ 목 데이터 — BE 연동 전. 지금은 `/app/rooms` 예약 액션이 이 스토어를 직접 채운다
+ * (`rooms/actions.ts`가 `TOP_LEVEL_PROJECTS`를 직접 참조하는 것과 같은 이유 — 아직
+ * `/app/meeting` 쪽 서버·액션 레이어가 없어서 격리막을 통째로 만들 소비자가 없다.
+ * `/app/meeting`이 생기면 그때 `meeting/server.ts`가 이 스토어 앞을 막는다).
+ * ⚠️ 상태를 `globalThis`에 매단다 — dev의 HMR로 `let`이 초기화되면 방금 만든 회의가 사라진다
+ *    (`rooms/mock/reservations.ts`와 같은 트릭).
+ */
+interface MeetingStore {
+  meetings: Meeting[];
+  sequence: number;
+}
+
+const globalStore = globalThis as typeof globalThis & {
+  __meetingStore?: MeetingStore;
+};
+const store: MeetingStore = (globalStore.__meetingStore ??= { meetings: [], sequence: 0 });
+
+export function listMockMeetings(): Meeting[] {
+  return store.meetings;
+}
+
+export function findMockMeeting(id: string): Meeting | null {
+  return store.meetings.find((meeting) => meeting.id === id) ?? null;
+}
+
+/**
+ * 회의 생성 — 회의실 예약과 짝지어 항상 같이 만들어진다(WORKFLOW.md §3-1).
+ * ⚠️ 여기서 참조 무결성(roomId·projectId·attendeeIds 존재 여부)을 다시 보지 않는다 —
+ *    호출부(`rooms/actions.ts`)가 예약을 검증할 때 이미 확인했다.
+ */
+export function addMockMeeting(draft: MeetingDraft): Meeting {
+  const meeting: Meeting = {
+    ...draft,
+    id: `meeting-${++store.sequence}`,
+    createdAt: new Date().toISOString(),
+  };
+  store.meetings = [...store.meetings, meeting];
+  return meeting;
+}

--- a/src/features/meeting/types.ts
+++ b/src/features/meeting/types.ts
@@ -1,0 +1,47 @@
+/**
+ * 회의(Meeting) — 격리막의 UI 계약(CLAUDE.md §Mock 격리막).
+ * ⚠️ **최소 스캐폴딩이다.** `/app/meeting`(목록·상세·캡처·AI 리뷰)은 별도 이슈다 — 지금은
+ *    회의실 예약이 만드는 레코드 하나만 담는다(WORKFLOW.md §3-1: "회의실 예약 = 회의 개설"이
+ *    하나의 동작이라, 예약만 저장하고 회의를 안 만들면 스펙과 어긋난다).
+ */
+
+import type { Authority } from "@/constants/authority";
+
+/** 회의 안건 대주제/소주제 한 쌍 — 자유 입력 텍스트다(고정 enum 아님, WORKFLOW.md §3-1). */
+export interface MeetingTopic {
+  main: string;
+  sub: string;
+}
+
+/**
+ * 회의 한 건.
+ * ⚠️ **프로젝트 태그는 항상 필수다**(WORKFLOW.md §3-1) — 프로젝트에 안 묶인 회의는 없다.
+ * ⚠️ `parentTeamActionId`는 **Host가 Owner가 아닐 때만** 있다(= 팀 액션 회의). Host가
+ *    Owner면 프로젝트 회의라 이 필드가 없다(WORKFLOW.md §3-1 "상위 팀 액션 노출 조건").
+ */
+export interface Meeting {
+  id: string;
+  title: string;
+  start: Date;
+  end: Date;
+  roomId: string;
+  roomName: string;
+  projectId: number;
+  projectTag: string;
+  /** 최소 1쌍(대주제+소주제) — 나머지는 "추가/삭제"로 늘고 준다. */
+  topics: MeetingTopic[];
+  attendeeIds: number[];
+  /** 개설자 — 회의 조작 권한의 기준(권한 ②축, `lib/permission.ts`의 `canOperateMeeting`). */
+  hostId: number;
+  hostAuthority: Authority;
+  /** Host의 소속 팀 — 팀 액션 회의의 상세 열람 범위 판정(`lib/permission.ts`의 `hostTeamId`)에 쓴다. */
+  hostTeamId?: number;
+  parentTeamActionId?: number;
+  /** 이 회의를 만든 예약 — 같은 동작이라 항상 있다(WORKFLOW.md §3-1). */
+  roomReservationId: string;
+  /** ISO datetime — 서버 기준 생성 시각. */
+  createdAt: string;
+}
+
+/** 회의 생성 입력 — id·createdAt은 서버(mock 스토어)가 채운다. */
+export type MeetingDraft = Omit<Meeting, "id" | "createdAt">;

--- a/src/features/meeting/types.ts
+++ b/src/features/meeting/types.ts
@@ -13,35 +13,46 @@ export interface MeetingTopic {
   sub: string;
 }
 
-/**
- * 회의 한 건.
- * ⚠️ **프로젝트 태그는 항상 필수다**(WORKFLOW.md §3-1) — 프로젝트에 안 묶인 회의는 없다.
- * ⚠️ `parentTeamActionId`는 **Host가 Owner가 아닐 때만** 있다(= 팀 액션 회의). Host가
- *    Owner면 프로젝트 회의라 이 필드가 없다(WORKFLOW.md §3-1 "상위 팀 액션 노출 조건").
- */
-export interface Meeting {
-  id: string;
+interface MeetingCommon {
   title: string;
   start: Date;
   end: Date;
   roomId: string;
   roomName: string;
+  /** ⚠️ 프로젝트 태그는 항상 필수다(WORKFLOW.md §3-1) — 프로젝트에 안 묶인 회의는 없다. */
   projectId: number;
   projectTag: string;
   /** 최소 1쌍(대주제+소주제) — 나머지는 "추가/삭제"로 늘고 준다. */
-  topics: MeetingTopic[];
+  topics: [MeetingTopic, ...MeetingTopic[]];
   attendeeIds: number[];
   /** 개설자 — 회의 조작 권한의 기준(권한 ②축, `lib/permission.ts`의 `canOperateMeeting`). */
   hostId: number;
-  hostAuthority: Authority;
-  /** Host의 소속 팀 — 팀 액션 회의의 상세 열람 범위 판정(`lib/permission.ts`의 `hostTeamId`)에 쓴다. */
-  hostTeamId?: number;
-  parentTeamActionId?: number;
   /** 이 회의를 만든 예약 — 같은 동작이라 항상 있다(WORKFLOW.md §3-1). */
   roomReservationId: string;
-  /** ISO datetime — 서버 기준 생성 시각. */
-  createdAt: string;
+}
+
+/**
+ * Owner가 개설 = 프로젝트 회의(WORKFLOW.md §2·§3-1). "상위 팀 액션" 개념 자체가 없다 —
+ * `hostTeamId`·`parentTeamActionId`는 아예 못 넣는다(타입으로 막는다).
+ */
+interface OwnerHostedMeeting extends MeetingCommon {
+  hostAuthority: Extract<Authority, "OWNER">;
+  hostTeamId?: undefined;
+  parentTeamActionId?: undefined;
+}
+
+/**
+ * Leader/Member가 개설 = 팀 액션 회의(WORKFLOW.md §5). 개설자의 소속 팀(`hostTeamId`)과
+ * 상위 팀 액션(`parentTeamActionId`)이 **둘 다 필수**다 — 하나만 있는 회의는 만들 수 없다.
+ */
+interface TeamActionHostedMeeting extends MeetingCommon {
+  hostAuthority: Extract<Authority, "LEADER" | "MEMBER">;
+  hostTeamId: number;
+  parentTeamActionId: number;
 }
 
 /** 회의 생성 입력 — id·createdAt은 서버(mock 스토어)가 채운다. */
-export type MeetingDraft = Omit<Meeting, "id" | "createdAt">;
+export type MeetingDraft = OwnerHostedMeeting | TeamActionHostedMeeting;
+
+/** 회의 한 건 — `MeetingDraft`에 서버가 채우는 두 필드(id·생성시각)만 더한다. */
+export type Meeting = MeetingDraft & { id: string; createdAt: string };

--- a/src/features/rooms/accent-color.ts
+++ b/src/features/rooms/accent-color.ts
@@ -1,6 +1,10 @@
 import { type PaletteColor, pickPaletteColor } from "@/lib/palette";
 
-/** 프로젝트에 안 묶인 예약(예: 팀 위클리 싱크)의 중립색 — `RoomReservationEvent`의 기본값으로도 쓴다. */
+/**
+ * `RoomReservationEvent`의 기본값 — prop이 비어 오는 순간(예: dev HMR)에도 화면 전체가
+ * 죽는 것보다 중립색으로라도 그리는 쪽을 택한다. 프로젝트 태그는 이제 항상 있어서
+ * (WORKFLOW.md §3-1) 정상 흐름에서는 이 색이 실제로 쓰일 일이 없다.
+ */
 export const NEUTRAL_ACCENT_COLOR: PaletteColor = {
   bgColor: "var(--secondary)",
   textColor: "var(--muted-foreground)",

--- a/src/features/rooms/actions.test.ts
+++ b/src/features/rooms/actions.test.ts
@@ -10,6 +10,7 @@ jest.mock("@/lib/mock-actor", () => ({
 
 import { revalidatePath } from "next/cache";
 
+import { listMockMeetings } from "@/features/meeting/mock/meetings";
 import { getMockActor } from "@/lib/mock-actor";
 
 import {
@@ -115,7 +116,7 @@ describe("회의실 추가·수정", () => {
 });
 
 describe("회의실 예약 생성 (Owner 개설 = 프로젝트 회의)", () => {
-  it("필수값이 다 있으면 성공하고 생성값을 돌려준다", async () => {
+  it("필수값이 다 있으면 성공하고 생성값을 돌려준다 — 연결된 회의(Meeting)도 같이 만들어진다", async () => {
     const result = await createRoomReservationAction({ errors: {} }, form(VALID_ENTRIES));
 
     expect(result.errors).toEqual({});
@@ -123,6 +124,17 @@ describe("회의실 예약 생성 (Owner 개설 = 프로젝트 회의)", () => {
     expect(result.created?.roomName).toBe("소회의실 B");
     expect(result.created?.projectTag).toBe("GOODS");
     expect(revalidatePathMock).toHaveBeenCalledWith("/app/rooms");
+
+    const meeting = listMockMeetings().find(
+      (item) => item.roomReservationId === result.created?.id,
+    );
+    expect(meeting).toBeDefined();
+    expect(meeting?.projectId).toBe(1);
+    expect(meeting?.projectTag).toBe("GOODS");
+    expect(meeting?.topics).toEqual(DEFAULT_TOPICS);
+    expect(meeting?.hostAuthority).toBe("OWNER");
+    expect(meeting?.hostTeamId).toBeUndefined();
+    expect(meeting?.parentTeamActionId).toBeUndefined();
   });
 
   it("제목이 비면 막고 revalidatePath를 안 부른다", async () => {
@@ -215,6 +227,18 @@ describe("회의실 예약 생성 (Owner 개설 = 프로젝트 회의)", () => {
     expect(result.errors).toEqual({});
   });
 
+  it("Owner인데 폼에 상위 팀 액션이 끼어 있으면 막는다(폼 조작 방어)", async () => {
+    const result = await createRoomReservationAction(
+      { errors: {} },
+      form({ ...VALID_ENTRIES, date: "2026-08-14", startTime: "09:30", parentTeamActionId: "1" }),
+    );
+
+    expect(result.errors.parentTeamActionId).toBe(
+      "Owner가 개설하는 회의에는 상위 팀 액션을 지정할 수 없어요",
+    );
+    expect(result.created).toBeUndefined();
+  });
+
   it("폼이 조작돼 존재하지 않는 회의실 id가 오면 막는다", async () => {
     const result = await createRoomReservationAction(
       { errors: {} },
@@ -287,6 +311,14 @@ describe("회의실 예약 생성 (Leader 개설 = 팀 액션 회의)", () => {
 
     expect(result.errors).toEqual({});
     expect(result.created).toBeDefined();
+
+    const meeting = listMockMeetings().find(
+      (item) => item.roomReservationId === result.created?.id,
+    );
+    expect(meeting).toBeDefined();
+    expect(meeting?.hostAuthority).toBe("LEADER");
+    expect(meeting?.hostTeamId).toBe(LEADER.teamId);
+    expect(meeting?.parentTeamActionId).toBe(1);
   });
 
   it("다른 팀 소속 팀 액션 id를 끼워 넣으면 막는다(폼 조작 방어)", async () => {

--- a/src/features/rooms/actions.test.ts
+++ b/src/features/rooms/actions.test.ts
@@ -2,8 +2,8 @@
 jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
 // isMock은 NEXT_PUBLIC_USE_MOCK 환경변수로 정해진다 — 테스트가 환경에 휘둘리지 않게 고정한다.
 jest.mock("@/mocks/config", () => ({ isMock: true }));
-// 기본은 실제 getMockActor()와 같은 값(OWNER, Admin 아님) — 회의실 관리 권한 테스트에서만
-// Admin 겸직 액터로 덮어쓴다(`canManageRooms`는 Admin 겸직자 전용이라 OWNER로는 절대 못 지나간다).
+// 기본은 실제 getMockActor()와 같은 값(OWNER, Admin 아님) — 회의실 관리·상위 팀 액션 권한
+// 테스트에서만 다른 역할·팀의 액터로 덮어쓴다.
 jest.mock("@/lib/mock-actor", () => ({
   getMockActor: jest.fn(() => ({ id: 1, role: "OWNER" })),
 }));
@@ -27,14 +27,22 @@ const VALID_ENTRIES: Record<string, string> = {
   date: "2026-08-11",
   startTime: "13:00",
   projectId: "1", // TOP_LEVEL_PROJECTS의 GOODS(id=1) — 실존 프로젝트여야 통과한다
-  topicMain: "PRODUCT",
-  topicSub: "ROADMAP_REVIEW",
 };
 
-const form = (entries: Record<string, string>, attendeeIds: number[] = [1]) => {
+const DEFAULT_TOPICS = [{ main: "제품", sub: "로드맵 검토" }];
+
+const form = (
+  entries: Record<string, string>,
+  attendeeIds: number[] = [1],
+  topics: { main: string; sub: string }[] = DEFAULT_TOPICS,
+) => {
   const data = new FormData();
   for (const [key, value] of Object.entries(entries)) data.append(key, value);
   for (const id of attendeeIds) data.append("attendeeIds", String(id));
+  for (const topic of topics) {
+    data.append("topicMain", topic.main);
+    data.append("topicSub", topic.sub);
+  }
   return data;
 };
 
@@ -106,13 +114,14 @@ describe("회의실 추가·수정", () => {
   });
 });
 
-describe("회의실 예약 생성", () => {
+describe("회의실 예약 생성 (Owner 개설 = 프로젝트 회의)", () => {
   it("필수값이 다 있으면 성공하고 생성값을 돌려준다", async () => {
     const result = await createRoomReservationAction({ errors: {} }, form(VALID_ENTRIES));
 
     expect(result.errors).toEqual({});
     expect(result.created?.title).toBe("새 회의");
     expect(result.created?.roomName).toBe("소회의실 B");
+    expect(result.created?.projectTag).toBe("GOODS");
     expect(revalidatePathMock).toHaveBeenCalledWith("/app/rooms");
   });
 
@@ -158,15 +167,52 @@ describe("회의실 예약 생성", () => {
     expect(result.created).toBeDefined();
   });
 
-  it("프로젝트 없이도 생성된다(예: 팀 위클리 싱크 같은 예약)", async () => {
+  it("프로젝트를 안 넣으면 막는다(WORKFLOW.md §3-1: 항상 필수)", async () => {
     const result = await createRoomReservationAction(
       { errors: {} },
       form({ ...VALID_ENTRIES, projectId: "", date: "2026-08-14" }),
     );
 
+    expect(result.errors.projectId).toBe("프로젝트를 선택해 주세요");
+    expect(result.created).toBeUndefined();
+  });
+
+  it("안건을 안 넣으면 막는다", async () => {
+    const result = await createRoomReservationAction(
+      { errors: {} },
+      form({ ...VALID_ENTRIES, date: "2026-08-14" }, [1], []),
+    );
+
+    expect(result.errors.topics).toBeDefined();
+    expect(result.created).toBeUndefined();
+  });
+
+  it("안건을 여러 쌍 넣으면 전부 저장된다", async () => {
+    const result = await createRoomReservationAction(
+      { errors: {} },
+      form(
+        { ...VALID_ENTRIES, date: "2026-08-14" },
+        [1],
+        [
+          { main: "제품", sub: "로드맵 검토" },
+          { main: "마케팅", sub: "캠페인 리뷰" },
+        ],
+      ),
+    );
+
+    expect(result.created?.topics).toEqual([
+      { main: "제품", sub: "로드맵 검토" },
+      { main: "마케팅", sub: "캠페인 리뷰" },
+    ]);
+  });
+
+  it("Owner는 상위 팀 액션 없이도 통과한다", async () => {
+    const result = await createRoomReservationAction(
+      { errors: {} },
+      form({ ...VALID_ENTRIES, date: "2026-08-14", startTime: "09:00" }),
+    );
+
     expect(result.errors).toEqual({});
-    expect(result.created?.projectId).toBeUndefined();
-    expect(result.created?.projectTag).toBeUndefined();
   });
 
   it("폼이 조작돼 존재하지 않는 회의실 id가 오면 막는다", async () => {
@@ -182,7 +228,7 @@ describe("회의실 예약 생성", () => {
   it("폼이 조작돼 존재하지 않는 프로젝트 id가 오면 막는다", async () => {
     const result = await createRoomReservationAction(
       { errors: {} },
-      form({ ...VALID_ENTRIES, projectId: "p-does-not-exist", date: "2026-08-15" }),
+      form({ ...VALID_ENTRIES, projectId: "999", date: "2026-08-15" }),
     );
 
     expect(result.errors.projectId).toBe("존재하지 않는 프로젝트예요");
@@ -199,31 +245,69 @@ describe("회의실 예약 생성", () => {
     expect(result.created).toBeUndefined();
   });
 
-  it("폼이 조작돼 대주제·소주제 조합이 안 맞으면 막는다", async () => {
-    const result = await createRoomReservationAction(
-      { errors: {} },
-      form({
-        ...VALID_ENTRIES,
-        date: "2026-08-15",
-        topicMain: "PRODUCT",
-        topicSub: "CHANNEL_STRATEGY",
-      }),
-    );
-
-    expect(result.errors.topicSub).toBe("대주제와 맞지 않는 소주제예요");
-    expect(result.created).toBeUndefined();
-  });
-
   it("폼이 조작돼 참석자 값이 숫자가 아니면 막는다", async () => {
     const data = new FormData();
     for (const [key, value] of Object.entries({ ...VALID_ENTRIES, date: "2026-08-15" })) {
       data.append(key, value);
     }
     data.append("attendeeIds", "not-a-number");
+    data.append("topicMain", "제품");
+    data.append("topicSub", "로드맵 검토");
 
     const result = await createRoomReservationAction({ errors: {} }, data);
 
     expect(result.errors.attendeeIds).toBe("참석자 값이 올바르지 않아요");
+    expect(result.created).toBeUndefined();
+  });
+});
+
+describe("회의실 예약 생성 (Leader 개설 = 팀 액션 회의)", () => {
+  const LEADER = { id: 5, role: "LEADER", teamId: 7, teamName: "개발팀" };
+
+  beforeEach(() => {
+    getMockActorMock.mockReturnValue(LEADER);
+  });
+
+  it("상위 팀 액션 없이 제출하면 막는다", async () => {
+    const result = await createRoomReservationAction(
+      { errors: {} },
+      form({ ...VALID_ENTRIES, date: "2026-08-16" }),
+    );
+
+    expect(result.errors.parentTeamActionId).toBe("상위 팀 액션을 선택해 주세요");
+    expect(result.created).toBeUndefined();
+  });
+
+  it("자기 팀의 진짜 팀 액션이면 통과하고, 회의에도 그대로 담긴다", async () => {
+    // projectId=1(GOODS)의 팀 액션 id=1("앱 개발 착수")은 team-actions 목데이터상 "개발팀" 소속이다.
+    const result = await createRoomReservationAction(
+      { errors: {} },
+      form({ ...VALID_ENTRIES, date: "2026-08-16", parentTeamActionId: "1" }),
+    );
+
+    expect(result.errors).toEqual({});
+    expect(result.created).toBeDefined();
+  });
+
+  it("다른 팀 소속 팀 액션 id를 끼워 넣으면 막는다(폼 조작 방어)", async () => {
+    // id=3("TV 광고 계약 및 모델 섭외")은 GOODS 프로젝트 소속이지만 팀은 "마케팅팀"이다.
+    const result = await createRoomReservationAction(
+      { errors: {} },
+      form({ ...VALID_ENTRIES, date: "2026-08-16", parentTeamActionId: "3" }),
+    );
+
+    expect(result.errors.parentTeamActionId).toBe("존재하지 않는 상위 팀 액션이에요");
+    expect(result.created).toBeUndefined();
+  });
+
+  it("다른 프로젝트 소속 팀 액션 id를 끼워 넣으면 막는다", async () => {
+    // id=7("협업툴 리뉴얼 착수")은 "개발팀" 소속이지만 COLLAB 프로젝트다 — 지금 고른 프로젝트는 GOODS(1).
+    const result = await createRoomReservationAction(
+      { errors: {} },
+      form({ ...VALID_ENTRIES, date: "2026-08-16", parentTeamActionId: "7" }),
+    );
+
+    expect(result.errors.parentTeamActionId).toBe("존재하지 않는 상위 팀 액션이에요");
     expect(result.created).toBeUndefined();
   });
 });

--- a/src/features/rooms/actions.ts
+++ b/src/features/rooms/actions.ts
@@ -2,7 +2,9 @@
 
 import { revalidatePath } from "next/cache";
 
+import { AUTHORITY } from "@/constants/authority";
 import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
+import { PROJECT_TEAM_ACTIONS_MOCK } from "@/features/project/mock/team-actions";
 import { getMockActor } from "@/lib/mock-actor";
 import { canManageRooms } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
@@ -14,6 +16,7 @@ import type {
   MeetingRoom,
   MeetingRoomDraft,
   MeetingRoomFormErrors,
+  MeetingTopicInput,
   RoomReservation,
   RoomReservationDraft,
   RoomReservationFormErrors,
@@ -34,17 +37,23 @@ export interface RoomReservationFormState {
   created?: RoomReservation;
 }
 
+function readTopics(formData: FormData): MeetingTopicInput[] {
+  const mains = formData.getAll("topicMain");
+  const subs = formData.getAll("topicSub");
+  return mains.map((main, index) => ({ main: String(main), sub: String(subs[index] ?? "") }));
+}
+
 function readDraft(formData: FormData): RoomReservationDraft {
-  const projectId = formData.get("projectId");
+  const parentTeamActionId = formData.get("parentTeamActionId");
   return {
     title: String(formData.get("title") ?? ""),
     roomId: String(formData.get("roomId") ?? ""),
     date: String(formData.get("date") ?? ""),
     startTime: String(formData.get("startTime") ?? ""),
-    projectId: projectId ? String(projectId) : undefined,
-    topicMain: String(formData.get("topicMain") ?? ""),
-    topicSub: String(formData.get("topicSub") ?? ""),
+    projectId: String(formData.get("projectId") ?? ""),
+    topics: readTopics(formData),
     attendeeIds: formData.getAll("attendeeIds").map(Number),
+    parentTeamActionId: parentTeamActionId ? Number(parentTeamActionId) : undefined,
   };
 }
 
@@ -68,7 +77,8 @@ export async function createRoomReservationAction(
   formData: FormData,
 ): Promise<RoomReservationFormState> {
   const draft = readDraft(formData);
-  const errors = validateRoomReservationDraft(draft);
+  const actor = getMockActor();
+  const errors = validateRoomReservationDraft(draft, { authority: actor.role });
   if (Object.keys(errors).length > 0) return { errors };
 
   if (!isMock) {
@@ -81,14 +91,23 @@ export async function createRoomReservationAction(
   if (!findMockRoom(draft.roomId)) {
     return { errors: { roomId: "존재하지 않는 회의실이에요" } };
   }
-  if (
-    draft.projectId &&
-    !TOP_LEVEL_PROJECTS.some((project) => String(project.id) === draft.projectId)
-  ) {
+  const project = TOP_LEVEL_PROJECTS.find((item) => String(item.id) === draft.projectId);
+  if (!project) {
     return { errors: { projectId: "존재하지 않는 프로젝트예요" } };
   }
   if (draft.attendeeIds.some((id) => !findMockMember(id))) {
     return { errors: { attendeeIds: "존재하지 않는 참석자가 있어요" } };
+  }
+  // ⚠️ Owner가 아니면 "상위 팀 액션"이 필수인데, 그 값이 진짜 이 프로젝트 소속이고 **자기
+  //    팀**에 하달된 게 맞는지까지 다시 본다 — 화면이 이미 걸러 보여줘도, 폼은 조작될 수 있어서
+  //    다른 팀의 팀 액션 id를 끼워 넣으면 그 팀 몫으로 회의가 잡히는 걸 여기서 막는다.
+  if (actor.role !== AUTHORITY.OWNER && draft.parentTeamActionId !== undefined) {
+    const teamAction = PROJECT_TEAM_ACTIONS_MOCK[project.tag]?.find(
+      (item) => item.id === draft.parentTeamActionId,
+    );
+    if (!teamAction || teamAction.team !== actor.teamName) {
+      return { errors: { parentTeamActionId: "존재하지 않는 상위 팀 액션이에요" } };
+    }
   }
 
   const { start, end } = toReservedRange(draft);
@@ -99,8 +118,7 @@ export async function createRoomReservationAction(
     return { errors: { roomId: "그 시간에는 이미 예약된 회의실이에요" } };
   }
 
-  const actor = getMockActor();
-  const created = addMockReservation(draft, actor.id);
+  const created = addMockReservation(draft, actor);
   revalidatePath(ROOMS_PATH);
   return { errors: {}, created };
 }

--- a/src/features/rooms/actions.ts
+++ b/src/features/rooms/actions.ts
@@ -2,11 +2,10 @@
 
 import { revalidatePath } from "next/cache";
 
-import { AUTHORITY } from "@/constants/authority";
 import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
 import { PROJECT_TEAM_ACTIONS_MOCK } from "@/features/project/mock/team-actions";
 import { getMockActor } from "@/lib/mock-actor";
-import { canManageRooms } from "@/lib/permission";
+import { canManageRooms, requiresParentTeamAction } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
 import { findMockMember } from "./mock/members";
@@ -78,7 +77,7 @@ export async function createRoomReservationAction(
 ): Promise<RoomReservationFormState> {
   const draft = readDraft(formData);
   const actor = getMockActor();
-  const errors = validateRoomReservationDraft(draft, { authority: actor.role });
+  const errors = validateRoomReservationDraft(draft, { role: actor.role });
   if (Object.keys(errors).length > 0) return { errors };
 
   if (!isMock) {
@@ -101,7 +100,7 @@ export async function createRoomReservationAction(
   // ⚠️ Owner가 아니면 "상위 팀 액션"이 필수인데, 그 값이 진짜 이 프로젝트 소속이고 **자기
   //    팀**에 하달된 게 맞는지까지 다시 본다 — 화면이 이미 걸러 보여줘도, 폼은 조작될 수 있어서
   //    다른 팀의 팀 액션 id를 끼워 넣으면 그 팀 몫으로 회의가 잡히는 걸 여기서 막는다.
-  if (actor.role !== AUTHORITY.OWNER && draft.parentTeamActionId !== undefined) {
+  if (requiresParentTeamAction(actor) && draft.parentTeamActionId !== undefined) {
     const teamAction = PROJECT_TEAM_ACTIONS_MOCK[project.tag]?.find(
       (item) => item.id === draft.parentTeamActionId,
     );

--- a/src/features/rooms/actions.ts
+++ b/src/features/rooms/actions.ts
@@ -8,6 +8,7 @@ import { getMockActor } from "@/lib/mock-actor";
 import { canManageRooms, requiresParentTeamAction } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
+import { RESERVATION_DURATION_MINUTES } from "./constants";
 import { findMockMember } from "./mock/members";
 import { addMockReservation, listMockReservationsByRoom } from "./mock/reservations";
 import { addMockRoom, findMockRoom, updateMockRoom } from "./mock/rooms";
@@ -20,11 +21,7 @@ import type {
   RoomReservationDraft,
   RoomReservationFormErrors,
 } from "./types";
-import {
-  RESERVATION_DURATION_MINUTES,
-  validateMeetingRoomDraft,
-  validateRoomReservationDraft,
-} from "./validate";
+import { validateMeetingRoomDraft, validateRoomReservationDraft } from "./validate";
 
 const ROOMS_PATH = "/app/rooms";
 const MANAGE_ROOMS_PATH = "/manage/rooms";

--- a/src/features/rooms/components/meeting-topic-list.tsx
+++ b/src/features/rooms/components/meeting-topic-list.tsx
@@ -36,7 +36,7 @@ export function MeetingTopicList({ topics, onChange, error }: MeetingTopicListPr
 
   return (
     <div className="flex flex-col gap-1.5">
-      <Label>회의 안건</Label>
+      <Label>회의 주제</Label>
       <div className="flex flex-col gap-2">
         {topics.map((topic, index) => (
           // 안건 줄은 고유 id가 없고 순서만 의미가 있다 — index를 key로 쓴다.
@@ -72,9 +72,15 @@ export function MeetingTopicList({ topics, onChange, error }: MeetingTopicListPr
         ))}
       </div>
       {error && <p className="text-destructive text-xs">{error}</p>}
-      <Button type="button" variant="outline" size="xs" className="w-fit" onClick={addTopic}>
-        <Plus aria-hidden />
-        안건 추가
+      <Button
+        type="button"
+        variant="link"
+        size="xs"
+        className="w-fit px-0 text-xs"
+        onClick={addTopic}
+      >
+        <Plus aria-hidden className="size-3.5" />
+        주제 추가
       </Button>
     </div>
   );

--- a/src/features/rooms/components/meeting-topic-list.tsx
+++ b/src/features/rooms/components/meeting-topic-list.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { Plus, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+import type { MeetingTopicInput } from "../types";
+
+interface MeetingTopicListProps {
+  topics: MeetingTopicInput[];
+  onChange: (topics: MeetingTopicInput[]) => void;
+  error?: string;
+}
+
+const EMPTY_TOPIC: MeetingTopicInput = { main: "", sub: "" };
+
+/**
+ * 회의 안건(대주제/소주제) 입력 — **자유 텍스트**다, 고정 목록에서 고르지 않는다
+ * (WORKFLOW.md §3-1). 첫 쌍은 필수, "안건 추가"로 늘리고 각 줄의 X로 줄인다(첫 줄은 못 뺀다 —
+ * 최소 1쌍은 항상 있어야 한다).
+ */
+export function MeetingTopicList({ topics, onChange, error }: MeetingTopicListProps) {
+  function updateTopic(index: number, patch: Partial<MeetingTopicInput>) {
+    onChange(topics.map((topic, i) => (i === index ? { ...topic, ...patch } : topic)));
+  }
+
+  function removeTopic(index: number) {
+    onChange(topics.filter((_, i) => i !== index));
+  }
+
+  function addTopic() {
+    onChange([...topics, EMPTY_TOPIC]);
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label>회의 안건</Label>
+      <div className="flex flex-col gap-2">
+        {topics.map((topic, index) => (
+          // 안건 줄은 고유 id가 없고 순서만 의미가 있다 — index를 key로 쓴다.
+          <div key={index} className="flex items-center gap-2">
+            <Input
+              value={topic.main}
+              onChange={(event) => updateTopic(index, { main: event.target.value })}
+              placeholder="대주제"
+              aria-label={`안건 ${index + 1} 대주제`}
+              aria-invalid={Boolean(error)}
+              className="flex-1"
+            />
+            <Input
+              value={topic.sub}
+              onChange={(event) => updateTopic(index, { sub: event.target.value })}
+              placeholder="소주제"
+              aria-label={`안건 ${index + 1} 소주제`}
+              aria-invalid={Boolean(error)}
+              className="flex-1"
+            />
+            {topics.length > 1 && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                aria-label={`안건 ${index + 1} 삭제`}
+                onClick={() => removeTopic(index)}
+              >
+                <X aria-hidden />
+              </Button>
+            )}
+          </div>
+        ))}
+      </div>
+      {error && <p className="text-destructive text-xs">{error}</p>}
+      <Button type="button" variant="outline" size="xs" className="w-fit" onClick={addTopic}>
+        <Plus aria-hidden />
+        안건 추가
+      </Button>
+    </div>
+  );
+}

--- a/src/features/rooms/components/meeting-topic-list.tsx
+++ b/src/features/rooms/components/meeting-topic-list.tsx
@@ -42,6 +42,7 @@ export function MeetingTopicList({ topics, onChange, error }: MeetingTopicListPr
           // 안건 줄은 고유 id가 없고 순서만 의미가 있다 — index를 key로 쓴다.
           <div key={index} className="flex items-center gap-2">
             <Input
+              name="topicMain"
               value={topic.main}
               onChange={(event) => updateTopic(index, { main: event.target.value })}
               placeholder="대주제"
@@ -50,6 +51,7 @@ export function MeetingTopicList({ topics, onChange, error }: MeetingTopicListPr
               className="flex-1"
             />
             <Input
+              name="topicSub"
               value={topic.sub}
               onChange={(event) => updateTopic(index, { sub: event.target.value })}
               placeholder="소주제"

--- a/src/features/rooms/components/room-attendee-picker.test.tsx
+++ b/src/features/rooms/components/room-attendee-picker.test.tsx
@@ -44,8 +44,7 @@ describe("RoomAttendeePicker", () => {
     const onChange = jest.fn();
     render(<RoomAttendeePicker members={MEMBERS} selectedIds={[1, 2]} onChange={onChange} />);
 
-    const checkboxes = screen.getAllByRole("checkbox");
-    await user.click(checkboxes[1]!); // 김서준
+    await user.click(screen.getByRole("checkbox", { name: "김서준" }));
 
     expect(onChange).toHaveBeenCalledWith([1]);
   });

--- a/src/features/rooms/components/room-attendee-picker.test.tsx
+++ b/src/features/rooms/components/room-attendee-picker.test.tsx
@@ -11,40 +11,57 @@ const MEMBERS: RoomMember[] = [
 ];
 
 describe("RoomAttendeePicker", () => {
-  it("이름을 검색하면 이미 선택된 사람은 빼고 결과를 보여준다", async () => {
-    const user = userEvent.setup();
-    render(<RoomAttendeePicker members={MEMBERS} selectedIds={[1]} onChange={jest.fn()} />);
+  it("검색 전에는 전체 목록을 보여준다", () => {
+    render(<RoomAttendeePicker members={MEMBERS} selectedIds={[]} onChange={jest.fn()} />);
 
-    await user.type(screen.getByRole("textbox", { name: "참석자 검색" }), "박");
-
-    // 이미 선택된 "박대표"는 칩으로만 남고, 검색 결과 버튼으로는 다시 뜨지 않는다.
-    expect(screen.queryByRole("button", { name: "박대표" })).not.toBeInTheDocument();
+    expect(screen.getByText("박대표")).toBeInTheDocument();
+    expect(screen.getByText("김서준")).toBeInTheDocument();
+    expect(screen.getByText("이하윤")).toBeInTheDocument();
   });
 
-  it("검색 결과를 누르면 선택 목록에 추가하고 검색어를 지운다", async () => {
+  it("이름을 검색하면 그 이름만 남는다", async () => {
+    const user = userEvent.setup();
+    render(<RoomAttendeePicker members={MEMBERS} selectedIds={[]} onChange={jest.fn()} />);
+
+    await user.type(screen.getByRole("textbox", { name: "참석자 검색" }), "김");
+
+    expect(screen.getByText("김서준")).toBeInTheDocument();
+    expect(screen.queryByText("박대표")).not.toBeInTheDocument();
+  });
+
+  it("체크하면 onChange에 추가된 id를 실어 보낸다", async () => {
     const user = userEvent.setup();
     const onChange = jest.fn();
     render(<RoomAttendeePicker members={MEMBERS} selectedIds={[]} onChange={onChange} />);
 
-    await user.type(screen.getByRole("textbox", { name: "참석자 검색" }), "김서준");
-    await user.click(screen.getByRole("button", { name: "김서준" }));
+    await user.click(screen.getByRole("checkbox", { name: "김서준" }));
 
     expect(onChange).toHaveBeenCalledWith([2]);
   });
 
-  it("선택된 사람의 X를 누르면 목록에서 뺀다", async () => {
+  it("이미 선택된 사람의 체크를 풀면 목록에서 뺀다", async () => {
     const user = userEvent.setup();
     const onChange = jest.fn();
     render(<RoomAttendeePicker members={MEMBERS} selectedIds={[1, 2]} onChange={onChange} />);
 
-    await user.click(screen.getByRole("button", { name: "김서준 제외" }));
+    const checkboxes = screen.getAllByRole("checkbox");
+    await user.click(checkboxes[1]!); // 김서준
 
     expect(onChange).toHaveBeenCalledWith([1]);
   });
 
-  it("아무도 선택 안 하면 안내 문구를 보여준다", () => {
+  it("선택 인원 수를 보여준다", () => {
+    render(<RoomAttendeePicker members={MEMBERS} selectedIds={[1, 2]} onChange={jest.fn()} />);
+
+    expect(screen.getByText("선택 2명")).toBeInTheDocument();
+  });
+
+  it("검색 결과가 없으면 안내 문구를 보여준다", async () => {
+    const user = userEvent.setup();
     render(<RoomAttendeePicker members={MEMBERS} selectedIds={[]} onChange={jest.fn()} />);
 
-    expect(screen.getByText("참석자를 검색해 선택하세요")).toBeInTheDocument();
+    await user.type(screen.getByRole("textbox", { name: "참석자 검색" }), "존재하지않는이름");
+
+    expect(screen.getByText("검색 결과가 없어요")).toBeInTheDocument();
   });
 });

--- a/src/features/rooms/components/room-attendee-picker.tsx
+++ b/src/features/rooms/components/room-attendee-picker.tsx
@@ -33,6 +33,8 @@ function AttendeeRow({
     <label className="hover:bg-muted flex cursor-pointer items-center gap-2.5 px-3 py-2 text-sm transition-colors">
       <input
         type="checkbox"
+        name="attendeeIds"
+        value={member.id}
         checked={checked}
         onChange={onToggle}
         className="accent-foreground size-3.5 shrink-0"

--- a/src/features/rooms/components/room-attendee-picker.tsx
+++ b/src/features/rooms/components/room-attendee-picker.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { Search, X } from "lucide-react";
+import { Search } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useProfileAvatar } from "@/hooks/use-profile-avatar";
 
 import type { RoomMember } from "../types";
 
@@ -13,36 +15,57 @@ interface RoomAttendeePickerProps {
   onChange: (ids: number[]) => void;
 }
 
-/** 검색 결과로 한 번에 보여줄 최대 인원 — `notice-company-picker.tsx`와 같은 값. */
-const MAX_RESULTS = 6;
+const AVATAR_SIZE = 20;
 
-/** 회의실 예약 "참석자" 선택 — 이름으로 검색해 여러 명을 골라 담는다(`notice-company-picker.tsx`와 같은 모양). */
+/** 참석자 목록 한 줄 — 아바타는 훅이라 참석자 수만큼 이 컴포넌트를 마운트해 각자 한 번씩 부른다. */
+function AttendeeRow({
+  member,
+  checked,
+  onToggle,
+}: {
+  member: RoomMember;
+  checked: boolean;
+  onToggle: () => void;
+}) {
+  const avatar = useProfileAvatar(member.id, AVATAR_SIZE);
+
+  return (
+    <label className="hover:bg-muted flex cursor-pointer items-center gap-2.5 px-3 py-2 text-sm transition-colors">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={onToggle}
+        className="accent-foreground size-3.5 shrink-0"
+      />
+      {avatar}
+      <span className="truncate">{member.name}</span>
+    </label>
+  );
+}
+
+/**
+ * 회의실 예약 "참석자" 선택 — 검색으로 좁히되, 결과는 **전체 목록을 체크박스로** 보여준다
+ * (디자인 반영). 검색 전에는 전체가 다 보이고, 검색하면 이름이 걸리는 사람만 남는다.
+ */
 export function RoomAttendeePicker({ members, selectedIds, onChange }: RoomAttendeePickerProps) {
   const [keyword, setKeyword] = useState("");
 
-  const selected = useMemo(
-    () => members.filter((member) => selectedIds.includes(member.id)),
-    [members, selectedIds],
-  );
-
-  const results = useMemo(() => {
+  const visible = useMemo(() => {
     const query = keyword.trim().toLowerCase();
-    if (!query) return [];
-    return members
-      .filter(
-        (member) => !selectedIds.includes(member.id) && member.name.toLowerCase().includes(query),
-      )
-      .slice(0, MAX_RESULTS);
-  }, [members, keyword, selectedIds]);
+    if (!query) return members;
+    return members.filter((member) => member.name.toLowerCase().includes(query));
+  }, [members, keyword]);
 
-  const handleAdd = (id: number) => {
-    onChange([...selectedIds, id]);
-    setKeyword("");
-  };
-  const handleRemove = (id: number) => onChange(selectedIds.filter((value) => value !== id));
+  function toggle(id: number) {
+    onChange(
+      selectedIds.includes(id) ? selectedIds.filter((value) => value !== id) : [...selectedIds, id],
+    );
+  }
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex h-full flex-col gap-2">
+      <Label>참석자</Label>
+
       <div className="relative">
         <Search
           className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2"
@@ -57,50 +80,22 @@ export function RoomAttendeePicker({ members, selectedIds, onChange }: RoomAtten
         />
       </div>
 
-      {keyword.trim().length > 0 && (
-        <div className="border-border overflow-hidden rounded-lg border">
-          {results.length === 0 ? (
-            <p className="text-muted-foreground px-3 py-3 text-xs">검색 결과가 없어요</p>
-          ) : (
-            <ul>
-              {results.map((member) => (
-                <li key={member.id}>
-                  <button
-                    type="button"
-                    onClick={() => handleAdd(member.id)}
-                    className="hover:bg-muted focus-visible:ring-ring flex w-full items-center px-3 py-2 text-left transition-colors focus-visible:ring-2 focus-visible:outline-none"
-                  >
-                    <span className="text-foreground truncate text-xs">{member.name}</span>
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
-      )}
-
-      {selected.length > 0 ? (
-        <div className="flex flex-wrap gap-1.5">
-          {selected.map((member) => (
-            <span
+      <div className="border-border min-h-0 flex-1 overflow-y-auto rounded-lg border">
+        {visible.length === 0 ? (
+          <p className="text-muted-foreground px-3 py-3 text-xs">검색 결과가 없어요</p>
+        ) : (
+          visible.map((member) => (
+            <AttendeeRow
               key={member.id}
-              className="bg-muted text-foreground inline-flex items-center gap-1 rounded-md py-1 pr-1 pl-2 text-xs"
-            >
-              {member.name}
-              <button
-                type="button"
-                onClick={() => handleRemove(member.id)}
-                aria-label={`${member.name} 제외`}
-                className="hover:bg-foreground/10 focus-visible:ring-ring flex size-4 items-center justify-center rounded transition-colors focus-visible:ring-2 focus-visible:outline-none"
-              >
-                <X className="size-3" aria-hidden />
-              </button>
-            </span>
-          ))}
-        </div>
-      ) : (
-        <p className="text-muted-foreground text-[11px]">참석자를 검색해 선택하세요</p>
-      )}
+              member={member}
+              checked={selectedIds.includes(member.id)}
+              onToggle={() => toggle(member.id)}
+            />
+          ))
+        )}
+      </div>
+
+      <p className="text-muted-foreground text-[11px]">선택 {selectedIds.length}명</p>
     </div>
   );
 }

--- a/src/features/rooms/components/room-picker-list.tsx
+++ b/src/features/rooms/components/room-picker-list.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+import type { MeetingRoom } from "../types";
+
+interface RoomPickerListProps {
+  rooms: MeetingRoom[];
+  selectedId: string;
+  onChange: (id: string) => void;
+  error?: boolean;
+}
+
+/**
+ * 예약 모달의 "회의실" 선택 — 드롭다운이 아니라 목록에서 바로 고르는 형태(디자인 반영).
+ * 회의실 개수가 적어(4곳) 펼쳐서 보여주는 쪽이 한 번 더 눌러야 하는 드롭다운보다 빠르다.
+ * ⚠️ 괄호 안은 "수용 인원"이 아니라 "위치"다 — 수용 인원 필드는 폐기됐다(WORKFLOW.md §10-A).
+ */
+export function RoomPickerList({ rooms, selectedId, onChange, error }: RoomPickerListProps) {
+  return (
+    <div className="flex flex-col gap-1.5" role="radiogroup" aria-label="회의실">
+      {rooms.map((room) => {
+        const selected = room.id === selectedId;
+        return (
+          <button
+            key={room.id}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            onClick={() => onChange(room.id)}
+            className={cn(
+              "flex items-center justify-between rounded-lg border px-3.5 py-2.5 text-left text-sm transition-colors",
+              selected ? "border-foreground bg-foreground/5" : "border-input hover:bg-muted",
+              error && !selected && "border-destructive/40",
+            )}
+          >
+            <span>{room.name}</span>
+            <span className="text-muted-foreground text-xs">{room.location}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/rooms/components/room-reservation-dialog.test.tsx
+++ b/src/features/rooms/components/room-reservation-dialog.test.tsx
@@ -36,7 +36,7 @@ function renderDialog(overrides: Partial<React.ComponentProps<typeof RoomReserva
       rooms={ROOMS}
       members={MEMBERS}
       projects={PROJECTS}
-      hostAuthority={AUTHORITY.OWNER}
+      showParentTeamAction={false}
       teamActions={TEAM_ACTIONS}
       onCreated={onCreated}
       {...overrides}
@@ -54,7 +54,7 @@ describe("RoomReservationDialog", () => {
         rooms={ROOMS}
         members={MEMBERS}
         projects={PROJECTS}
-        hostAuthority={AUTHORITY.OWNER}
+        showParentTeamAction={false}
         teamActions={TEAM_ACTIONS}
         onCreated={jest.fn()}
       />,
@@ -80,14 +80,14 @@ describe("RoomReservationDialog", () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
-  it("Owner가 열면 상위 팀 액션 필드가 없다", () => {
-    renderDialog({ hostAuthority: AUTHORITY.OWNER });
+  it("showParentTeamAction이 false면 상위 팀 액션 필드가 없다(Owner 개설)", () => {
+    renderDialog({ showParentTeamAction: false });
 
     expect(screen.queryByRole("combobox", { name: "상위 팀 액션" })).not.toBeInTheDocument();
   });
 
-  it("Leader가 열면 상위 팀 액션 필드가 뜬다", () => {
-    renderDialog({ hostAuthority: AUTHORITY.LEADER });
+  it("showParentTeamAction이 true면 상위 팀 액션 필드가 뜬다(Leader/Member 개설)", () => {
+    renderDialog({ showParentTeamAction: true });
 
     expect(screen.getByRole("combobox", { name: "상위 팀 액션" })).toBeInTheDocument();
   });

--- a/src/features/rooms/components/room-reservation-dialog.test.tsx
+++ b/src/features/rooms/components/room-reservation-dialog.test.tsx
@@ -60,13 +60,15 @@ describe("RoomReservationDialog", () => {
       />,
     );
 
-    expect(screen.queryByText("회의실을 예약할까요?")).not.toBeInTheDocument();
+    expect(screen.queryByText("회의실 예약")).not.toBeInTheDocument();
   });
 
   it("클릭한 슬롯의 날짜·시각을 안내한다", () => {
     renderDialog();
 
-    expect(screen.getByText(/8월 11일\(화\) 10:00부터 30분간 진행됩니다\./)).toBeInTheDocument();
+    expect(screen.getByText("화 8/11")).toBeInTheDocument();
+    expect(screen.getByText("10:00 - 10:30")).toBeInTheDocument();
+    expect(screen.getByText("30분 · 즉시 확정")).toBeInTheDocument();
   });
 
   it("취소를 누르면 onOpenChange(false)를 부른다", async () => {
@@ -95,7 +97,7 @@ describe("RoomReservationDialog", () => {
     const { onCreated } = renderDialog();
 
     await user.type(screen.getByLabelText("회의 제목"), "새 회의");
-    await user.click(screen.getByRole("button", { name: "등록" }));
+    await user.click(screen.getByRole("button", { name: "즉시 예약" }));
 
     await waitFor(() => {
       const roomError = screen.getByText(

--- a/src/features/rooms/components/room-reservation-dialog.test.tsx
+++ b/src/features/rooms/components/room-reservation-dialog.test.tsx
@@ -1,12 +1,12 @@
+import { AUTHORITY } from "@/constants/authority";
+
 jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
 jest.mock("@/lib/mock-actor", () => ({
-  getMockActor: jest.fn(() => ({ id: 1, role: "OWNER" })),
+  getMockActor: jest.fn(() => ({ id: 1, role: AUTHORITY.OWNER })),
 }));
 
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-
-import { AUTHORITY } from "@/constants/authority";
 
 import type { MeetingRoom, RoomMember, RoomProjectOption, RoomTeamActionOption } from "../types";
 import { RoomReservationDialog } from "./room-reservation-dialog";
@@ -83,13 +83,13 @@ describe("RoomReservationDialog", () => {
   it("Owner가 열면 상위 팀 액션 필드가 없다", () => {
     renderDialog({ hostAuthority: AUTHORITY.OWNER });
 
-    expect(screen.queryByText("상위 팀 액션")).not.toBeInTheDocument();
+    expect(screen.queryByRole("combobox", { name: "상위 팀 액션" })).not.toBeInTheDocument();
   });
 
   it("Leader가 열면 상위 팀 액션 필드가 뜬다", () => {
     renderDialog({ hostAuthority: AUTHORITY.LEADER });
 
-    expect(screen.getByText("상위 팀 액션")).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "상위 팀 액션" })).toBeInTheDocument();
   });
 
   it("필수값을 안 채우고 등록을 누르면 필드별 오류를 보여주고 onCreated는 안 부른다", async () => {

--- a/src/features/rooms/components/room-reservation-dialog.test.tsx
+++ b/src/features/rooms/components/room-reservation-dialog.test.tsx
@@ -1,9 +1,14 @@
 jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/lib/mock-actor", () => ({
+  getMockActor: jest.fn(() => ({ id: 1, role: "OWNER" })),
+}));
 
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import type { MeetingRoom, RoomMember, RoomProjectOption } from "../types";
+import { AUTHORITY } from "@/constants/authority";
+
+import type { MeetingRoom, RoomMember, RoomProjectOption, RoomTeamActionOption } from "../types";
 import { RoomReservationDialog } from "./room-reservation-dialog";
 
 const ROOMS: MeetingRoom[] = [
@@ -16,7 +21,8 @@ const ROOMS: MeetingRoom[] = [
   },
 ];
 const MEMBERS: RoomMember[] = [{ id: 1, name: "박대표" }];
-const PROJECTS: RoomProjectOption[] = [{ id: "p-goods", name: "굿즈 프로젝트", tag: "GOODS" }];
+const PROJECTS: RoomProjectOption[] = [{ id: "1", name: "굿즈 프로젝트", tag: "GOODS" }];
+const TEAM_ACTIONS: RoomTeamActionOption[] = [];
 
 const SLOT_START = new Date("2026-08-11T10:00:00");
 
@@ -30,6 +36,8 @@ function renderDialog(overrides: Partial<React.ComponentProps<typeof RoomReserva
       rooms={ROOMS}
       members={MEMBERS}
       projects={PROJECTS}
+      hostAuthority={AUTHORITY.OWNER}
+      teamActions={TEAM_ACTIONS}
       onCreated={onCreated}
       {...overrides}
     />,
@@ -46,6 +54,8 @@ describe("RoomReservationDialog", () => {
         rooms={ROOMS}
         members={MEMBERS}
         projects={PROJECTS}
+        hostAuthority={AUTHORITY.OWNER}
+        teamActions={TEAM_ACTIONS}
         onCreated={jest.fn()}
       />,
     );
@@ -68,6 +78,18 @@ describe("RoomReservationDialog", () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
+  it("Owner가 열면 상위 팀 액션 필드가 없다", () => {
+    renderDialog({ hostAuthority: AUTHORITY.OWNER });
+
+    expect(screen.queryByText("상위 팀 액션")).not.toBeInTheDocument();
+  });
+
+  it("Leader가 열면 상위 팀 액션 필드가 뜬다", () => {
+    renderDialog({ hostAuthority: AUTHORITY.LEADER });
+
+    expect(screen.getByText("상위 팀 액션")).toBeInTheDocument();
+  });
+
   it("필수값을 안 채우고 등록을 누르면 필드별 오류를 보여주고 onCreated는 안 부른다", async () => {
     const user = userEvent.setup();
     const { onCreated } = renderDialog();
@@ -82,7 +104,15 @@ describe("RoomReservationDialog", () => {
       );
       expect(roomError).toBeInTheDocument();
     });
-    expect(screen.getByText("대주제를 선택해 주세요")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        (_content, element) =>
+          element?.tagName === "P" && element.textContent === "프로젝트를 선택해 주세요",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("회의 안건(대주제·소주제)을 한 쌍 이상 입력해 주세요"),
+    ).toBeInTheDocument();
     expect(screen.getByText("참석자를 한 명 이상 선택해 주세요")).toBeInTheDocument();
     expect(onCreated).not.toHaveBeenCalled();
   });

--- a/src/features/rooms/components/room-reservation-dialog.tsx
+++ b/src/features/rooms/components/room-reservation-dialog.tsx
@@ -7,6 +7,7 @@ import { Bell } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import type { Authority } from "@/constants/authority";
+import { requiresParentTeamAction } from "@/lib/permission";
 
 import type {
   MeetingRoom,
@@ -77,6 +78,7 @@ export function RoomReservationDialog({
 }: RoomReservationDialogProps) {
   const { state, isPending, form, setForm, handleOpenChange, handleSubmit } =
     useRoomReservationForm({ slotStart, onCreated, onOpenChange });
+  const showParentTeamAction = requiresParentTeamAction({ role: hostAuthority });
 
   return (
     <Dialog open={slotStart !== null} onOpenChange={handleOpenChange}>
@@ -95,7 +97,7 @@ export function RoomReservationDialog({
               errors={state.errors}
               rooms={rooms}
               projects={projects}
-              hostAuthority={hostAuthority}
+              showParentTeamAction={showParentTeamAction}
               teamActions={teamActions}
             />
 

--- a/src/features/rooms/components/room-reservation-dialog.tsx
+++ b/src/features/rooms/components/room-reservation-dialog.tsx
@@ -7,9 +7,8 @@ import { useFormStatus } from "react-dom";
 
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import type { Authority } from "@/constants/authority";
-import { requiresParentTeamAction } from "@/lib/permission";
 
+import { RESERVATION_DURATION_MINUTES } from "../constants";
 import type {
   MeetingRoom,
   RoomMember,
@@ -17,7 +16,6 @@ import type {
   RoomReservation,
   RoomTeamActionOption,
 } from "../types";
-import { RESERVATION_DURATION_MINUTES } from "../validate";
 import { RoomAttendeePicker } from "./room-attendee-picker";
 import { RoomReservationFields } from "./room-reservation-fields";
 import { useRoomReservationForm } from "./use-room-reservation-form";
@@ -30,8 +28,10 @@ interface RoomReservationDialogProps {
   rooms: MeetingRoom[];
   members: RoomMember[];
   projects: RoomProjectOption[];
-  /** 지금 모달을 여는 사람의 권한 — Owner가 아니면 "상위 팀 액션" 필드가 뜬다(WORKFLOW.md §3-1). */
-  hostAuthority: Authority;
+  /** "상위 팀 액션" 필드를 보여줄지 — `page.tsx`(서버 컴포넌트)가 `requiresParentTeamAction`으로
+   *  미리 계산해 내려준다. `lib/permission.ts`는 `server-only`라 이 클라이언트 컴포넌트에서
+   *  직접 못 부른다. */
+  showParentTeamAction: boolean;
   teamActions: RoomTeamActionOption[];
   /** 생성 성공 시 호출 — 재조회 없이 부모 화면에 바로 얹는다(§최적화: action 리턴값 그대로 반영). */
   onCreated: (created: RoomReservation) => void;
@@ -97,7 +97,7 @@ export function RoomReservationDialog({
   rooms,
   members,
   projects,
-  hostAuthority,
+  showParentTeamAction,
   teamActions,
   onCreated,
 }: RoomReservationDialogProps) {
@@ -106,7 +106,6 @@ export function RoomReservationDialog({
     onCreated,
     onOpenChange,
   });
-  const showParentTeamAction = requiresParentTeamAction({ role: hostAuthority });
 
   return (
     <Dialog open={slotStart !== null} onOpenChange={handleOpenChange}>

--- a/src/features/rooms/components/room-reservation-dialog.tsx
+++ b/src/features/rooms/components/room-reservation-dialog.tsx
@@ -3,6 +3,7 @@
 import { format } from "date-fns";
 import { ko } from "date-fns/locale";
 import { Bell } from "lucide-react";
+import { useFormStatus } from "react-dom";
 
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
@@ -58,13 +59,37 @@ function SlotSummary({ slotStart }: { slotStart: Date }) {
 }
 
 /**
+ * 취소·제출 버튼 — `useFormStatus`는 `<form>`의 **자손** 컴포넌트에서만 호출할 수 있어서
+ * `RoomReservationDialog`(그 `<form>`을 직접 그리는 컴포넌트) 안이 아니라 여기로 뺐다.
+ */
+function DialogActions({ onCancel }: { onCancel: () => void }) {
+  const { pending } = useFormStatus();
+
+  return (
+    <div className="flex shrink-0 gap-2">
+      <Button type="button" variant="outline" disabled={pending} onClick={onCancel}>
+        취소
+      </Button>
+      <Button type="submit" variant="ink" disabled={pending}>
+        {pending ? "예약 중" : "즉시 예약"}
+      </Button>
+    </div>
+  );
+}
+
+/**
  * 회의실 예약 모달 — `/app/rooms` 예약이 유일한 회의 개설 진입점이다(CLAUDE.md §라우트 그룹).
  * 왼쪽 열(제목·회의실·프로젝트·상위 팀 액션·회의 주제)과 오른쪽 열(참석자)로 나눈 2단 레이아웃
- * (디자인 반영, 2026-08-07).
- * 폼 상태·제출 로직은 `useRoomReservationForm`, 왼쪽 열 필드는 `RoomReservationFields`로 뺐다
+ * (디자인 반영, 2026-08-07) — 좁은 화면에서는 1열로 쌓이고 `sm` 이상에서만 2열이 된다.
+ * 폼 상태는 `useRoomReservationForm`, 왼쪽 열 필드는 `RoomReservationFields`로 뺐다
  * (CLAUDE.md §폴더·네이밍: 200줄↑ 분리·로직=커스텀훅) — 여기는 모달 뼈대만 조립한다.
+ * ⚠️ **실제 `<form action={formAction}>`으로 제출한다.** `title`·회의 주제·참석자는 전부
+ *    네이티브 입력(`name` 속성)이라 그대로 실리고, `roomId`·`projectId`·`parentTeamActionId`·
+ *    `date`·`startTime`은 네이티브 입력이 아닌 값(위젯 상태·계산값)이라 hidden input으로
+ *    따로 실어 보낸다.
  * ⚠️ 하단 알림 안내 문구는 **아직 실제로 안 보낸다** — SSE 알림 배너(WORKFLOW.md §9)는 별도
- *    이슈로 빠져 있다. 문구만 먼저 넣어 둔 것이고, 실제 발송 연동은 그 이슈에서 붙인다.
+ *    이슈로 빠져 있다. 문구가 "아직 준비 중"이라고 정직하게 말하고, 실제 발송 연동은 그
+ *    이슈에서 붙인다(CLAUDE.md §정직성).
  */
 export function RoomReservationDialog({
   slotStart,
@@ -76,8 +101,11 @@ export function RoomReservationDialog({
   teamActions,
   onCreated,
 }: RoomReservationDialogProps) {
-  const { state, isPending, form, setForm, handleOpenChange, handleSubmit } =
-    useRoomReservationForm({ slotStart, onCreated, onOpenChange });
+  const { state, formAction, form, setForm, handleOpenChange } = useRoomReservationForm({
+    slotStart,
+    onCreated,
+    onOpenChange,
+  });
   const showParentTeamAction = requiresParentTeamAction({ role: hostAuthority });
 
   return (
@@ -87,52 +115,56 @@ export function RoomReservationDialog({
           <DialogTitle>회의실 예약</DialogTitle>
         </DialogHeader>
 
-        <div className="flex max-h-[70vh] flex-col gap-4 overflow-y-auto px-6 py-4">
-          {slotStart && <SlotSummary slotStart={slotStart} />}
+        <form action={formAction}>
+          <input
+            type="hidden"
+            name="date"
+            value={slotStart ? format(slotStart, "yyyy-MM-dd") : ""}
+          />
+          <input
+            type="hidden"
+            name="startTime"
+            value={slotStart ? format(slotStart, "HH:mm") : ""}
+          />
+          <input type="hidden" name="roomId" value={form.roomId} />
+          <input type="hidden" name="projectId" value={form.projectId} />
+          <input type="hidden" name="parentTeamActionId" value={form.parentTeamActionId} />
 
-          <div className="grid grid-cols-[1fr_260px] gap-6">
-            <RoomReservationFields
-              form={form}
-              setForm={setForm}
-              errors={state.errors}
-              rooms={rooms}
-              projects={projects}
-              showParentTeamAction={showParentTeamAction}
-              teamActions={teamActions}
-            />
+          <div className="flex max-h-[70vh] flex-col gap-4 overflow-y-auto px-6 py-4">
+            {slotStart && <SlotSummary slotStart={slotStart} />}
 
-            <div className="flex flex-col gap-1.5">
-              <RoomAttendeePicker
-                members={members}
-                selectedIds={form.attendeeIds}
-                onChange={(attendeeIds) => setForm((prev) => ({ ...prev, attendeeIds }))}
+            <div className="grid grid-cols-1 gap-6 sm:grid-cols-[1fr_260px]">
+              <RoomReservationFields
+                form={form}
+                setForm={setForm}
+                errors={state.errors}
+                rooms={rooms}
+                projects={projects}
+                showParentTeamAction={showParentTeamAction}
+                teamActions={teamActions}
               />
-              {state.errors.attendeeIds && (
-                <p className="text-destructive text-xs">{state.errors.attendeeIds}</p>
-              )}
+
+              <div className="flex flex-col gap-1.5">
+                <RoomAttendeePicker
+                  members={members}
+                  selectedIds={form.attendeeIds}
+                  onChange={(attendeeIds) => setForm((prev) => ({ ...prev, attendeeIds }))}
+                />
+                {state.errors.attendeeIds && (
+                  <p className="text-destructive text-xs">{state.errors.attendeeIds}</p>
+                )}
+              </div>
             </div>
           </div>
-        </div>
 
-        <div className="border-border flex items-center justify-between gap-4 border-t px-6 py-4">
-          <p className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-[11px] break-keep">
-            <Bell className="size-3.5 shrink-0" aria-hidden />
-            예약 확정 시 + 시작 10분 전, 참석자에게 알림이 발송됩니다.
-          </p>
-          <div className="flex shrink-0 gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              disabled={isPending}
-              onClick={() => handleOpenChange(false)}
-            >
-              취소
-            </Button>
-            <Button type="button" variant="ink" disabled={isPending} onClick={handleSubmit}>
-              {isPending ? "예약 중" : "즉시 예약"}
-            </Button>
+          <div className="border-border flex items-center justify-between gap-4 border-t px-6 py-4">
+            <p className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-[11px] break-keep">
+              <Bell className="size-3.5 shrink-0" aria-hidden />
+              예약 확정·시작 10분 전 알림 발송 기능은 아직 준비 중입니다.
+            </p>
+            <DialogActions onCancel={() => handleOpenChange(false)} />
           </div>
-        </div>
+        </form>
       </DialogContent>
     </Dialog>
   );

--- a/src/features/rooms/components/room-reservation-dialog.tsx
+++ b/src/features/rooms/components/room-reservation-dialog.tsx
@@ -11,8 +11,15 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import type { Authority } from "@/constants/authority";
 
-import type { MeetingRoom, RoomMember, RoomProjectOption, RoomReservation } from "../types";
+import type {
+  MeetingRoom,
+  RoomMember,
+  RoomProjectOption,
+  RoomReservation,
+  RoomTeamActionOption,
+} from "../types";
 import { RoomReservationFields } from "./room-reservation-fields";
 import { useRoomReservationForm } from "./use-room-reservation-form";
 
@@ -24,6 +31,9 @@ interface RoomReservationDialogProps {
   rooms: MeetingRoom[];
   members: RoomMember[];
   projects: RoomProjectOption[];
+  /** 지금 모달을 여는 사람의 권한 — Owner가 아니면 "상위 팀 액션" 필드가 뜬다(WORKFLOW.md §3-1). */
+  hostAuthority: Authority;
+  teamActions: RoomTeamActionOption[];
   /** 생성 성공 시 호출 — 재조회 없이 부모 화면에 바로 얹는다(§최적화: action 리턴값 그대로 반영). */
   onCreated: (created: RoomReservation) => void;
 }
@@ -41,9 +51,11 @@ export function RoomReservationDialog({
   rooms,
   members,
   projects,
+  hostAuthority,
+  teamActions,
   onCreated,
 }: RoomReservationDialogProps) {
-  const { state, isPending, form, setForm, topicSubOptions, handleOpenChange, handleSubmit } =
+  const { state, isPending, form, setForm, handleOpenChange, handleSubmit } =
     useRoomReservationForm({ slotStart, onCreated, onOpenChange });
 
   return (
@@ -64,7 +76,8 @@ export function RoomReservationDialog({
           rooms={rooms}
           members={members}
           projects={projects}
-          topicSubOptions={topicSubOptions}
+          hostAuthority={hostAuthority}
+          teamActions={teamActions}
         />
 
         <div className="mt-2 flex justify-end gap-2">

--- a/src/features/rooms/components/room-reservation-dialog.tsx
+++ b/src/features/rooms/components/room-reservation-dialog.tsx
@@ -2,15 +2,10 @@
 
 import { format } from "date-fns";
 import { ko } from "date-fns/locale";
+import { Bell } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import type { Authority } from "@/constants/authority";
 
 import type {
@@ -20,6 +15,8 @@ import type {
   RoomReservation,
   RoomTeamActionOption,
 } from "../types";
+import { RESERVATION_DURATION_MINUTES } from "../validate";
+import { RoomAttendeePicker } from "./room-attendee-picker";
 import { RoomReservationFields } from "./room-reservation-fields";
 import { useRoomReservationForm } from "./use-room-reservation-form";
 
@@ -38,12 +35,35 @@ interface RoomReservationDialogProps {
   onCreated: (created: RoomReservation) => void;
 }
 
+/** 상단 슬롯 요약 — 요일·날짜 / 시간대 / "30분 · 즉시 확정" 세 칸을 한 줄에 나눠 보여준다. */
+function SlotSummary({ slotStart }: { slotStart: Date }) {
+  const slotEnd = new Date(slotStart.getTime() + RESERVATION_DURATION_MINUTES * 60_000);
+
+  return (
+    <div className="border-border bg-secondary/50 flex items-center gap-3 rounded-lg border px-3.5 py-2.5 text-[13px]">
+      <span className="font-medium">{format(slotStart, "EEE M/d", { locale: ko })}</span>
+      <span className="text-border" aria-hidden>
+        |
+      </span>
+      <span className="tabular-nums">
+        {format(slotStart, "HH:mm")} - {format(slotEnd, "HH:mm")}
+      </span>
+      <span className="text-border" aria-hidden>
+        |
+      </span>
+      <span className="text-muted-foreground">{RESERVATION_DURATION_MINUTES}분 · 즉시 확정</span>
+    </div>
+  );
+}
+
 /**
  * 회의실 예약 모달 — `/app/rooms` 예약이 유일한 회의 개설 진입점이다(CLAUDE.md §라우트 그룹).
- * ⚠️ `ConfirmDialog`를 안 쓴다 — 필드가 여러 개라 두 버튼 동일폭 레이아웃이 안 맞는다. 대신
- *    같은 표식 없는 순수 `Dialog`로 만들고, 제출 버튼은 하단 우측에 둔다(DESIGN.md §4 여백).
- * 폼 상태·제출 로직은 `useRoomReservationForm`, 입력 필드는 `RoomReservationFields`로 뺐다
+ * 왼쪽 열(제목·회의실·프로젝트·상위 팀 액션·회의 주제)과 오른쪽 열(참석자)로 나눈 2단 레이아웃
+ * (디자인 반영, 2026-08-07).
+ * 폼 상태·제출 로직은 `useRoomReservationForm`, 왼쪽 열 필드는 `RoomReservationFields`로 뺐다
  * (CLAUDE.md §폴더·네이밍: 200줄↑ 분리·로직=커스텀훅) — 여기는 모달 뼈대만 조립한다.
+ * ⚠️ 하단 알림 안내 문구는 **아직 실제로 안 보낸다** — SSE 알림 배너(WORKFLOW.md §9)는 별도
+ *    이슈로 빠져 있다. 문구만 먼저 넣어 둔 것이고, 실제 발송 연동은 그 이슈에서 붙인다.
  */
 export function RoomReservationDialog({
   slotStart,
@@ -60,38 +80,56 @@ export function RoomReservationDialog({
 
   return (
     <Dialog open={slotStart !== null} onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-[440px]">
-        <DialogHeader>
-          <DialogTitle>회의실을 예약할까요?</DialogTitle>
-          <DialogDescription>
-            {slotStart &&
-              `${format(slotStart, "M월 d일(EEE)", { locale: ko })} ${format(slotStart, "HH:mm")}부터 30분간 진행됩니다.`}
-          </DialogDescription>
+      <DialogContent className="gap-0 p-0 sm:max-w-[720px]">
+        <DialogHeader className="border-border border-b px-6 py-4">
+          <DialogTitle>회의실 예약</DialogTitle>
         </DialogHeader>
 
-        <RoomReservationFields
-          form={form}
-          setForm={setForm}
-          errors={state.errors}
-          rooms={rooms}
-          members={members}
-          projects={projects}
-          hostAuthority={hostAuthority}
-          teamActions={teamActions}
-        />
+        <div className="flex max-h-[70vh] flex-col gap-4 overflow-y-auto px-6 py-4">
+          {slotStart && <SlotSummary slotStart={slotStart} />}
 
-        <div className="mt-2 flex justify-end gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            disabled={isPending}
-            onClick={() => handleOpenChange(false)}
-          >
-            취소
-          </Button>
-          <Button type="button" variant="ink" disabled={isPending} onClick={handleSubmit}>
-            {isPending ? "등록 중" : "등록"}
-          </Button>
+          <div className="grid grid-cols-[1fr_260px] gap-6">
+            <RoomReservationFields
+              form={form}
+              setForm={setForm}
+              errors={state.errors}
+              rooms={rooms}
+              projects={projects}
+              hostAuthority={hostAuthority}
+              teamActions={teamActions}
+            />
+
+            <div className="flex flex-col gap-1.5">
+              <RoomAttendeePicker
+                members={members}
+                selectedIds={form.attendeeIds}
+                onChange={(attendeeIds) => setForm((prev) => ({ ...prev, attendeeIds }))}
+              />
+              {state.errors.attendeeIds && (
+                <p className="text-destructive text-xs">{state.errors.attendeeIds}</p>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="border-border flex items-center justify-between gap-4 border-t px-6 py-4">
+          <p className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-[11px] break-keep">
+            <Bell className="size-3.5 shrink-0" aria-hidden />
+            예약 확정 시 + 시작 10분 전, 참석자에게 알림이 발송됩니다.
+          </p>
+          <div className="flex shrink-0 gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              disabled={isPending}
+              onClick={() => handleOpenChange(false)}
+            >
+              취소
+            </Button>
+            <Button type="button" variant="ink" disabled={isPending} onClick={handleSubmit}>
+              {isPending ? "예약 중" : "즉시 예약"}
+            </Button>
+          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/src/features/rooms/components/room-reservation-fields.tsx
+++ b/src/features/rooms/components/room-reservation-fields.tsx
@@ -11,7 +11,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { AUTHORITY, type Authority } from "@/constants/authority";
 
 import type {
   MeetingRoom,
@@ -29,8 +28,11 @@ interface RoomReservationFieldsProps {
   errors: RoomReservationFormErrors;
   rooms: MeetingRoom[];
   projects: RoomProjectOption[];
-  /** 지금 예약 모달을 여는 사람의 권한 — Owner가 아니면 "상위 팀 액션"이 뜬다(WORKFLOW.md §3-1). */
-  hostAuthority: Authority;
+  /**
+   * "상위 팀 액션" 필드를 보여줄지 — 판정은 `lib/permission.ts`의 `requiresParentTeamAction`
+   * 한 곳에서 하고, 이 컴포넌트는 그 결과 boolean만 받는다(권한 판정을 화면에 흩어 두지 않는다).
+   */
+  showParentTeamAction: boolean;
   /** Host의 팀에 하달된 팀 액션 전체(프로젝트 무관) — 지금 고른 프로젝트로 화면에서 다시 거른다. */
   teamActions: RoomTeamActionOption[];
 }
@@ -45,7 +47,7 @@ export function RoomReservationFields({
   errors,
   rooms,
   projects,
-  hostAuthority,
+  showParentTeamAction,
   teamActions,
 }: RoomReservationFieldsProps) {
   const selectedProjectTag = projects.find((project) => project.id === form.projectId)?.tag;
@@ -105,7 +107,7 @@ export function RoomReservationFields({
         {errors.projectId && <p className="text-destructive text-xs">{errors.projectId}</p>}
       </div>
 
-      {hostAuthority !== AUTHORITY.OWNER && (
+      {showParentTeamAction && (
         <div className="flex flex-col gap-1.5">
           <Label htmlFor="reservation-parent-team-action">상위 팀 액션</Label>
           <Select

--- a/src/features/rooms/components/room-reservation-fields.tsx
+++ b/src/features/rooms/components/room-reservation-fields.tsx
@@ -61,6 +61,7 @@ export function RoomReservationFields({
         <Label htmlFor="reservation-title">회의 제목</Label>
         <Input
           id="reservation-title"
+          name="title"
           value={form.title}
           onChange={(event) => setForm((prev) => ({ ...prev, title: event.target.value }))}
           placeholder="회의 제목을 입력하세요"

--- a/src/features/rooms/components/room-reservation-fields.tsx
+++ b/src/features/rooms/components/room-reservation-fields.tsx
@@ -15,13 +15,12 @@ import { AUTHORITY, type Authority } from "@/constants/authority";
 
 import type {
   MeetingRoom,
-  RoomMember,
   RoomProjectOption,
   RoomReservationFormErrors,
   RoomTeamActionOption,
 } from "../types";
 import { MeetingTopicList } from "./meeting-topic-list";
-import { RoomAttendeePicker } from "./room-attendee-picker";
+import { RoomPickerList } from "./room-picker-list";
 import type { RoomReservationFormValues } from "./use-room-reservation-form";
 
 interface RoomReservationFieldsProps {
@@ -29,7 +28,6 @@ interface RoomReservationFieldsProps {
   setForm: Dispatch<SetStateAction<RoomReservationFormValues>>;
   errors: RoomReservationFormErrors;
   rooms: MeetingRoom[];
-  members: RoomMember[];
   projects: RoomProjectOption[];
   /** 지금 예약 모달을 여는 사람의 권한 — Owner가 아니면 "상위 팀 액션"이 뜬다(WORKFLOW.md §3-1). */
   hostAuthority: Authority;
@@ -37,13 +35,15 @@ interface RoomReservationFieldsProps {
   teamActions: RoomTeamActionOption[];
 }
 
-/** 예약 모달의 입력 필드 전부 — 제목·회의실·프로젝트·안건·상위 팀 액션·참석자(`room-reservation-dialog.tsx`에서 뺀 조각). */
+/**
+ * 예약 모달 왼쪽 열 — 제목·회의실·프로젝트·상위 팀 액션·회의 주제(`room-reservation-dialog.tsx`가
+ * 오른쪽 열의 참석자 패널과 나란히 배치한다).
+ */
 export function RoomReservationFields({
   form,
   setForm,
   errors,
   rooms,
-  members,
   projects,
   hostAuthority,
   teamActions,
@@ -61,33 +61,20 @@ export function RoomReservationFields({
           id="reservation-title"
           value={form.title}
           onChange={(event) => setForm((prev) => ({ ...prev, title: event.target.value }))}
-          placeholder="회의 제목을 입력해 주세요"
+          placeholder="회의 제목을 입력하세요"
           aria-invalid={Boolean(errors.title)}
         />
         {errors.title && <p className="text-destructive text-xs">{errors.title}</p>}
       </div>
 
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="reservation-room">회의실</Label>
-        <Select
-          value={form.roomId}
-          onValueChange={(value) => setForm((prev) => ({ ...prev, roomId: value ?? "" }))}
-        >
-          <SelectTrigger
-            id="reservation-room"
-            aria-invalid={Boolean(errors.roomId)}
-            className="w-full"
-          >
-            <SelectValue placeholder="회의실을 선택해 주세요" />
-          </SelectTrigger>
-          <SelectContent>
-            {rooms.map((room) => (
-              <SelectItem key={room.id} value={room.id}>
-                {room.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <Label>회의실</Label>
+        <RoomPickerList
+          rooms={rooms}
+          selectedId={form.roomId}
+          onChange={(roomId) => setForm((prev) => ({ ...prev, roomId }))}
+          error={Boolean(errors.roomId)}
+        />
         {errors.roomId && <p className="text-destructive text-xs">{errors.roomId}</p>}
       </div>
 
@@ -105,7 +92,7 @@ export function RoomReservationFields({
             aria-invalid={Boolean(errors.projectId)}
             className="w-full"
           >
-            <SelectValue placeholder="프로젝트를 선택해 주세요" />
+            <SelectValue placeholder="프로젝트 선택" />
           </SelectTrigger>
           <SelectContent>
             {projects.map((project) => (
@@ -134,9 +121,7 @@ export function RoomReservationFields({
               className="w-full"
             >
               <SelectValue
-                placeholder={
-                  form.projectId ? "상위 팀 액션을 선택해 주세요" : "프로젝트를 먼저 선택해 주세요"
-                }
+                placeholder={form.projectId ? "상위 팀 액션 선택" : "프로젝트를 먼저 선택해 주세요"}
               />
             </SelectTrigger>
             <SelectContent>
@@ -158,16 +143,6 @@ export function RoomReservationFields({
         onChange={(topics) => setForm((prev) => ({ ...prev, topics }))}
         error={errors.topics}
       />
-
-      <div className="flex flex-col gap-1.5">
-        <Label>참석자</Label>
-        <RoomAttendeePicker
-          members={members}
-          selectedIds={form.attendeeIds}
-          onChange={(attendeeIds) => setForm((prev) => ({ ...prev, attendeeIds }))}
-        />
-        {errors.attendeeIds && <p className="text-destructive text-xs">{errors.attendeeIds}</p>}
-      </div>
     </div>
   );
 }

--- a/src/features/rooms/components/room-reservation-fields.tsx
+++ b/src/features/rooms/components/room-reservation-fields.tsx
@@ -11,16 +11,18 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { MEETING_TOPIC_MAIN_LABEL, type MeetingTopicSub } from "@/constants/meeting";
+import { AUTHORITY, type Authority } from "@/constants/authority";
 
 import type {
   MeetingRoom,
   RoomMember,
   RoomProjectOption,
   RoomReservationFormErrors,
+  RoomTeamActionOption,
 } from "../types";
+import { MeetingTopicList } from "./meeting-topic-list";
 import { RoomAttendeePicker } from "./room-attendee-picker";
-import { NO_PROJECT_VALUE, type RoomReservationFormValues } from "./use-room-reservation-form";
+import type { RoomReservationFormValues } from "./use-room-reservation-form";
 
 interface RoomReservationFieldsProps {
   form: RoomReservationFormValues;
@@ -29,10 +31,13 @@ interface RoomReservationFieldsProps {
   rooms: MeetingRoom[];
   members: RoomMember[];
   projects: RoomProjectOption[];
-  topicSubOptions: MeetingTopicSub[];
+  /** 지금 예약 모달을 여는 사람의 권한 — Owner가 아니면 "상위 팀 액션"이 뜬다(WORKFLOW.md §3-1). */
+  hostAuthority: Authority;
+  /** Host의 팀에 하달된 팀 액션 전체(프로젝트 무관) — 지금 고른 프로젝트로 화면에서 다시 거른다. */
+  teamActions: RoomTeamActionOption[];
 }
 
-/** 예약 모달의 입력 필드 전부 — 제목·회의실·프로젝트·대주제/소주제·참석자(`room-reservation-dialog.tsx`에서 뺀 조각). */
+/** 예약 모달의 입력 필드 전부 — 제목·회의실·프로젝트·안건·상위 팀 액션·참석자(`room-reservation-dialog.tsx`에서 뺀 조각). */
 export function RoomReservationFields({
   form,
   setForm,
@@ -40,8 +45,14 @@ export function RoomReservationFields({
   rooms,
   members,
   projects,
-  topicSubOptions,
+  hostAuthority,
+  teamActions,
 }: RoomReservationFieldsProps) {
+  const selectedProjectTag = projects.find((project) => project.id === form.projectId)?.tag;
+  const availableTeamActions = teamActions.filter(
+    (teamAction) => teamAction.projectTag === selectedProjectTag,
+  );
+
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-1.5">
@@ -85,14 +96,18 @@ export function RoomReservationFields({
         <Select
           value={form.projectId}
           onValueChange={(value) =>
-            setForm((prev) => ({ ...prev, projectId: value ?? NO_PROJECT_VALUE }))
+            // 프로젝트를 바꾸면 그 프로젝트 소속이 아닌 상위 팀 액션 선택은 의미가 없어진다.
+            setForm((prev) => ({ ...prev, projectId: value ?? "", parentTeamActionId: "" }))
           }
         >
-          <SelectTrigger id="reservation-project" className="w-full">
+          <SelectTrigger
+            id="reservation-project"
+            aria-invalid={Boolean(errors.projectId)}
+            className="w-full"
+          >
             <SelectValue placeholder="프로젝트를 선택해 주세요" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value={NO_PROJECT_VALUE}>없음</SelectItem>
             {projects.map((project) => (
               <SelectItem key={project.id} value={project.id}>
                 {project.name}
@@ -103,58 +118,46 @@ export function RoomReservationFields({
         {errors.projectId && <p className="text-destructive text-xs">{errors.projectId}</p>}
       </div>
 
-      <div className="grid grid-cols-2 gap-3">
+      {hostAuthority !== AUTHORITY.OWNER && (
         <div className="flex flex-col gap-1.5">
-          <Label htmlFor="reservation-topic-main">대주제</Label>
+          <Label htmlFor="reservation-parent-team-action">상위 팀 액션</Label>
           <Select
-            value={form.topicMain}
+            value={form.parentTeamActionId}
             onValueChange={(value) =>
-              setForm((prev) => ({ ...prev, topicMain: value ?? "", topicSub: "" }))
+              setForm((prev) => ({ ...prev, parentTeamActionId: value ?? "" }))
             }
+            disabled={!form.projectId}
           >
             <SelectTrigger
-              id="reservation-topic-main"
-              aria-invalid={Boolean(errors.topicMain)}
+              id="reservation-parent-team-action"
+              aria-invalid={Boolean(errors.parentTeamActionId)}
               className="w-full"
             >
-              <SelectValue placeholder="대주제" />
+              <SelectValue
+                placeholder={
+                  form.projectId ? "상위 팀 액션을 선택해 주세요" : "프로젝트를 먼저 선택해 주세요"
+                }
+              />
             </SelectTrigger>
             <SelectContent>
-              {Object.entries(MEETING_TOPIC_MAIN_LABEL).map(([value, label]) => (
-                <SelectItem key={value} value={value}>
-                  {label}
+              {availableTeamActions.map((teamAction) => (
+                <SelectItem key={teamAction.id} value={String(teamAction.id)}>
+                  {teamAction.name}
                 </SelectItem>
               ))}
             </SelectContent>
           </Select>
-          {errors.topicMain && <p className="text-destructive text-xs">{errors.topicMain}</p>}
+          {errors.parentTeamActionId && (
+            <p className="text-destructive text-xs">{errors.parentTeamActionId}</p>
+          )}
         </div>
+      )}
 
-        <div className="flex flex-col gap-1.5">
-          <Label htmlFor="reservation-topic-sub">소주제</Label>
-          <Select
-            value={form.topicSub}
-            onValueChange={(value) => setForm((prev) => ({ ...prev, topicSub: value ?? "" }))}
-            disabled={!form.topicMain}
-          >
-            <SelectTrigger
-              id="reservation-topic-sub"
-              aria-invalid={Boolean(errors.topicSub)}
-              className="w-full"
-            >
-              <SelectValue placeholder="소주제" />
-            </SelectTrigger>
-            <SelectContent>
-              {topicSubOptions.map((sub) => (
-                <SelectItem key={sub.value} value={sub.value}>
-                  {sub.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          {errors.topicSub && <p className="text-destructive text-xs">{errors.topicSub}</p>}
-        </div>
-      </div>
+      <MeetingTopicList
+        topics={form.topics}
+        onChange={(topics) => setForm((prev) => ({ ...prev, topics }))}
+        error={errors.topics}
+      />
 
       <div className="flex flex-col gap-1.5">
         <Label>참석자</Label>

--- a/src/features/rooms/components/rooms-board.tsx
+++ b/src/features/rooms/components/rooms-board.tsx
@@ -2,7 +2,15 @@
 
 import { useState } from "react";
 
-import type { MeetingRoom, RoomMember, RoomProjectOption, RoomReservation } from "../types";
+import type { Authority } from "@/constants/authority";
+
+import type {
+  MeetingRoom,
+  RoomMember,
+  RoomProjectOption,
+  RoomReservation,
+  RoomTeamActionOption,
+} from "../types";
 import { RoomListPanel } from "./room-list-panel";
 import { RoomReservationDialog } from "./room-reservation-dialog";
 import { WeeklyRoomCalendarLoader } from "./weekly-room-calendar-loader";
@@ -12,6 +20,8 @@ interface RoomsBoardProps {
   rooms: MeetingRoom[];
   members: RoomMember[];
   projects: RoomProjectOption[];
+  hostAuthority: Authority;
+  teamActions: RoomTeamActionOption[];
   /** "YYYY-MM-DD" — 이 주의 월요일. 서버 컴포넌트가 이 주 기준으로 `initialReservations`를 내려준다. */
   week: string;
 }
@@ -29,6 +39,8 @@ export function RoomsBoard({
   rooms,
   members,
   projects,
+  hostAuthority,
+  teamActions,
   week,
 }: RoomsBoardProps) {
   const [reservations, setReservations] = useState(initialReservations);
@@ -50,6 +62,8 @@ export function RoomsBoard({
         rooms={rooms}
         members={members}
         projects={projects}
+        hostAuthority={hostAuthority}
+        teamActions={teamActions}
         onCreated={(created) => setReservations((prev) => [...prev, created])}
       />
     </div>

--- a/src/features/rooms/components/rooms-board.tsx
+++ b/src/features/rooms/components/rooms-board.tsx
@@ -2,8 +2,6 @@
 
 import { useState } from "react";
 
-import type { Authority } from "@/constants/authority";
-
 import type {
   MeetingRoom,
   RoomMember,
@@ -20,7 +18,10 @@ interface RoomsBoardProps {
   rooms: MeetingRoom[];
   members: RoomMember[];
   projects: RoomProjectOption[];
-  hostAuthority: Authority;
+  /** "상위 팀 액션" 필드를 보여줄지 — 서버 컴포넌트(`page.tsx`)가 `requiresParentTeamAction`으로
+   *  미리 계산해 내려준다. `lib/permission.ts`는 `server-only`라 클라이언트 컴포넌트에서 직접
+   *  못 부른다(여기·`RoomReservationDialog`가 전부 client). */
+  showParentTeamAction: boolean;
   teamActions: RoomTeamActionOption[];
   /** "YYYY-MM-DD" — 이 주의 월요일. 서버 컴포넌트가 이 주 기준으로 `initialReservations`를 내려준다. */
   week: string;
@@ -39,7 +40,7 @@ export function RoomsBoard({
   rooms,
   members,
   projects,
-  hostAuthority,
+  showParentTeamAction,
   teamActions,
   week,
 }: RoomsBoardProps) {
@@ -62,7 +63,7 @@ export function RoomsBoard({
         rooms={rooms}
         members={members}
         projects={projects}
-        hostAuthority={hostAuthority}
+        showParentTeamAction={showParentTeamAction}
         teamActions={teamActions}
         onCreated={(created) => setReservations((prev) => [...prev, created])}
       />

--- a/src/features/rooms/components/use-room-reservation-form.ts
+++ b/src/features/rooms/components/use-room-reservation-form.ts
@@ -4,22 +4,21 @@ import { format } from "date-fns";
 import { useActionState, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
-import { MEETING_TOPIC_SUB, type MeetingTopicMain } from "@/constants/meeting";
-
 import { createRoomReservationAction, type RoomReservationFormState } from "../actions";
-import type { RoomReservation } from "../types";
-
-export const NO_PROJECT_VALUE = "__none__";
+import type { MeetingTopicInput, RoomReservation } from "../types";
 
 const INITIAL_STATE: RoomReservationFormState = { errors: {} };
+
+const EMPTY_TOPIC: MeetingTopicInput = { main: "", sub: "" };
 
 const EMPTY_FORM = {
   title: "",
   roomId: "",
-  projectId: NO_PROJECT_VALUE,
-  topicMain: "",
-  topicSub: "",
+  projectId: "",
+  topics: [EMPTY_TOPIC] as MeetingTopicInput[],
   attendeeIds: [] as number[],
+  /** Select 값은 문자열이라 여기서도 문자열로 든다 — 없으면 빈 문자열("Owner 개설"이거나 아직 안 골랐을 때). */
+  parentTeamActionId: "",
 };
 
 export type RoomReservationFormValues = typeof EMPTY_FORM;
@@ -35,6 +34,8 @@ interface UseRoomReservationFormOptions {
  * (CLAUDE.md §폴더·네이밍: 로직=커스텀훅).
  * ⚠️ shadcn `Select`는 네이티브 `<select>`가 아니라 `FormData`에 자동으로 안 실린다 —
  *    `add-todo-dialog.tsx`와 같은 방식으로 상태를 들고 있다가 제출 시 직접 `FormData`를 만든다.
+ * ⚠️ 회의 안건(`topics`)은 (대주제, 소주제) 자유 텍스트 쌍의 배열이다 — `topicMain`/`topicSub`를
+ *    같은 순서로 반복 추가해서 넘기고, 서버(`readTopics`, `actions.ts`)가 인덱스로 다시 짝짓는다.
  */
 export function useRoomReservationForm({
   slotStart,
@@ -69,23 +70,21 @@ export function useRoomReservationForm({
     formData.set("roomId", form.roomId);
     formData.set("date", format(slotStart, "yyyy-MM-dd"));
     formData.set("startTime", format(slotStart, "HH:mm"));
-    if (form.projectId !== NO_PROJECT_VALUE) formData.set("projectId", form.projectId);
-    formData.set("topicMain", form.topicMain);
-    formData.set("topicSub", form.topicSub);
+    formData.set("projectId", form.projectId);
+    for (const topic of form.topics) {
+      formData.append("topicMain", topic.main);
+      formData.append("topicSub", topic.sub);
+    }
+    if (form.parentTeamActionId) formData.set("parentTeamActionId", form.parentTeamActionId);
     for (const id of form.attendeeIds) formData.append("attendeeIds", String(id));
     formAction(formData);
   }
-
-  const topicSubOptions = form.topicMain
-    ? (MEETING_TOPIC_SUB[form.topicMain as MeetingTopicMain] ?? [])
-    : [];
 
   return {
     state,
     isPending,
     form,
     setForm,
-    topicSubOptions,
     handleOpenChange,
     handleSubmit,
   };

--- a/src/features/rooms/components/use-room-reservation-form.ts
+++ b/src/features/rooms/components/use-room-reservation-form.ts
@@ -1,6 +1,5 @@
 "use client";
 
-import { format } from "date-fns";
 import { useActionState, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
@@ -32,17 +31,17 @@ interface UseRoomReservationFormOptions {
 /**
  * 예약 모달의 폼 상태·제출 흐름 — `RoomReservationDialog`를 200줄 아래로 유지하려고 뺐다
  * (CLAUDE.md §폴더·네이밍: 로직=커스텀훅).
- * ⚠️ shadcn `Select`는 네이티브 `<select>`가 아니라 `FormData`에 자동으로 안 실린다 —
- *    `add-todo-dialog.tsx`와 같은 방식으로 상태를 들고 있다가 제출 시 직접 `FormData`를 만든다.
- * ⚠️ 회의 안건(`topics`)은 (대주제, 소주제) 자유 텍스트 쌍의 배열이다 — `topicMain`/`topicSub`를
- *    같은 순서로 반복 추가해서 넘기고, 서버(`readTopics`, `actions.ts`)가 인덱스로 다시 짝짓는다.
+ * ⚠️ 실제 `<form action={formAction}>`으로 제출한다(`notice-form.tsx`와 같은 패턴) — shadcn
+ *    `Select`·`RoomPickerList`처럼 네이티브 입력이 아닌 위젯은 `RoomReservationDialog`가 hidden
+ *    input으로 값을 따로 실어 보낸다. `title`·참석자 체크박스·안건 입력은 전부 진짜 네이티브
+ *    입력이라 `name`만 있으면 된다 — 여기서 `FormData`를 직접 만들지 않는다.
  */
 export function useRoomReservationForm({
   slotStart,
   onCreated,
   onOpenChange,
 }: UseRoomReservationFormOptions) {
-  const [state, formAction, isPending] = useActionState(createRoomReservationAction, INITIAL_STATE);
+  const [state, formAction] = useActionState(createRoomReservationAction, INITIAL_STATE);
   const [form, setForm] = useState<RoomReservationFormValues>(EMPTY_FORM);
   const handledCreatedId = useRef<string | null>(null);
 
@@ -61,31 +60,12 @@ export function useRoomReservationForm({
     onOpenChange(open);
   }
 
-  function handleSubmit() {
-    // ⚠️ 버튼도 `disabled={isPending}`지만, 클릭과 그 disabled가 반영되는 렌더 사이의 좁은 틈에
-    //    두 번째 클릭이 끼어들면 예약이 두 번 생성될 수 있다 — 여기서도 같은 조건으로 막는다.
-    if (isPending || !slotStart) return;
-    const formData = new FormData();
-    formData.set("title", form.title);
-    formData.set("roomId", form.roomId);
-    formData.set("date", format(slotStart, "yyyy-MM-dd"));
-    formData.set("startTime", format(slotStart, "HH:mm"));
-    formData.set("projectId", form.projectId);
-    for (const topic of form.topics) {
-      formData.append("topicMain", topic.main);
-      formData.append("topicSub", topic.sub);
-    }
-    if (form.parentTeamActionId) formData.set("parentTeamActionId", form.parentTeamActionId);
-    for (const id of form.attendeeIds) formData.append("attendeeIds", String(id));
-    formAction(formData);
-  }
-
   return {
     state,
-    isPending,
+    formAction,
     form,
     setForm,
     handleOpenChange,
-    handleSubmit,
+    slotStart,
   };
 }

--- a/src/features/rooms/components/weekly-room-calendar.css
+++ b/src/features/rooms/components/weekly-room-calendar.css
@@ -74,6 +74,21 @@
   border-top: none;
 }
 
+/*
+  빈 슬롯 클릭 = 예약 모달을 연다 — 클릭 가능한 영역이라는 걸 커서·hover 배경으로 알린다.
+  ⚠️ 예약이 이미 있는 칸도 이 클래스를 그대로 갖고 있지만, 그 위엔 `RoomReservationEvent`가
+  덮어 그려져서(§Mock 격리막) 실제로는 그 막대의 클릭 핸들러가 우선한다 — 빈 칸에서만
+  보이는 hover라 헷갈리지 않는다.
+*/
+.rbc-day-slot .rbc-time-slot {
+  cursor: pointer;
+  transition: background-color 100ms;
+}
+
+.rbc-day-slot .rbc-time-slot:hover {
+  background-color: color-mix(in srgb, var(--foreground) 6%, transparent);
+}
+
 .rbc-day-slot .rbc-time-slot {
   border-top: 1px dashed color-mix(in srgb, var(--border) 60%, transparent);
 }

--- a/src/features/rooms/constants.ts
+++ b/src/features/rooms/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * 클라이언트·서버 양쪽에서 쓰는 순수 상수만 모은다.
+ * ⚠️ `validate.ts`에 두지 않는다 — `validate.ts`는 `lib/permission.ts`(`server-only`)를
+ *    가져오는데, 이 상수는 클라이언트 컴포넌트(`room-reservation-dialog.tsx`)도 써야 해서
+ *    그 경로로 가져오면 `server-only`가 클라이언트 번들까지 끌려온다(빌드 에러).
+ */
+
+/** 예약 길이 — 팀 확정: 30분 한 타임, 연장하지 않는다(CLAUDE.md §브라우저 API). */
+export const RESERVATION_DURATION_MINUTES = 30;

--- a/src/features/rooms/mock/reservations.test.ts
+++ b/src/features/rooms/mock/reservations.test.ts
@@ -1,3 +1,7 @@
+import { AUTHORITY } from "@/constants/authority";
+import { listMockMeetings } from "@/features/meeting/mock/meetings";
+import type { Actor } from "@/lib/permission";
+
 import {
   addMockReservation,
   findMockReservation,
@@ -11,24 +15,25 @@ const DRAFT = {
   date: "2026-08-10",
   startTime: "10:30",
   projectId: "1", // TOP_LEVEL_PROJECTS의 GOODS(id=1)
-  topicMain: "PRODUCT",
-  topicSub: "ROADMAP_REVIEW",
+  topics: [{ main: "제품", sub: "로드맵 검토" }],
   attendeeIds: [1, 2],
 };
+
+const OWNER: Actor = { id: 3, role: AUTHORITY.OWNER };
+const LEADER: Actor = { id: 5, role: AUTHORITY.LEADER, teamId: 7, teamName: "개발팀" };
 
 describe("회의실 예약 mock 스토어", () => {
   it("시드 데이터가 회의실별로 최소 한 건씩 있다", () => {
     expect(listMockReservationsByRoom("room-large").length).toBeGreaterThan(0);
   });
 
-  it("예약을 추가하면 앞뒤 공백을 지우고 회의실 이름·소주제 라벨·프로젝트 태그를 채운다", () => {
+  it("예약을 추가하면 앞뒤 공백을 지우고 회의실 이름·프로젝트 태그를 채운다", () => {
     const before = listMockReservations().length;
 
-    const created = addMockReservation(DRAFT, 3);
+    const created = addMockReservation(DRAFT, OWNER);
 
     expect(created.title).toBe("신규 회의");
     expect(created.roomName).toBe("소회의실 B");
-    expect(created.topicSub).toBe("로드맵 검토");
     expect(created.projectTag).toBe("GOODS");
     expect(created.ownerId).toBe(3);
     // 시작 10:30 + 고정 30분 = 종료 11:00
@@ -37,10 +42,28 @@ describe("회의실 예약 mock 스토어", () => {
     expect(findMockReservation(created.id)).toEqual(created);
   });
 
-  it("프로젝트에 안 묶인 예약은 projectTag 없이 만들어진다", () => {
-    const created = addMockReservation({ ...DRAFT, projectId: undefined }, 3);
-    expect(created.projectId).toBeUndefined();
-    expect(created.projectTag).toBeUndefined();
+  it("예약과 같이 회의(Meeting)도 만들어진다(WORKFLOW.md §3-1: 예약=회의 개설)", () => {
+    const before = listMockMeetings().length;
+
+    const created = addMockReservation(DRAFT, OWNER);
+
+    const meetings = listMockMeetings();
+    expect(meetings).toHaveLength(before + 1);
+    const meeting = meetings[meetings.length - 1];
+    expect(meeting?.roomReservationId).toBe(created.id);
+    expect(meeting?.hostId).toBe(OWNER.id);
+    expect(meeting?.hostAuthority).toBe(AUTHORITY.OWNER);
+    expect(meeting?.hostTeamId).toBeUndefined();
+  });
+
+  it("Leader가 만들면 회의에 hostTeamId가 담긴다", () => {
+    addMockReservation({ ...DRAFT, parentTeamActionId: 1 }, LEADER);
+
+    const meetings = listMockMeetings();
+    const meeting = meetings[meetings.length - 1];
+    expect(meeting?.hostAuthority).toBe(AUTHORITY.LEADER);
+    expect(meeting?.hostTeamId).toBe(7);
+    expect(meeting?.parentTeamActionId).toBe(1);
   });
 
   it("없는 id는 조회 시 null을 돌려준다", () => {

--- a/src/features/rooms/mock/reservations.ts
+++ b/src/features/rooms/mock/reservations.ts
@@ -4,8 +4,8 @@ import type { MeetingDraft, MeetingTopic } from "@/features/meeting/types";
 import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
 import { type Actor, requiresParentTeamAction } from "@/lib/permission";
 
+import { RESERVATION_DURATION_MINUTES } from "../constants";
 import type { RoomReservation, RoomReservationDraft } from "../types";
-import { RESERVATION_DURATION_MINUTES } from "../validate";
 import { findMockRoom } from "./rooms";
 
 /**

--- a/src/features/rooms/mock/reservations.ts
+++ b/src/features/rooms/mock/reservations.ts
@@ -1,5 +1,7 @@
-import { MEETING_TOPIC_SUB, type MeetingTopicMain } from "@/constants/meeting";
+import { AUTHORITY } from "@/constants/authority";
+import { addMockMeeting } from "@/features/meeting/mock/meetings";
 import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
+import type { Actor } from "@/lib/permission";
 
 import type { RoomReservation, RoomReservationDraft } from "../types";
 import { RESERVATION_DURATION_MINUTES } from "../validate";
@@ -20,6 +22,7 @@ interface ReservationStore {
  * 오늘(2026-08-06)이 속한 주(월 8/3~금 8/7) 기준 시드.
  * ⚠️ **회의는 예외 없이 30분 고정이다**(팀 확정, CLAUDE.md §브라우저 API) — 목 데이터도 이
  *    규칙을 그대로 지킨다. 90분·2시간짜리 목업을 두면 "30분 고정"이 화면에서부터 거짓말이 된다.
+ * ⚠️ **프로젝트 태그는 전부 채워져 있다**(WORKFLOW.md §3-1 확정 — 프로젝트 없는 예약은 없다).
  */
 const INITIAL: RoomReservation[] = [
   {
@@ -29,8 +32,9 @@ const INITIAL: RoomReservation[] = [
     end: new Date("2026-08-03T09:30:00"),
     roomId: "room-small-b",
     roomName: "소회의실 B",
-    topicMain: "TEAM",
-    topicSub: "위클리 싱크",
+    projectId: "1",
+    projectTag: "GOODS",
+    topics: [{ main: "팀 운영", sub: "위클리 싱크" }],
     attendeeIds: [1, 2, 3],
     ownerId: 1,
   },
@@ -43,8 +47,7 @@ const INITIAL: RoomReservation[] = [
     roomName: "대회의실",
     projectId: "2",
     projectTag: "BRAND",
-    topicMain: "MARKETING",
-    topicSub: "채널 전략",
+    topics: [{ main: "마케팅", sub: "채널 전략" }],
     attendeeIds: [1, 2, 3],
     ownerId: 2,
   },
@@ -57,8 +60,7 @@ const INITIAL: RoomReservation[] = [
     roomName: "대회의실",
     projectId: "1",
     projectTag: "GOODS",
-    topicMain: "PRODUCT",
-    topicSub: "로드맵 검토",
+    topics: [{ main: "제품", sub: "로드맵 검토" }],
     attendeeIds: [1, 2, 3, 4],
     ownerId: 1,
   },
@@ -71,8 +73,7 @@ const INITIAL: RoomReservation[] = [
     roomName: "소회의실 A",
     projectId: "3",
     projectTag: "COLLAB",
-    topicMain: "INFRA",
-    topicSub: "마이그레이션 리뷰",
+    topics: [{ main: "인프라", sub: "마이그레이션 리뷰" }],
     attendeeIds: [4, 5, 6],
     ownerId: 4,
   },
@@ -83,8 +84,9 @@ const INITIAL: RoomReservation[] = [
     end: new Date("2026-08-06T11:30:00"),
     roomId: "room-video",
     roomName: "화상회의실",
-    topicMain: "TEAM",
-    topicSub: "위클리 싱크",
+    projectId: "3",
+    projectTag: "COLLAB",
+    topics: [{ main: "팀 운영", sub: "위클리 싱크" }],
     attendeeIds: [2, 3, 7],
     ownerId: 2,
   },
@@ -111,18 +113,19 @@ export function findMockReservation(id: string): RoomReservation | null {
 }
 
 /**
- * 예약 생성 — 시작 시각 + 고정 30분으로 종료 시각을 계산하고, roomId/projectId/topicSub
- * 코드값을 표시용 이름·태그·라벨로 채워 넣는다(컴포넌트는 코드값을 모른다, §Mock 격리막).
- * ⚠️ 같은 회의실·시간대 중복 여부는 여기서 보지 않는다 — 호출부(`actions.ts`)가 먼저 확인한다.
+ * 예약 생성 — 시작 시각 + 고정 30분으로 종료 시각을 계산하고, roomId/projectId를 표시용
+ * 이름·태그로 채워 넣는다(컴포넌트는 코드값을 모른다, §Mock 격리막).
+ * ⚠️ **회의(Meeting)도 같이 만든다**(WORKFLOW.md §3-1: "회의실 예약 = 회의 개설"은 한 동작) —
+ *    `features/meeting/mock/meetings.ts`를 직접 부른다(그 도메인엔 아직 소비할 화면이 없어
+ *    server.ts 격리막이 없다, `rooms/actions.ts`가 `TOP_LEVEL_PROJECTS`를 직접 참조하는 것과
+ *    같은 이유).
+ * ⚠️ 참조 무결성(roomId/projectId/attendeeIds/parentTeamActionId 존재 여부)은 여기서 다시
+ *    안 본다 — 호출부(`actions.ts`)가 먼저 확인한 뒤에만 이 함수를 부른다.
  */
-export function addMockReservation(draft: RoomReservationDraft, ownerId: number): RoomReservation {
+export function addMockReservation(draft: RoomReservationDraft, actor: Actor): RoomReservation {
   const room = findMockRoom(draft.roomId);
   const start = new Date(`${draft.date}T${draft.startTime}:00`);
   const end = new Date(start.getTime() + RESERVATION_DURATION_MINUTES * 60_000);
-  const topicMain = draft.topicMain as MeetingTopicMain;
-  const topicSub =
-    MEETING_TOPIC_SUB[topicMain]?.find((sub) => sub.value === draft.topicSub)?.label ??
-    draft.topicSub;
   const project = TOP_LEVEL_PROJECTS.find((item) => String(item.id) === draft.projectId);
 
   const reservation: RoomReservation = {
@@ -133,12 +136,29 @@ export function addMockReservation(draft: RoomReservationDraft, ownerId: number)
     roomId: draft.roomId,
     roomName: room?.name ?? draft.roomId,
     projectId: draft.projectId,
-    projectTag: project?.tag,
-    topicMain,
-    topicSub,
+    projectTag: project?.tag ?? "",
+    topics: draft.topics.map((topic) => ({ main: topic.main.trim(), sub: topic.sub.trim() })),
     attendeeIds: draft.attendeeIds,
-    ownerId,
+    ownerId: actor.id,
   };
   store.reservations = [...store.reservations, reservation];
+
+  addMockMeeting({
+    title: reservation.title,
+    start: reservation.start,
+    end: reservation.end,
+    roomId: reservation.roomId,
+    roomName: reservation.roomName,
+    projectId: project?.id ?? 0,
+    projectTag: reservation.projectTag,
+    topics: reservation.topics,
+    attendeeIds: reservation.attendeeIds,
+    hostId: actor.id,
+    hostAuthority: actor.role,
+    hostTeamId: actor.role === AUTHORITY.OWNER ? undefined : actor.teamId,
+    parentTeamActionId: draft.parentTeamActionId,
+    roomReservationId: reservation.id,
+  });
+
   return reservation;
 }

--- a/src/features/rooms/mock/reservations.ts
+++ b/src/features/rooms/mock/reservations.ts
@@ -1,7 +1,8 @@
-import { AUTHORITY } from "@/constants/authority";
+import { AUTHORITY, type Authority } from "@/constants/authority";
 import { addMockMeeting } from "@/features/meeting/mock/meetings";
+import type { MeetingDraft, MeetingTopic } from "@/features/meeting/types";
 import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
-import type { Actor } from "@/lib/permission";
+import { type Actor, requiresParentTeamAction } from "@/lib/permission";
 
 import type { RoomReservation, RoomReservationDraft } from "../types";
 import { RESERVATION_DURATION_MINUTES } from "../validate";
@@ -143,7 +144,12 @@ export function addMockReservation(draft: RoomReservationDraft, actor: Actor): R
   };
   store.reservations = [...store.reservations, reservation];
 
-  addMockMeeting({
+  // ⚠️ `Meeting.topics`는 최소 1개짜리 튜플 타입이다 — `validateRoomReservationDraft`가 이미
+  //    최소 1쌍을 보장했으니 여기서 그 사실을 튜플로 그대로 옮긴다(캐스팅 없이).
+  const [firstTopic, ...restTopics] = reservation.topics;
+  const topics: [MeetingTopic, ...MeetingTopic[]] = [firstTopic!, ...restTopics];
+
+  const meetingCommon = {
     title: reservation.title,
     start: reservation.start,
     end: reservation.end,
@@ -151,14 +157,27 @@ export function addMockReservation(draft: RoomReservationDraft, actor: Actor): R
     roomName: reservation.roomName,
     projectId: project?.id ?? 0,
     projectTag: reservation.projectTag,
-    topics: reservation.topics,
+    topics,
     attendeeIds: reservation.attendeeIds,
     hostId: actor.id,
-    hostAuthority: actor.role,
-    hostTeamId: actor.role === AUTHORITY.OWNER ? undefined : actor.teamId,
-    parentTeamActionId: draft.parentTeamActionId,
     roomReservationId: reservation.id,
-  });
+  };
+
+  // ⚠️ `Meeting`은 Owner 개설/팀 액션 개설을 판별식 유니언으로 나눠 둔다(hostTeamId·
+  //    parentTeamActionId가 둘 다 있거나 둘 다 없거나만 허용) — 그래서 여기서도 분기해서
+  //    만든다. Leader/Member 분기의 `!`는 `actions.ts`가 이미 상위 팀 액션·자기 팀 소속을
+  //    검증한 뒤에만 이 함수를 부르기 때문에 안전하다. SYSTEM 역할은 `/app/rooms`를 쓰지
+  //    않아(회사 소속이 아님) 이 분기에 올 일이 없다.
+  const meetingDraft: MeetingDraft = requiresParentTeamAction(actor)
+    ? {
+        ...meetingCommon,
+        hostAuthority: actor.role as Extract<Authority, "LEADER" | "MEMBER">,
+        hostTeamId: actor.teamId!,
+        parentTeamActionId: draft.parentTeamActionId!,
+      }
+    : { ...meetingCommon, hostAuthority: AUTHORITY.OWNER };
+
+  addMockMeeting(meetingDraft);
 
   return reservation;
 }

--- a/src/features/rooms/server.ts
+++ b/src/features/rooms/server.ts
@@ -2,10 +2,9 @@ import "server-only";
 
 import { endOfWeek, startOfWeek } from "date-fns";
 
-import { AUTHORITY } from "@/constants/authority";
 import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
 import { PROJECT_TEAM_ACTIONS_MOCK } from "@/features/project/mock/team-actions";
-import type { Actor } from "@/lib/permission";
+import { type Actor, requiresParentTeamAction } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
 import { listMockMembers } from "./mock/members";
@@ -66,7 +65,7 @@ export async function getReservableProjects(): Promise<RoomProjectOption[]> {
  */
 export async function getReservableTeamActions(actor: Actor): Promise<RoomTeamActionOption[]> {
   if (!isMock) throw new Error("팀 액션 목록 조회 API가 아직 연결되지 않았습니다.");
-  if (actor.role === AUTHORITY.OWNER || !actor.teamName) return [];
+  if (!requiresParentTeamAction(actor) || !actor.teamName) return [];
 
   const options: RoomTeamActionOption[] = [];
   for (const [projectTag, teamActions] of Object.entries(PROJECT_TEAM_ACTIONS_MOCK)) {

--- a/src/features/rooms/server.ts
+++ b/src/features/rooms/server.ts
@@ -2,13 +2,22 @@ import "server-only";
 
 import { endOfWeek, startOfWeek } from "date-fns";
 
+import { AUTHORITY } from "@/constants/authority";
 import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
+import { PROJECT_TEAM_ACTIONS_MOCK } from "@/features/project/mock/team-actions";
+import type { Actor } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
 import { listMockMembers } from "./mock/members";
 import { listMockReservations } from "./mock/reservations";
 import { listMockRooms } from "./mock/rooms";
-import type { MeetingRoom, RoomMember, RoomProjectOption, RoomReservation } from "./types";
+import type {
+  MeetingRoom,
+  RoomMember,
+  RoomProjectOption,
+  RoomReservation,
+  RoomTeamActionOption,
+} from "./types";
 
 /**
  * 그 주(월요일 시작)와 겹치는 예약만 걸러 내려준다. 격리막(CLAUDE.md §Mock 격리막).
@@ -48,4 +57,24 @@ export async function getReservableProjects(): Promise<RoomProjectOption[]> {
     }));
   }
   throw new Error("프로젝트 목록 조회 API가 아직 연결되지 않았습니다.");
+}
+
+/**
+ * 예약 폼의 "상위 팀 액션" select용 — Host가 Owner면 빈 배열(그 필드가 아예 안 뜬다,
+ * WORKFLOW.md §3-1). Leader/Member면 **자기 팀**에 하달된 팀 액션만, 어느 프로젝트 것인지
+ * `projectTag`로 같이 내려줘 화면이 지금 고른 프로젝트로 다시 거른다.
+ */
+export async function getReservableTeamActions(actor: Actor): Promise<RoomTeamActionOption[]> {
+  if (!isMock) throw new Error("팀 액션 목록 조회 API가 아직 연결되지 않았습니다.");
+  if (actor.role === AUTHORITY.OWNER || !actor.teamName) return [];
+
+  const options: RoomTeamActionOption[] = [];
+  for (const [projectTag, teamActions] of Object.entries(PROJECT_TEAM_ACTIONS_MOCK)) {
+    for (const teamAction of teamActions) {
+      if (teamAction.team === actor.teamName) {
+        options.push({ id: teamAction.id, name: teamAction.name, projectTag });
+      }
+    }
+  }
+  return options;
 }

--- a/src/features/rooms/types.ts
+++ b/src/features/rooms/types.ts
@@ -3,8 +3,6 @@
  * 컴포넌트는 이 타입만 알고, 목/실서버 분기는 `server.ts`가 끝낸다.
  */
 
-import type { MeetingTopicMain } from "@/constants/meeting";
-
 /**
  * 회의실 한 곳.
  * ⚠️ **"수용 인원" 필드는 없다**(WORKFLOW.md §10-A 확정 — 전면 폐기). 화면·모달·데이터 구조
@@ -50,9 +48,26 @@ export interface RoomProjectOption {
 }
 
 /**
+ * 예약 폼의 "상위 팀 액션" select가 쓰는 경량 항목 — Host가 Owner가 아닐 때만 뜬다
+ * (WORKFLOW.md §3-1). `projectTag`로 지금 고른 프로젝트에 속한 것만 걸러 보여준다.
+ */
+export interface RoomTeamActionOption {
+  id: number;
+  name: string;
+  projectTag: string;
+}
+
+/** 회의 안건 대주제/소주제 한 쌍 — 자유 입력 텍스트다(고정 enum 아님, WORKFLOW.md §3-1). */
+export interface MeetingTopicInput {
+  main: string;
+  sub: string;
+}
+
+/**
  * 주간 캘린더 한 칸에 그려지는 예약 건. react-big-calendar의 start/end 접근자가 이 필드명을 그대로 쓴다.
  * ⚠️ 막대 색은 여기 없다 — `projectTag`를 화면에서 `pickPaletteColor`에 넘겨 그때 뽑는다
  *    (프로젝트 태그·아바타와 같은 팔레트, CLAUDE.md §디자인 토큰: 하드코딩 금지).
+ * ⚠️ 프로젝트 태그는 **항상 있다**(WORKFLOW.md §3-1 확정 — 프로젝트 없는 회의는 없다).
  */
 export interface RoomReservation {
   id: string;
@@ -61,12 +76,10 @@ export interface RoomReservation {
   end: Date;
   roomId: string;
   roomName: string;
-  /** 프로젝트에 안 묶인 예약도 있다(예: 팀 위클리 싱크) — 그럴 땐 중립색을 쓴다. */
-  projectId?: string;
-  projectTag?: string;
-  topicMain: MeetingTopicMain;
-  /** 소주제 라벨(한글) — 목록·상세 표시용으로 이미 라벨을 들고 있다. */
-  topicSub: string;
+  projectId: string;
+  projectTag: string;
+  /** 최소 1쌍 — 나머지는 폼에서 "추가/삭제"로 늘고 준다. */
+  topics: MeetingTopicInput[];
   attendeeIds: number[];
   /** 담당자 — 이 예약의 시간을 바꿀 수 있는 유일한 사람(권한 ②축, CLAUDE.md §권한). */
   ownerId: number;
@@ -76,6 +89,8 @@ export interface RoomReservation {
  * 회의실 예약 폼 입력 — 화면과 서버가 같은 스키마(`validate.ts`)로 검증한다.
  * ⚠️ 종료 시각은 입력받지 않는다 — 예약은 **30분 한 타임 고정**이라(팀 확정,
  *    CLAUDE.md §브라우저 API) 시작 시각만 받고 길이는 서버가 계산한다.
+ * ⚠️ "회의실 예약 = 회의 개설"이 한 동작이라(WORKFLOW.md §3-1) 이 드래프트가 회의 쪽 입력도
+ *    같이 들고 있다 — `parentTeamActionId`는 Host가 Owner가 아닐 때만 필수다.
  */
 export interface RoomReservationDraft {
   title: string;
@@ -84,12 +99,12 @@ export interface RoomReservationDraft {
   date: string;
   /** "HH:mm" — 30분 단위 슬롯의 시작 시각 */
   startTime: string;
-  projectId?: string;
-  /** MEETING_TOPIC_MAIN 코드값 */
-  topicMain: string;
-  /** MEETING_TOPIC_SUB[topicMain]의 value 코드값 */
-  topicSub: string;
+  /** 항상 필수다(WORKFLOW.md §3-1) — "프로젝트에 안 묶인 예약"은 없다. */
+  projectId: string;
+  topics: MeetingTopicInput[];
   attendeeIds: number[];
+  /** Host가 Leader/Member일 때만 필수 — 그 프로젝트 내 자기 팀에 하달된 팀 액션 중 하나. */
+  parentTeamActionId?: number;
 }
 
 export type RoomReservationFormErrors = Partial<Record<keyof RoomReservationDraft, string>>;

--- a/src/features/rooms/validate.test.ts
+++ b/src/features/rooms/validate.test.ts
@@ -2,8 +2,8 @@ import { AUTHORITY } from "@/constants/authority";
 
 import { validateMeetingRoomDraft, validateRoomReservationDraft } from "./validate";
 
-const OWNER_HOST = { authority: AUTHORITY.OWNER };
-const LEADER_HOST = { authority: AUTHORITY.LEADER };
+const OWNER_HOST = { role: AUTHORITY.OWNER };
+const LEADER_HOST = { role: AUTHORITY.LEADER };
 
 const VALID_DRAFT = {
   title: "주간 싱크",
@@ -125,6 +125,16 @@ describe("회의실 예약 검증", () => {
       LEADER_HOST,
     );
     expect(errors.parentTeamActionId).toBeUndefined();
+  });
+
+  it("Host가 Owner인데 상위 팀 액션을 넣으면 막는다(폼 조작 방어)", () => {
+    const errors = validateRoomReservationDraft(
+      { ...VALID_DRAFT, parentTeamActionId: 1 },
+      OWNER_HOST,
+    );
+    expect(errors.parentTeamActionId).toBe(
+      "Owner가 개설하는 회의에는 상위 팀 액션을 지정할 수 없어요",
+    );
   });
 
   it("참석자가 한 명도 없으면 막는다", () => {

--- a/src/features/rooms/validate.test.ts
+++ b/src/features/rooms/validate.test.ts
@@ -1,92 +1,142 @@
+import { AUTHORITY } from "@/constants/authority";
+
 import { validateMeetingRoomDraft, validateRoomReservationDraft } from "./validate";
+
+const OWNER_HOST = { authority: AUTHORITY.OWNER };
+const LEADER_HOST = { authority: AUTHORITY.LEADER };
 
 const VALID_DRAFT = {
   title: "주간 싱크",
   roomId: "room-large",
   date: "2026-08-10",
   startTime: "10:00",
-  projectId: "p-goods",
-  topicMain: "PRODUCT",
-  topicSub: "ROADMAP_REVIEW",
+  projectId: "1",
+  topics: [{ main: "제품", sub: "로드맵 검토" }],
   attendeeIds: [1],
 };
 
 describe("회의실 예약 검증", () => {
   it("전부 채우면 통과한다", () => {
-    expect(validateRoomReservationDraft(VALID_DRAFT)).toEqual({});
+    expect(validateRoomReservationDraft(VALID_DRAFT, OWNER_HOST)).toEqual({});
   });
 
   it("제목이 비면 막는다", () => {
-    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, title: "   " });
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, title: "   " }, OWNER_HOST);
     expect(errors.title).toBe("회의 제목을 입력해 주세요");
   });
 
   it("회의실을 안 고르면 막는다", () => {
-    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, roomId: "" });
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, roomId: "" }, OWNER_HOST);
     expect(errors.roomId).toBeDefined();
   });
 
   it("날짜 형식이 아니면 막는다", () => {
-    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, date: "2026/08/10" });
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, date: "2026/08/10" }, OWNER_HOST);
     expect(errors.date).toBe("올바른 날짜가 아니에요");
   });
 
   it("존재하지 않는 날짜는 막는다", () => {
-    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, date: "2026-02-30" });
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, date: "2026-02-30" }, OWNER_HOST);
     expect(errors.date).toBe("올바른 날짜가 아니에요");
   });
 
   it("30분 단위가 아닌 시작 시각은 막는다", () => {
-    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, startTime: "10:15" });
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, startTime: "10:15" }, OWNER_HOST);
     expect(errors.startTime).toBe("예약은 30분 단위로만 가능해요");
   });
 
   it("운영 시작(09:00) 이전은 막는다", () => {
-    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, startTime: "08:30" });
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, startTime: "08:30" }, OWNER_HOST);
     expect(errors.startTime).toBe("회의실 운영 시간(09:00~18:00) 안에서 선택해 주세요");
   });
 
   it("30분을 더하면 운영 종료(18:00)를 넘는 시작 시각은 막는다", () => {
-    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, startTime: "17:45" });
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, startTime: "17:45" }, OWNER_HOST);
     expect(errors.startTime).toBeDefined();
   });
 
   it("운영 종료 딱 맞춰 끝나는 17:30 시작은 통과한다", () => {
-    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, startTime: "17:30" });
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, startTime: "17:30" }, OWNER_HOST);
     expect(errors.startTime).toBeUndefined();
   });
 
-  it("프로젝트 없이도 통과한다(예: 팀 위클리 싱크)", () => {
-    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, projectId: undefined });
-    expect(errors.projectId).toBeUndefined();
+  it("프로젝트를 안 고르면 막는다(WORKFLOW.md §3-1: 항상 필수)", () => {
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, projectId: "" }, OWNER_HOST);
+    expect(errors.projectId).toBe("프로젝트를 선택해 주세요");
   });
 
-  it("대주제를 안 고르면 막는다", () => {
-    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, topicMain: "" });
-    expect(errors.topicMain).toBeDefined();
+  it("안건을 하나도 안 채우면 막는다", () => {
+    const errors = validateRoomReservationDraft(
+      { ...VALID_DRAFT, topics: [{ main: "", sub: "" }] },
+      OWNER_HOST,
+    );
+    expect(errors.topics).toBe("회의 안건(대주제·소주제)을 한 쌍 이상 입력해 주세요");
   });
 
-  it("소주제를 안 고르면 막는다", () => {
-    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, topicSub: "" });
-    expect(errors.topicSub).toBeDefined();
+  it("첫 안건의 소주제만 비어도 막는다", () => {
+    const errors = validateRoomReservationDraft(
+      { ...VALID_DRAFT, topics: [{ main: "제품", sub: "" }] },
+      OWNER_HOST,
+    );
+    expect(errors.topics).toBeDefined();
   });
 
-  it("대주제와 안 맞는 소주제 조합은 막는다", () => {
-    const errors = validateRoomReservationDraft({
-      ...VALID_DRAFT,
-      topicMain: "PRODUCT",
-      topicSub: "CHANNEL_STRATEGY",
-    });
-    expect(errors.topicSub).toBe("대주제와 맞지 않는 소주제예요");
+  it("둘째 안건부터는 비어 있으면 막는다(첫 쌍만 있어도 안 됨)", () => {
+    const errors = validateRoomReservationDraft(
+      {
+        ...VALID_DRAFT,
+        topics: [
+          { main: "제품", sub: "로드맵 검토" },
+          { main: "", sub: "" },
+        ],
+      },
+      OWNER_HOST,
+    );
+    expect(errors.topics).toBe("빈 안건 칸이 있어요 — 채우거나 삭제해 주세요");
+  });
+
+  it("안건을 여러 쌍 다 채우면 통과한다", () => {
+    const errors = validateRoomReservationDraft(
+      {
+        ...VALID_DRAFT,
+        topics: [
+          { main: "제품", sub: "로드맵 검토" },
+          { main: "마케팅", sub: "캠페인 리뷰" },
+        ],
+      },
+      OWNER_HOST,
+    );
+    expect(errors.topics).toBeUndefined();
+  });
+
+  it("Host가 Owner면 상위 팀 액션 없이도 통과한다", () => {
+    const errors = validateRoomReservationDraft(VALID_DRAFT, OWNER_HOST);
+    expect(errors.parentTeamActionId).toBeUndefined();
+  });
+
+  it("Host가 Leader면 상위 팀 액션이 없으면 막는다", () => {
+    const errors = validateRoomReservationDraft(VALID_DRAFT, LEADER_HOST);
+    expect(errors.parentTeamActionId).toBe("상위 팀 액션을 선택해 주세요");
+  });
+
+  it("Host가 Leader여도 상위 팀 액션을 채우면 통과한다", () => {
+    const errors = validateRoomReservationDraft(
+      { ...VALID_DRAFT, parentTeamActionId: 1 },
+      LEADER_HOST,
+    );
+    expect(errors.parentTeamActionId).toBeUndefined();
   });
 
   it("참석자가 한 명도 없으면 막는다", () => {
-    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, attendeeIds: [] });
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, attendeeIds: [] }, OWNER_HOST);
     expect(errors.attendeeIds).toBe("참석자를 한 명 이상 선택해 주세요");
   });
 
   it("참석자 값이 정수가 아니면 막는다", () => {
-    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, attendeeIds: [Number.NaN] });
+    const errors = validateRoomReservationDraft(
+      { ...VALID_DRAFT, attendeeIds: [Number.NaN] },
+      OWNER_HOST,
+    );
     expect(errors.attendeeIds).toBe("참석자 값이 올바르지 않아요");
   });
 });

--- a/src/features/rooms/validate.ts
+++ b/src/features/rooms/validate.ts
@@ -1,6 +1,7 @@
 import { isValid, parse } from "date-fns";
 
-import { AUTHORITY, type Authority } from "@/constants/authority";
+import type { Authority } from "@/constants/authority";
+import { requiresParentTeamAction } from "@/lib/permission";
 
 import type {
   MeetingRoomDraft,
@@ -37,12 +38,12 @@ function toMinutes(time: string): number {
  * ⚠️ **참조 무결성도 여기서 안 본다** — `roomId`·`projectId`가 실제로 존재하는지, 골라 낸
  *    `parentTeamActionId`가 진짜 그 프로젝트·그 팀의 것인지는 `actions.ts`가 목/실서버 조회
  *    뒤에 따로 확인한다(§권한: 화면 숨김은 UX일 뿐 보안이 아니다). 여기는 **형식**만 본다.
- * @param host "상위 팀 액션" 필수 여부는 회의를 여는 사람의 권한에 달렸다(WORKFLOW.md §3-1) —
- *   Owner면 이 필드가 없어도 되고, Leader/Member면 반드시 있어야 한다.
+ * @param host "상위 팀 액션" 필수 여부는 회의를 여는 사람의 권한에 달렸다(`requiresParentTeamAction`,
+ *   WORKFLOW.md §3-1) — Owner면 이 필드가 없어도 되고, Leader/Member면 반드시 있어야 한다.
  */
 export function validateRoomReservationDraft(
   draft: RoomReservationDraft,
-  host: { authority: Authority },
+  host: { role: Authority },
 ): RoomReservationFormErrors {
   const errors: RoomReservationFormErrors = {};
 
@@ -77,8 +78,12 @@ export function validateRoomReservationDraft(
 
   // ⚠️ Owner가 개설하면 이 필드가 아예 없다(= 프로젝트 회의) — Leader/Member면 반드시 있어야
   //    한다(= 팀 액션 회의, WORKFLOW.md §3-1 "상위 팀 액션 노출 조건").
-  if (host.authority !== AUTHORITY.OWNER && !draft.parentTeamActionId) {
-    errors.parentTeamActionId = "상위 팀 액션을 선택해 주세요";
+  if (requiresParentTeamAction(host)) {
+    if (!draft.parentTeamActionId) errors.parentTeamActionId = "상위 팀 액션을 선택해 주세요";
+  } else if (draft.parentTeamActionId !== undefined) {
+    // ⚠️ Owner는 반대로 이 필드를 아예 못 넣는다 — Owner 개설 회의(프로젝트 회의)엔 상위 팀
+    //    액션 개념이 없다(WORKFLOW.md §2). 폼이 조작돼 값이 들어와도 여기서 막는다.
+    errors.parentTeamActionId = "Owner가 개설하는 회의에는 상위 팀 액션을 지정할 수 없어요";
   }
 
   if (draft.attendeeIds.length === 0) {

--- a/src/features/rooms/validate.ts
+++ b/src/features/rooms/validate.ts
@@ -3,6 +3,7 @@ import { isValid, parse } from "date-fns";
 import type { Authority } from "@/constants/authority";
 import { requiresParentTeamAction } from "@/lib/permission";
 
+import { RESERVATION_DURATION_MINUTES } from "./constants";
 import type {
   MeetingRoomDraft,
   MeetingRoomFormErrors,
@@ -14,9 +15,6 @@ const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 const TIME_PATTERN = /^([01]\d|2[0-3]):(00|30)$/;
 /** 회의실 운영 시작·종료 시각용 — 예약 슬롯(`TIME_PATTERN`)과 달리 30분 단위 제약이 없다. */
 const GENERAL_TIME_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/;
-
-/** 예약 길이 — 팀 확정: 30분 한 타임, 연장하지 않는다(CLAUDE.md §브라우저 API). */
-export const RESERVATION_DURATION_MINUTES = 30;
 
 const OPERATING_START_MINUTES = 9 * 60;
 const OPERATING_END_MINUTES = 18 * 60;

--- a/src/features/rooms/validate.ts
+++ b/src/features/rooms/validate.ts
@@ -1,6 +1,6 @@
 import { isValid, parse } from "date-fns";
 
-import { MEETING_TOPIC_SUB, type MeetingTopicMain } from "@/constants/meeting";
+import { AUTHORITY, type Authority } from "@/constants/authority";
 
 import type {
   MeetingRoomDraft,
@@ -34,9 +34,15 @@ function toMinutes(time: string): number {
  * 회의실 예약 폼 검증 — 화면(모달)과 서버(Server Action)가 **이 함수 하나**로 본다.
  * ⚠️ 같은 회의실·시간대 중복 여부는 여기서 보지 않는다 — 그건 기존 예약 목록이 있어야 판단할 수
  *    있어 `actions.ts`가 목/실서버 조회 뒤에 따로 확인한다.
+ * ⚠️ **참조 무결성도 여기서 안 본다** — `roomId`·`projectId`가 실제로 존재하는지, 골라 낸
+ *    `parentTeamActionId`가 진짜 그 프로젝트·그 팀의 것인지는 `actions.ts`가 목/실서버 조회
+ *    뒤에 따로 확인한다(§권한: 화면 숨김은 UX일 뿐 보안이 아니다). 여기는 **형식**만 본다.
+ * @param host "상위 팀 액션" 필수 여부는 회의를 여는 사람의 권한에 달렸다(WORKFLOW.md §3-1) —
+ *   Owner면 이 필드가 없어도 되고, Leader/Member면 반드시 있어야 한다.
  */
 export function validateRoomReservationDraft(
   draft: RoomReservationDraft,
+  host: { authority: Authority },
 ): RoomReservationFormErrors {
   const errors: RoomReservationFormErrors = {};
 
@@ -60,15 +66,19 @@ export function validateRoomReservationDraft(
     }
   }
 
-  // ⚠️ 프로젝트는 선택값이다 — "팀 위클리 싱크"처럼 프로젝트에 안 묶인 예약도 있다
-  //    (types.ts의 RoomReservation.projectId, mock/reservations.ts 시드가 이미 그렇다).
-  if (!draft.topicMain.trim()) errors.topicMain = "대주제를 선택해 주세요";
-  if (!draft.topicSub.trim()) errors.topicSub = "소주제를 선택해 주세요";
-  else if (draft.topicMain.trim()) {
-    const validSubs = MEETING_TOPIC_SUB[draft.topicMain as MeetingTopicMain];
-    if (!validSubs?.some((sub) => sub.value === draft.topicSub)) {
-      errors.topicSub = "대주제와 맞지 않는 소주제예요";
-    }
+  // ⚠️ 프로젝트는 이제 항상 필수다(WORKFLOW.md §3-1 확정) — 프로젝트에 안 묶인 예약은 없다.
+  if (!draft.projectId.trim()) errors.projectId = "프로젝트를 선택해 주세요";
+
+  if (draft.topics.length === 0 || !draft.topics[0]?.main.trim() || !draft.topics[0]?.sub.trim()) {
+    errors.topics = "회의 안건(대주제·소주제)을 한 쌍 이상 입력해 주세요";
+  } else if (draft.topics.some((topic) => !topic.main.trim() || !topic.sub.trim())) {
+    errors.topics = "빈 안건 칸이 있어요 — 채우거나 삭제해 주세요";
+  }
+
+  // ⚠️ Owner가 개설하면 이 필드가 아예 없다(= 프로젝트 회의) — Leader/Member면 반드시 있어야
+  //    한다(= 팀 액션 회의, WORKFLOW.md §3-1 "상위 팀 액션 노출 조건").
+  if (host.authority !== AUTHORITY.OWNER && !draft.parentTeamActionId) {
+    errors.parentTeamActionId = "상위 팀 액션을 선택해 주세요";
   }
 
   if (draft.attendeeIds.length === 0) {

--- a/src/lib/permission.ts
+++ b/src/lib/permission.ts
@@ -176,6 +176,16 @@ export function canManageRooms(actor: Actor): boolean {
 }
 
 /**
+ * 회의실 예약(=회의 개설) 시 "상위 팀 액션"이 필수인가 — **Owner만 예외**다(WORKFLOW.md §3-1).
+ * Owner가 열면 프로젝트 회의라 이 필드가 아예 없고, Leader/Member가 열면 팀 액션 회의라 반드시
+ * 있어야 한다. 판정을 한 곳에 모아 화면(`room-reservation-fields.tsx`)·검증(`validate.ts`)·
+ * 조회(`rooms/server.ts`의 `getReservableTeamActions`)가 전부 같은 기준을 쓰게 한다.
+ */
+export function requiresParentTeamAction(actor: { role: Authority }): boolean {
+  return actor.role !== AUTHORITY.OWNER;
+}
+
+/**
  * 팀 범위 안인지 — **teamId가 같은지만 본다**(백엔드 스키마 확정, 2026-08-06 단순화).
  * ⚠️ 예전엔 부서 트리 조상 경로(`departmentPath`)를 비교했지만, 팀은 계층이 없는 플랫 목록이라
  *    이제 필요 없다 — LEADER 자신의 roleId가 "리더"든 "없음"이든 무관하게 teamId만 같으면 된다.

--- a/src/lib/permission.ts
+++ b/src/lib/permission.ts
@@ -31,6 +31,15 @@ export interface Actor {
    *    이 권한 판정에는 쓰지 않는다 — 범위 판정은 teamId 하나로 끝난다.
    */
   teamId?: number;
+  /**
+   * 소속 팀 이름 — `teamId`와 별개다. **팀 registry(id↔이름 매핑)가 아직 없어서** 둘이
+   * 같은 값을 가리키는지 이 파일은 보장하지 않는다.
+   * ⚠️ `teamId`는 권한 범위 비교(`isWithinTeamScope`)에만 쓰고, 이 필드는 프로젝트
+   *    도메인이 팀을 **이름 문자열**로만 다루는 곳(`ProjectTeamAction.team` 등)과 매칭할 때만
+   *    쓴다(예: 회의실 예약의 "상위 팀 액션" select — 그 프로젝트 내 자기 팀에 하달된 팀
+   *    액션만 골라야 하는데, 그 목록이 이름으로만 저장돼 있다). OWNER는 `undefined`.
+   */
+  teamName?: string;
 }
 
 /* ───────── ① 권한 축 ───────── */


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정
- [x] design — UI/UX 변경
- [ ] feature / style / refactor / docs / test / chore / merge

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 / 조직 / 공유 셸 · 디자인 시스템 / 공통 · 인프라

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

- 예약 모달을 시안 디자인에 맞춰 2단 레이아웃(왼쪽 필드 / 오른쪽 참석자)으로 개편
- 회의실 선택: 드롭다운 → 목록 카드 클릭형(`RoomPickerList` 신규). 괄호 안은 "인원"이 아니라
  실제 존재하는 필드인 "위치"로 표시(수용 인원 필드는 이미 폐기됨 — 없는 데이터를 지어내지 않음)
- 참석자 선택: 검색 결과만 보이던 방식 → 전체 목록을 체크박스로 상시 표시 + 검색으로 좁힘
- 상단 슬롯 안내를 문장형에서 요일/시간/확정안내 3단 배지 바로 교체
- 헤더·버튼 라벨을 시안 워딩("회의실 예약", "즉시 예약")에 맞춤
- 주간 캘린더 빈 슬롯에 `cursor: pointer` + hover 시 배경 어둡게(`--foreground` 6% 틴트) 추가

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`fix/rooms-reservation-modal-design#214`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #214`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [x] 🔐 권한 2축 검사 — 순수 UI 레이아웃 변경, 검증·권한 로직은 안 건드림(#212에서 이미 처리)
- [ ] 🧬 zod — 미사용(기존 패턴 유지)
- [x] 🕵️ 정직성 — 알림 발송 문구가 아직 미구현 기능이라는 걸 코드 주석·이슈에 명시
- [x] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨(`color-mix(in srgb, var(--foreground) ...)` 등 토큰 기반)

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [x] ♿ a11y — 회의실 카드에 `role="radiogroup"`/`radio`, 참석자 체크박스에 라벨 연결
- [x] ♻️ 재사용 확인 — 기존 Button/Input/Select 그대로 사용, 신규는 `RoomPickerList`뿐
- [x] 🧪 loading/error/empty — 참석자 검색 결과 없음 안내 유지
- [ ] 브라우저 전용 API — 해당 없음

---

## 🔗 연관 이슈

Closes #214

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
| (문장형 안내, 드롭다운 회의실·참석자) | (배지 바 + 회의실 카드 + 참석자 체크박스, 시안 첨부) |

⚠️ 브라우저 실제 렌더링 미검증(이전부터 이어진 dev 서버 이슈) — 코드 리뷰·유닛테스트로만 확인.

---

## 💬 리뷰 포인트

- 회의실 카드에서 "인원" 대신 "위치"를 보여주는 게 시안 의도와 맞는지(수용 인원 필드 폐기로 인한 불가피한 대체)
- 알림 발송 안내 문구를 미구현 상태로 먼저 넣는 것에 대한 팀 합의

---

## 📝 추가 메모

`npx jest`(전체 65개 스위트, 742개) · `npx tsc --noEmit` · `npx eslint` 전부 통과 확인함.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 회의 주제를 대분류·소분류 코드 대신 자유 텍스트로 여러 개 입력할 수 있습니다.
  * 회의실을 목록에서 선택하고, 참석자를 검색·체크박스로 관리할 수 있습니다.
  * 프로젝트와 상위 팀 액션을 예약 정보에 연결할 수 있습니다.
  * 예약 생성 시 회의 정보가 함께 기록됩니다.

* **개선 사항**
  * 권한에 따라 프로젝트 및 상위 팀 액션 입력을 검증합니다.
  * 예약 화면을 2단 구성의 새로운 모달 UI로 개선했습니다.
  * 시간 슬롯에 마우스를 올리면 선택 가능한 상태가 더 명확하게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->