### PR TITLE
[FEAT] 검색 기능 구현 #225

### DIFF
--- a/src/app/(shell)/app/rooms/layout.tsx
+++ b/src/app/(shell)/app/rooms/layout.tsx
@@ -1,3 +1,4 @@
+import { CalendarRange } from "lucide-react";
 import type { ReactNode } from "react";
 
 import { PageHeader } from "@/features/shell/components/page-header";
@@ -6,11 +7,15 @@ interface RoomsLayoutProps {
   children: ReactNode;
 }
 
-/** 사이드바에서 바로 닿는 화면이라 뒤로가기를 두지 않는다(`calendar`·`notice` 목록과 같은 규칙). */
+/**
+ * 사이드바에서 바로 닿는 화면이라 뒤로가기를 두지 않는다(`calendar`·`notice` 목록과 같은 규칙).
+ * ⚠️ 아이콘은 사이드바의 "회의실" 항목(`sidebar-item.tsx`의 `room: CalendarRange`)과 같은 걸 쓴다 —
+ *    메뉴에서 본 아이콘과 화면 머리의 아이콘이 다르면 같은 화면으로 안 읽힌다.
+ */
 export default function RoomsLayout({ children }: RoomsLayoutProps) {
   return (
     <>
-      <PageHeader title="회의실" />
+      <PageHeader title="회의실" icon={CalendarRange} />
       {children}
     </>
   );

--- a/src/app/(shell)/app/search/error.tsx
+++ b/src/app/(shell)/app/search/error.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { ScreenError } from "@/components/common/screen-error";
+
+export default function Error({ reset }: { reset: () => void }) {
+  return <ScreenError title="검색을 불러오지 못했습니다" reset={reset} isInsideShell />;
+}

--- a/src/app/(shell)/app/search/error.tsx
+++ b/src/app/(shell)/app/search/error.tsx
@@ -2,6 +2,10 @@
 
 import { ScreenError } from "@/components/common/screen-error";
 
-export default function Error({ reset }: { reset: () => void }) {
+interface SearchErrorProps {
+  reset: () => void;
+}
+
+export default function Error({ reset }: SearchErrorProps) {
   return <ScreenError title="검색을 불러오지 못했습니다" reset={reset} isInsideShell />;
 }

--- a/src/app/(shell)/app/search/layout.tsx
+++ b/src/app/(shell)/app/search/layout.tsx
@@ -1,0 +1,13 @@
+import { Search } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { PageHeader } from "@/features/shell/components/page-header";
+
+export default function SearchLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <PageHeader title="검색" icon={Search} meta="⌘K" />
+      {children}
+    </>
+  );
+}

--- a/src/app/(shell)/app/search/layout.tsx
+++ b/src/app/(shell)/app/search/layout.tsx
@@ -3,7 +3,11 @@ import type { ReactNode } from "react";
 
 import { PageHeader } from "@/features/shell/components/page-header";
 
-export default function SearchLayout({ children }: { children: ReactNode }) {
+interface SearchLayoutProps {
+  children: ReactNode;
+}
+
+export default function SearchLayout({ children }: SearchLayoutProps) {
   return (
     <>
       <PageHeader title="검색" icon={Search} meta="⌘K" />

--- a/src/app/(shell)/app/search/loading.tsx
+++ b/src/app/(shell)/app/search/loading.tsx
@@ -1,0 +1,28 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <main className="min-h-0 flex-1 overflow-y-auto px-8 py-7">
+      <div className="mx-auto w-full max-w-[1440px]">
+        <div className="mx-auto flex w-full max-w-[720px] flex-col gap-7">
+          <Skeleton className="h-11 w-full rounded-xl" />
+          <div className="flex flex-col gap-3">
+            <Skeleton className="h-4 w-24 rounded" />
+            <div className="flex gap-2">
+              <Skeleton className="h-7 w-24 rounded-full" />
+              <Skeleton className="h-7 w-20 rounded-full" />
+              <Skeleton className="h-7 w-24 rounded-full" />
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <Skeleton className="h-16 w-full rounded-xl" />
+            <Skeleton className="h-16 w-full rounded-xl" />
+            <Skeleton className="h-16 w-full rounded-xl" />
+            <Skeleton className="h-16 w-full rounded-xl" />
+          </div>
+          <Skeleton className="h-48 w-full rounded-2xl" />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/app/search/page.tsx
+++ b/src/app/(shell)/app/search/page.tsx
@@ -1,33 +1,53 @@
 import type { Metadata } from "next";
+import type { ReactNode } from "react";
 
 import { SearchInput } from "@/features/search/components/search-input";
 import { SearchLanding } from "@/features/search/components/search-landing";
 import { SearchResultsPanel } from "@/features/search/components/search-results-panel";
 import { parseSearchQuery } from "@/features/search/lib";
-import { getSearchHome, getSearchResults } from "@/features/search/server";
+import { getSearchHome, getSearchProjects, getSearchResults } from "@/features/search/server";
 
 export const metadata: Metadata = {
   title: "검색",
 };
 
+interface SearchPageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
 /**
  * 검색 — 키워드가 없으면 랜딩(최근 검색어·최근 본 항목·둘러보기), 있으면 결과 목록이다.
  * 조회뿐이라 Server Component 하나로 끝난다. 검색창·필터만 잎사귀로 나가 있다(CLAUDE.md §핵심 4원칙 1).
+ *
+ * ⚠️ **`getSearchHome()`은 랜딩일 때만 부른다.** 결과 화면이 필요한 건 필터용 프로젝트
+ *    목록뿐인데 `getSearchHome()`은 최근 검색어·최근 본 항목까지 같이 불러온다 —
+ *    그걸 늘 같이 부르면 랜딩 쪽 조회가 실패했을 때 검색 결과 화면까지 같이 죽는다.
  */
-export default async function SearchPage({
-  searchParams,
-}: {
-  searchParams: Promise<Record<string, string | string[] | undefined>>;
-}) {
+export default async function SearchPage({ searchParams }: SearchPageProps) {
   const query = parseSearchQuery(await searchParams);
-  const home = await getSearchHome();
-  const results = query.keyword.trim() ? await getSearchResults(query) : null;
+  const keyword = query.keyword.trim();
 
   // 탭이 이어받을 조건 — `category`만 빼고 그대로 넘긴다
   const baseParams = new URLSearchParams();
   if (query.keyword) baseParams.set("q", query.keyword);
   if (query.projectTag) baseParams.set("project", query.projectTag);
   if (query.period !== "all") baseParams.set("period", query.period);
+
+  let content: ReactNode;
+  if (keyword) {
+    const [results, projects] = await Promise.all([getSearchResults(query), getSearchProjects()]);
+    content = (
+      <SearchResultsPanel
+        results={results}
+        query={query}
+        projects={projects}
+        baseParams={baseParams}
+      />
+    );
+  } else {
+    const home = await getSearchHome();
+    content = <SearchLanding home={home} />;
+  }
 
   return (
     <main className="min-h-0 flex-1 overflow-y-auto px-8 py-7">
@@ -38,17 +58,7 @@ export default async function SearchPage({
       <div className="mx-auto w-full max-w-[1440px]">
         <div className="mx-auto flex w-full max-w-[720px] flex-col gap-7">
           <SearchInput keyword={query.keyword} />
-
-          {results ? (
-            <SearchResultsPanel
-              results={results}
-              query={query}
-              projects={home.projects}
-              baseParams={baseParams}
-            />
-          ) : (
-            <SearchLanding home={home} />
-          )}
+          {content}
         </div>
       </div>
     </main>

--- a/src/app/(shell)/app/search/page.tsx
+++ b/src/app/(shell)/app/search/page.tsx
@@ -1,0 +1,56 @@
+import type { Metadata } from "next";
+
+import { SearchInput } from "@/features/search/components/search-input";
+import { SearchLanding } from "@/features/search/components/search-landing";
+import { SearchResultsPanel } from "@/features/search/components/search-results-panel";
+import { parseSearchQuery } from "@/features/search/lib";
+import { getSearchHome, getSearchResults } from "@/features/search/server";
+
+export const metadata: Metadata = {
+  title: "검색",
+};
+
+/**
+ * 검색 — 키워드가 없으면 랜딩(최근 검색어·최근 본 항목·둘러보기), 있으면 결과 목록이다.
+ * 조회뿐이라 Server Component 하나로 끝난다. 검색창·필터만 잎사귀로 나가 있다(CLAUDE.md §핵심 4원칙 1).
+ */
+export default async function SearchPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const query = parseSearchQuery(await searchParams);
+  const home = await getSearchHome();
+  const results = query.keyword.trim() ? await getSearchResults(query) : null;
+
+  // 탭이 이어받을 조건 — `category`만 빼고 그대로 넘긴다
+  const baseParams = new URLSearchParams();
+  if (query.keyword) baseParams.set("q", query.keyword);
+  if (query.projectTag) baseParams.set("project", query.projectTag);
+  if (query.period !== "all") baseParams.set("period", query.period);
+
+  return (
+    <main className="min-h-0 flex-1 overflow-y-auto px-8 py-7">
+      {/*
+        ⚠️ 바깥은 다른 목록 화면과 같은 1440(§DESIGN 4 폭)이지만, 검색은 한 줄 입력에서
+           시작하는 화면이라 안쪽 내용은 공지 상세처럼 720으로 좁힌다(§DESIGN 1 "읽는 글은 좁게").
+      */}
+      <div className="mx-auto w-full max-w-[1440px]">
+        <div className="mx-auto flex w-full max-w-[720px] flex-col gap-7">
+          <SearchInput keyword={query.keyword} />
+
+          {results ? (
+            <SearchResultsPanel
+              results={results}
+              query={query}
+              projects={home.projects}
+              baseParams={baseParams}
+            />
+          ) : (
+            <SearchLanding home={home} />
+          )}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/features/search/actions.ts
+++ b/src/features/search/actions.ts
@@ -1,5 +1,7 @@
 "use server";
 
+import { revalidatePath } from "next/cache";
+
 import { isMock } from "@/mocks/config";
 
 import { addMockRecentSearch } from "./mock/recent-searches";
@@ -16,6 +18,8 @@ export async function recordSearchAction(keyword: string): Promise<void> {
 
   if (isMock) {
     addMockRecentSearch(trimmed, new Date().toISOString());
+    // 랜딩(검색어 없음)이 최근 검색어를 보여주는 화면이라, 그 경로를 다시 검증하게 한다.
+    revalidatePath("/app/search");
     return;
   }
 

--- a/src/features/search/actions.ts
+++ b/src/features/search/actions.ts
@@ -1,0 +1,24 @@
+"use server";
+
+import { isMock } from "@/mocks/config";
+
+import { addMockRecentSearch } from "./mock/recent-searches";
+
+/**
+ * 검색 기록 — 검색창에서 값을 확정(입력을 멈춘 뒤)했을 때 클라이언트가 부른다.
+ * ⚠️ 화면에 결과를 돌려주지 않는다. 이 액션은 **기록만** 하고, 결과는 페이지가
+ *    `?q=`로 다시 조회해서 보여준다 — 액션이 결과까지 들고 있으면 새로고침·직접 링크로
+ *    들어왔을 때와 화면이 갈린다.
+ */
+export async function recordSearchAction(keyword: string): Promise<void> {
+  const trimmed = keyword.trim();
+  if (!trimmed) return;
+
+  if (isMock) {
+    addMockRecentSearch(trimmed, new Date().toISOString());
+    return;
+  }
+
+  // ⚠️ 미구현 — API 스펙 확정 후 검색 기록 경로로 POST한다.
+  throw new Error("검색 기록 API가 아직 연결되지 않았습니다.");
+}

--- a/src/features/search/components/browse-lists.tsx
+++ b/src/features/search/components/browse-lists.tsx
@@ -5,8 +5,14 @@ import { pickPaletteColor } from "@/lib/palette";
 
 import type { PersonBrowseItem, ProjectBrowseItem } from "../types";
 
+interface BrowseProjectsProps {
+  projects: ProjectBrowseItem[];
+}
+
 /** 검색어 없이 프로젝트를 훑어보는 목록 — 순수 이동이라 서버에서 그린다 */
-export function BrowseProjects({ projects }: { projects: ProjectBrowseItem[] }) {
+export function BrowseProjects({ projects }: BrowseProjectsProps) {
+  if (projects.length === 0) return null;
+
   return (
     <div>
       <h2 className="text-muted-foreground mb-3 text-[12px] leading-4">프로젝트로 찾기</h2>
@@ -37,11 +43,17 @@ export function BrowseProjects({ projects }: { projects: ProjectBrowseItem[] }) 
   );
 }
 
+interface BrowsePeopleProps {
+  people: PersonBrowseItem[];
+}
+
 /**
  * 검색어 없이 사람을 훑어보는 목록.
  * ⚠️ **구성원 상세 화면이 없다** — 눌러도 갈 곳이 없어 링크로 만들지 않는다(§명세에 없는 기능은 안 만든다).
  */
-export function BrowsePeople({ people }: { people: PersonBrowseItem[] }) {
+export function BrowsePeople({ people }: BrowsePeopleProps) {
+  if (people.length === 0) return null;
+
   return (
     <div>
       <h2 className="text-muted-foreground mb-3 text-[12px] leading-4">사람으로 찾기</h2>

--- a/src/features/search/components/browse-lists.tsx
+++ b/src/features/search/components/browse-lists.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link";
+
+import { AUTHORITY_BADGE_CLASS, AUTHORITY_LABEL } from "@/constants/authority";
+import { pickPaletteColor } from "@/lib/palette";
+
+import type { PersonBrowseItem, ProjectBrowseItem } from "../types";
+
+/** 검색어 없이 프로젝트를 훑어보는 목록 — 순수 이동이라 서버에서 그린다 */
+export function BrowseProjects({ projects }: { projects: ProjectBrowseItem[] }) {
+  return (
+    <div>
+      <h2 className="text-muted-foreground mb-3 text-[12px] leading-4">프로젝트로 찾기</h2>
+      <ul className="border-border bg-card divide-border divide-y overflow-hidden rounded-2xl border">
+        {projects.map((project) => {
+          const color = pickPaletteColor(project.tag);
+          return (
+            <li key={project.id}>
+              <Link
+                href={`/app/projects/${project.id}`}
+                className="hover:bg-foreground/[0.03] focus-visible:ring-ring flex items-center gap-2.5 px-5 py-3.5 text-[13px] transition-colors focus-visible:ring-2 focus-visible:outline-hidden"
+              >
+                <span
+                  className="size-2 shrink-0 rounded-full"
+                  style={{ backgroundColor: color.solidColor }}
+                  aria-hidden
+                />
+                <span className="min-w-0 flex-1 truncate">{project.name}</span>
+                <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
+                  회의 {project.meetingCount}건
+                </span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+/**
+ * 검색어 없이 사람을 훑어보는 목록.
+ * ⚠️ **구성원 상세 화면이 없다** — 눌러도 갈 곳이 없어 링크로 만들지 않는다(§명세에 없는 기능은 안 만든다).
+ */
+export function BrowsePeople({ people }: { people: PersonBrowseItem[] }) {
+  return (
+    <div>
+      <h2 className="text-muted-foreground mb-3 text-[12px] leading-4">사람으로 찾기</h2>
+      <ul className="border-border bg-card divide-border divide-y overflow-hidden rounded-2xl border">
+        {people.map((person) => (
+          <li key={person.id} className="flex items-center gap-2.5 px-5 py-3.5 text-[13px]">
+            <span className="min-w-0 flex-1 truncate">{person.name}</span>
+            <span
+              className={`${AUTHORITY_BADGE_CLASS[person.authority]} shrink-0 rounded px-1.5 py-0.5 text-[10px] leading-4`}
+            >
+              {AUTHORITY_LABEL[person.authority]}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/features/search/components/kind-badge.tsx
+++ b/src/features/search/components/kind-badge.tsx
@@ -3,11 +3,15 @@ import { Badge } from "@/components/ui/badge";
 import type { SearchKind } from "../types";
 import { SEARCH_KIND_LABEL } from "../types";
 
+interface KindBadgeProps {
+  kind: SearchKind;
+}
+
 /**
  * 결과 종류 표식 — **무채색뿐이다**(DESIGN §5). 색으로 종류를 가르지 않는다,
  * 이미 정해진 색 자리(상태점·프로젝트 태그·에러)와 겹치면 뜻이 두 개가 된다.
  */
-export function KindBadge({ kind }: { kind: SearchKind }) {
+export function KindBadge({ kind }: KindBadgeProps) {
   return (
     <Badge variant="outline" className="w-11 shrink-0 justify-center font-normal">
       {SEARCH_KIND_LABEL[kind]}

--- a/src/features/search/components/kind-badge.tsx
+++ b/src/features/search/components/kind-badge.tsx
@@ -1,0 +1,16 @@
+import { Badge } from "@/components/ui/badge";
+
+import type { SearchKind } from "../types";
+import { SEARCH_KIND_LABEL } from "../types";
+
+/**
+ * 결과 종류 표식 — **무채색뿐이다**(DESIGN §5). 색으로 종류를 가르지 않는다,
+ * 이미 정해진 색 자리(상태점·프로젝트 태그·에러)와 겹치면 뜻이 두 개가 된다.
+ */
+export function KindBadge({ kind }: { kind: SearchKind }) {
+  return (
+    <Badge variant="outline" className="w-11 shrink-0 justify-center font-normal">
+      {SEARCH_KIND_LABEL[kind]}
+    </Badge>
+  );
+}

--- a/src/features/search/components/match-text.tsx
+++ b/src/features/search/components/match-text.tsx
@@ -1,0 +1,27 @@
+import { splitByMatch } from "../lib";
+
+/**
+ * 검색어에 걸린 글자를 표시한다 — **화면이 왜 떴는지 말하게 하려고** 쓴다(`match-text.ts`와 같은 이유).
+ * ⚠️ **색을 안 쓴다.** 색으로 알리는 건 에러(빨강)뿐이라(§디자인 토큰) 옅은 먹색 바탕과
+ *    글자 진하기로 나타낸다. `mark`를 쓰는 건 스크린리더에도 표시가 남기 때문이다(§a11y).
+ */
+export function MatchText({ text, keyword }: { text: string; keyword: string }) {
+  const parts = splitByMatch(text, keyword);
+
+  return (
+    <>
+      {parts.map((part, index) =>
+        part.isMatch ? (
+          <mark
+            key={`${index}-${part.text}`}
+            className="bg-foreground/10 text-foreground rounded-[2px] font-medium"
+          >
+            {part.text}
+          </mark>
+        ) : (
+          part.text
+        ),
+      )}
+    </>
+  );
+}

--- a/src/features/search/components/recent-search-chips.tsx
+++ b/src/features/search/components/recent-search-chips.tsx
@@ -1,0 +1,28 @@
+import { Clock } from "lucide-react";
+import Link from "next/link";
+
+import type { RecentSearchEntry } from "../types";
+
+/** 최근 검색어 — 누르면 그 검색어로 바로 찾는다. 순수 이동이라 서버에서 그린다. */
+export function RecentSearchChips({ entries }: { entries: RecentSearchEntry[] }) {
+  if (entries.length === 0) return null;
+
+  return (
+    <div>
+      <h2 className="text-muted-foreground mb-3 text-[12px] leading-4">최근 검색어</h2>
+      <ul className="flex flex-wrap gap-2">
+        {entries.map((entry) => (
+          <li key={entry.keyword}>
+            <Link
+              href={`/app/search?q=${encodeURIComponent(entry.keyword)}`}
+              className="border-border text-foreground hover:bg-foreground/5 focus-visible:ring-ring flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-[12px] leading-4 transition-colors focus-visible:ring-2 focus-visible:outline-hidden"
+            >
+              <Clock className="text-muted-foreground/70 size-3" aria-hidden />
+              {entry.keyword}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/features/search/components/recent-search-chips.tsx
+++ b/src/features/search/components/recent-search-chips.tsx
@@ -3,8 +3,12 @@ import Link from "next/link";
 
 import type { RecentSearchEntry } from "../types";
 
+interface RecentSearchChipsProps {
+  entries: RecentSearchEntry[];
+}
+
 /** 최근 검색어 — 누르면 그 검색어로 바로 찾는다. 순수 이동이라 서버에서 그린다. */
-export function RecentSearchChips({ entries }: { entries: RecentSearchEntry[] }) {
+export function RecentSearchChips({ entries }: RecentSearchChipsProps) {
   if (entries.length === 0) return null;
 
   return (

--- a/src/features/search/components/recently-viewed-grid.tsx
+++ b/src/features/search/components/recently-viewed-grid.tsx
@@ -1,0 +1,81 @@
+import Link from "next/link";
+
+import { formatDate } from "@/lib/date";
+
+import type { SearchResultItem } from "../types";
+import { KindBadge } from "./kind-badge";
+
+/**
+ * 최근 본 항목 — 2열 카드. 순수 표시(+ 프로젝트만 이동)라 서버에서 그린다.
+ *
+ * ⚠️ **프로젝트만 링크다.** 회의·액션·사람 상세는 이 검색 목이 별도로 부여한 값이라
+ *    실제 회의·액션 상세 화면의 id 체계와 안 이어져 있다 — 안 되는 이동을 만드느니
+ *    지금은 정보만 보여준다(§명세에 없는 기능은 안 만든다). 연동되면 실제 id로 이어 붙인다.
+ */
+export function RecentlyViewedGrid({ items }: { items: SearchResultItem[] }) {
+  if (items.length === 0) return null;
+
+  return (
+    <div>
+      <h2 className="text-muted-foreground mb-3 text-[12px] leading-4">최근 본 항목</h2>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {items.map((item) => (
+          <RecentlyViewedCard key={`${item.kind}-${item.id}`} item={item} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function meta(item: SearchResultItem): string {
+  switch (item.kind) {
+    case "MEETING":
+      return `${item.projectName} · ${formatDate(item.meetingDate)}`;
+    case "ACTION":
+      return `${item.assigneeName} · 마감 ${formatDate(item.dueDate)}`;
+    case "PROJECT":
+      return `회의 ${item.meetingCount}건 · 액션 ${item.actionCount}건`;
+    case "PERSON":
+      return item.team ?? "소속 없음";
+  }
+}
+
+function title(item: SearchResultItem): string {
+  switch (item.kind) {
+    case "MEETING":
+    case "ACTION":
+      return item.title;
+    case "PROJECT":
+    case "PERSON":
+      return item.name;
+  }
+}
+
+function RecentlyViewedCard({ item }: { item: SearchResultItem }) {
+  const inner = (
+    <>
+      <KindBadge kind={item.kind} />
+      <div className="min-w-0 flex-1">
+        <p className="text-foreground truncate text-[13px] leading-5 font-semibold">
+          {title(item)}
+        </p>
+        <p className="text-muted-foreground mt-1 truncate text-[11px] leading-4">{meta(item)}</p>
+      </div>
+    </>
+  );
+
+  const shape = "border-border flex items-start gap-3 rounded-xl border p-4";
+
+  if (item.kind === "PROJECT") {
+    return (
+      <Link
+        href={`/app/projects/${item.id}`}
+        className={`${shape} hover:bg-foreground/[0.03] transition-colors`}
+      >
+        {inner}
+      </Link>
+    );
+  }
+
+  return <div className={shape}>{inner}</div>;
+}

--- a/src/features/search/components/recently-viewed-grid.tsx
+++ b/src/features/search/components/recently-viewed-grid.tsx
@@ -5,6 +5,10 @@ import { formatDate } from "@/lib/date";
 import type { SearchResultItem } from "../types";
 import { KindBadge } from "./kind-badge";
 
+interface RecentlyViewedGridProps {
+  items: SearchResultItem[];
+}
+
 /**
  * 최근 본 항목 — 2열 카드. 순수 표시(+ 프로젝트만 이동)라 서버에서 그린다.
  *
@@ -12,7 +16,7 @@ import { KindBadge } from "./kind-badge";
  *    실제 회의·액션 상세 화면의 id 체계와 안 이어져 있다 — 안 되는 이동을 만드느니
  *    지금은 정보만 보여준다(§명세에 없는 기능은 안 만든다). 연동되면 실제 id로 이어 붙인다.
  */
-export function RecentlyViewedGrid({ items }: { items: SearchResultItem[] }) {
+export function RecentlyViewedGrid({ items }: RecentlyViewedGridProps) {
   if (items.length === 0) return null;
 
   return (
@@ -51,7 +55,11 @@ function title(item: SearchResultItem): string {
   }
 }
 
-function RecentlyViewedCard({ item }: { item: SearchResultItem }) {
+interface RecentlyViewedCardProps {
+  item: SearchResultItem;
+}
+
+function RecentlyViewedCard({ item }: RecentlyViewedCardProps) {
   const inner = (
     <>
       <KindBadge kind={item.kind} />

--- a/src/features/search/components/search-filter-bar.tsx
+++ b/src/features/search/components/search-filter-bar.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useMemo } from "react";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+import type { ProjectBrowseItem, SearchPeriod } from "../types";
+import { SEARCH_PERIOD, SEARCH_PERIOD_LABEL } from "../types";
+
+const ALL_PROJECTS_VALUE = "all";
+const ALL_PROJECTS_LABEL = "전체 프로젝트";
+
+/**
+ * 결과를 좁히는 두 조건 — 프로젝트·기간. **상호작용 잎사귀**만 클라이언트다.
+ * 값을 바꾸면 주소(`?project=&period=`)를 바꿔 서버가 다시 걸러 준다 — 화면 안 상태로
+ * 들고 있지 않는다(§핵심 4원칙 1).
+ */
+export function SearchFilterBar({
+  projects,
+  projectTag,
+  period,
+}: {
+  projects: ProjectBrowseItem[];
+  projectTag: string | null;
+  period: SearchPeriod;
+}) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  /*
+    ⚠️ `Select`에 `items`(값→라벨 맵)를 넘긴다. `SelectValue`는 지금 골라진 값의 라벨을
+       열려 있는 목록(`SelectItem`)에서 찾는데, 닫혀 있을 때는 그 목록이 아직 렌더되지 않아
+       **원문 값**(`GOODS`·`7d`)이 그대로 보인다 — `company-filter-bar.tsx`와 같은 이유.
+  */
+  const projectItems = useMemo(
+    () => ({
+      [ALL_PROJECTS_VALUE]: ALL_PROJECTS_LABEL,
+      ...Object.fromEntries(projects.map((project) => [project.tag, project.name])),
+    }),
+    [projects],
+  );
+
+  const setParam = useCallback(
+    (key: string, value: string, isDefault: boolean) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (isDefault) params.delete(key);
+      else params.set(key, value);
+
+      router.replace(`/app/search${params.size > 0 ? `?${params}` : ""}`, { scroll: false });
+    },
+    [router, searchParams],
+  );
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-muted-foreground text-xs">필터:</span>
+
+      <Select
+        items={projectItems}
+        value={projectTag ?? ALL_PROJECTS_VALUE}
+        onValueChange={(next) => {
+          const value = String(next);
+          setParam("project", value, value === ALL_PROJECTS_VALUE);
+        }}
+      >
+        <SelectTrigger size="sm" className="w-[160px]">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={ALL_PROJECTS_VALUE}>전체 프로젝트</SelectItem>
+          {projects.map((project) => (
+            <SelectItem key={project.tag} value={project.tag}>
+              {project.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Select
+        items={SEARCH_PERIOD_LABEL}
+        value={period}
+        onValueChange={(next) => {
+          const value = next as SearchPeriod;
+          setParam("period", value, value === SEARCH_PERIOD.ALL);
+        }}
+      >
+        <SelectTrigger size="sm" className="w-[140px]">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {Object.values(SEARCH_PERIOD).map((value) => (
+            <SelectItem key={value} value={value}>
+              {SEARCH_PERIOD_LABEL[value]}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/src/features/search/components/search-input.tsx
+++ b/src/features/search/components/search-input.tsx
@@ -2,7 +2,7 @@
 
 import { Search, X } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { Input } from "@/components/ui/input";
 
@@ -10,6 +10,10 @@ import { recordSearchAction } from "../actions";
 
 /** 적기를 멈춘 뒤 이만큼 지나면 보낸다 — 짧으면 요청이 줄줄이 나가고 길면 굼떠 보인다 */
 const SEARCH_DEBOUNCE_MS = 300;
+
+interface SearchInputProps {
+  keyword: string;
+}
 
 /**
  * 검색창 — **상호작용 잎사귀만** 클라이언트다(§핵심 4원칙 1).
@@ -19,11 +23,14 @@ const SEARCH_DEBOUNCE_MS = 300;
  * ⚠️ **적는 동안 기록하지 않는다.** 한 글자마다 최근 검색어를 남기면 "ㅈ"·"제"·"제품"이
  *    전부 기록된다 — 잠깐 멈추면 그때 주소를 바꾸고, 그때 딱 한 번만 기록한다.
  */
-export function SearchInput({ keyword }: { keyword: string }) {
+export function SearchInput({ keyword }: SearchInputProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
 
   const [value, setValue] = useState(keyword);
+  /* 마지막으로 `value`를 맞춘 주소값 — 아래 렌더 중 동기화가 한 번만 일어나게 지키는 표시다 */
+  const [syncedKeyword, setSyncedKeyword] = useState(keyword);
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const commit = useCallback(
     (next: string) => {
@@ -38,10 +45,26 @@ export function SearchInput({ keyword }: { keyword: string }) {
     [router, searchParams],
   );
 
+  /*
+    ⚠️ **주소가 바깥에서 바뀌면 입력칸도 맞춘다 — 렌더 중에, 이펙트가 아니다**
+       (react.dev "Adjusting some state when a prop changes"). 최근 검색어 칩·탭처럼
+       `Link`로 `q`가 바뀌는 경로가 따로 있다 — 그때 입력칸이 옛 글자를 그대로 들고 있으면
+       주소와 화면이 다른 말을 한다.
+    ⚠️ 여기서 타이머를 직접 건드리지 않는다(ref는 렌더 중에 못 읽는다) — `value`가 이
+       렌더에서 `keyword`로 맞춰지면 아래 디바운스 이펙트가 다시 돌면서 **그 이펙트의
+       클린업이** 밀린 타이머를 알아서 지운다.
+  */
+  if (keyword !== syncedKeyword) {
+    setSyncedKeyword(keyword);
+    setValue(keyword);
+  }
+
   useEffect(() => {
     if (value.trim() === keyword.trim()) return;
-    const timer = setTimeout(() => commit(value), SEARCH_DEBOUNCE_MS);
-    return () => clearTimeout(timer);
+    debounceTimer.current = setTimeout(() => commit(value), SEARCH_DEBOUNCE_MS);
+    return () => {
+      if (debounceTimer.current) clearTimeout(debounceTimer.current);
+    };
   }, [value, keyword, commit]);
 
   return (

--- a/src/features/search/components/search-input.tsx
+++ b/src/features/search/components/search-input.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Search, X } from "lucide-react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+
+import { Input } from "@/components/ui/input";
+
+import { recordSearchAction } from "../actions";
+
+/** 적기를 멈춘 뒤 이만큼 지나면 보낸다 — 짧으면 요청이 줄줄이 나가고 길면 굼떠 보인다 */
+const SEARCH_DEBOUNCE_MS = 300;
+
+/**
+ * 검색창 — **상호작용 잎사귀만** 클라이언트다(§핵심 4원칙 1).
+ *
+ * ⚠️ 검색어는 **주소에 적는다**(`?q=`). 화면 안 상태로 두면 새로고침·뒤로 가기에서
+ *    조건이 날아가고, 찾은 결과를 남에게 링크로 보낼 수도 없다(`people-search.tsx`와 같은 규칙).
+ * ⚠️ **적는 동안 기록하지 않는다.** 한 글자마다 최근 검색어를 남기면 "ㅈ"·"제"·"제품"이
+ *    전부 기록된다 — 잠깐 멈추면 그때 주소를 바꾸고, 그때 딱 한 번만 기록한다.
+ */
+export function SearchInput({ keyword }: { keyword: string }) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const [value, setValue] = useState(keyword);
+
+  const commit = useCallback(
+    (next: string) => {
+      const trimmed = next.trim();
+      const params = new URLSearchParams(searchParams.toString());
+      if (trimmed) params.set("q", trimmed);
+      else params.delete("q");
+
+      router.replace(`/app/search${params.size > 0 ? `?${params}` : ""}`, { scroll: false });
+      if (trimmed) void recordSearchAction(trimmed);
+    },
+    [router, searchParams],
+  );
+
+  useEffect(() => {
+    if (value.trim() === keyword.trim()) return;
+    const timer = setTimeout(() => commit(value), SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [value, keyword, commit]);
+
+  return (
+    <div className="relative w-full">
+      <Search
+        className="text-muted-foreground/70 pointer-events-none absolute top-1/2 left-4 size-4 -translate-y-1/2"
+        aria-hidden
+      />
+      <Input
+        id="workbench-search"
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        placeholder="회의·액션·프로젝트·사람을 검색해 보세요"
+        className="h-11 rounded-xl pl-11"
+      />
+      <label htmlFor="workbench-search" className="sr-only">
+        검색
+      </label>
+
+      {value.length > 0 && (
+        <button
+          type="button"
+          aria-label="검색어 지우기"
+          onClick={() => setValue("")}
+          className="text-muted-foreground hover:text-foreground focus-visible:ring-ring absolute top-1/2 right-3 flex size-6 -translate-y-1/2 items-center justify-center rounded-md focus-visible:ring-2 focus-visible:outline-hidden"
+        >
+          <X className="size-4" aria-hidden />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/features/search/components/search-landing.tsx
+++ b/src/features/search/components/search-landing.tsx
@@ -3,8 +3,12 @@ import { BrowsePeople, BrowseProjects } from "./browse-lists";
 import { RecentSearchChips } from "./recent-search-chips";
 import { RecentlyViewedGrid } from "./recently-viewed-grid";
 
+interface SearchLandingProps {
+  home: SearchHome;
+}
+
 /** 검색어가 없을 때의 화면 — 최근 검색어 → 최근 본 항목 → 둘러보기 순서(CLAUDE.md §화면은 위에서 아래로) */
-export function SearchLanding({ home }: { home: SearchHome }) {
+export function SearchLanding({ home }: SearchLandingProps) {
   const isEmpty =
     home.recentSearches.length === 0 &&
     home.recentlyViewed.length === 0 &&

--- a/src/features/search/components/search-landing.tsx
+++ b/src/features/search/components/search-landing.tsx
@@ -1,0 +1,32 @@
+import type { SearchHome } from "../types";
+import { BrowsePeople, BrowseProjects } from "./browse-lists";
+import { RecentSearchChips } from "./recent-search-chips";
+import { RecentlyViewedGrid } from "./recently-viewed-grid";
+
+/** 검색어가 없을 때의 화면 — 최근 검색어 → 최근 본 항목 → 둘러보기 순서(CLAUDE.md §화면은 위에서 아래로) */
+export function SearchLanding({ home }: { home: SearchHome }) {
+  const isEmpty =
+    home.recentSearches.length === 0 &&
+    home.recentlyViewed.length === 0 &&
+    home.projects.length === 0 &&
+    home.people.length === 0;
+
+  if (isEmpty) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-1 py-24 text-center">
+        <p className="text-foreground text-sm font-medium">아직 둘러볼 게 없어요</p>
+        <p className="text-muted-foreground text-xs">검색어를 입력해 찾아보세요.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-7">
+      <RecentSearchChips entries={home.recentSearches} />
+      <RecentlyViewedGrid items={home.recentlyViewed} />
+
+      <BrowseProjects projects={home.projects} />
+      <BrowsePeople people={home.people} />
+    </div>
+  );
+}

--- a/src/features/search/components/search-result-row.tsx
+++ b/src/features/search/components/search-result-row.tsx
@@ -1,0 +1,95 @@
+import { AUTHORITY_BADGE_CLASS, AUTHORITY_LABEL } from "@/constants/authority";
+import { formatDate } from "@/lib/date";
+import { pickPaletteColor } from "@/lib/palette";
+import { cn } from "@/lib/utils";
+
+import type { SearchResultItem } from "../types";
+import { KindBadge } from "./kind-badge";
+import { MatchText } from "./match-text";
+
+const ROW_SHAPE = "flex items-start gap-3 px-6 py-4";
+
+/** 결과 한 줄 — 종류마다 제목·발췌·보조 정보가 달라 안에서 갈라 그린다. 순수 표시라 서버에서 그린다. */
+export function SearchResultRow({ item, keyword }: { item: SearchResultItem; keyword: string }) {
+  return (
+    <li className={cn(ROW_SHAPE, "border-border not-first:border-t")}>
+      <KindBadge kind={item.kind} />
+
+      <div className="min-w-0 flex-1">
+        <p className="text-foreground truncate text-[13px] leading-5 font-semibold">
+          <MatchText text={rowTitle(item)} keyword={keyword} />
+        </p>
+        {rowSnippet(item) && (
+          <p className="text-muted-foreground mt-1 truncate text-[12px] leading-4">
+            {rowSnippet(item)}
+          </p>
+        )}
+        <p className="text-muted-foreground/70 mt-1.5 flex items-center gap-1.5 text-[11px] leading-4">
+          <ProjectDot item={item} />
+          {rowMeta(item)}
+        </p>
+      </div>
+
+      {item.kind === "PERSON" && (
+        <span
+          className={cn(
+            AUTHORITY_BADGE_CLASS[item.authority],
+            "shrink-0 rounded px-1.5 py-0.5 text-[10px] leading-4",
+          )}
+        >
+          {AUTHORITY_LABEL[item.authority]}
+        </span>
+      )}
+    </li>
+  );
+}
+
+function ProjectDot({ item }: { item: SearchResultItem }) {
+  const tag =
+    item.kind === "MEETING" || item.kind === "ACTION"
+      ? item.projectTag
+      : item.kind === "PROJECT"
+        ? item.tag
+        : null;
+  if (!tag) return null;
+
+  const color = pickPaletteColor(tag);
+  return (
+    <span
+      className="size-1.5 shrink-0 rounded-full"
+      style={{ backgroundColor: color.solidColor }}
+      aria-hidden
+    />
+  );
+}
+
+function rowTitle(item: SearchResultItem): string {
+  switch (item.kind) {
+    case "MEETING":
+    case "ACTION":
+      return item.title;
+    case "PROJECT":
+      return item.name;
+    case "PERSON":
+      return item.name;
+  }
+}
+
+function rowSnippet(item: SearchResultItem): string | null {
+  if (item.kind === "MEETING") return item.snippet;
+  if (item.kind === "PERSON") return item.description;
+  return null;
+}
+
+function rowMeta(item: SearchResultItem): string {
+  switch (item.kind) {
+    case "MEETING":
+      return `${item.projectName} · ${formatDate(item.meetingDate)}`;
+    case "ACTION":
+      return `${item.assigneeName} · 마감 ${formatDate(item.dueDate)}`;
+    case "PROJECT":
+      return `회의 ${item.meetingCount}건 · 액션 ${item.actionCount}건`;
+    case "PERSON":
+      return item.team ?? "소속 없음";
+  }
+}

--- a/src/features/search/components/search-result-row.tsx
+++ b/src/features/search/components/search-result-row.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import { AUTHORITY_BADGE_CLASS, AUTHORITY_LABEL } from "@/constants/authority";
 import { formatDate } from "@/lib/date";
 import { pickPaletteColor } from "@/lib/palette";
@@ -9,10 +11,22 @@ import { MatchText } from "./match-text";
 
 const ROW_SHAPE = "flex items-start gap-3 px-6 py-4";
 
-/** 결과 한 줄 — 종류마다 제목·발췌·보조 정보가 달라 안에서 갈라 그린다. 순수 표시라 서버에서 그린다. */
-export function SearchResultRow({ item, keyword }: { item: SearchResultItem; keyword: string }) {
-  return (
-    <li className={cn(ROW_SHAPE, "border-border not-first:border-t")}>
+interface SearchResultRowProps {
+  item: SearchResultItem;
+  keyword: string;
+}
+
+/**
+ * 결과 한 줄 — 종류마다 제목·발췌·보조 정보가 달라 안에서 갈라 그린다. 순수 표시(+ 프로젝트만
+ * 이동)라 서버에서 그린다.
+ *
+ * ⚠️ **프로젝트만 링크다.** 회의·액션 상세는 이 검색 목이 별도로 부여한 값이라 실제 상세
+ *    화면의 id 체계와 안 이어져 있다(`recently-viewed-grid.tsx`와 같은 이유) — 프로젝트는
+ *    실제 프로젝트 id를 그대로 쓰므로 `/app/projects/:id`가 유효하다.
+ */
+export function SearchResultRow({ item, keyword }: SearchResultRowProps) {
+  const content = (
+    <>
       <KindBadge kind={item.kind} />
 
       <div className="min-w-0 flex-1">
@@ -21,12 +35,12 @@ export function SearchResultRow({ item, keyword }: { item: SearchResultItem; key
         </p>
         {rowSnippet(item) && (
           <p className="text-muted-foreground mt-1 truncate text-[12px] leading-4">
-            {rowSnippet(item)}
+            <MatchText text={rowSnippet(item) ?? ""} keyword={keyword} />
           </p>
         )}
         <p className="text-muted-foreground/70 mt-1.5 flex items-center gap-1.5 text-[11px] leading-4">
           <ProjectDot item={item} />
-          {rowMeta(item)}
+          <MatchText text={rowMeta(item)} keyword={keyword} />
         </p>
       </div>
 
@@ -40,8 +54,23 @@ export function SearchResultRow({ item, keyword }: { item: SearchResultItem; key
           {AUTHORITY_LABEL[item.authority]}
         </span>
       )}
-    </li>
+    </>
   );
+
+  if (item.kind === "PROJECT") {
+    return (
+      <li className="border-border not-first:border-t">
+        <Link
+          href={`/app/projects/${item.id}`}
+          className={cn(ROW_SHAPE, "hover:bg-foreground/[0.03] transition-colors")}
+        >
+          {content}
+        </Link>
+      </li>
+    );
+  }
+
+  return <li className={cn(ROW_SHAPE, "border-border not-first:border-t")}>{content}</li>;
 }
 
 function ProjectDot({ item }: { item: SearchResultItem }) {

--- a/src/features/search/components/search-results-panel.tsx
+++ b/src/features/search/components/search-results-panel.tsx
@@ -1,0 +1,58 @@
+import { SearchX } from "lucide-react";
+
+import type { ProjectBrowseItem, SearchQuery, SearchResults } from "../types";
+import { SearchFilterBar } from "./search-filter-bar";
+import { SearchResultRow } from "./search-result-row";
+import { SearchTabs } from "./search-tabs";
+
+/**
+ * 검색어가 있을 때의 화면 — 탭·필터·결과 목록을 한 카드에 담는다(DESIGN §2 카드 anatomy).
+ * 순수 표시 + 이동뿐이라 서버에서 그린다. 조건을 바꾸는 잎사귀(입력·셀렉트)만 클라이언트다.
+ */
+export function SearchResultsPanel({
+  results,
+  query,
+  projects,
+  baseParams,
+}: {
+  results: SearchResults;
+  query: SearchQuery;
+  projects: ProjectBrowseItem[];
+  /** `category`를 뺀 나머지 조건(`q`·`project`·`period`) — 탭이 그대로 이어받는다 */
+  baseParams: URLSearchParams;
+}) {
+  return (
+    <section className="border-border bg-card overflow-hidden rounded-2xl border">
+      <div className="px-6 pt-5">
+        <SearchTabs counts={results.counts} active={query.category} searchParams={baseParams} />
+      </div>
+
+      <div className="flex items-center justify-between gap-3 px-6 py-3">
+        <SearchFilterBar projects={projects} projectTag={query.projectTag} period={query.period} />
+        <p className="text-muted-foreground shrink-0 text-xs tabular-nums">
+          결과 {results.items.length}건
+        </p>
+      </div>
+
+      {results.items.length === 0 ? (
+        <div className="border-border flex flex-col items-center gap-2 border-t px-6 py-16 text-center">
+          <SearchX className="text-muted-foreground/50 size-6" aria-hidden />
+          <p className="text-foreground text-sm font-medium">검색 결과가 없어요</p>
+          <p className="text-muted-foreground text-xs">
+            다른 검색어로 찾거나 필터를 전체로 바꿔보세요.
+          </p>
+        </div>
+      ) : (
+        <ul className="border-border border-t">
+          {results.items.map((item) => (
+            <SearchResultRow
+              key={`${item.kind}-${item.id}`}
+              item={item}
+              keyword={results.keyword}
+            />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/features/search/components/search-tabs.tsx
+++ b/src/features/search/components/search-tabs.tsx
@@ -1,0 +1,65 @@
+import Link from "next/link";
+
+import { cn } from "@/lib/utils";
+
+import type { SearchCategory, SearchCategoryCounts } from "../types";
+import { SEARCH_CATEGORY, SEARCH_CATEGORY_LABEL } from "../types";
+
+const TAB_ORDER: SearchCategory[] = [
+  SEARCH_CATEGORY.ALL,
+  SEARCH_CATEGORY.MEETING,
+  SEARCH_CATEGORY.ACTION,
+  SEARCH_CATEGORY.PROJECT,
+  SEARCH_CATEGORY.PERSON,
+];
+
+function countFor(counts: SearchCategoryCounts, category: SearchCategory): number {
+  if (category === SEARCH_CATEGORY.ALL) return counts.total;
+  return counts[category];
+}
+
+/**
+ * 결과 카테고리 탭 — **순수 이동**이라 서버에서 그린다(클라이언트로 뺄 이유가 없다).
+ * 지금 켠 조건(`?q=&project=&period=`)은 그대로 두고 `category`만 바꾼다.
+ */
+export function SearchTabs({
+  counts,
+  active,
+  searchParams,
+}: {
+  counts: SearchCategoryCounts;
+  active: SearchCategory;
+  searchParams: URLSearchParams;
+}) {
+  return (
+    <div role="tablist" className="border-border flex gap-1 border-b">
+      {TAB_ORDER.map((category) => {
+        const params = new URLSearchParams(searchParams);
+        if (category === SEARCH_CATEGORY.ALL) params.delete("category");
+        else params.set("category", category);
+
+        const isActive = category === active;
+
+        return (
+          <Link
+            key={category}
+            href={`/app/search?${params}`}
+            role="tab"
+            aria-selected={isActive}
+            replace
+            scroll={false}
+            className={cn(
+              "focus-visible:ring-ring -mb-px flex items-center gap-1.5 border-b-2 px-3 py-2.5 text-[13px] leading-5 transition-colors focus-visible:ring-2 focus-visible:outline-hidden",
+              isActive
+                ? "border-foreground text-foreground font-semibold"
+                : "text-muted-foreground hover:text-foreground border-transparent",
+            )}
+          >
+            {SEARCH_CATEGORY_LABEL[category]}
+            <span className="tabular-nums">{countFor(counts, category)}</span>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/search/lib.ts
+++ b/src/features/search/lib.ts
@@ -1,0 +1,95 @@
+import type {
+  SearchCategory,
+  SearchKind,
+  SearchPeriod,
+  SearchQuery,
+  SearchResultItem,
+} from "./types";
+import { SEARCH_CATEGORY, SEARCH_PERIOD } from "./types";
+
+/** 글자 한 토막 — 검색어에 걸린 자리인지 함께 들고 있다 */
+export interface TextPart {
+  text: string;
+  isMatch: boolean;
+}
+
+/**
+ * 검색어에 걸린 자리를 갈라낸다 — 제목 어디가 왜 걸렸는지 보여주려고 쓴다.
+ *
+ * ⚠️ **정규식을 안 쓴다.** 검색어는 사람이 아무 글자나 치는 값이라 `(`·`*` 같은 게 들어오면
+ *    정규식이 터지거나 엉뚱한 데가 걸린다 — 글자를 그대로 찾는다.
+ * ⚠️ 찾을 때만 소문자로 맞추고 **보여주는 건 원문 그대로**다.
+ */
+export function splitByMatch(text: string, keyword: string): TextPart[] {
+  const needle = keyword.trim().toLowerCase();
+  if (!needle) return [{ text, isMatch: false }];
+
+  const haystack = text.toLowerCase();
+  const parts: TextPart[] = [];
+  let cursor = 0;
+
+  while (cursor < text.length) {
+    const hit = haystack.indexOf(needle, cursor);
+    if (hit < 0) {
+      parts.push({ text: text.slice(cursor), isMatch: false });
+      break;
+    }
+    if (hit > cursor) parts.push({ text: text.slice(cursor, hit), isMatch: false });
+    parts.push({ text: text.slice(hit, hit + needle.length), isMatch: true });
+    cursor = hit + needle.length;
+  }
+
+  return parts;
+}
+
+/** 대소문자를 가리지 않고 포함하는지 */
+export function textIncludes(haystack: string, keyword: string): boolean {
+  return haystack.toLowerCase().includes(keyword.trim().toLowerCase());
+}
+
+const KIND_TO_CATEGORY: Record<SearchKind, Exclude<SearchCategory, "all">> = {
+  MEETING: "meeting",
+  ACTION: "action",
+  PROJECT: "project",
+  PERSON: "person",
+};
+
+/** 결과 한 건의 종류를 탭 카테고리 값으로 바꾼다 */
+export function categoryOf(item: SearchResultItem): Exclude<SearchCategory, "all"> {
+  return KIND_TO_CATEGORY[item.kind];
+}
+
+/** 주소가 같은 이름을 여러 번 줄 수 있어(`?q=김&q=이`) 값이 배열로도 온다 — 첫 값만 쓴다 */
+function firstValue(value: string | string[] | undefined): string {
+  if (Array.isArray(value)) return value[0] ?? "";
+  return value ?? "";
+}
+
+const VALID_CATEGORIES = Object.values(SEARCH_CATEGORY);
+const VALID_PERIODS = Object.values(SEARCH_PERIOD);
+
+/**
+ * 주소(`searchParams`)를 검색 조건으로 바꾼다.
+ *
+ * ⚠️ **모르는 값은 조용히 기본값으로 물러난다.** 주소는 사람이 손으로도 칠 수 있어
+ *    `?category=hack` 같은 값이 올 수 있다 — 타입을 좁혀 두지 않으면 그대로 필터 로직에
+ *    흘러들어 알 수 없는 동작을 한다.
+ */
+export function parseSearchQuery(
+  searchParams: Record<string, string | string[] | undefined>,
+): SearchQuery {
+  const category = firstValue(searchParams.category);
+  const period = firstValue(searchParams.period);
+  const project = firstValue(searchParams.project).trim();
+
+  return {
+    keyword: firstValue(searchParams.q),
+    category: (VALID_CATEGORIES as string[]).includes(category)
+      ? (category as SearchCategory)
+      : SEARCH_CATEGORY.ALL,
+    period: (VALID_PERIODS as string[]).includes(period)
+      ? (period as SearchPeriod)
+      : SEARCH_PERIOD.ALL,
+    projectTag: project.length > 0 ? project : null,
+  };
+}

--- a/src/features/search/mock/data.ts
+++ b/src/features/search/mock/data.ts
@@ -1,0 +1,162 @@
+import { AUTHORITY } from "@/constants/domain";
+
+import type {
+  SearchActionResult,
+  SearchMeetingResult,
+  SearchPersonResult,
+  SearchProjectResult,
+} from "../types";
+
+/**
+ * ⚠️ 목 데이터 — BE 연동 전(ERD·API 스펙 미확정). 프로젝트·사람은 다른 화면의 목과
+ *    **같은 이름**을 쓴다(GOODS·BRAND·COLLAB, 박대표·김서준·이하윤·박도현) — 화면을 오갈 때
+ *    같은 회사로 보이게 하려고다(§정직한 목업).
+ */
+
+const GOODS_PROJECT: SearchProjectResult = {
+  kind: "PROJECT",
+  id: 1,
+  name: "연예인 굿즈 쇼핑몰 앱 구축",
+  tag: "GOODS",
+  meetingCount: 24,
+  actionCount: 11,
+};
+
+const BRAND_PROJECT: SearchProjectResult = {
+  kind: "PROJECT",
+  id: 2,
+  name: "3분기 마케팅 브랜드 리뉴얼",
+  tag: "BRAND",
+  meetingCount: 8,
+  actionCount: 4,
+};
+
+const COLLAB_PROJECT: SearchProjectResult = {
+  kind: "PROJECT",
+  id: 3,
+  name: "사내 협업툴 리뉴얼",
+  tag: "COLLAB",
+  meetingCount: 12,
+  actionCount: 4,
+};
+
+export const SEARCH_MOCK_PROJECTS: SearchProjectResult[] = [
+  GOODS_PROJECT,
+  BRAND_PROJECT,
+  COLLAB_PROJECT,
+];
+
+const ROADMAP_MEETING: SearchMeetingResult = {
+  kind: "MEETING",
+  id: 101,
+  title: "8월 로드맵 점검 회의",
+  snippet: "결제 연동을 이번 스프린트 최우선 과제로 확정했습니다.",
+  projectName: "연예인 굿즈 쇼핑몰 앱 구축",
+  projectTag: "GOODS",
+  meetingDate: "2026-08-05",
+};
+
+const BRAND_KICKOFF_MEETING: SearchMeetingResult = {
+  kind: "MEETING",
+  id: 102,
+  title: "브랜드 캠페인 킥오프",
+  snippet: "3분기 캠페인 컨셉과 채널별 일정을 확정했습니다.",
+  projectName: "3분기 마케팅 브랜드 리뉴얼",
+  projectTag: "BRAND",
+  meetingDate: "2026-07-28",
+};
+
+const COLLAB_REQUIREMENT_MEETING: SearchMeetingResult = {
+  kind: "MEETING",
+  id: 103,
+  title: "협업툴 요구사항 회의",
+  snippet: "회의·문서·일정 흐름을 하나로 잇기로 했습니다.",
+  projectName: "사내 협업툴 리뉴얼",
+  projectTag: "COLLAB",
+  meetingDate: "2026-07-20",
+};
+
+export const SEARCH_MOCK_MEETINGS: SearchMeetingResult[] = [
+  ROADMAP_MEETING,
+  BRAND_KICKOFF_MEETING,
+  COLLAB_REQUIREMENT_MEETING,
+];
+
+const PAYMENT_API_ACTION: SearchActionResult = {
+  kind: "ACTION",
+  id: 201,
+  title: "결제 모듈 API 명세 작성",
+  assigneeId: 4,
+  assigneeName: "박도현",
+  dueDate: "2026-08-12",
+  projectTag: "GOODS",
+};
+
+const CAMPAIGN_VISUAL_ACTION: SearchActionResult = {
+  kind: "ACTION",
+  id: 202,
+  title: "캠페인 비주얼 시안 제작",
+  assigneeId: 3,
+  assigneeName: "이하윤",
+  dueDate: "2026-08-02",
+  projectTag: "BRAND",
+};
+
+const MEETING_NOTE_TEMPLATE_ACTION: SearchActionResult = {
+  kind: "ACTION",
+  id: 203,
+  title: "회의록 템플릿 정의",
+  assigneeId: 2,
+  assigneeName: "김서준",
+  dueDate: "2026-08-09",
+  projectTag: "COLLAB",
+};
+
+export const SEARCH_MOCK_ACTIONS: SearchActionResult[] = [
+  PAYMENT_API_ACTION,
+  CAMPAIGN_VISUAL_ACTION,
+  MEETING_NOTE_TEMPLATE_ACTION,
+];
+
+export const SEARCH_MOCK_PEOPLE: SearchPersonResult[] = [
+  {
+    kind: "PERSON",
+    id: 1,
+    name: "박대표",
+    authority: AUTHORITY.OWNER,
+    team: null,
+    description: "기업 전체를 관리합니다.",
+  },
+  {
+    kind: "PERSON",
+    id: 2,
+    name: "김서준",
+    authority: AUTHORITY.LEADER,
+    team: "개발팀",
+    description: "회의록 템플릿 정의를 담당합니다.",
+  },
+  {
+    kind: "PERSON",
+    id: 3,
+    name: "이하윤",
+    authority: AUTHORITY.MEMBER,
+    team: "개발팀",
+    description: "캠페인 비주얼 시안 제작을 담당합니다.",
+  },
+  {
+    kind: "PERSON",
+    id: 4,
+    name: "박도현",
+    authority: AUTHORITY.MEMBER,
+    team: "개발팀",
+    description: "결제 모듈 API 명세 작성을 담당합니다.",
+  },
+];
+
+/** 최근 본 항목 — 회의 둘·액션 하나·프로젝트 하나(2×2로 그린다) */
+export const SEARCH_MOCK_RECENTLY_VIEWED = [
+  ROADMAP_MEETING,
+  PAYMENT_API_ACTION,
+  BRAND_KICKOFF_MEETING,
+  GOODS_PROJECT,
+];

--- a/src/features/search/mock/recent-searches.ts
+++ b/src/features/search/mock/recent-searches.ts
@@ -1,0 +1,39 @@
+import type { RecentSearchEntry } from "../types";
+
+/**
+ * ⚠️ 목 데이터 — BE 연동 전. **서버 프로세스 메모리에만 있다**(재시작하면 초기값으로 되돌아간다).
+ * `recordSearchAction`이 이 배열을 직접 바꾼다 — 실제 DB 흉내다.
+ * ⚠️ 로그인(세션)이 없어 "이 사용자의 최근 검색"이 아니라 **전역**으로 흉내 낸다(§정직성).
+ * ⚠️ `globalThis`에 매단다 — dev의 HMR로 `let`이 초기화되면 방금 한 검색이 사라진다.
+ */
+const INITIAL: RecentSearchEntry[] = [
+  { keyword: "로드맵", searchedAt: "2026-08-06T09:00:00+09:00" },
+  { keyword: "API 명세", searchedAt: "2026-08-07T11:30:00+09:00" },
+  { keyword: "브랜드 캠페인", searchedAt: "2026-08-07T15:10:00+09:00" },
+];
+
+/** 한 번에 들고 있는 최근 검색어 수 — 넘치면 오래된 것부터 밀어낸다 */
+const MAX_ENTRIES = 5;
+
+const globalStore = globalThis as typeof globalThis & { __recentSearchStore?: RecentSearchEntry[] };
+const store = (globalStore.__recentSearchStore ??= INITIAL);
+
+/** 최근 것이 앞에 오도록 정렬해 돌려준다 */
+export function listMockRecentSearches(): RecentSearchEntry[] {
+  return [...store].sort((a, b) => b.searchedAt.localeCompare(a.searchedAt)).slice(0, MAX_ENTRIES);
+}
+
+/**
+ * 검색 기록 — 같은 검색어가 이미 있으면 시각만 갱신해 맨 앞으로 올린다.
+ * ⚠️ `searchedAt`은 서버에서 계산해 넘긴다(클라이언트 시계를 믿지 않는다).
+ */
+export function addMockRecentSearch(keyword: string, searchedAt: string): void {
+  const trimmed = keyword.trim();
+  if (!trimmed) return;
+
+  const withoutDuplicate = store.filter((entry) => entry.keyword !== trimmed);
+  const next = [{ keyword: trimmed, searchedAt }, ...withoutDuplicate].slice(0, MAX_ENTRIES);
+
+  store.length = 0;
+  store.push(...next);
+}

--- a/src/features/search/server.ts
+++ b/src/features/search/server.ts
@@ -21,18 +21,22 @@ import type {
 
 /** 검색 — 격리막(CLAUDE.md). 연동할 때 고칠 곳은 이 파일과 매퍼뿐이고 컴포넌트는 건드리지 않는다. */
 
+function mapProjectsForBrowse(): ProjectBrowseItem[] {
+  return SEARCH_MOCK_PROJECTS.map((project) => ({
+    id: project.id,
+    name: project.name,
+    tag: project.tag,
+    meetingCount: project.meetingCount,
+  }));
+}
+
 /** 검색어가 없을 때(랜딩)의 화면 — 최근 검색어·최근 본 항목·둘러보기 목록 */
 export async function getSearchHome(): Promise<SearchHome> {
   if (isMock) {
     return {
       recentSearches: listMockRecentSearches(),
       recentlyViewed: SEARCH_MOCK_RECENTLY_VIEWED,
-      projects: SEARCH_MOCK_PROJECTS.map((project): ProjectBrowseItem => ({
-        id: project.id,
-        name: project.name,
-        tag: project.tag,
-        meetingCount: project.meetingCount,
-      })),
+      projects: mapProjectsForBrowse(),
       people: SEARCH_MOCK_PEOPLE.map((person) => ({
         id: person.id,
         name: person.name,
@@ -45,12 +49,30 @@ export async function getSearchHome(): Promise<SearchHome> {
   throw new Error("검색 랜딩 API가 아직 연결되지 않았습니다.");
 }
 
-/** 마감·회의 일시가 이 기간 안에 드는지 — 기간이 없는 값(프로젝트·사람)은 항상 통과시킨다 */
+/**
+ * 결과 화면의 프로젝트 필터 목록.
+ *
+ * ⚠️ **`getSearchHome()`을 대신 쓰지 않는다.** 그건 최근 검색어·최근 본 항목까지 같이 불러오는
+ *    랜딩 전용 조회라, 검색어가 있는 화면(결과 목록)에서 그걸 불러오면 랜딩 쪽 API가 실패했을 때
+ *    결과 화면까지 같이 죽는다 — 결과 화면이 실제로 필요한 건 필터용 프로젝트 목록뿐이다.
+ */
+export async function getSearchProjects(): Promise<ProjectBrowseItem[]> {
+  if (isMock) return mapProjectsForBrowse();
+
+  // ⚠️ 미구현 — API 스펙 확정 후 프로젝트 목록 경로로 fetch하고 매퍼로 UI 계약에 맞춘다.
+  throw new Error("검색 필터용 프로젝트 목록 API가 아직 연결되지 않았습니다.");
+}
+
+/**
+ * 마감·회의 일시가 이 기간 **안**에 드는지 — 기간이 없는 값(프로젝트·사람)은 항상 통과시킨다.
+ * ⚠️ **미래 날짜는 포함하지 않는다.** "최근 N일"은 지난 일을 묻는 말이라, 아직 안 지난
+ *    마감일까지 걸리면 "최근"이라는 말과 어긋난다.
+ */
 function withinPeriod(iso: string, days: number | null, todayMs: number): boolean {
   if (days === null) return true;
   const target = new Date(`${iso}T00:00:00`).getTime();
   const diffDays = (todayMs - target) / 86_400_000;
-  return diffDays >= -days && diffDays <= days;
+  return diffDays >= 0 && diffDays <= days;
 }
 
 const PERIOD_DAYS: Record<SearchQuery["period"], number | null> = {
@@ -67,7 +89,9 @@ function matchesKeyword(item: SearchResultItem, keyword: string): boolean {
     case "ACTION":
       return textIncludes(item.title, keyword) || textIncludes(item.assigneeName, keyword);
     case "PROJECT":
-      return textIncludes(item.name, keyword) || textIncludes(item.tag, keyword);
+      // ⚠️ 태그는 안 찾는다 — 화면에 안 내보내는 내부 식별자라(CLAUDE.md §도메인 상수),
+      //    태그로만 걸리면 사용자는 왜 이 프로젝트가 떴는지 알 길이 없다.
+      return textIncludes(item.name, keyword);
     case "PERSON":
       return (
         textIncludes(item.name, keyword) ||

--- a/src/features/search/server.ts
+++ b/src/features/search/server.ts
@@ -1,0 +1,154 @@
+import "server-only";
+
+import { isMock } from "@/mocks/config";
+
+import { categoryOf, textIncludes } from "./lib";
+import {
+  SEARCH_MOCK_ACTIONS,
+  SEARCH_MOCK_MEETINGS,
+  SEARCH_MOCK_PEOPLE,
+  SEARCH_MOCK_PROJECTS,
+  SEARCH_MOCK_RECENTLY_VIEWED,
+} from "./mock/data";
+import { listMockRecentSearches } from "./mock/recent-searches";
+import type {
+  ProjectBrowseItem,
+  SearchHome,
+  SearchQuery,
+  SearchResultItem,
+  SearchResults,
+} from "./types";
+
+/** 검색 — 격리막(CLAUDE.md). 연동할 때 고칠 곳은 이 파일과 매퍼뿐이고 컴포넌트는 건드리지 않는다. */
+
+/** 검색어가 없을 때(랜딩)의 화면 — 최근 검색어·최근 본 항목·둘러보기 목록 */
+export async function getSearchHome(): Promise<SearchHome> {
+  if (isMock) {
+    return {
+      recentSearches: listMockRecentSearches(),
+      recentlyViewed: SEARCH_MOCK_RECENTLY_VIEWED,
+      projects: SEARCH_MOCK_PROJECTS.map((project): ProjectBrowseItem => ({
+        id: project.id,
+        name: project.name,
+        tag: project.tag,
+        meetingCount: project.meetingCount,
+      })),
+      people: SEARCH_MOCK_PEOPLE.map((person) => ({
+        id: person.id,
+        name: person.name,
+        authority: person.authority,
+      })),
+    };
+  }
+
+  // ⚠️ 미구현 — API 스펙 확정 후 검색 랜딩 경로로 fetch하고 매퍼로 UI 계약에 맞춘다.
+  throw new Error("검색 랜딩 API가 아직 연결되지 않았습니다.");
+}
+
+/** 마감·회의 일시가 이 기간 안에 드는지 — 기간이 없는 값(프로젝트·사람)은 항상 통과시킨다 */
+function withinPeriod(iso: string, days: number | null, todayMs: number): boolean {
+  if (days === null) return true;
+  const target = new Date(`${iso}T00:00:00`).getTime();
+  const diffDays = (todayMs - target) / 86_400_000;
+  return diffDays >= -days && diffDays <= days;
+}
+
+const PERIOD_DAYS: Record<SearchQuery["period"], number | null> = {
+  all: null,
+  "7d": 7,
+  "30d": 30,
+  "90d": 90,
+};
+
+function matchesKeyword(item: SearchResultItem, keyword: string): boolean {
+  switch (item.kind) {
+    case "MEETING":
+      return textIncludes(item.title, keyword) || textIncludes(item.snippet, keyword);
+    case "ACTION":
+      return textIncludes(item.title, keyword) || textIncludes(item.assigneeName, keyword);
+    case "PROJECT":
+      return textIncludes(item.name, keyword) || textIncludes(item.tag, keyword);
+    case "PERSON":
+      return (
+        textIncludes(item.name, keyword) ||
+        textIncludes(item.description, keyword) ||
+        (item.team !== null && textIncludes(item.team, keyword))
+      );
+  }
+}
+
+function matchesProject(item: SearchResultItem, projectTag: string | null): boolean {
+  if (!projectTag) return true;
+  switch (item.kind) {
+    case "MEETING":
+    case "ACTION":
+      return item.projectTag === projectTag;
+    case "PROJECT":
+      return item.tag === projectTag;
+    case "PERSON":
+      // 사람은 특정 프로젝트에 속하지 않는다 — 프로젝트 필터를 걸어도 그대로 둔다
+      return true;
+  }
+}
+
+function matchesPeriod(
+  item: SearchResultItem,
+  period: SearchQuery["period"],
+  todayMs: number,
+): boolean {
+  const days = PERIOD_DAYS[period];
+  if (item.kind === "MEETING") return withinPeriod(item.meetingDate, days, todayMs);
+  if (item.kind === "ACTION") return withinPeriod(item.dueDate, days, todayMs);
+  return true;
+}
+
+function allItems(): SearchResultItem[] {
+  return [
+    ...SEARCH_MOCK_MEETINGS,
+    ...SEARCH_MOCK_ACTIONS,
+    ...SEARCH_MOCK_PROJECTS,
+    ...SEARCH_MOCK_PEOPLE,
+  ];
+}
+
+/** 검색 결과 — 카테고리 탭 숫자는 키워드·프로젝트·기간까지 반영해 센다(탭을 눌러도 숫자가 안 흔들리게). */
+export async function getSearchResults(query: SearchQuery): Promise<SearchResults> {
+  const keyword = query.keyword.trim();
+
+  if (!isMock) {
+    // ⚠️ 미구현 — API 스펙 확정 후 검색 경로로 fetch하고 매퍼로 UI 계약에 맞춘다.
+    throw new Error("검색 API가 아직 연결되지 않았습니다.");
+  }
+
+  if (!keyword) {
+    return {
+      keyword,
+      counts: { total: 0, meeting: 0, action: 0, project: 0, person: 0 },
+      items: [],
+    };
+  }
+
+  const todayMs = Date.now();
+  const matched = allItems().filter(
+    (item) =>
+      matchesKeyword(item, keyword) &&
+      matchesProject(item, query.projectTag) &&
+      matchesPeriod(item, query.period, todayMs),
+  );
+
+  const counts = matched.reduce(
+    (acc, item) => {
+      acc.total += 1;
+      acc[categoryOf(item)] += 1;
+      return acc;
+    },
+    { total: 0, meeting: 0, action: 0, project: 0, person: 0 },
+  );
+
+  const items =
+    query.category === "all"
+      ? matched
+      : matched.filter((item) => categoryOf(item) === query.category);
+
+  return { keyword, counts, items };
+}

--- a/src/features/search/types.ts
+++ b/src/features/search/types.ts
@@ -1,0 +1,151 @@
+import type { Authority } from "@/constants/domain";
+
+/**
+ * 검색 — 격리막의 UI 계약(CLAUDE.md §Mock 격리막).
+ * 컴포넌트는 이 타입만 알고, 목/실서버 분기는 `server.ts`가 끝낸다.
+ */
+
+export const SEARCH_KIND = {
+  MEETING: "MEETING",
+  ACTION: "ACTION",
+  PROJECT: "PROJECT",
+  PERSON: "PERSON",
+} as const;
+export type SearchKind = (typeof SEARCH_KIND)[keyof typeof SEARCH_KIND];
+
+export const SEARCH_KIND_LABEL: Record<SearchKind, string> = {
+  MEETING: "회의",
+  ACTION: "액션",
+  PROJECT: "프로젝트",
+  PERSON: "사람",
+};
+
+export interface SearchMeetingResult {
+  kind: "MEETING";
+  id: number;
+  title: string;
+  /** 검색어가 걸린 자리를 보여주는 발췌 — 요약의 한 조각 */
+  snippet: string;
+  projectName: string;
+  projectTag: string;
+  /** `YYYY-MM-DD` */
+  meetingDate: string;
+}
+
+export interface SearchActionResult {
+  kind: "ACTION";
+  id: number;
+  title: string;
+  assigneeId: number;
+  assigneeName: string;
+  /** `YYYY-MM-DD` */
+  dueDate: string;
+  projectTag: string;
+}
+
+export interface SearchProjectResult {
+  kind: "PROJECT";
+  id: number;
+  name: string;
+  tag: string;
+  meetingCount: number;
+  actionCount: number;
+}
+
+export interface SearchPersonResult {
+  kind: "PERSON";
+  id: number;
+  name: string;
+  authority: Authority;
+  team: string | null;
+  /** 그 사람을 설명하는 한 줄 — 최근 담당한 일 */
+  description: string;
+}
+
+export type SearchResultItem =
+  SearchMeetingResult | SearchActionResult | SearchProjectResult | SearchPersonResult;
+
+export interface SearchCategoryCounts {
+  total: number;
+  meeting: number;
+  action: number;
+  project: number;
+  person: number;
+}
+
+/** 검색 결과 화면이 한 번에 받는 것 */
+export interface SearchResults {
+  keyword: string;
+  /** 카테고리·프로젝트·기간 필터와 무관하게 **키워드만으로** 센 전체 건수 — 탭 숫자용 */
+  counts: SearchCategoryCounts;
+  /** 지금 고른 탭·필터로 걸러진 목록 */
+  items: SearchResultItem[];
+}
+
+export interface RecentSearchEntry {
+  keyword: string;
+  /** ISO datetime */
+  searchedAt: string;
+}
+
+export interface ProjectBrowseItem {
+  id: number;
+  name: string;
+  tag: string;
+  meetingCount: number;
+}
+
+export interface PersonBrowseItem {
+  id: number;
+  name: string;
+  authority: Authority;
+}
+
+/** 검색어가 없을 때(랜딩) 보여줄 것 */
+export interface SearchHome {
+  recentSearches: RecentSearchEntry[];
+  recentlyViewed: SearchResultItem[];
+  projects: ProjectBrowseItem[];
+  people: PersonBrowseItem[];
+}
+
+export const SEARCH_CATEGORY = {
+  ALL: "all",
+  MEETING: "meeting",
+  ACTION: "action",
+  PROJECT: "project",
+  PERSON: "person",
+} as const;
+export type SearchCategory = (typeof SEARCH_CATEGORY)[keyof typeof SEARCH_CATEGORY];
+
+export const SEARCH_CATEGORY_LABEL: Record<SearchCategory, string> = {
+  all: "전체",
+  meeting: "회의",
+  action: "액션",
+  project: "프로젝트",
+  person: "사람",
+};
+
+export const SEARCH_PERIOD = {
+  ALL: "all",
+  WEEK: "7d",
+  MONTH: "30d",
+  QUARTER: "90d",
+} as const;
+export type SearchPeriod = (typeof SEARCH_PERIOD)[keyof typeof SEARCH_PERIOD];
+
+export const SEARCH_PERIOD_LABEL: Record<SearchPeriod, string> = {
+  all: "전체 기간",
+  "7d": "최근 7일",
+  "30d": "최근 30일",
+  "90d": "최근 3개월",
+};
+
+/** 검색 화면이 주소(`searchParams`)에서 읽는 조건 전부 */
+export interface SearchQuery {
+  keyword: string;
+  category: SearchCategory;
+  /** `null` = 전체 프로젝트 */
+  projectTag: string | null;
+  period: SearchPeriod;
+}

--- a/src/features/search/types.ts
+++ b/src/features/search/types.ts
@@ -76,7 +76,10 @@ export interface SearchCategoryCounts {
 /** 검색 결과 화면이 한 번에 받는 것 */
 export interface SearchResults {
   keyword: string;
-  /** 카테고리·프로젝트·기간 필터와 무관하게 **키워드만으로** 센 전체 건수 — 탭 숫자용 */
+  /**
+   * 탭 숫자용 건수 — **프로젝트·기간 필터는 반영하고 카테고리(탭)만 무시하고** 센다.
+   * 그래서 탭을 눌러도 숫자 자체는 안 흔들리지만, 프로젝트·기간을 바꾸면 같이 바뀐다.
+   */
   counts: SearchCategoryCounts;
   /** 지금 고른 탭·필터로 걸러진 목록 */
   items: SearchResultItem[];

--- a/src/features/shell/nav-config.test.ts
+++ b/src/features/shell/nav-config.test.ts
@@ -176,6 +176,7 @@ describe("화면이 있으면 자동으로 이어진다", () => {
     ["/team", "대시보드"],
     ["/my", "대시보드"],
     ["/app/projects", "프로젝트"],
+    ["/app/search", "검색"],
     ["/app/calendar", "캘린더"],
     ["/app/notice", "공지"],
     ["/app/me", "마이페이지"],
@@ -189,10 +190,6 @@ describe("화면이 있으면 자동으로 이어진다", () => {
 
     expect(item).toBeDefined();
     expect(item?.isReady).toBe(true);
-  });
-
-  it.each([["/app/search", "검색"]])("아직 없는 화면 `%s`(%s)는 준비 중으로 남는다", (href) => {
-    expect(everyItem.find((candidate) => candidate.href === href)?.isReady).toBe(false);
   });
 
   /*


### PR DESCRIPTION
## 📋 PR 타입
- [x] feature — 새로운 기능 추가

---

## 🗂 작업 영역
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 공통 · 인프라

---

## 🙋 관련 역할
- [x] 공통

---

## 📝 작업 내용
- 사이드바 "검색"(`/app/search`) 화면 신규 구현 — 키워드 검색 + 카테고리 탭/프로젝트·기간 필터
- 랜딩 상태(검색어 없음)에서 최근 검색어·최근 본 항목·프로젝트/사람 둘러보기 제공
- 백엔드 API 미확정 → `features/search`에 mock↔live 격리막(`server.ts`/`actions.ts`) 구성

---

## ✅ 작업 체크리스트

**기본**
- [x] 브랜치 명명 규칙 준수 (`feature/search-keyword-search#{이슈번호}`, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**
- [x] 🔐 권한 2축 검사 — 공용 화면이라 역할 가드 없음(§권한 조건 참고), 컴포넌트 레벨 가드 불필요
- [ ] 🧬 zod — (미적용: 이 화면은 조회 전용이라 폼 스키마 없음, 검증 대상 아님)
- [x] 🕵️ 정직성 — 미구현 API 경로에 명시적 에러/주석, 연결 안 되는 상세 링크(회의·액션)는 만들지 않음
- [x] 🎨 디자인 토큰 사용 (DESIGN.md 폭·색·카드 규칙 준수, 다크 값 토큰만 사용)

**품질**
- [x] ⚡ 최적화 — 대부분 Server Component, 클라이언트 잎사귀 최소화
- [x] ♿ a11y (label · role · alt · 키보드) — `mark` 하이라이트, `role="tablist"`, `sr-only` 라벨
- [x] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 확인 후 신규 작성)
- [x] 🧪 loading / error / empty 3상태
- [x] 브라우저 전용 API 사용 없음

---

## 🔗 연관 이슈
Closes #225
---

## 📸 스크린샷 (선택)
| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트
- 회의·액션 결과는 상세 화면과 id 체계가 안 이어져 있어 **링크로 만들지 않았다** (프로젝트만 링크) — 연동 전 임시 판단이라 다른 방향이 나을지 의견 부탁
- 검색 결과 폭을 1440 목록 안에 720으로 좁힌 것(§DESIGN 공지 상세 패턴 준용)이 맞는 방향인지

---

## 📝 추가 메모
디자인 시안이 아직 미정이라 DESIGN.md 규격(카드/색/폭)에 맞춰 구성함. 시안 확정되면 세부 스타일은 조정 필요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 회의실 화면 헤더에 캘린더 아이콘을 추가했습니다.
  * 통합 검색으로 회의, 액션, 프로젝트, 사람을 검색할 수 있습니다.
  * 검색어 강조, 카테고리 탭, 프로젝트·기간 필터를 제공합니다.
  * 최근 검색어와 최근 본 항목, 프로젝트·사람 탐색을 지원합니다.
  * 검색 중 로딩 화면과 오류 발생 시 재시도 기능을 제공합니다.
* **개선**
  * 검색 결과에 유형, 관련 정보, 날짜 및 권한을 보기 쉽게 표시합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

