### PR TITLE
[FIX] 토스트가 성공·실패를 구분하지 않던 것 #231

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -40,6 +40,7 @@
   --color-input: var(--input);
   --color-border: var(--border);
   --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
   --color-muted-foreground: var(--muted-foreground);
@@ -123,6 +124,13 @@
   --accent: #fafaf9;
   --accent-foreground: #1c1917;
   --destructive: #ef4444; /* 에러 */
+  /*
+    에러 면 **위에** 얹는 글자·아이콘. 두 모드 모두 흰색이다 — 뒤집지 않는다.
+    ⚠️ 이 짝이 있어야 실패 토스트가 성립한다. 빨강을 글자에 쓰면 알약 배경이 모드마다
+       뒤집혀(라이트 거의 검정 · 다크 거의 흰색) 같은 빨강의 대비가 정반대로 움직인다.
+       면을 빨강으로 칠하고 글자를 흰색으로 고정해야 두 모드가 같은 조합이 된다.
+  */
+  --destructive-foreground: #ffffff;
   --border: #e7e5e4;
   --input: #e7e5e4;
   /* 포커스 링 = 먹색. 파랑(액센트)은 강조가 과했다 — 빨강(에러)만 색으로 알린다 */
@@ -251,6 +259,7 @@
   --accent: #2e2a28;
   --accent-foreground: #fafaf9;
   --destructive: #ef4444;
+  --destructive-foreground: #ffffff;
   --border: #33302d;
   --input: #33302d;
   /* 다크에서는 먹색이 안 보인다 — 밝은 회백색으로 뒤집는다 */
@@ -451,6 +460,7 @@
     --success: #22c55e;
     --warning: #f59e0b;
     --destructive: #dc2626;
+    --destructive-foreground: #ffffff;
     --primary: #3b82f6;
     --primary-foreground: #fafaf9;
     --status-todo: #a8a29e;
@@ -507,6 +517,7 @@
     --input: #e7e5e4;
     --ring: #1c1917;
     --destructive: #dc2626;
+    --destructive-foreground: #ffffff;
     --primary: #3b82f6;
     --primary-foreground: #fafaf9;
 
@@ -571,6 +582,7 @@
     --success: #22c55e;
     --warning: #f59e0b;
     --destructive: #ef4444;
+    --destructive-foreground: #ffffff;
     --primary: #3b82f6;
     --primary-foreground: #ffffff;
     --status-todo: #8a827d;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -41,6 +41,7 @@
   --color-border: var(--border);
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
+  --color-destructive-surface: var(--destructive-surface);
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
   --color-muted-foreground: var(--muted-foreground);
@@ -131,6 +132,15 @@
        면을 빨강으로 칠하고 글자를 흰색으로 고정해야 두 모드가 같은 조합이 된다.
   */
   --destructive-foreground: #ffffff;
+  /*
+    **글자를 얹는** 에러 면. `--destructive`(#ef4444)보다 한 단 어둡다.
+    ⚠️ 나누는 이유는 **기준이 다르기 때문**이다. `--destructive`는 상태점·막대처럼 글자가 안
+       얹히는 자리에 쓰여 3:1이면 되는데, 그 위에 흰 글자를 올리면 **3.76:1**이라 본문 기준
+       4.5:1에 못 미친다. 한 단 어두운 #dc2626은 **4.83:1**이라 통과한다.
+    ⚠️ DESIGN §명도·대비의 "팔레트 원색은 600단계"와 같은 이야기다 — #ef4444는 500,
+       #dc2626이 600이다.
+  */
+  --destructive-surface: #dc2626;
   --border: #e7e5e4;
   --input: #e7e5e4;
   /* 포커스 링 = 먹색. 파랑(액센트)은 강조가 과했다 — 빨강(에러)만 색으로 알린다 */
@@ -260,6 +270,7 @@
   --accent-foreground: #fafaf9;
   --destructive: #ef4444;
   --destructive-foreground: #ffffff;
+  --destructive-surface: #dc2626;
   --border: #33302d;
   --input: #33302d;
   /* 다크에서는 먹색이 안 보인다 — 밝은 회백색으로 뒤집는다 */
@@ -461,6 +472,7 @@
     --warning: #f59e0b;
     --destructive: #dc2626;
     --destructive-foreground: #ffffff;
+    --destructive-surface: #dc2626;
     --primary: #3b82f6;
     --primary-foreground: #fafaf9;
     --status-todo: #a8a29e;
@@ -518,6 +530,7 @@
     --ring: #1c1917;
     --destructive: #dc2626;
     --destructive-foreground: #ffffff;
+    --destructive-surface: #dc2626;
     --primary: #3b82f6;
     --primary-foreground: #fafaf9;
 
@@ -583,6 +596,7 @@
     --warning: #f59e0b;
     --destructive: #ef4444;
     --destructive-foreground: #ffffff;
+    --destructive-surface: #dc2626;
     --primary: #3b82f6;
     --primary-foreground: #ffffff;
     --status-todo: #8a827d;

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -57,6 +57,22 @@ export function Toaster(props: ToasterProps) {
           */
           title: "font-medium! line-clamp-1",
           description: "text-background/70! text-xs! leading-[18px]!",
+          /*
+            **실패는 알약째 빨강이다.**
+
+            ⚠️ 아이콘만 빨갛게 칠하는 방법을 먼저 봤는데, **한 색으로는 두 모드를 못 맞춘다.**
+               이 알약은 배경이 `--foreground` 기반이라 모드마다 뒤집힌다 — 라이트에서는
+               거의 검정(51,48,46), 다크에서는 거의 흰색(220,219,218)이다. 같은 빨강의
+               대비가 정반대로 움직여서, `#ef4444`는 라이트 3.48로 되지만 다크 2.72로 미달이고
+               (아이콘 기준 3:1), 더 진한 `#dc2626`은 그 반대다.
+            ⚠️ 배경을 `--destructive`로 칠하고 글자를 흰색으로 두면 **두 모드가 같은 조합**이
+               되어 뒤집힘이 사라진다. 흰 글자 위 `#ef4444`는 어느 모드에서나 같은 대비다.
+            ⚠️ 빨강을 여기 쓰는 건 규칙 위반이 아니다 — DESIGN §5가 색으로 알리도록 허용한
+               유일한 자리가 **에러**다. 토스트는 사라지는 보조 알림인데 실패는 놓치면 안 된다.
+            ⚠️ 인라인 `style`이 클래스를 이기므로 `!`로 되받는다.
+          */
+          error:
+            "bg-destructive! text-white! [&_[data-description]]:text-white/70! [&_[data-icon]]:text-white!",
           // ⚠️ sonner 기본 성공 아이콘은 **초록**이다. 색으로 알리는 건 에러뿐이라 글자색을 따르게 한다.
           icon: "text-background! m-0! size-4! shrink-0 [&>svg]:size-4 [&_*]:fill-current [&_*]:stroke-current",
           actionButton: "bg-background! text-foreground!",

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -71,10 +71,15 @@ export function Toaster(props: ToasterProps) {
                유일한 자리가 **에러**다. 토스트는 사라지는 보조 알림인데 실패는 놓치면 안 된다.
             ⚠️ 글자·아이콘은 **`--destructive-foreground` 토큰**이다. 생 `white`를 쓰면
                토큰만 쓴다는 규칙이 깨지고, 나중에 에러 면 색을 바꿀 때 짝이 따로 논다.
+            ⚠️ 면은 `--destructive`가 아니라 **`--destructive-surface`**(한 단 어둡다)다.
+               `--destructive`(#ef4444) 위 흰 글자는 **3.76:1**이라 본문 기준 4.5:1에 못 미친다 —
+               처음에 아이콘 기준 3:1만 따지다 놓쳤다. #dc2626은 4.83:1이라 통과한다.
+            ⚠️ **설명줄의 `/70` 감쇠를 걷었다.** 기본 토스트는 먹색 면이라 흐려도 읽히지만
+               이 면에서는 2.98:1까지 떨어진다. 층은 **글자 크기**(13px/12px)가 이미 만든다.
             ⚠️ 인라인 `style`이 클래스를 이기므로 `!`로 되받는다.
           */
           error:
-            "bg-destructive! text-destructive-foreground! [&_[data-description]]:text-destructive-foreground/70! [&_[data-icon]]:text-destructive-foreground!",
+            "bg-destructive-surface! text-destructive-foreground! [&_[data-description]]:text-destructive-foreground! [&_[data-icon]]:text-destructive-foreground!",
           // ⚠️ sonner 기본 성공 아이콘은 **초록**이다. 색으로 알리는 건 에러뿐이라 글자색을 따르게 한다.
           icon: "text-background! m-0! size-4! shrink-0 [&>svg]:size-4 [&_*]:fill-current [&_*]:stroke-current",
           actionButton: "bg-background! text-foreground!",

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -69,10 +69,12 @@ export function Toaster(props: ToasterProps) {
                되어 뒤집힘이 사라진다. 흰 글자 위 `#ef4444`는 어느 모드에서나 같은 대비다.
             ⚠️ 빨강을 여기 쓰는 건 규칙 위반이 아니다 — DESIGN §5가 색으로 알리도록 허용한
                유일한 자리가 **에러**다. 토스트는 사라지는 보조 알림인데 실패는 놓치면 안 된다.
+            ⚠️ 글자·아이콘은 **`--destructive-foreground` 토큰**이다. 생 `white`를 쓰면
+               토큰만 쓴다는 규칙이 깨지고, 나중에 에러 면 색을 바꿀 때 짝이 따로 논다.
             ⚠️ 인라인 `style`이 클래스를 이기므로 `!`로 되받는다.
           */
           error:
-            "bg-destructive! text-white! [&_[data-description]]:text-white/70! [&_[data-icon]]:text-white!",
+            "bg-destructive! text-destructive-foreground! [&_[data-description]]:text-destructive-foreground/70! [&_[data-icon]]:text-destructive-foreground!",
           // ⚠️ sonner 기본 성공 아이콘은 **초록**이다. 색으로 알리는 건 에러뿐이라 글자색을 따르게 한다.
           icon: "text-background! m-0! size-4! shrink-0 [&>svg]:size-4 [&_*]:fill-current [&_*]:stroke-current",
           actionButton: "bg-background! text-foreground!",

--- a/src/features/billing/components/billing-view.tsx
+++ b/src/features/billing/components/billing-view.tsx
@@ -56,7 +56,7 @@ export function BillingView({ overview, config, canManage }: BillingViewProps) {
   const handleToggleCancel = async () => {
     const result = await toggleCancelAction(isCanceling).catch(() => null);
     if (!result?.isSuccess) {
-      toast(result?.message ?? "구독 상태를 바꾸지 못했습니다");
+      toast.error(result?.message ?? "구독 상태를 바꾸지 못했습니다");
       return;
     }
     setSubscription((prev) => ({
@@ -67,7 +67,7 @@ export function BillingView({ overview, config, canManage }: BillingViewProps) {
       ⚠️ **한 줄로 끝낸다.** 언제까지 쓸 수 있는지·언제 청구되는지는 화면의 해지 카드가
          계속 보여 준다 — 사라지는 토스트에 옮겨 적으면 읽기도 전에 없어진다(DECISIONS §토스트).
     */
-    toast(isCanceling ? "구독을 계속 이어갑니다" : "구독을 해지했습니다");
+    toast.success(isCanceling ? "구독을 계속 이어갑니다" : "구독을 해지했습니다");
   };
 
   /*
@@ -95,15 +95,15 @@ export function BillingView({ overview, config, canManage }: BillingViewProps) {
 
       if (!result.isSuccess || !result.method) {
         // ⚠️ 토스트는 한 줄(220px)이라 짧게 쓴다 — 길면 잘린다(`sonner.tsx`)
-        toast(result.message ?? "결제 수단을 바꾸지 못했습니다");
+        toast.error(result.message ?? "결제 수단을 바꾸지 못했습니다");
         return;
       }
 
       setMethod(result.method);
-      toast(isFirst ? "결제 수단을 등록했습니다" : "결제 수단을 변경했습니다");
+      toast.success(isFirst ? "결제 수단을 등록했습니다" : "결제 수단을 변경했습니다");
     } catch {
       // 결제사 창을 닫은 경우 — 여기서만 예외로 온다
-      toast("결제 수단을 바꾸지 못했습니다");
+      toast.error("결제 수단을 바꾸지 못했습니다");
     }
   };
 

--- a/src/features/board/actions.ts
+++ b/src/features/board/actions.ts
@@ -18,13 +18,25 @@ const BOARD_PATH = "/app/board";
  * ⚠️ 화면의 드래그 제약은 UX일 뿐이다 — 여기서도 `canMoveCard`로 다시 검증한다
  *    (§권한과 같은 원칙: 화면 숨김은 보안이 아니다).
  */
-export async function commitBoardChangesAction(boardType: BoardType, changes: BoardChange[]) {
+/**
+ * 옮긴 카드를 저장한다 — **실제로 반영한 건수를 돌려준다.**
+ *
+ * ⚠️ 요청한 수와 반영한 수는 다를 수 있다. 카드가 그 사이 사라졌거나(`!item`) 옮길 수 없는
+ *    칸이면(`canMoveCard`) 조용히 건너뛴다 — 부르는 쪽이 요청 수를 그대로 "N건 반영했습니다"
+ *    라고 말하면 화면이 거짓말을 한다(§정직성).
+ */
+export async function commitBoardChangesAction(
+  boardType: BoardType,
+  changes: BoardChange[],
+): Promise<{ appliedCount: number }> {
   if (!isMock) {
     throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
   }
 
   const today = new Date();
   const items = boardType === "project" ? TOP_LEVEL_PROJECTS : findAllPersonalItems();
+
+  let appliedCount = 0;
 
   for (const change of changes) {
     const item = items.find((candidate) => candidate.id === change.id);
@@ -37,9 +49,11 @@ export async function commitBoardChangesAction(boardType: BoardType, changes: Bo
     if (!canMoveCard(currentColumn, change.toColumn)) continue;
 
     applyColumnChange(item, change.toColumn);
+    appliedCount += 1;
   }
 
   revalidatePath(BOARD_PATH);
+  return { appliedCount };
 }
 
 function findAllPersonalItems() {

--- a/src/features/board/components/board-view.tsx
+++ b/src/features/board/components/board-view.tsx
@@ -89,10 +89,26 @@ export function BoardView({ boardType, cards, todayIso }: BoardViewProps) {
       toColumn,
     }));
     startTransition(async () => {
-      await commitBoardChangesAction(boardType, changes);
-      setOverrides({});
-      setConfirmOpen(false);
-      toast.success(`${changes.length}건 반영했습니다`);
+      /*
+        ⚠️ **요청 수가 아니라 반영 수를 말한다.** 카드가 그 사이 사라졌거나 옮길 수 없는 칸이면
+           액션이 조용히 건너뛴다 — 요청 수를 그대로 적으면 안 옮겨진 것까지 옮겼다고 말한다.
+        ⚠️ **던지는 경우도 잡는다.** 돌려주는 실패 값만 보면 Server Action이 reject될 때
+           아무 말도 없이 창만 닫힌다 — 사용자는 저장된 줄 안다(§정직성).
+      */
+      try {
+        const { appliedCount } = await commitBoardChangesAction(boardType, changes);
+        setOverrides({});
+        setConfirmOpen(false);
+
+        if (appliedCount === 0) {
+          toast.error("옮기지 못했습니다");
+          return;
+        }
+        toast.success(`${appliedCount}건 반영했습니다`);
+      } catch {
+        setConfirmOpen(false);
+        toast.error("옮기지 못했습니다");
+      }
     });
   }
 

--- a/src/features/board/components/board-view.tsx
+++ b/src/features/board/components/board-view.tsx
@@ -77,7 +77,7 @@ export function BoardView({ boardType, cards, todayIso }: BoardViewProps) {
     const to = event.over.id as BoardColumnId;
     if (from === to) return;
     if (!canMoveCard(from, to)) {
-      toast("여기로는 옮길 수 없습니다");
+      toast.error("여기로는 옮길 수 없습니다");
       return;
     }
     setOverrides((prev) => ({ ...prev, [card.id]: to }));
@@ -92,7 +92,7 @@ export function BoardView({ boardType, cards, todayIso }: BoardViewProps) {
       await commitBoardChangesAction(boardType, changes);
       setOverrides({});
       setConfirmOpen(false);
-      toast(`${changes.length}건 반영했습니다`);
+      toast.success(`${changes.length}건 반영했습니다`);
     });
   }
 

--- a/src/features/meeting/review/components/meeting-review-view.tsx
+++ b/src/features/meeting/review/components/meeting-review-view.tsx
@@ -116,11 +116,16 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
         // "alreadyConfirmed"도 결과적으로 확정된 상태다 — 다른 탭에서 먼저 확정한 경우까지 포함.
         setConfirmOpen(false);
         setIsConfirmed(true);
-        toast(
-          result.status === "confirmed"
-            ? `${result.createdCount}건의 액션을 분배했습니다`
-            : "이미 확정된 회의입니다",
-        );
+        /*
+          ⚠️ 둘은 **다른 일**이다 — 내가 방금 확정한 것과, 다른 탭에서 이미 확정돼 있던 것.
+             앞은 성공(체크)이고 뒤는 알림이라 아이콘 없이 둔다. 뒤를 성공으로 띄우면
+             내가 분배한 것처럼 읽힌다(§정직성).
+        */
+        if (result.status === "confirmed") {
+          toast.success(`${result.createdCount}건의 액션을 분배했습니다`);
+        } else {
+          toast("이미 확정된 회의입니다");
+        }
       } catch {
         // ⚠️ 다이얼로그를 열어 둔 채 원인을 적는다 — 토스트만 띄우면 몇 초 뒤엔 실패했던 사실이
         //    사라져 사용자가 같은 버튼을 다시 누른다(§confirm-dialog "토스트는 보조다").

--- a/src/features/storage/components/storage-view.tsx
+++ b/src/features/storage/components/storage-view.tsx
@@ -75,7 +75,7 @@ export function StorageView({ overview, config, canManage, today }: StorageViewP
 
       if (!result.isSuccess) {
         // ⚠️ 토스트는 한 줄(220px)이라 짧게 쓴다 — 길면 잘린다(`sonner.tsx`)
-        toast(result.message ?? "삭제하지 못했습니다");
+        toast.error(result.message ?? "삭제하지 못했습니다");
         return;
       }
 
@@ -87,9 +87,9 @@ export function StorageView({ overview, config, canManage, today }: StorageViewP
       */
       setProjects((prev) => prev.filter((project) => project.tag !== target.tag));
       setTarget(null);
-      toast(`${formatGb(freed)}를 삭제했습니다`);
+      toast.success(`${formatGb(freed)}를 삭제했습니다`);
     } catch {
-      toast("삭제하지 못했습니다");
+      toast.error("삭제하지 못했습니다");
     } finally {
       setIsPending(false);
     }

--- a/src/features/system/components/pipeline-retry-button.tsx
+++ b/src/features/system/components/pipeline-retry-button.tsx
@@ -37,9 +37,9 @@ export function PipelineRetryButton({ meetingId }: PipelineRetryButtonProps) {
       const response = await retryPipelineAction(meetingId);
       if (response.success) {
         setIsDone(true);
-        toast("재처리를 요청했습니다");
+        toast.success("재처리를 요청했습니다");
       } else {
-        toast("재처리하지 못했습니다");
+        toast.error("재처리하지 못했습니다");
       }
     });
   };

--- a/src/features/system/components/pipeline-retry-button.tsx
+++ b/src/features/system/components/pipeline-retry-button.tsx
@@ -34,11 +34,19 @@ export function PipelineRetryButton({ meetingId }: PipelineRetryButtonProps) {
 
   const handleRetry = () => {
     startTransition(async () => {
-      const response = await retryPipelineAction(meetingId);
-      if (response.success) {
-        setIsDone(true);
-        toast.success("재처리를 요청했습니다");
-      } else {
+      /*
+        ⚠️ **던지는 경우도 잡는다.** 돌려주는 실패 값만 보면 Server Action이 reject될 때
+           아무 말도 없이 버튼만 되살아난다 — 눌렀는데 아무 일도 안 일어난 것처럼 보인다.
+      */
+      try {
+        const response = await retryPipelineAction(meetingId);
+        if (response.success) {
+          setIsDone(true);
+          toast.success("재처리를 요청했습니다");
+          return;
+        }
+        toast.error("재처리하지 못했습니다");
+      } catch {
         toast.error("재처리하지 못했습니다");
       }
     });

--- a/src/features/system/components/subscription-table.tsx
+++ b/src/features/system/components/subscription-table.tsx
@@ -72,9 +72,9 @@ export function SubscriptionTable({ subscriptions }: SubscriptionTableProps) {
     startTransition(async () => {
       const response = await sendUnpaidNoticeAction(companyId);
       if (response.success) {
-        toast("안내 메일을 발송했습니다");
+        toast.success("안내 메일을 발송했습니다");
       } else {
-        toast("발송하지 못했습니다");
+        toast.error("발송하지 못했습니다");
       }
       setNoticeTarget(null);
     });

--- a/src/features/system/components/subscription-table.tsx
+++ b/src/features/system/components/subscription-table.tsx
@@ -70,13 +70,23 @@ export function SubscriptionTable({ subscriptions }: SubscriptionTableProps) {
     if (!target) return;
 
     startTransition(async () => {
-      const response = await sendUnpaidNoticeAction(companyId);
-      if (response.success) {
-        toast.success("안내 메일을 발송했습니다");
-      } else {
+      /*
+        ⚠️ **던지는 경우도 잡는다.** 돌려주는 실패 값만 보면 Server Action이 reject될 때
+           토스트도 없고 확인 창도 안 닫혀, 사용자가 같은 버튼을 다시 누른다(메일이 두 번 나간다).
+        ⚠️ 그래서 창 닫기는 `finally`다 — 성공이든 실패든 창은 닫고, 결과는 토스트가 말한다.
+      */
+      try {
+        const response = await sendUnpaidNoticeAction(companyId);
+        if (response.success) {
+          toast.success("안내 메일을 발송했습니다");
+          return;
+        }
         toast.error("발송하지 못했습니다");
+      } catch {
+        toast.error("발송하지 못했습니다");
+      } finally {
+        setNoticeTarget(null);
       }
-      setNoticeTarget(null);
     });
   };
 


### PR DESCRIPTION
## 📋 PR 타입

- [ ] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [ ] style · refactor · docs · test · chore · merge
- [x] design — UI/UX 변경

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [x] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

**실패한 일과 잘 끝난 일이 똑같이 생겼습니다.** 토스트를 전부 맨 `toast()`로 띄우고 있어서 `구독을 해지했습니다`와 `구독 상태를 바꾸지 못했습니다`가 같은 먹색 알약이었습니다. 토스트는 사라지는 알림이라 그 짧은 순간에 구분이 안 되면, 실패한 걸 성공으로 알고 다음 일로 넘어갑니다.

- 실패 토스트를 **알약째 `--destructive` + 흰 글자**로 (`sonner.tsx`)
- 호출부 **8곳**을 `toast.error()`로, 성공은 `toast.success()`로 갈랐습니다

### ⚠️ 아이콘만 빨갛게 칠하는 방법을 먼저 해 봤고, 되돌렸습니다

**한 색으로는 두 모드를 못 맞춥니다.** 이 알약은 배경이 `--foreground` 기반이라 모드마다 뒤집힙니다 — 라이트에서 거의 검정(51,48,46), 다크에서 거의 흰색(220,219,218)입니다. 같은 빨강의 대비가 정반대로 움직입니다.

| 색 | 라이트 | 다크 |
| --- | --- | --- |
| `#ef4444` | 3.48 ✅ | 2.72 ❌ |
| `#dc2626` | ❌ | ✅ |

아이콘 기준 3:1을 두 모드에서 동시에 넘기는 값이 없습니다. **배경을 `--destructive`로 칠하고 글자를 흰색**으로 두면 두 모드가 같은 조합이 되어 뒤집힘 자체가 사라집니다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`design/toast-error#231`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 권한 2축 검사 — 해당 없음(표시 계층)
- [ ] 🧬 zod — 해당 없음
- [x] 🕵️ 정직성 — **이 PR이 그 이야기입니다.** 실패를 성공처럼 보이게 두지 않습니다
- [x] 🎨 디자인 토큰 사용 — `--destructive` 토큰. 생 hex 없음. 두 모드 대비를 실제로 계산해 확인

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [x] ♿ a11y — 흰 글자 위 `--destructive`는 두 모드에서 같은 대비. 색만으로 알리지 않습니다(문구가 이미 `~하지 못했습니다`)
- [x] ♻️ 재사용 확인 — 생김새는 `sonner.tsx` 한 곳이 정합니다. 호출부는 `toast.error`/`toast.success`만 고릅니다
- [ ] 🧪 3상태 — 해당 없음
- [ ] 브라우저 전용 API 미사용

---

## 🔗 연관 이슈

Closes #231

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
| 성공·실패가 같은 먹색 알약 | 실패만 빨간 알약 |

---

## 💬 리뷰 포인트

**맨 `toast()`로 남겨 둔 3건은 일부러입니다** — 성공도 실패도 아닌 알림입니다.

- 사이드바 둘 — `OO은 준비 중입니다`
- 리뷰 화면 — `이미 확정된 회의입니다`. 내가 방금 확정한 것과 다른 탭에서 이미 확정돼 있던 것은 **다른 일**이라, 뒤를 성공으로 띄우면 내가 분배한 것처럼 읽힙니다

**토스트를 안 쓰는 실패는 안 건드렸습니다.** 기업 설정(화면에 남기는 오류 상자)·캡처 마이크 실패(화면에 남김)·폼 검증(칸 밑 인라인)은 DESIGN §7이 정한 자리라 그대로입니다.

---

## 📝 추가 메모

전 호출부를 훑어 확인했습니다 — `toast.error` 12건 · `toast.success` 24건 · 맨 `toast()` 3건(의도), 오분류 없음.

814개 테스트·타입체크·린트 통과.

⚠️ 연동 때 챙길 것 하나: `capture-view.tsx`의 종료 처리는 `capture.end()` 결과를 안 보고 성공 토스트를 띄웁니다. 지금은 목이라 실패할 일이 없고 요약 자체는 서버가 재시도하지만, **종료 알림 API가 실패**하는 경우는 다른 이야기입니다. 종료는 되돌릴 수 없는 동작이라 조용히 넘어가면 안 됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 구독, 결제 수단, 게시판, 회의 결과, 저장소, 재처리 및 안내 메일 발송 결과가 성공·오류 유형별 토스트로 표시됩니다.
  * 오류 발생 시에도 작업이 안정적으로 마무리되고, 관련 창이 자동으로 닫히도록 개선되었습니다.
  * 게시판 저장 결과에 실제 반영된 항목 수가 표시되며, 반영되지 않은 경우 오류로 안내됩니다.
  * 오류 토스트의 배경, 텍스트 및 아이콘 색상이 개선되었습니다.
  * 이미 처리된 회의 결과는 별도의 일반 알림으로 안내됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->