### PR TITLE
[FEAT] 마이페이지 — 요약이 중단된 회의 그룹 추가(목업) #224

### DIFF
--- a/src/app/(shell)/app/me/page.tsx
+++ b/src/app/(shell)/app/me/page.tsx
@@ -2,6 +2,7 @@ import { ClipboardList, RotateCcw } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
 
+import { TASK_GROUP } from "@/constants/profile";
 import { ScreenScaleCard } from "@/features/appearance/components/screen-scale-card";
 import { ThemeCard } from "@/features/appearance/components/theme-card";
 import { listPendingReviewsForViewer } from "@/features/meeting/review/server";
@@ -51,6 +52,9 @@ export default async function AppMePage({ searchParams }: AppMePageProps) {
     <div className="flex-1 overflow-y-auto px-8 py-7">
       <div className="mx-auto w-full max-w-[1440px]">
         <div className="mx-auto flex w-full max-w-[600px] flex-col gap-5">
+          {/* ⚠️ 화면 전체에 보이는 제목은 없지만 `h1`은 페이지당 하나 있어야 한다(§SEO·a11y) */}
+          <h1 className="sr-only">마이페이지</h1>
+
           <nav aria-label="마이페이지 탭" className="border-border flex gap-4 border-b">
             {PROFILE_TABS.map((t) => (
               <Link
@@ -73,18 +77,18 @@ export default async function AppMePage({ searchParams }: AppMePageProps) {
             <div className="flex flex-col gap-5">
               <TaskGroupSection
                 icon={ClipboardList}
-                title="미확정 액션"
+                title={TASK_GROUP.UNCONFIRMED_ACTION.title}
                 count={pendingReviews.length}
-                emptyMessage="미확정 액션이 없습니다."
+                emptyMessage={TASK_GROUP.UNCONFIRMED_ACTION.emptyMessage}
               >
                 <UnconfirmedActionList reviews={pendingReviews} />
               </TaskGroupSection>
 
               <TaskGroupSection
                 icon={RotateCcw}
-                title="요약이 중단된 회의"
+                title={TASK_GROUP.STALLED_SUMMARY.title}
                 count={stalledSummaries.length}
-                emptyMessage="요약이 중단된 회의가 없습니다."
+                emptyMessage={TASK_GROUP.STALLED_SUMMARY.emptyMessage}
               >
                 <StalledSummaryList summaries={stalledSummaries} />
               </TaskGroupSection>

--- a/src/app/(shell)/app/me/page.tsx
+++ b/src/app/(shell)/app/me/page.tsx
@@ -1,11 +1,15 @@
+import { ClipboardList, RotateCcw } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
 
 import { ScreenScaleCard } from "@/features/appearance/components/screen-scale-card";
 import { ThemeCard } from "@/features/appearance/components/theme-card";
 import { listPendingReviewsForViewer } from "@/features/meeting/review/server";
+import { listStalledSummariesForViewer } from "@/features/meeting/summary/server";
 import { ProfileHeader } from "@/features/profile/components/profile-header";
 import { ProfileInfoCard } from "@/features/profile/components/profile-info-card";
+import { StalledSummaryList } from "@/features/profile/components/stalled-summary-list";
+import { TaskGroupSection } from "@/features/profile/components/task-group-section";
 import { UnconfirmedActionList } from "@/features/profile/components/unconfirmed-action-list";
 import { parseProfileTab, PROFILE_TABS } from "@/features/profile/lib";
 import { getMyProfile } from "@/features/profile/server";
@@ -27,17 +31,20 @@ interface AppMePageProps {
  *    "기본 정보"는 팀 디자인(피그마)을 그대로 반영했지만, 이 화면에서 값을 고칠 수 있다는
  *    뜻은 아니다 — 편집 API·정책이 확정되면 그때 붙인다.
  * ⚠️ 배율은 **기기 설정**이라 서버에 저장하지 않는다(`ScreenScaleCard` 그대로 유지).
- * ⚠️ "미확정 액션" 탭은 **여기 있어야 한다** — "내 액션"(`/app/my/actions`)은 Owner가
+ * ⚠️ "처리할 일" 탭은 **여기 있어야 한다** — "내 액션"(`/app/my/actions`)은 Owner가
  *    접근 못 하는데, 회의 Host는 Owner일 수 있다(2026-08-07 사용자 확정, WORKFLOW.md 미기재
- *    — 이 화면 자체가 이번에 새로 나온 정책).
+ *    — 이 화면 자체가 새로 나온 정책). "요약이 중단된 회의" 그룹도 같은 이유로 여기 둔다
+ *    (BE #177 대응, 2026-08-08 — 실시간 진행 배너를 놓친 사람이 뒤늦게 발견하는 자리).
  */
 export default async function AppMePage({ searchParams }: AppMePageProps) {
   const activeTab = parseProfileTab((await searchParams).tab);
   const viewer = await getViewer();
+  const isTaskTab = activeTab === "unconfirmed";
 
-  const [profile, pendingReviews] = await Promise.all([
+  const [profile, pendingReviews, stalledSummaries] = await Promise.all([
     getMyProfile(),
-    activeTab === "unconfirmed" ? listPendingReviewsForViewer(viewer.id) : Promise.resolve([]),
+    isTaskTab ? listPendingReviewsForViewer(viewer.id) : Promise.resolve([]),
+    isTaskTab ? listStalledSummariesForViewer(viewer.id) : Promise.resolve([]),
   ]);
 
   return (
@@ -62,8 +69,26 @@ export default async function AppMePage({ searchParams }: AppMePageProps) {
             ))}
           </nav>
 
-          {activeTab === "unconfirmed" ? (
-            <UnconfirmedActionList reviews={pendingReviews} />
+          {isTaskTab ? (
+            <div className="flex flex-col gap-5">
+              <TaskGroupSection
+                icon={ClipboardList}
+                title="미확정 액션"
+                count={pendingReviews.length}
+                emptyMessage="미확정 액션이 없습니다."
+              >
+                <UnconfirmedActionList reviews={pendingReviews} />
+              </TaskGroupSection>
+
+              <TaskGroupSection
+                icon={RotateCcw}
+                title="요약이 중단된 회의"
+                count={stalledSummaries.length}
+                emptyMessage="요약이 중단된 회의가 없습니다."
+              >
+                <StalledSummaryList summaries={stalledSummaries} />
+              </TaskGroupSection>
+            </div>
           ) : (
             <div className="flex flex-col gap-7">
               <div className="flex flex-col gap-5">

--- a/src/constants/meeting.ts
+++ b/src/constants/meeting.ts
@@ -36,6 +36,14 @@ export const AI_SUMMARY_STATUS = {
   SUMMARIZING: "SUMMARIZING",
   REVIEWED: "REVIEWED",
   DISTRIBUTED: "DISTRIBUTED",
+  /**
+   * ⚠️ BE #177(2026-08-08): 서버가 죽어 끊긴 것도, 실제로 분석이 실패한 것도 전부
+   *    이 값으로 온다. 둘을 가르는 건 `stalled` 플래그(층별)다 — 상태 하나 더 만들지
+   *    않는다(§도메인 상수: 파생값은 계산). 이 상수엔 `stalled` 자체를 안 담는다 —
+   *    회의 하나 안의 여러 층 중 일부만 stalled일 수 있어서, 그 판정은 화면(마이페이지
+   *    "요약이 중단된 회의")이 층 목록을 보고 계산한다.
+   */
+  FAILED: "FAILED",
 } as const;
 export type AiSummaryStatus = (typeof AI_SUMMARY_STATUS)[keyof typeof AI_SUMMARY_STATUS];
 
@@ -44,6 +52,7 @@ export const AI_SUMMARY_STATUS_LABEL: Record<AiSummaryStatus, string> = {
   SUMMARIZING: "요약 중",
   REVIEWED: "검토 완료",
   DISTRIBUTED: "분배 완료",
+  FAILED: "실패",
 };
 
 /*

--- a/src/constants/profile.ts
+++ b/src/constants/profile.ts
@@ -30,3 +30,15 @@ export const PROFILE_TAB_LABEL: Record<ProfileTab, string> = {
 };
 
 export const DEFAULT_PROFILE_TAB: ProfileTab = PROFILE_TAB.INFO;
+
+/** "처리할 일" 탭의 그룹 카드 문구 — 화면(`page.tsx`)에 한글을 직접 적지 않는다(§도메인 상수). */
+export const TASK_GROUP = {
+  UNCONFIRMED_ACTION: {
+    title: "미확정 액션",
+    emptyMessage: "미확정 액션이 없습니다.",
+  },
+  STALLED_SUMMARY: {
+    title: "요약이 중단된 회의",
+    emptyMessage: "요약이 중단된 회의가 없습니다.",
+  },
+} as const;

--- a/src/constants/profile.ts
+++ b/src/constants/profile.ts
@@ -10,9 +10,13 @@ export const PROFILE_INFO_ROW_LABEL = {
 } as const;
 
 /**
- * 마이페이지 탭 — "미확정 액션"은 2026-08-07 사용자 확정. "내 액션"(`/app/my/actions`)에
- * 두려 했으나 Owner가 접근 못 하는 화면이라, 회의 Host가 Owner여도 항상 볼 수 있는
- * 마이페이지 쪽으로 옮겼다(WORKFLOW.md 미기재 — 이 화면 자체가 이번에 새로 확정된 정책).
+ * 마이페이지 탭 — "처리할 일"은 2026-08-07 사용자 확정(당시 라벨은 "미확정 액션").
+ * "내 액션"(`/app/my/actions`)에 두려 했으나 Owner가 접근 못 하는 화면이라, 회의
+ * Host가 Owner여도 항상 볼 수 있는 마이페이지 쪽으로 옮겼다(WORKFLOW.md 미기재 —
+ * 이 화면 자체가 새로 확정된 정책).
+ * ⚠️ 2026-08-08 "요약이 중단된 회의" 그룹이 추가되면서 라벨을 "미확정 액션"→
+ *    "처리할 일"로 넓혔다 — 값(`unconfirmed`)은 그대로 두고 라벨만 바꿨다(URL·분기
+ *    코드 안 건드림).
  */
 export const PROFILE_TAB = {
   INFO: "info",
@@ -22,7 +26,7 @@ export type ProfileTab = (typeof PROFILE_TAB)[keyof typeof PROFILE_TAB];
 
 export const PROFILE_TAB_LABEL: Record<ProfileTab, string> = {
   info: "기본 정보",
-  unconfirmed: "미확정 액션",
+  unconfirmed: "처리할 일",
 };
 
 export const DEFAULT_PROFILE_TAB: ProfileTab = PROFILE_TAB.INFO;

--- a/src/features/meeting/summary/actions.ts
+++ b/src/features/meeting/summary/actions.ts
@@ -1,0 +1,32 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { getViewer } from "@/features/shell/viewer";
+import { canOperateMeeting } from "@/lib/permission";
+import { isMock } from "@/mocks/config";
+
+import { findMockStalledSummary, removeMockStalledSummary } from "./mock/stalled-summaries";
+
+/**
+ * [다시 분석] — 재분석 큐에 다시 넣는다.
+ * ⚠️ 실제 재분석 API 경로가 아직 BE와 확정 전이다(§연동 검증, BE #177 관련 요청함) —
+ *    지금은 mock으로 "목록에서 빠진다"까지만 흉내낸다.
+ * ⚠️ Host만 요청할 수 있다 — 화면 버튼 숨김은 보안이 아니다(CLAUDE.md §권한).
+ */
+export async function retryMeetingSummaryAction(meetingId: string): Promise<void> {
+  if (!isMock) {
+    throw new Error("서버 연동 미구현 — 재분석 API 경로 확정 후 매퍼 작성");
+  }
+
+  const item = findMockStalledSummary(meetingId);
+  if (!item) return;
+
+  const viewer = await getViewer();
+  if (!canOperateMeeting(viewer, { ownerId: item.hostId })) {
+    throw new Error("권한이 없습니다.");
+  }
+
+  removeMockStalledSummary(meetingId);
+  revalidatePath("/app/me");
+}

--- a/src/features/meeting/summary/mock/stalled-summaries.ts
+++ b/src/features/meeting/summary/mock/stalled-summaries.ts
@@ -1,0 +1,54 @@
+import type { StalledSummaryInfo } from "../types";
+
+/**
+ * ⚠️ 목 데이터 — BE 연동 전(CLAUDE.md §정직한 목업). BE #177이 확정되기 전이라
+ *    "회의 목록에서 상태로 걸러 온다"를 흉내만 낸다 — 실제로는 필터/목록 API가
+ *    확정돼야 한다(§연동 검증, BE에 요청해 둠).
+ * ⚠️ `globalThis`에 매달아 dev HMR로 사라지지 않게 한다(`review/mock`와 같은 트릭).
+ */
+interface StalledSummaryStore {
+  items: Record<string, StalledSummaryInfo & { hostId: number }>;
+}
+
+const globalStore = globalThis as typeof globalThis & {
+  __stalledSummaryStore?: StalledSummaryStore;
+};
+
+function seedStore(): StalledSummaryStore {
+  return {
+    items: {
+      "meeting-summary-1": {
+        meetingId: "meeting-summary-1",
+        meetingTitle: "9월 스프린트 리뷰",
+        isStalled: true,
+        hostId: 1,
+      },
+      "meeting-summary-2": {
+        meetingId: "meeting-summary-2",
+        meetingTitle: "협업툴 리뉴얼 프로젝트 킥오프",
+        isStalled: false,
+        hostId: 1,
+      },
+    },
+  };
+}
+
+function getStore(): StalledSummaryStore {
+  if (!globalStore.__stalledSummaryStore) {
+    globalStore.__stalledSummaryStore = seedStore();
+  }
+  return globalStore.__stalledSummaryStore;
+}
+
+export function listMockStalledSummaries(): (StalledSummaryInfo & { hostId: number })[] {
+  return Object.values(getStore().items);
+}
+
+export function findMockStalledSummary(meetingId: string) {
+  return getStore().items[meetingId] ?? null;
+}
+
+/** [다시 분석] — mock에선 목록에서 그냥 빼서 "재분석 큐로 넘어감"을 흉내낸다. */
+export function removeMockStalledSummary(meetingId: string): void {
+  delete getStore().items[meetingId];
+}

--- a/src/features/meeting/summary/server.ts
+++ b/src/features/meeting/summary/server.ts
@@ -1,0 +1,15 @@
+import { listMockStalledSummaries } from "./mock/stalled-summaries";
+import type { StalledSummaryInfo } from "./types";
+
+/**
+ * 마이페이지 "요약이 중단된 회의" 목록 — 이 사람이 Host인 것만 모아 보여준다
+ * (WORKFLOW.md §3-4 "Host만 접근"과 같은 축, `review/server.ts`의
+ * `listPendingReviewsForViewer`와 같은 패턴).
+ */
+export async function listStalledSummariesForViewer(
+  viewerId: number,
+): Promise<StalledSummaryInfo[]> {
+  return listMockStalledSummaries()
+    .filter((item) => item.hostId === viewerId)
+    .map(({ meetingId, meetingTitle, isStalled }) => ({ meetingId, meetingTitle, isStalled }));
+}

--- a/src/features/meeting/summary/types.ts
+++ b/src/features/meeting/summary/types.ts
@@ -1,0 +1,18 @@
+/**
+ * 마이페이지 "요약이 중단된 회의" 그룹의 **UI 계약**(CLAUDE.md §Mock 격리막).
+ *
+ * ⚠️ 실시간 진행 배너(폴링·axios)는 이 이슈 범위가 아니다 — 여기는 브라우저를 닫아
+ *    실시간 알림을 놓친 사람이 마이페이지에서 뒤늦게 발견하고 재분석을 요청하는
+ *    자리다(BE #177 대응, 2026-08-08 팀 확정).
+ */
+
+/**
+ * 회의 하나당 한 줄 — `AI_SUMMARY_STATUS.FAILED`인 회의만 여기 온다.
+ * ⚠️ `isStalled`가 실제 표시를 가른다: true면 "서버 문제로 중단됨"(다시 분석하면 대개
+ *    해결), false면 "분석 자체가 실패함"(문구만 다르고 재분석 흐름은 동일).
+ */
+export interface StalledSummaryInfo {
+  meetingId: string;
+  meetingTitle: string;
+  isStalled: boolean;
+}

--- a/src/features/profile/components/stalled-summary-list.tsx
+++ b/src/features/profile/components/stalled-summary-list.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { retryMeetingSummaryAction } from "@/features/meeting/summary/actions";
+import type { StalledSummaryInfo } from "@/features/meeting/summary/types";
+
+interface StalledSummaryListProps {
+  summaries: StalledSummaryInfo[];
+}
+
+/**
+ * "요약이 중단된 회의" 그룹의 행들 — 실시간 진행 배너를 놓친 사람(브라우저를 닫았던
+ * 경우 등)이 여기서 뒤늦게 발견하고 [다시 분석]을 요청한다(BE #177 대응).
+ * ⚠️ `isStalled`로 문구만 가른다 — 재분석 흐름 자체는 서버 문제든 실제 실패든 같다.
+ * ⚠️ 카드 틀·빈 상태는 `TaskGroupSection`이 맡는다 — 여기는 행만 그린다.
+ */
+export function StalledSummaryList({ summaries }: StalledSummaryListProps) {
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function handleRetry(meetingId: string) {
+    setPendingId(meetingId);
+    startTransition(async () => {
+      await retryMeetingSummaryAction(meetingId);
+      toast("재분석을 요청했습니다");
+      setPendingId(null);
+    });
+  }
+
+  return (
+    <>
+      {summaries.map((summary) => {
+        const isRowPending = isPending && pendingId === summary.meetingId;
+        return (
+          <div
+            key={summary.meetingId}
+            className="border-border flex items-center justify-between gap-3 border-t px-7 py-4 first:border-t-0"
+          >
+            <div className="flex min-w-0 flex-col gap-0.5">
+              <p className="truncate text-[13px] leading-5 font-medium">{summary.meetingTitle}</p>
+              <p className="text-muted-foreground text-[12px] leading-4">
+                {summary.isStalled ? "AI 요약이 중단됐습니다" : "AI 요약에 실패했습니다"}
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={isRowPending}
+              onClick={() => handleRetry(summary.meetingId)}
+            >
+              {isRowPending ? "요청 중" : "다시 분석"}
+            </Button>
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/src/features/profile/components/stalled-summary-list.tsx
+++ b/src/features/profile/components/stalled-summary-list.tsx
@@ -49,7 +49,12 @@ export function StalledSummaryList({ summaries }: StalledSummaryListProps) {
               type="button"
               variant="outline"
               size="sm"
-              disabled={isRowPending}
+              /*
+                ⚠️ **행 하나가 아니라 전부 잠근다.** `pendingId`만 보고 잠그면 요청이 도는
+                   동안 다른 행을 눌러 `pendingId`가 바뀌는 순간 첫 행의 버튼이 다시 풀려
+                   같은 회의에 중복 요청을 보낼 수 있다(CodeRabbit 지적, 2026-08-09).
+              */
+              disabled={isPending}
               onClick={() => handleRetry(summary.meetingId)}
             >
               {isRowPending ? "요청 중" : "다시 분석"}

--- a/src/features/profile/components/task-group-section.tsx
+++ b/src/features/profile/components/task-group-section.tsx
@@ -1,0 +1,40 @@
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+interface TaskGroupSectionProps {
+  icon: LucideIcon;
+  title: string;
+  count: number;
+  emptyMessage: string;
+  children: ReactNode;
+}
+
+/**
+ * 마이페이지 "처리할 일" 탭의 그룹 카드 — 회의 관련 두 그룹("미확정 액션"·"요약이
+ * 중단된 회의")이 같은 모양을 쓴다(`features/meeting/review/action-review-group.tsx`와
+ * 같은 결 — 카드 헤더에 아이콘+제목+건수, 없으면 빈 문구).
+ */
+export function TaskGroupSection({
+  icon: Icon,
+  title,
+  count,
+  emptyMessage,
+  children,
+}: TaskGroupSectionProps) {
+  return (
+    <section className="border-border bg-card rounded-2xl border">
+      <div className="flex items-baseline justify-between gap-3 px-7 pt-6 pb-3">
+        <h3 className="flex items-center gap-2 text-[15px] leading-6 font-semibold tracking-[-0.2px]">
+          <Icon className="text-foreground size-4" aria-hidden />
+          {title}
+        </h3>
+        <p className="text-muted-foreground text-[12px] leading-4 tabular-nums">{count}건</p>
+      </div>
+      {count === 0 ? (
+        <p className="text-muted-foreground px-7 pt-1 pb-6 text-[13px] leading-5">{emptyMessage}</p>
+      ) : (
+        <div className="flex flex-col">{children}</div>
+      )}
+    </section>
+  );
+}

--- a/src/features/profile/components/task-group-section.tsx
+++ b/src/features/profile/components/task-group-section.tsx
@@ -24,10 +24,10 @@ export function TaskGroupSection({
   return (
     <section className="border-border bg-card rounded-2xl border">
       <div className="flex items-baseline justify-between gap-3 px-7 pt-6 pb-3">
-        <h3 className="flex items-center gap-2 text-[15px] leading-6 font-semibold tracking-[-0.2px]">
+        <h2 className="flex items-center gap-2 text-[15px] leading-6 font-semibold tracking-[-0.2px]">
           <Icon className="text-foreground size-4" aria-hidden />
           {title}
-        </h3>
+        </h2>
         <p className="text-muted-foreground text-[12px] leading-4 tabular-nums">{count}건</p>
       </div>
       {count === 0 ? (

--- a/src/features/profile/components/unconfirmed-action-list.tsx
+++ b/src/features/profile/components/unconfirmed-action-list.tsx
@@ -8,21 +8,14 @@ interface UnconfirmedActionListProps {
 }
 
 /**
- * 마이페이지 "미확정 액션" 탭 — **회의 제목으로 줄을 나눈다**(사용자 확정, 2026-08-07).
+ * "미확정 액션" 그룹의 행들 — **회의 제목으로 줄을 나눈다**(사용자 확정, 2026-08-07).
  * 부제는 "분배 확정지어야 할 액션 N건". 줄을 누르면 그 회의의 리뷰 화면으로 이동해
  * 그대로 이어서 처리한다(`/app/meeting/:id/review`, 새 화면을 안 만들고 재사용).
+ * ⚠️ 카드 틀·빈 상태는 `TaskGroupSection`이 맡는다 — 여기는 행만 그린다.
  */
 export function UnconfirmedActionList({ reviews }: UnconfirmedActionListProps) {
-  if (reviews.length === 0) {
-    return (
-      <div className="border-border bg-card rounded-2xl border px-7 py-10 text-center">
-        <p className="text-muted-foreground text-[13px] leading-5">미확정 액션이 없습니다.</p>
-      </div>
-    );
-  }
-
   return (
-    <div className="border-border bg-card flex flex-col rounded-2xl border">
+    <>
       {reviews.map((review) => (
         <Link
           key={review.meetingId}
@@ -38,6 +31,6 @@ export function UnconfirmedActionList({ reviews }: UnconfirmedActionListProps) {
           <ChevronRight className="text-muted-foreground/50 size-4 shrink-0" aria-hidden />
         </Link>
       ))}
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [x] OWNER (대표)
- [x] LEADER (팀장)
- [x] MEMBER (사원)
- [ ] ADMIN (관리자)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

BACKEND #177(회의 처리 상태 조회 stalled 판정)을 계기로, AI 요약이 서버 문제로 끊기거나(stalled) 실제로 분석에 실패하면(FAILED) 실시간 진행 배너를 놓친 사람(브라우저 종료 등)이 다시 로그인했을 때 발견할 자리가 필요했습니다. "미확정 액션"(리뷰 확정 안 한 회의)과 같은 이유로, 마이페이지에 "요약이 중단된 회의" 그룹을 추가해 그 자리에서 바로 재분석을 요청할 수 있게 합니다.

⚠️ 이번 PR은 **마이페이지 UI 뼈대(목업)까지만**입니다. 실제 폴링·지속형 진행 배너·axios 전환·BE 신규 엔드포인트(회의 목록 필터, 재분석 경로) 연동은 팀 결정은 됐으나 착수 시점이 아니라 범위 밖입니다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [ ] 🔐 권한 2축 검사 — 해당 없음(목업 UI뼈대)
- [ ] 🧬 zod — 해당 없음
- [x] 🕵️ 정직성 — 재분석 서버 액션이 mock임을 명시, 데모 데이터 고정임을 확인법에 적음
- [x] 🎨 디자인 토큰 사용 · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [x] ♿ a11y — 빈 상태 문구·재분석 버튼 접근성 확인
- [x] ♻️ 재사용 확인 — "미확정 액션" 그룹과 같은 카드 패턴 재사용
- [x] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API 미사용

---

## 🔗 연관 이슈

Closes #224

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

**알려진 한계(이번 PR 범위 밖)**

- 재분석 서버 액션은 mock — 실제 재분석 API 경로가 BE와 아직 미확정(#177 관련 질의 전달함)
- "요약이 중단된 회의" 목록은 데모 데이터 고정 — 실제로는 BE가 회의 목록에 `aiSummaryStatus`/`stalled` 필드 또는 필터 쿼리를 제공해야 함
- 실시간 진행 배너(폴링) 자체는 아직 어떤 화면에도 없음 — 별도 이슈로 진행 예정

---

## 📝 추가 메모

확인법 —

- `/app/me?tab=unconfirmed` — 탭 라벨이 "처리할 일"로 바뀌었는지, 그 안에 "미확정 액션"/"요약이 중단된 회의" 두 그룹 카드가 뜨는지 확인
- "요약이 중단된 회의" 카드에 데모 2건("9월 스프린트 리뷰"=중단됨, "협업툴 리뉴얼 프로젝트 킥오프"=실패) 확인, 문구가 다른지 확인
- [다시 분석] 클릭 시 목록에서 빠지고 토스트가 뜨는지 확인
- 두 그룹 다 비었을 때 각각의 빈 상태 문구가 뜨는지 확인

`npx tsc --noEmit` / lint 통과 확인됨(커밋·푸시 훅에서 자동 실행).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 마이페이지의 **처리할 일** 탭에서 미확정 리뷰와 요약이 중단된 회의를 그룹별로 확인할 수 있습니다.
  * 중단되거나 실패한 회의 요약에 대해 재분석을 요청할 수 있습니다.
  * 재분석 요청 중에는 버튼이 비활성화되고 완료 안내가 표시됩니다.

* **개선 사항**
  * 요약 실패 상태와 표시 라벨이 추가되었습니다.
  * 각 그룹에 항목이 없을 때 안내 문구가 표시됩니다.
  * 페이지 접근성이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
