### PR TITLE
[FEAT] 팀원 관리 화면 /team/members — 카드 아코디언 #228

### DIFF
--- a/src/app/(shell)/(authority)/team/members/error.tsx
+++ b/src/app/(shell)/(authority)/team/members/error.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { ScreenError } from "@/components/common/screen-error";
+
+export default function Error({ reset }: { reset: () => void }) {
+  return <ScreenError title="팀원 정보를 불러오지 못했습니다" reset={reset} isInsideShell />;
+}

--- a/src/app/(shell)/(authority)/team/members/layout.tsx
+++ b/src/app/(shell)/(authority)/team/members/layout.tsx
@@ -1,0 +1,14 @@
+import { UserRoundCheck } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { PageHeader } from "@/features/shell/components/page-header";
+
+/** 팀원 관리 상단바 — 사이드바에서 바로 닿는 화면이라 backTo는 두지 않는다. */
+export default function TeamMembersLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <PageHeader title="팀원 관리" icon={UserRoundCheck} />
+      {children}
+    </>
+  );
+}

--- a/src/app/(shell)/(authority)/team/members/loading.tsx
+++ b/src/app/(shell)/(authority)/team/members/loading.tsx
@@ -1,0 +1,17 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
+      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-5">
+        <Skeleton className="h-14 w-full rounded-lg" />
+        <Skeleton className="h-8 w-full rounded-lg" />
+        <div className="flex flex-col gap-3">
+          <Skeleton className="h-16 w-full rounded-2xl" />
+          <Skeleton className="h-16 w-full rounded-2xl" />
+          <Skeleton className="h-16 w-full rounded-2xl" />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/(authority)/team/members/page.tsx
+++ b/src/app/(shell)/(authority)/team/members/page.tsx
@@ -1,0 +1,54 @@
+import type { Metadata } from "next";
+
+import { TeamMemberAccordionCard } from "@/features/team/members/components/team-member-accordion-card";
+import { TeamMemberControls } from "@/features/team/members/components/team-member-controls";
+import { parseTeamMemberFilter, parseTeamMemberSort } from "@/features/team/members/lib";
+import { getTeamMemberStatuses } from "@/features/team/members/server";
+
+export const metadata: Metadata = {
+  title: "팀원 관리",
+};
+
+interface TeamMembersPageProps {
+  searchParams: Promise<{ sort?: string; filter?: string }>;
+}
+
+/**
+ * 팀원 관리 — 카드 아코디언(WORKFLOW.md §팀원 관리).
+ * ⚠️ 팀원 ~6명 규모 가정 — 페이지네이션 없이 전부 렌더링한다.
+ */
+export default async function TeamMembersPage({ searchParams }: TeamMembersPageProps) {
+  const params = await searchParams;
+  const sort = parseTeamMemberSort(params.sort);
+  const filter = parseTeamMemberFilter(params.filter);
+  const members = await getTeamMemberStatuses(sort, filter);
+
+  return (
+    <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
+      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-5">
+        <div>
+          <h2 className="text-[22px] leading-[30px] font-semibold tracking-[-0.4px]">팀원 현황</h2>
+          <p className="text-muted-foreground mt-1 text-[13px] leading-5">
+            누가 과부하인지, 누구에게 일을 더 줄 수 있는지 확인해요.
+          </p>
+        </div>
+
+        <TeamMemberControls activeSort={sort} activeFilter={filter} />
+
+        {members.length === 0 ? (
+          <div className="border-border bg-card rounded-2xl border px-7 py-10 text-center">
+            <p className="text-muted-foreground text-[13px] leading-5">
+              조건에 맞는 팀원이 없습니다.
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {members.map((member) => (
+              <TeamMemberAccordionCard key={member.id} member={member} />
+            ))}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/constants/team-member.ts
+++ b/src/constants/team-member.ts
@@ -1,0 +1,29 @@
+/** 팀원 관리(`/team/members`) 정렬·필터 값 — URL `?sort=`·`?filter=`에 그대로 쓴다. */
+
+/** 정렬 3종(WORKFLOW.md §팀원 관리). */
+export const TEAM_MEMBER_SORT = {
+  ACTION_COUNT: "actionCount",
+  PROGRESS: "progress",
+  DELAYED: "delayed",
+} as const;
+export type TeamMemberSort = (typeof TEAM_MEMBER_SORT)[keyof typeof TEAM_MEMBER_SORT];
+
+export const TEAM_MEMBER_SORT_LABEL: Record<TeamMemberSort, string> = {
+  actionCount: "담당 액션 많은 순",
+  progress: "진척 낮은 순",
+  delayed: "지연 있는 순",
+};
+
+/** 필터 3종 — 재직/휴직만 있다(퇴사자는 팀 로스터에서 이미 빠진 상태로 온다). */
+export const TEAM_MEMBER_FILTER = {
+  ALL: "all",
+  ACTIVE: "active",
+  VACATION: "vacation",
+} as const;
+export type TeamMemberFilter = (typeof TEAM_MEMBER_FILTER)[keyof typeof TEAM_MEMBER_FILTER];
+
+export const TEAM_MEMBER_FILTER_LABEL: Record<TeamMemberFilter, string> = {
+  all: "전체",
+  active: "재직",
+  vacation: "휴직",
+};

--- a/src/features/team/members/components/team-member-accordion-card.tsx
+++ b/src/features/team/members/components/team-member-accordion-card.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { ChevronDown } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import {
+  ACTION_DELAYED_LABEL,
+  ACTION_STATUS,
+  ACTION_STATUS_LABEL,
+  isDelayed,
+  MEMBER_STATUS,
+  MEMBER_STATUS_LABEL,
+} from "@/constants/domain";
+import { useProfileAvatar } from "@/hooks/use-profile-avatar";
+import { formatMonthDayWeekday } from "@/lib/date";
+import { pickPaletteColor } from "@/lib/palette";
+import { cn } from "@/lib/utils";
+
+import { getMemberProgressPercent } from "../lib";
+import type { TeamMemberStatusItem } from "../types";
+
+interface TeamMemberAccordionCardProps {
+  member: TeamMemberStatusItem;
+}
+
+/**
+ * 팀원 한 명 = 카드 한 장, 접었다 펼친다(WORKFLOW.md §팀원 관리).
+ * ⚠️ 펼침 상태는 **이 카드 안에서만** 의미 있는 화면 상태라 URL에 안 싣는다(로컬 state로 충분 —
+ *    정렬·필터처럼 공유·새로고침 후에도 남아야 하는 값과는 다르다).
+ */
+export function TeamMemberAccordionCard({ member }: TeamMemberAccordionCardProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const avatar = useProfileAvatar(member.id, 36);
+  const isVacation = member.status === MEMBER_STATUS.VACATION;
+  const percent = getMemberProgressPercent(member.actions);
+  const doneCount = member.actions.filter((action) => action.status === ACTION_STATUS.DONE).length;
+
+  return (
+    <div className="border-border bg-card overflow-hidden rounded-2xl border">
+      <button
+        type="button"
+        aria-expanded={isExpanded}
+        aria-label={`${member.name} 카드 ${isExpanded ? "접기" : "펼치기"}`}
+        onClick={() => setIsExpanded((prev) => !prev)}
+        className="hover:bg-muted/40 flex w-full cursor-pointer items-center gap-4 px-6 py-4 text-left transition-colors"
+      >
+        {avatar}
+
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <span className="flex items-center gap-1.5 text-[14px] leading-5 font-semibold">
+            <span className="truncate">{member.name}</span>
+            <span className="text-muted-foreground shrink-0 text-[12px] leading-4 font-normal">
+              ({member.role || "없음"})
+            </span>
+          </span>
+          <span className="text-muted-foreground truncate text-[12px] leading-4">
+            {member.position} · {member.teamName}
+          </span>
+        </div>
+
+        <span className="flex-1" aria-hidden />
+
+        <Badge
+          variant={isVacation ? "outline" : "secondary"}
+          className={cn("shrink-0", isVacation && "border-warning text-warning")}
+        >
+          {MEMBER_STATUS_LABEL[member.status]}
+        </Badge>
+
+        <span className="text-muted-foreground shrink-0 text-[13px] leading-5 tabular-nums">
+          담당 액션 {member.actions.length}개
+        </span>
+
+        <div className="flex w-[168px] shrink-0 items-center gap-2">
+          <Progress value={percent} className="w-32" />
+          <span className="text-foreground w-8 shrink-0 text-right text-[12px] leading-4 font-medium tabular-nums">
+            {percent}%
+          </span>
+        </div>
+
+        <ChevronDown
+          className={cn(
+            "text-muted-foreground size-4 shrink-0 transition-transform",
+            isExpanded && "rotate-180",
+          )}
+          aria-hidden
+        />
+      </button>
+
+      {isExpanded && (
+        <div className="border-border border-t">
+          <p className="text-muted-foreground px-6 pt-4 pb-2 text-[12px] leading-4">
+            개인 액션 · {doneCount}/{member.actions.length} 완료
+          </p>
+
+          {member.actions.length === 0 ? (
+            <p className="text-muted-foreground px-6 pb-5 text-[13px] leading-5">
+              맡고 있는 액션이 없습니다.
+            </p>
+          ) : (
+            <ul>
+              {member.actions.map((action) => {
+                const tagColor = pickPaletteColor(action.projectTag);
+                const delayed = isDelayed(action);
+                return (
+                  <li key={action.id}>
+                    <Link
+                      href={`/app/actions/${action.id}`}
+                      className="hover:bg-muted/50 flex items-center gap-3 px-6 py-2.5 transition-colors"
+                    >
+                      <span
+                        className="w-fit shrink-0 rounded px-1.5 py-0.5 font-mono text-[10px] font-semibold"
+                        style={{ backgroundColor: tagColor.bgColor, color: tagColor.textColor }}
+                      >
+                        {action.projectTag}
+                      </span>
+                      <span className="text-muted-foreground w-[132px] shrink-0 truncate text-[12px] leading-4">
+                        {action.parentTeamActionName}
+                      </span>
+                      <span className="min-w-0 flex-1 truncate text-[13px] leading-5">
+                        {action.title}
+                      </span>
+                      <span
+                        className={cn(
+                          "w-[52px] shrink-0 rounded border px-1.5 py-0.5 text-center text-[11px] leading-4",
+                          delayed
+                            ? "border-destructive/40 text-destructive"
+                            : "border-border text-muted-foreground",
+                        )}
+                      >
+                        {delayed ? ACTION_DELAYED_LABEL : ACTION_STATUS_LABEL[action.status]}
+                      </span>
+                      <time
+                        dateTime={action.dueDate}
+                        className="text-muted-foreground w-20 shrink-0 text-right text-[12px] leading-4 whitespace-nowrap tabular-nums"
+                      >
+                        {formatMonthDayWeekday(action.dueDate)}
+                      </time>
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/team/members/components/team-member-controls.tsx
+++ b/src/features/team/members/components/team-member-controls.tsx
@@ -30,15 +30,15 @@ function buildHref(sort: TeamMemberSort, filter: TeamMemberFilter): string {
  */
 export function TeamMemberControls({ activeSort, activeFilter }: TeamMemberControlsProps) {
   return (
-    <div className="flex items-center justify-between gap-4">
-      <div className="flex items-center gap-3">
+    <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-3">
+      <div className="flex flex-wrap items-center gap-3">
         <span className="text-muted-foreground text-[12px] leading-4">정렬</span>
-        <div role="group" aria-label="정렬" className="flex items-center gap-1">
+        <div role="group" aria-label="정렬" className="flex flex-wrap items-center gap-1">
           {TEAM_MEMBER_SORT_TABS.map((tab) => (
             <Link
               key={tab.sort}
               href={buildHref(tab.sort, activeFilter)}
-              aria-pressed={activeSort === tab.sort}
+              aria-current={activeSort === tab.sort ? "page" : undefined}
               className={cn(
                 "rounded-lg px-2.5 py-1.5 text-[13px] leading-5 transition-colors",
                 activeSort === tab.sort
@@ -52,14 +52,14 @@ export function TeamMemberControls({ activeSort, activeFilter }: TeamMemberContr
         </div>
       </div>
 
-      <div className="flex items-center gap-3">
+      <div className="flex flex-wrap items-center gap-3">
         <span className="text-muted-foreground text-[12px] leading-4">필터</span>
-        <div role="group" aria-label="필터" className="flex items-center gap-1">
+        <div role="group" aria-label="필터" className="flex flex-wrap items-center gap-1">
           {TEAM_MEMBER_FILTER_TABS.map((tab) => (
             <Link
               key={tab.filter}
               href={buildHref(activeSort, tab.filter)}
-              aria-pressed={activeFilter === tab.filter}
+              aria-current={activeFilter === tab.filter ? "page" : undefined}
               className={cn(
                 "rounded-lg px-2.5 py-1.5 text-[13px] leading-5 transition-colors",
                 activeFilter === tab.filter

--- a/src/features/team/members/components/team-member-controls.tsx
+++ b/src/features/team/members/components/team-member-controls.tsx
@@ -1,0 +1,77 @@
+import Link from "next/link";
+
+import { cn } from "@/lib/utils";
+
+import {
+  DEFAULT_TEAM_MEMBER_FILTER,
+  DEFAULT_TEAM_MEMBER_SORT,
+  TEAM_MEMBER_FILTER_TABS,
+  TEAM_MEMBER_SORT_TABS,
+  type TeamMemberFilter,
+  type TeamMemberSort,
+} from "../lib";
+
+interface TeamMemberControlsProps {
+  activeSort: TeamMemberSort;
+  activeFilter: TeamMemberFilter;
+}
+
+function buildHref(sort: TeamMemberSort, filter: TeamMemberFilter): string {
+  const params = new URLSearchParams();
+  if (sort !== DEFAULT_TEAM_MEMBER_SORT) params.set("sort", sort);
+  if (filter !== DEFAULT_TEAM_MEMBER_FILTER) params.set("filter", filter);
+  const query = params.toString();
+  return query ? `/team/members?${query}` : "/team/members";
+}
+
+/**
+ * 정렬·필터 컨트롤 — **서버우선 `<Link>`**다(project 목록·팀원 목록과 같은 결).
+ * 한쪽을 바꿀 때 다른 쪽 값은 그대로 유지해야 해서 둘 다 항상 같이 넘긴다.
+ */
+export function TeamMemberControls({ activeSort, activeFilter }: TeamMemberControlsProps) {
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <div className="flex items-center gap-3">
+        <span className="text-muted-foreground text-[12px] leading-4">정렬</span>
+        <div role="group" aria-label="정렬" className="flex items-center gap-1">
+          {TEAM_MEMBER_SORT_TABS.map((tab) => (
+            <Link
+              key={tab.sort}
+              href={buildHref(tab.sort, activeFilter)}
+              aria-pressed={activeSort === tab.sort}
+              className={cn(
+                "rounded-lg px-2.5 py-1.5 text-[13px] leading-5 transition-colors",
+                activeSort === tab.sort
+                  ? "bg-foreground text-background font-medium"
+                  : "text-muted-foreground hover:bg-muted",
+              )}
+            >
+              {tab.label}
+            </Link>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <span className="text-muted-foreground text-[12px] leading-4">필터</span>
+        <div role="group" aria-label="필터" className="flex items-center gap-1">
+          {TEAM_MEMBER_FILTER_TABS.map((tab) => (
+            <Link
+              key={tab.filter}
+              href={buildHref(activeSort, tab.filter)}
+              aria-pressed={activeFilter === tab.filter}
+              className={cn(
+                "rounded-lg px-2.5 py-1.5 text-[13px] leading-5 transition-colors",
+                activeFilter === tab.filter
+                  ? "bg-foreground text-background font-medium"
+                  : "text-muted-foreground hover:bg-muted",
+              )}
+            >
+              {tab.label}
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/team/members/lib.ts
+++ b/src/features/team/members/lib.ts
@@ -1,0 +1,101 @@
+import { ACTION_STATUS, isDelayed, MEMBER_STATUS } from "@/constants/domain";
+
+import type { TeamMemberAction, TeamMemberStatusItem } from "./types";
+
+/** 정렬 3종(WORKFLOW.md §팀원 관리) — 값은 URL `?sort=`에 그대로 쓴다. */
+export const TEAM_MEMBER_SORT = {
+  ACTION_COUNT: "actionCount",
+  PROGRESS: "progress",
+  DELAYED: "delayed",
+} as const;
+export type TeamMemberSort = (typeof TEAM_MEMBER_SORT)[keyof typeof TEAM_MEMBER_SORT];
+
+export const TEAM_MEMBER_SORT_LABEL: Record<TeamMemberSort, string> = {
+  actionCount: "담당 액션 많은 순",
+  progress: "진척 낮은 순",
+  delayed: "지연 있는 순",
+};
+
+export const TEAM_MEMBER_SORT_TABS: { sort: TeamMemberSort; label: string }[] = [
+  TEAM_MEMBER_SORT.ACTION_COUNT,
+  TEAM_MEMBER_SORT.PROGRESS,
+  TEAM_MEMBER_SORT.DELAYED,
+].map((sort) => ({ sort, label: TEAM_MEMBER_SORT_LABEL[sort] }));
+
+export const DEFAULT_TEAM_MEMBER_SORT: TeamMemberSort = TEAM_MEMBER_SORT.ACTION_COUNT;
+
+/** URL의 `?sort=` 값을 안전하게 정렬로 — 모르는 값이면 기본(담당 액션 많은 순). */
+export function parseTeamMemberSort(value: string | undefined): TeamMemberSort {
+  return TEAM_MEMBER_SORT_TABS.find((t) => t.sort === value)?.sort ?? DEFAULT_TEAM_MEMBER_SORT;
+}
+
+/** 필터 3종 — 재직/휴직만 있다(퇴사자는 팀 로스터에서 이미 빠진 상태로 온다). */
+export const TEAM_MEMBER_FILTER = {
+  ALL: "all",
+  ACTIVE: "active",
+  VACATION: "vacation",
+} as const;
+export type TeamMemberFilter = (typeof TEAM_MEMBER_FILTER)[keyof typeof TEAM_MEMBER_FILTER];
+
+export const TEAM_MEMBER_FILTER_LABEL: Record<TeamMemberFilter, string> = {
+  all: "전체",
+  active: "재직",
+  vacation: "휴직",
+};
+
+export const TEAM_MEMBER_FILTER_TABS: { filter: TeamMemberFilter; label: string }[] = [
+  TEAM_MEMBER_FILTER.ALL,
+  TEAM_MEMBER_FILTER.ACTIVE,
+  TEAM_MEMBER_FILTER.VACATION,
+].map((filter) => ({ filter, label: TEAM_MEMBER_FILTER_LABEL[filter] }));
+
+export const DEFAULT_TEAM_MEMBER_FILTER: TeamMemberFilter = TEAM_MEMBER_FILTER.ALL;
+
+/** URL의 `?filter=` 값을 안전하게 필터로 — 모르는 값이면 기본(전체). */
+export function parseTeamMemberFilter(value: string | undefined): TeamMemberFilter {
+  return (
+    TEAM_MEMBER_FILTER_TABS.find((t) => t.filter === value)?.filter ?? DEFAULT_TEAM_MEMBER_FILTER
+  );
+}
+
+/** 그 팀원 개인 액션 완료율(%) — 액션이 없으면 0(진척 없음이 아니라 계산 불가). */
+export function getMemberProgressPercent(actions: TeamMemberAction[]): number {
+  if (actions.length === 0) return 0;
+  const done = actions.filter((action) => action.status === ACTION_STATUS.DONE).length;
+  return Math.round((done / actions.length) * 100);
+}
+
+/**
+ * 지연 액션 수 — 저장 상태가 아니라 마감일로 계산한다(§도메인 상수: 파생값은 계산).
+ */
+export function countDelayedActions(actions: TeamMemberAction[]): number {
+  return actions.filter((action) => isDelayed(action)).length;
+}
+
+export function filterTeamMembers(
+  members: TeamMemberStatusItem[],
+  filter: TeamMemberFilter,
+): TeamMemberStatusItem[] {
+  if (filter === TEAM_MEMBER_FILTER.ALL) return members;
+  const status =
+    filter === TEAM_MEMBER_FILTER.ACTIVE ? MEMBER_STATUS.ACTIVE : MEMBER_STATUS.VACATION;
+  return members.filter((member) => member.status === status);
+}
+
+/** ⚠️ 원본 배열을 바꾸지 않는다 — 복사본을 정렬해 돌려준다. */
+export function sortTeamMembers(
+  members: TeamMemberStatusItem[],
+  sort: TeamMemberSort,
+): TeamMemberStatusItem[] {
+  const sorted = [...members];
+  if (sort === TEAM_MEMBER_SORT.PROGRESS) {
+    sorted.sort(
+      (a, b) => getMemberProgressPercent(a.actions) - getMemberProgressPercent(b.actions),
+    );
+  } else if (sort === TEAM_MEMBER_SORT.DELAYED) {
+    sorted.sort((a, b) => countDelayedActions(b.actions) - countDelayedActions(a.actions));
+  } else {
+    sorted.sort((a, b) => b.actions.length - a.actions.length);
+  }
+  return sorted;
+}

--- a/src/features/team/members/lib.ts
+++ b/src/features/team/members/lib.ts
@@ -1,20 +1,16 @@
 import { ACTION_STATUS, isDelayed, MEMBER_STATUS } from "@/constants/domain";
+import {
+  TEAM_MEMBER_FILTER,
+  TEAM_MEMBER_FILTER_LABEL,
+  TEAM_MEMBER_SORT,
+  TEAM_MEMBER_SORT_LABEL,
+  type TeamMemberFilter,
+  type TeamMemberSort,
+} from "@/constants/team-member";
 
 import type { TeamMemberAction, TeamMemberStatusItem } from "./types";
 
-/** 정렬 3종(WORKFLOW.md §팀원 관리) — 값은 URL `?sort=`에 그대로 쓴다. */
-export const TEAM_MEMBER_SORT = {
-  ACTION_COUNT: "actionCount",
-  PROGRESS: "progress",
-  DELAYED: "delayed",
-} as const;
-export type TeamMemberSort = (typeof TEAM_MEMBER_SORT)[keyof typeof TEAM_MEMBER_SORT];
-
-export const TEAM_MEMBER_SORT_LABEL: Record<TeamMemberSort, string> = {
-  actionCount: "담당 액션 많은 순",
-  progress: "진척 낮은 순",
-  delayed: "지연 있는 순",
-};
+export type { TeamMemberFilter, TeamMemberSort };
 
 export const TEAM_MEMBER_SORT_TABS: { sort: TeamMemberSort; label: string }[] = [
   TEAM_MEMBER_SORT.ACTION_COUNT,
@@ -28,20 +24,6 @@ export const DEFAULT_TEAM_MEMBER_SORT: TeamMemberSort = TEAM_MEMBER_SORT.ACTION_
 export function parseTeamMemberSort(value: string | undefined): TeamMemberSort {
   return TEAM_MEMBER_SORT_TABS.find((t) => t.sort === value)?.sort ?? DEFAULT_TEAM_MEMBER_SORT;
 }
-
-/** 필터 3종 — 재직/휴직만 있다(퇴사자는 팀 로스터에서 이미 빠진 상태로 온다). */
-export const TEAM_MEMBER_FILTER = {
-  ALL: "all",
-  ACTIVE: "active",
-  VACATION: "vacation",
-} as const;
-export type TeamMemberFilter = (typeof TEAM_MEMBER_FILTER)[keyof typeof TEAM_MEMBER_FILTER];
-
-export const TEAM_MEMBER_FILTER_LABEL: Record<TeamMemberFilter, string> = {
-  all: "전체",
-  active: "재직",
-  vacation: "휴직",
-};
 
 export const TEAM_MEMBER_FILTER_TABS: { filter: TeamMemberFilter; label: string }[] = [
   TEAM_MEMBER_FILTER.ALL,

--- a/src/features/team/members/mock/roster.ts
+++ b/src/features/team/members/mock/roster.ts
@@ -1,0 +1,39 @@
+import { MEMBER_STATUS } from "@/constants/domain";
+
+import type { TeamMemberRosterEntry } from "../types";
+
+/**
+ * ⚠️ 목 데이터 — BE 연동 전. 로그인 팀장 = 김서준(개발팀장) 기준, 팀원 = 이하윤·박도현
+ * (팀 대시보드 mock과 같은 인물, `features/team/mock/dashboard.ts` 참고).
+ * ⚠️ 대시보드 미니 표와 달리 **팀장 본인도 명단에 들어간다**(WORKFLOW.md §팀원 관리
+ * 스크린샷 기준 — "팀원 현황"은 팀 전체를, 대시보드는 본인 몫을 따로 뺀 KPI로 본다).
+ * ⚠️ **김서준(팀장) 항목은 목 데이터라 들어있는 것**이다(사용자 확인, 2026-08-08) — 실제
+ *    연동 시 이 화면(로그인한 팀장 본인 시점)엔 팀장이 명단에 없을 가능성이 높다. BE
+ *    스펙 확정되면 "본인 포함 여부"부터 다시 확인할 것.
+ */
+export const TEAM_MEMBER_ROSTER_MOCK: TeamMemberRosterEntry[] = [
+  {
+    id: "member-lee",
+    name: "이하윤",
+    position: "선임",
+    role: "프론트엔드",
+    teamName: "개발팀",
+    status: MEMBER_STATUS.ACTIVE,
+  },
+  {
+    id: "member-park",
+    name: "박도현",
+    position: "주임",
+    role: "백엔드",
+    teamName: "개발팀",
+    status: MEMBER_STATUS.ACTIVE,
+  },
+  {
+    id: "member-kim",
+    name: "김서준",
+    position: "팀장",
+    role: "팀장",
+    teamName: "개발팀",
+    status: MEMBER_STATUS.ACTIVE,
+  },
+];

--- a/src/features/team/members/server.ts
+++ b/src/features/team/members/server.ts
@@ -1,0 +1,52 @@
+import {
+  TEAM_ACTION_DETAIL_MOCK,
+  TEAM_ACTION_PERSONAL_ITEMS_MOCK,
+} from "@/features/project/mock/team-action-detail";
+
+import {
+  filterTeamMembers,
+  sortTeamMembers,
+  type TeamMemberFilter,
+  type TeamMemberSort,
+} from "./lib";
+import { TEAM_MEMBER_ROSTER_MOCK } from "./mock/roster";
+import type { TeamMemberAction, TeamMemberStatusItem } from "./types";
+
+/**
+ * ⚠️ 목 데이터라도 **새 데이터를 안 만든다** — 팀 액션 상세(`project` 피처)의
+ * `TEAM_ACTION_PERSONAL_ITEMS_MOCK`이 이미 담당자별 개인 액션의 정본이다(보드도 이걸
+ * 그대로 쓴다, `board/server.ts`). 여기서 담당자 이름으로 걸러 모으기만 한다 —
+ * 두 벌을 따로 두면 화면마다 같은 사람의 액션 개수가 달라진다.
+ */
+function buildMemberActions(memberName: string): TeamMemberAction[] {
+  const actions: TeamMemberAction[] = [];
+  for (const [teamActionId, items] of Object.entries(TEAM_ACTION_PERSONAL_ITEMS_MOCK)) {
+    const parent = TEAM_ACTION_DETAIL_MOCK[Number(teamActionId)];
+    if (!parent) continue;
+    for (const item of items) {
+      if (item.assigneeName !== memberName) continue;
+      actions.push({
+        id: item.id,
+        projectTag: parent.projectTag,
+        parentTeamActionName: parent.name,
+        title: item.title,
+        status: item.status,
+        dueDate: item.dueDate,
+      });
+    }
+  }
+  return actions;
+}
+
+/** "팀원 관리" 목록 — 정렬·필터는 서버에서 적용한다(서버우선, `?sort=`·`?filter=`). */
+export async function getTeamMemberStatuses(
+  sort: TeamMemberSort,
+  filter: TeamMemberFilter,
+): Promise<TeamMemberStatusItem[]> {
+  const members: TeamMemberStatusItem[] = TEAM_MEMBER_ROSTER_MOCK.map((member) => ({
+    ...member,
+    actions: buildMemberActions(member.name),
+  }));
+
+  return sortTeamMembers(filterTeamMembers(members, filter), sort);
+}

--- a/src/features/team/members/types.ts
+++ b/src/features/team/members/types.ts
@@ -1,0 +1,32 @@
+import type { ActionStatus, MemberStatus } from "@/constants/domain";
+
+/**
+ * "팀원 관리"(`/team/members`) 화면의 **UI 계약**(CLAUDE.md §Mock 격리막).
+ * WORKFLOW.md §팀원 관리 — 카드 아코디언, 접힘/펼침.
+ */
+
+/** 펼친 카드 안 액션 한 줄 — 프로젝트 태그·상위 팀 액션명이 상태·마감일과 함께 나온다. */
+export interface TeamMemberAction {
+  id: number;
+  projectTag: string;
+  parentTeamActionName: string;
+  title: string;
+  status: ActionStatus;
+  dueDate: string;
+}
+
+/** 명단 한 줄(액션 제외) — 로스터 mock과 조회 결과가 이 모양을 공유한다. */
+export interface TeamMemberRosterEntry {
+  id: string;
+  name: string;
+  position: string;
+  /** 팀 내 세부 역할(프론트엔드 등). 없으면 "없음". */
+  role: string;
+  teamName: string;
+  status: MemberStatus;
+}
+
+/** 팀원 카드 한 장 — 접힌 요약에 필요한 값 + 펼치면 보이는 액션 목록. */
+export interface TeamMemberStatusItem extends TeamMemberRosterEntry {
+  actions: TeamMemberAction[];
+}


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [x] LEADER (팀장)
- [ ] OWNER (대표)
- [ ] MEMBER (사원)
- [ ] ADMIN (관리자)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

WORKFLOW.md §팀원 관리(`/team/members`) 스펙대로 팀장이 자기 팀원 현황을 접었다 펼치는 카드로 확인하는 화면입니다. 접힌 요약엔 아바타·이름(역할)·직급·팀명·재직/휴직 뱃지·담당 액션 수·진척도 바가 나오고, 펼치면 그 팀원의 개인 액션(프로젝트 태그·상위 팀 액션명·상태·마감일)이 나옵니다. 액션 클릭 시 기존 개인 액션 상세(`/app/actions/:actionId`)로 이동합니다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [x] 🔐 권한 2축 검사 — LEADER 본인 팀 스코프
- [ ] 🧬 zod — 해당 없음
- [x] 🕵️ 정직성 — 목 기준임을 명시, mock 한계(아래) 주석으로 남김
- [x] 🎨 디자인 토큰 사용 · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [x] ♿ a11y — 아코디언 펼침/접힘 접근성 확인
- [x] ♻️ 재사용 확인 — 정렬·필터 URL 쿼리 패턴 재사용
- [x] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API 미사용

---

## 🔗 연관 이슈

Closes #228

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

**알려진 한계**

mock이라 김서준(팀장) 항목이 명단에 포함돼 있습니다 — 실제 연동 시 로그인한 팀장 본인이 명단에 들어가야 하는지 BE 확정 후 재확인 필요(주석으로 남겨둠).

---

## 📝 추가 메모

확인법 —

- `/team/members` — 이하윤(선임·프론트엔드)·박도현(주임·백엔드)·김서준(팀장) 3장의 카드 확인, 클릭하면 펼쳐지는지 확인
- 정렬 3종(담당 액션 많은/진척 낮은/지연 있는 순), 필터 3종(전체/재직/휴직) 클릭 시 URL 쿼리(`?sort=`·`?filter=`)가 바뀌고 목록이 그에 맞게 재정렬/재필터되는지 확인
- 펼친 액션 행 클릭 시 해당 개인 액션 상세로 이동하는지 확인

`npx tsc --noEmit` / lint 통과 확인됨(커밋·푸시 훅에서 자동 실행).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 팀원 관리 화면을 추가했습니다.
  - 팀원별 역할, 조직, 상태, 담당 액션 수와 진행률을 확인할 수 있습니다.
  - 팀원 카드를 펼쳐 액션 목록, 상태, 마감일 및 지연 여부를 확인할 수 있습니다.
  - 액션 수, 진행률, 지연 여부 기준으로 정렬하고 재직 상태별로 필터링할 수 있습니다.
  - 담당 액션이 없는 경우 빈 상태 안내를 표시합니다.

- **사용성 개선**
  - 화면 로딩 중 스켈레톤 UI를 제공합니다.
  - 오류 발생 시 안내 메시지와 재시도 기능을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
