### PR TITLE
[FIX] 회의 캡처 자막 다듬기 — 박스 복원·인식 중 표시·시각 기준 #221

### DIFF
--- a/src/features/meeting/capture/capture-view.tsx
+++ b/src/features/meeting/capture/capture-view.tsx
@@ -150,7 +150,12 @@ export function CaptureView({ meeting }: { meeting: MeetingCaptureInfo }) {
                끝까지 자라고, 그 안에서만 스크롤이 생긴다.
           */}
           <div className="grid min-h-0 flex-1 grid-cols-1 gap-7 lg:grid-cols-[minmax(0,1fr)_360px]">
-            <TranscriptCard chunks={capture.chunks} isRecording={isRecording} isPaused={isPaused} />
+            <TranscriptCard
+              chunks={capture.chunks}
+              partial={capture.partial}
+              isRecording={isRecording}
+              isPaused={isPaused}
+            />
             <AttendeeCard attendees={meeting.attendees} />
           </div>
         </div>
@@ -166,10 +171,16 @@ export function CaptureView({ meeting }: { meeting: MeetingCaptureInfo }) {
         onOpenChange={() => setIsConfirming(false)}
         title="회의를 종료하고 요약을 진행할까요?"
         description={
+          /*
+            ⚠️ **세 줄을 비슷한 길이로 끊는다**(DESIGN §6). `요약은 백그라운드에서 진행되니
+               목록으로 돌아가 다른 일을 하셔도 됩니다`(34자)는 창 폭(약 27자)을 넘겨
+               `하셔도 / 됩니다`로 갈라졌다 — `<br />`은 넘치지 않을 때만 줄바꿈 자리를 정한다.
+            ⚠️ "기다리지 않아도 된다"는 뜻은 **백그라운드**라는 낱말이 이미 담고 있다.
+          */
           <>
             녹음이 끝나고 마지막 파일이 제출됩니다.
             <br />
-            요약은 백그라운드에서 진행되니 목록으로 돌아가 다른 일을 하셔도 됩니다.
+            요약은 백그라운드에서 진행됩니다.
             <br />
             종료한 뒤에는 다시 녹음할 수 없습니다.
           </>
@@ -185,11 +196,13 @@ export function CaptureView({ meeting }: { meeting: MeetingCaptureInfo }) {
             ⚠️ **바로 목록으로 돌려보낸다**(팀 확정). 요약 API는 응답이 오래 걸려서 서버가
                백그라운드로 돌린다 — 여기서 기다리게 두면 아무것도 못 하는 화면을 몇 분씩
                쳐다보게 된다. 창을 닫아도 안전한 일이라 붙잡을 이유가 없다(§3-3 4).
-            ⚠️ 토스트는 **한 줄(220px)**이다(DESIGN §7) — 글자 자리가 184px뿐이라 문장을 넣으면
-               잘린다. "백그라운드에서 진행한다"는 설명은 **바로 위 확인 창**이 맡는다.
-               떠나기 전에 읽는 자리가 거기라서, 사라지는 토스트보다 낫다.
+            ⚠️ 토스트가 **"백그라운드"를 말한다**(팀 확정: 목록으로 보낸 뒤에 그렇게 전한다).
+               옮겨 간 화면에서 처음 보는 말이 이거라, 여기서 안 하면 왜 목록으로 튕겼는지
+               모른 채 요약을 기다리게 된다.
+            ⚠️ 한 줄(220px)이라 글자 자리가 **184px**뿐이다(DESIGN §7) — 이 문구는 153px다.
+               더 길게 쓰려면 잘린다.
           */
-          toast.success("요약을 시작했습니다");
+          toast.success("백그라운드에서 요약 중입니다");
           router.push("/app/meeting");
         }}
       />
@@ -261,28 +274,40 @@ function EnterCard({
 /** 실시간 자막 — 화자 구분 없이 청크 단위다(§3-2) */
 function TranscriptCard({
   chunks,
+  partial,
   isRecording,
   isPaused,
 }: {
   chunks: { id: string; at: string; text: string }[];
+  partial: string;
   isRecording: boolean;
   isPaused: boolean;
 }) {
   const listRef = useRef<HTMLOListElement>(null);
+  /** 바닥에 붙어 있는가 — **새 줄이 들어오기 전** 값이라야 판정이 맞다 */
+  const isPinnedRef = useRef(true);
 
   /*
-    ⚠️ **새 문장이 오면 바닥으로 따라간다.** 안 그러면 자막이 화면 밖에서 쌓여, 진행자가
-       말할 때마다 직접 스크롤을 내려야 한다.
-    ⚠️ 위로 올려 지난 말을 읽는 중이면 **끌어내리지 않는다.** 읽던 자리를 빼앗는 게
-       놓친 한 줄보다 성가시다 — 바닥 근처에 있을 때만 따라간다.
+    ⚠️ **삽입 뒤에 거리를 재면 안 된다.** 새 문장이 이미 높이를 늘린 뒤라, 긴 문장 하나가
+       들어오면 "멀어졌다"고 잘못 읽고 따라가지 않는다 — 그래서 스크롤할 때마다 미리 적어 둔다.
+    ⚠️ 위로 올려 지난 말을 읽는 중이면 **끌어내리지 않는다.** 읽던 자리를 빼앗는 게 놓친
+       한 줄보다 성가시다.
+  */
+  const handleScroll = () => {
+    const list = listRef.current;
+    if (!list) return;
+    isPinnedRef.current = list.scrollHeight - list.scrollTop - list.clientHeight <= 80;
+  };
+
+  /*
+    ⚠️ 흐린 줄(`partial`)이 자라도 같이 따라간다 — 말하는 동안 그 줄이 화면 밖으로 나가면
+       인식되고 있는지 볼 수가 없다.
   */
   useEffect(() => {
     const list = listRef.current;
-    if (!list) return;
-    const distanceFromBottom = list.scrollHeight - list.scrollTop - list.clientHeight;
-    if (distanceFromBottom > 120) return;
+    if (!list || !isPinnedRef.current) return;
     list.scrollTop = list.scrollHeight;
-  }, [chunks.length]);
+  }, [chunks.length, partial]);
 
   return (
     <section className="border-border bg-card flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-2xl border">
@@ -309,7 +334,7 @@ function TranscriptCard({
         </span>
       </div>
 
-      {chunks.length === 0 ? (
+      {chunks.length === 0 && !partial ? (
         /* 빈 상태 — 왜 비었는지, 무엇을 하면 되는지 말한다(DESIGN §8) */
         <div className="flex flex-1 flex-col items-center justify-center gap-2 px-7 pb-12 text-center">
           <Mic className="text-muted-foreground/50 size-6" aria-hidden />
@@ -323,25 +348,63 @@ function TranscriptCard({
       ) : (
         <ol
           ref={listRef}
-          className="flex min-h-0 flex-1 flex-col gap-2.5 overflow-y-auto px-7 pb-6"
+          onScroll={handleScroll}
+          className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-7 pb-6"
         >
+          {/*
+            ⚠️ **시간은 왼쪽 고정폭 홈통이다** — 상세 화면의 발화 기록과 같은 모양이다.
+               같은 내용을 두 화면이 다르게 그리면 회의가 끝나는 순간 기록이 낯설어진다.
+            ⚠️ 한때 줄마다 테두리 카드에 시각을 윗줄로 올렸는데, 한 문장이 90px를 먹어
+               화면에 대여섯 줄밖에 안 들어왔다 — 실시간 자막은 **흐름이 보여야** 한다.
+            ⚠️ `자동 인식` 꼬리표를 줄마다 붙이지 않는다. 모든 줄이 같은 값이라 아무것도
+               구분하지 못하면서 자리만 먹었다 — 그 말은 카드 머리가 한 번 한다.
+          */}
           {chunks.map((chunk) => (
+            /*
+              ⚠️ **한 문장이 옅은 박스 하나다.** 줄만 그어 두니 짧은 말("그대여")에서는 글자가
+                 왼쪽 200px만 채우고 오른쪽 800px이 허옇게 비어, 화면 반쪽만 쓰는 것처럼
+                 보였다 — 박스가 폭을 끝까지 채워 주면 그 빈 자리가 면으로 읽힌다.
+              ⚠️ 시각은 박스 **안쪽 왼쪽 홈통**이다. 윗줄로 올리면 한 문장이 두 줄을 먹어
+                 한 화면에 대여섯 개밖에 안 들어온다.
+            */
             <li
               key={chunk.id}
-              className="border-border bg-secondary/40 rounded-lg border px-4 py-3"
+              className="border-border bg-secondary/40 flex items-baseline gap-3.5 rounded-lg border px-4 py-2.5"
             >
-              <div className="flex items-baseline justify-between gap-3">
-                <span className="text-muted-foreground text-[11px] leading-4 tabular-nums">
-                  {chunk.at}
-                </span>
-                {/* AI가 아니라 브라우저 받아쓰기다 — "AI"라고 쓰지 않는다(CLAUDE.md §AI 기능) */}
-                <span className="text-muted-foreground/70 shrink-0 text-[11px] leading-4">
-                  자동 인식
-                </span>
-              </div>
-              <p className="pt-1 text-[13px] leading-5 break-keep">{chunk.text}</p>
+              {/* 시각은 **참고값**이다 — 문장보다 한 단계 작고 옅게 둬서 눈이 글에 먼저 간다 */}
+              <span className="text-muted-foreground/60 w-9 shrink-0 text-[11px] leading-5 tabular-nums">
+                {chunk.at}
+              </span>
+              <p className="min-w-0 flex-1 text-[13px] leading-5 break-keep">{chunk.text}</p>
             </li>
           ))}
+
+          {/*
+            아직 확정 전인 말.
+            ⚠️ 확정된 줄과 **같은 홈통**에 두되 시각 자리는 비운다 — 아직 시각이 정해지지
+               않았고, 확정되는 순간 그 자리에 채워지며 자연스럽게 이어진다.
+            ⚠️ **기울임을 쓰지 않는다.** 한글 폰트는 이탤릭이 없어서 브라우저가 글자를 억지로
+               기울이는데(가짜 기울임), 획이 뭉개져 깨진 글씨로 보인다 — 곧 뒤집힐 값이라는 건
+               **옅은 색과 깜빡이는 점**이 말한다.
+          */}
+          {partial && (
+            /*
+              ⚠️ 확정된 줄과 **같은 박스**를 쓰되 테두리를 점선으로 둔다 — 자리는 같아서
+                 확정되는 순간 매끄럽게 이어지고, 아직 굳지 않은 값이라는 건 선이 말한다.
+            */
+            <li className="border-border/70 flex items-baseline gap-3.5 rounded-lg border border-dashed px-4 py-2.5">
+              {/*
+                시각 자리에 **듣고 있다는 표시**를 둔다. 시각은 문장이 확정될 때 정해지므로
+                아직 비어 있는데, 그냥 비워 두면 앞줄이 밀린 것처럼 보였다.
+              */}
+              <span className="flex w-9 shrink-0 items-center pt-2" aria-hidden>
+                <span className="bg-foreground/40 size-1.5 animate-pulse rounded-full" />
+              </span>
+              <p className="text-muted-foreground min-w-0 flex-1 text-[13px] leading-5 break-keep">
+                {partial}
+              </p>
+            </li>
+          )}
         </ol>
       )}
     </section>

--- a/src/features/meeting/capture/capture-view.tsx
+++ b/src/features/meeting/capture/capture-view.tsx
@@ -190,7 +190,25 @@ export function CaptureView({ meeting }: { meeting: MeetingCaptureInfo }) {
         mark="alert"
         onConfirm={() => {
           setIsConfirming(false);
-          capture.end();
+
+          /*
+            ⚠️ **끄는 일이 실패해도 화면은 넘어가야 한다.** `capture.end()`는 지금 로컬 정리다
+               — 녹음기·STT를 멈추고 상태를 `ENDED`로 바꾼다. 그런데 `MediaRecorder.stop()`은
+               상태가 어긋나면 던지고(`InvalidStateError`), 여기서 던지면 **토스트도 이동도
+               안 일어난 채** 이미 닫힌 확인 창만 남는다 — 종료를 눌렀는데 아무 일도 안 난
+               것처럼 보이고, 되돌릴 수 없는 동작이라 다시 누르지도 못한다.
+            ⚠️ 그래서 잡고 넘어간다. 마이크 표시등이 남는 건 화면을 떠날 때 정리 효과가
+               한 번 더 끈다(`use-capture`의 unmount 정리).
+            ⚠️ **연동 때 여기가 갈린다.** 종료 알림 API(§3-3 4)가 붙으면 `end()`가 서버를
+               부르게 되고, 그때는 **실패를 삼키면 안 된다** — 마지막 세그먼트가 확정되지
+               않았는데 "요약을 시작했습니다"라고 말하게 된다. 그 시점에 이 자리를
+               `try { await ... } catch { toast.error(...) }`로 바꾸고 이동을 막아야 한다.
+          */
+          try {
+            capture.end();
+          } catch {
+            // 로컬 정리 실패는 사용자가 할 수 있는 일이 없다 — 흐름만 잇는다
+          }
 
           /*
             ⚠️ **바로 목록으로 돌려보낸다**(팀 확정). 요약 API는 응답이 오래 걸려서 서버가

--- a/src/features/meeting/capture/phase.test.ts
+++ b/src/features/meeting/capture/phase.test.ts
@@ -4,6 +4,7 @@ import {
   closedSegmentCountOf,
   formatRecordedTime,
   isCapturing,
+  nextUtteranceStart,
   recordedMsOf,
   SEGMENT_MS,
   showsWorkspace,
@@ -90,5 +91,30 @@ describe("경과 시간 표기", () => {
 
   it("음수는 0으로 본다", () => {
     expect(formatRecordedTime(-5_000)).toBe("00:00");
+  });
+});
+
+describe("발화 시작 시각", () => {
+  it("첫 중간 결과에서 지금 시각을 잡는다", () => {
+    expect(nextUtteranceStart(null, "안녕하", 10_000)).toBe(10_000);
+  });
+
+  /* ⚠️ 한 문장이 자라는 동안 시작 시각은 처음 그대로여야 한다 — 말 끝이 아니라 말 시작이다 */
+  it("이미 잡았으면 덮어쓰지 않는다", () => {
+    expect(nextUtteranceStart(10_000, "안녕하세요 반갑", 12_000)).toBe(10_000);
+  });
+
+  /*
+    ⚠️ 여기가 이 함수의 존재 이유다. 일시정지·세션 종료로 중간 결과가 확정 없이 사라질 때
+       안 지우면 **다음 문장이 앞 문장의 시각을 물려받는다**.
+  */
+  it("빈 문자열이 오면 지운다 — 다음 문장이 옛 시각을 물려받지 않게", () => {
+    expect(nextUtteranceStart(20_000, "", 320_000)).toBeNull();
+  });
+
+  it("지운 뒤 새 문장은 그때 시각을 잡는다", () => {
+    const cleared = nextUtteranceStart(20_000, "", 320_000);
+
+    expect(nextUtteranceStart(cleared, "다시 말하면", 320_000)).toBe(320_000);
   });
 });

--- a/src/features/meeting/capture/phase.ts
+++ b/src/features/meeting/capture/phase.ts
@@ -103,3 +103,25 @@ export function formatRecordedTime(ms: number): string {
   const ss = String(seconds).padStart(2, "0");
   return hours > 0 ? `${hours}:${mm}:${ss}` : `${mm}:${ss}`;
 }
+
+/**
+ * 다음 **발화 시작 시각** — 자막 한 줄에 찍히는 값이다.
+ *
+ * 자막 시각은 문장이 확정된 순간(= 말이 **끝난** 시각)이 아니라 **감지한 시점**이다(팀 확정).
+ * 10초에 시작해 2초간 말하면 `00:10`이지 `00:12`가 아니다.
+ *
+ * ⚠️ **빈 문자열은 시작 시각을 지운다.** 중간 결과는 확정 없이 사라지는 길이 여럿이다 —
+ *    일시정지, 세션이 조용해서 스스로 닫히는 경우, STT가 죽는 경우. 그때 안 지우면 그 문장의
+ *    시작 ms가 남아 **다음 문장이 앞 문장의 시각을 물려받는다**(00:20에 말하다 멈추고 5분 쉰 뒤
+ *    한 말이 `00:20`으로 찍힌다) — 고치려던 것이 정반대가 된다.
+ * ⚠️ 이미 잡아 둔 값은 **덮어쓰지 않는다.** 한 문장이 여러 중간 결과로 자라는 동안 시작 시각은
+ *    처음 그대로여야 한다.
+ */
+export function nextUtteranceStart(
+  current: number | null,
+  text: string,
+  elapsedMs: number,
+): number | null {
+  if (!text) return null;
+  return current ?? elapsedMs;
+}

--- a/src/features/meeting/capture/recorder.ts
+++ b/src/features/meeting/capture/recorder.ts
@@ -73,7 +73,20 @@ export function createCaptureRecorder(handlers: RecorderHandlers): CaptureRecord
   return {
     async start() {
       try {
-        stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        /*
+          ⚠️ **기본값에 맡기지 않는다.** 회의실 노트북 마이크는 에어컨·타자 소리를 그대로
+             담는데, 이 파일이 곧 **정본 자막의 재료**다 — 회의 중 서버가 하는 일이
+             받아쓰기와 적재이기 때문이다(§3-3). 화면의 실시간 자막보다 이쪽이 중요하다.
+          ⚠️ 말소리는 단일 채널이면 충분하다. 스테레오로 담으면 파일만 두 배가 된다.
+        */
+        stream = await navigator.mediaDevices.getUserMedia({
+          audio: {
+            echoCancellation: true,
+            noiseSuppression: true,
+            autoGainControl: true,
+            channelCount: 1,
+          },
+        });
       } catch {
         handlers.onFatal("마이크를 열지 못했습니다. 브라우저 권한을 확인해 주세요.");
         return false;

--- a/src/features/meeting/capture/stt.ts
+++ b/src/features/meeting/capture/stt.ts
@@ -23,6 +23,15 @@ export interface SttEngine {
 export interface SttHandlers {
   /** 문장이 확정될 때마다 — 서버로도 이 단위로 보낸다(§3-3 자막 청크 전송 API) */
   onChunk(text: string): void;
+  /**
+   * 아직 확정 전인 말 — 화면에 흐리게 비춘다.
+   *
+   * ⚠️ **서버로 보내지 않는다.** 중간 결과는 말이 이어지면서 통째로 뒤집힌다 —
+   *    쌓아 두면 같은 말이 여러 번 남는다(확정본만 §3-3의 청크다).
+   * ⚠️ 이걸 보여주는 이유는 정확도가 아니라 **되짚을 기회**다. 잘못 알아들은 게 바로
+   *    보이면 진행자가 그 자리에서 다시 말할 수 있다.
+   */
+  onPartial(text: string): void;
   /** 되돌릴 수 없는 실패(권한 거부 등) — 화면이 안내를 띄운다 */
   onFatal(message: string): void;
 }
@@ -114,19 +123,31 @@ export function createSttEngine(handlers: SttHandlers): SttEngine | null {
     const instance = new Ctor();
     instance.lang = "ko-KR";
     instance.continuous = true;
-    // 확정된 문장만 올린다 — 중간 결과까지 보내면 같은 말이 여러 번 쌓인다
-    instance.interimResults = false;
+    /*
+      ⚠️ 중간 결과를 **받되 쌓지는 않는다.** 확정본만 목록에 넣고, 중간 것은 흐린 한 줄로
+         비쳤다 사라진다 — 켜 두면 말하는 동안 화면이 반응해서 마이크가 죽었는지 알 수 있다.
+    */
+    instance.interimResults = true;
 
     instance.onresult = (event) => {
+      let pending = "";
+
       for (let i = event.resultIndex; i < event.results.length; i += 1) {
         const result = event.results[i];
-        if (!result?.isFinal) continue;
-        const text = result[0]?.transcript?.trim();
+        const text = result?.[0]?.transcript?.trim();
         if (!text) continue;
-        // 한 문장이라도 받았으면 정상이다 — 물러설 시간을 되돌린다
-        emptyRestarts = 0;
-        handlers.onChunk(text);
+
+        if (result?.isFinal) {
+          // 한 문장이라도 받았으면 정상이다 — 물러설 시간을 되돌린다
+          emptyRestarts = 0;
+          handlers.onChunk(text);
+        } else {
+          pending = pending ? `${pending} ${text}` : text;
+        }
       }
+
+      // 확정으로 넘어간 순간 흐린 줄을 비운다 — 안 비우면 같은 말이 두 줄로 보인다
+      handlers.onPartial(pending);
     };
 
     instance.onerror = (event) => {
@@ -180,6 +201,7 @@ export function createSttEngine(handlers: SttHandlers): SttEngine | null {
     },
     stop() {
       stopped = true;
+      handlers.onPartial("");
       if (retryTimer !== null) {
         window.clearTimeout(retryTimer);
         retryTimer = null;

--- a/src/features/meeting/capture/stt.ts
+++ b/src/features/meeting/capture/stt.ts
@@ -153,6 +153,9 @@ export function createSttEngine(handlers: SttHandlers): SttEngine | null {
     instance.onerror = (event) => {
       if (!isFatalSttError(event.error)) return;
       stopped = true;
+      // ⚠️ 비추던 문장을 지운다 — 안 지우면 받아쓰기가 죽었는데 점선 줄이 계속 깜빡여
+      //    **아직 듣고 있는 것처럼** 보인다(§정직성). 어차피 확정 안 돼 서버로도 안 간다.
+      handlers.onPartial("");
       handlers.onFatal(FATAL_MESSAGE[event.error] ?? "자막을 받지 못했습니다.");
     };
 
@@ -168,9 +171,16 @@ export function createSttEngine(handlers: SttHandlers): SttEngine | null {
       emptyRestarts += 1;
       if (emptyRestarts > MAX_EMPTY_RESTARTS) {
         stopped = true;
+        handlers.onPartial("");
         handlers.onFatal("자막을 계속 받지 못했습니다. 마이크와 네트워크를 확인해 주세요.");
         return;
       }
+
+      /*
+        ⚠️ 다시 열기 전에 비춘 문장을 지운다. 세션이 닫히면 그 중간 결과는 **확정되지 않는다** —
+           그대로 두면 다음 결과가 올 때까지(몇 분이든) 낡은 문장이 깜빡이며 남는다.
+      */
+      handlers.onPartial("");
 
       const delay = Math.min(200 * 2 ** (emptyRestarts - 1), 5_000);
       retryTimer = window.setTimeout(() => {

--- a/src/features/meeting/capture/use-capture.ts
+++ b/src/features/meeting/capture/use-capture.ts
@@ -35,6 +35,8 @@ export interface UseCaptureResult {
   /** 실제 녹음 누적 ms — 일시정지는 빠진다 */
   recordedMs: number;
   chunks: TranscriptChunk[];
+  /** 아직 확정 전인 말 — 화면에 흐리게 비추고 서버로는 안 보낸다 */
+  partial: string;
   /** 되돌릴 수 없는 실패 한 줄 — 화면에 남긴다(토스트는 사라진다) */
   error: string | null;
   enter(): void;
@@ -51,6 +53,7 @@ export function useCapture(): UseCaptureResult {
   const [phase, setPhase] = useState<CapturePhase>(CAPTURE_PHASE.BEFORE_ENTER);
   const [spans, setSpans] = useState<RecordingSpan[]>([]);
   const [chunks, setChunks] = useState<TranscriptChunk[]>([]);
+  const [partial, setPartial] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [now, setNow] = useState(() => Date.now());
 
@@ -98,22 +101,53 @@ export function useCapture(): UseCaptureResult {
     recorderRef.current?.rotate(closed);
   }, [phase, recordedMs]);
 
+  /**
+   * 지금 말하는 중인 문장이 **시작된** 시각(녹음 기준 ms). 아직 없으면 `null`.
+   *
+   * ⚠️ 확정된 순간을 찍으면 **말이 끝난 시각**이 된다. 10초에 시작해 2초 동안 말한 문장이
+   *    `00:12`로 남는데, 팀이 정한 건 "10초에 안녕하세요라고 하면 `00:10`"이다 —
+   *    문장을 **감지한 시점**이 기준이다.
+   */
+  const utteranceStartRef = useRef<number | null>(null);
+
+  /** 녹음 시작 기준 지금까지의 경과(ms) — 일시정지는 빠진다 */
+  const elapsedNow = useCallback(() => recordedMsOf(spansRef.current, Date.now()), []);
+
+  /*
+    말이 시작되는 순간을 잡아 둔다 — 중간 결과가 처음 뜨는 때다.
+    ⚠️ 이미 잡아 뒀으면 덮어쓰지 않는다. 한 문장이 이어지는 동안 중간 결과는 여러 번 온다.
+  */
+  const markPartial = useCallback(
+    (text: string) => {
+      if (text && utteranceStartRef.current === null) utteranceStartRef.current = elapsedNow();
+      setPartial(text);
+    },
+    [elapsedNow],
+  );
+
   /*
     ⚠️ 자막 시각은 **녹음 시작 기준 경과 시간**이다(팀 확정). 벽시계(`10:04`)로 찍으면 나중에
-       기록을 볼 때 녹음의 어느 지점인지 알 수 없다 — 회의 시작 10초 뒤의 말은 `00:10`이다.
+       기록을 볼 때 녹음의 어느 지점인지 알 수 없다.
     ⚠️ 일시정지 구간은 빠진다. 위 타이머·10분 세그먼트와 **같은 시계**를 쓴다 — 자막만 다른
        기준으로 세면 나중에 오디오와 자막이 어긋난다.
     ⚠️ 구간을 `spansRef`로 읽는다. `spans` 상태를 의존성에 넣으면 문장이 쌓일 때마다 STT
        엔진에 새 콜백이 물려 재시작이 걸린다.
   */
-  const pushChunk = useCallback((text: string) => {
-    const at = formatRecordedTime(recordedMsOf(spansRef.current, Date.now()));
-    setChunks((prev) => [
-      ...prev,
-      // 같은 문장이 반복돼도 키가 겹치지 않게 순번을 쓴다
-      { id: `chunk-${prev.length}-${Date.now()}`, at, text },
-    ]);
-  }, []);
+  const pushChunk = useCallback(
+    (text: string) => {
+      // 중간 결과 없이 바로 확정되는 짧은 말은 잡아 둔 게 없다 — 그때는 지금이 곧 시작이다
+      const startedAt = utteranceStartRef.current ?? elapsedNow();
+      utteranceStartRef.current = null;
+
+      const at = formatRecordedTime(startedAt);
+      setChunks((prev) => [
+        ...prev,
+        // 같은 문장이 반복돼도 키가 겹치지 않게 순번을 쓴다
+        { id: `chunk-${prev.length}-${Date.now()}`, at, text },
+      ]);
+    },
+    [elapsedNow],
+  );
 
   const teardown = useCallback(() => {
     sttRef.current?.stop();
@@ -182,7 +216,12 @@ export function useCapture(): UseCaptureResult {
       return;
     }
 
-    const stt = createSttEngine({ onChunk: pushChunk, onFatal: setError });
+    utteranceStartRef.current = null;
+    const stt = createSttEngine({
+      onChunk: pushChunk,
+      onPartial: markPartial,
+      onFatal: setError,
+    });
     stt?.start();
     sttRef.current = stt;
 
@@ -191,7 +230,7 @@ export function useCapture(): UseCaptureResult {
     setNow(at);
     setSpans((prev) => [...prev, { from: at, to: null }]);
     setPhase(CAPTURE_PHASE.RECORDING);
-  }, [pushChunk]);
+  }, [pushChunk, markPartial]);
 
   const pause = useCallback(() => {
     sttRef.current?.stop();
@@ -226,5 +265,5 @@ export function useCapture(): UseCaptureResult {
     setPhase(CAPTURE_PHASE.ENDED);
   }, [teardown]);
 
-  return { phase, support, recordedMs, chunks, error, enter, start, pause, resume, end };
+  return { phase, support, recordedMs, chunks, partial, error, enter, start, pause, resume, end };
 }

--- a/src/features/meeting/capture/use-capture.ts
+++ b/src/features/meeting/capture/use-capture.ts
@@ -8,6 +8,7 @@ import {
   closedSegmentCountOf,
   formatRecordedTime,
   isCapturing,
+  nextUtteranceStart,
   recordedMsOf,
   type RecordingSpan,
 } from "./phase";
@@ -119,7 +120,14 @@ export function useCapture(): UseCaptureResult {
   */
   const markPartial = useCallback(
     (text: string) => {
-      if (text && utteranceStartRef.current === null) utteranceStartRef.current = elapsedNow();
+      /*
+        ⚠️ **빈 문자열로 오면 시작 시각도 지운다.** 중간 결과는 확정 없이 사라지는 길이 여럿이다
+           — 일시정지(`stt.stop()`), 세션이 조용해서 스스로 닫히는 경우. 그때 지우지 않으면
+           그 문장의 시작 ms가 남아 **다음 문장이 앞 문장의 시각을 물려받는다**:
+           00:20에 말하다 멈추고 5분 쉰 뒤 한 말이 `00:20`으로 찍힌다.
+           시각을 "감지한 시점"으로 맞추려던 것이 오히려 정반대가 된다.
+      */
+      utteranceStartRef.current = nextUtteranceStart(utteranceStartRef.current, text, elapsedNow());
       setPartial(text);
     },
     [elapsedNow],
@@ -234,6 +242,9 @@ export function useCapture(): UseCaptureResult {
 
   const pause = useCallback(() => {
     sttRef.current?.stop();
+    // ⚠️ `stt.stop()`이 `onPartial("")`로 이미 비우지만, STT가 없는 경우(미지원·이미 죽음)엔
+    //    그 경로가 안 돈다 — 여기서 한 번 더 확실히 끊는다.
+    utteranceStartRef.current = null;
     recorderRef.current?.pause();
     // TODO(BE 협의): CAP-02 일시정지 이벤트
     const at = Date.now();


### PR DESCRIPTION
## 📋 PR 타입

- [ ] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [x] design — UI/UX 변경
- [ ] style · refactor · docs · test · chore · merge

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [x] OWNER (대표)
- [ ] ADMIN (관리자)
- [x] LEADER (팀장)
- [x] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

> 권한이 아니라 **그 회의의 Host인지**로 갈립니다 — 세 역할 모두 자기가 연 회의에서는 Host입니다(WORKFLOW §3-3).

---

## 📝 작업 내용

`/app/meeting/:id/capture`의 실시간 자막과 종료 흐름을 다듬습니다.

- **자막 한 문장 = 옅은 박스 하나.** 박스를 뺐더니 짧은 말(`그대여`)이 왼쪽 200px만 채우고 오른쪽이 허옇게 비어 **화면 반쪽만 쓰는 것처럼** 보였습니다. 시각은 박스 안 왼쪽 홈통에 둡니다
- **인식 중인 문장을 비춥니다** — 점선 박스 + 깜빡이는 점. 한글에 가짜 기울임을 걸면 글자가 뭉개져서 뺐습니다
- **자막 시각을 감지한 시점으로** 고쳤습니다. 문장이 확정된 순간을 찍고 있었는데 그건 **말이 끝난 시각**이라, 10초에 시작해 2초간 말하면 `00:12`로 남았습니다 — 팀 확정은 "10초에 안녕하세요 하면 `00:10`"입니다
- **종료 토스트가 백그라운드를 알립니다.** 전엔 `요약을 시작했습니다`뿐이라 **왜 목록으로 튕겼는지** 알 수 없었습니다. 220px 한 줄 규격 안에서 해결했습니다
- 종료 확인 창 설명 줄바꿈 정리 — 창 폭을 넘겨 낱말이 갈라지던 것
- **녹음 오디오 제약** 추가(잡음 억제·에코 제거·모노). 정본 자막은 서버가 이 파일로 만듭니다(WORKFLOW §3-3)

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`design/meeting-capture-caption#221`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 권한 2축 검사 — 캡처는 **그 회의 Host 1명만**입니다(`canOperateMeeting`). 이 PR은 그 안의 표시·녹음 설정만 손댔고 판정은 안 건드렸습니다
- [ ] 🧬 zod — 해당 없음
- [x] 🕵️ 정직성 — 인식 중인 문장을 **확정된 자막과 다르게**(점선) 그립니다. 아직 안 굳은 값을 굳은 것처럼 보이지 않게 합니다
- [x] 🎨 디자인 토큰 사용 (생 hex 없음) · 다크 값도 정의됨

**품질**

- [x] ⚡ 최적화 — 녹음 오디오 제약으로 잡음·에코를 줄이고 모노로 받습니다
- [x] ♿ a11y — 인식 중 표시를 점선 + 점으로 두어 색만으로 알리지 않습니다
- [x] ♻️ 재사용 확인 — 토스트·확인 창은 공용 컴포넌트 그대로
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 마이크·자막 실패는 **화면에 남깁니다**(토스트로만 알리면 자리를 비운 사이에 사라집니다)
- [x] 브라우저 전용 API — STT(`webkitSpeechRecognition`)·`MediaRecorder`. 미지원·권한 거부 안내는 이미 있고 이 PR이 유지합니다

---

## 🔗 연관 이슈

Closes #221

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
| 짧은 자막이 오른쪽을 비움 · 시각이 말 끝 | 옅은 박스 한 줄 · 시각이 말 시작 |

---

## 💬 리뷰 포인트

- **자막 시각 기준이 바뀝니다.** `00:12`(말 끝) → `00:10`(감지 시점). 나중에 서버가 만드는 정본 자막과 기준이 같아야 하니 봐주세요
- **한글 가짜 기울임을 뺐습니다** — `font-style: italic`을 한글에 걸면 글꼴에 이탤릭이 없어 브라우저가 억지로 기울여 글자가 뭉개집니다. 인식 중 표시는 점선 박스가 맡습니다

---

## 📝 추가 메모

develop(#222 머지분) 위로 리베이스했습니다. 814개 테스트·타입체크·린트·빌드 통과.

⚠️ 연동 때 챙길 것: 종료 처리가 `capture.end()` 결과를 안 보고 성공 토스트를 띄웁니다. 지금은 목이라 실패할 일이 없고 요약 자체는 서버가 재시도하지만, **종료 알림 API가 실패**하는 경우는 다른 이야기입니다 — 종료는 되돌릴 수 없어 조용히 넘어가면 안 됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 실시간 자막에 음성 인식 중인 임시 텍스트를 표시합니다.
  * 확정 자막은 발화 시작 시점과 함께 정리되어 표시됩니다.
  * 자막 자동 스크롤이 사용자가 하단을 보고 있을 때만 작동합니다.

* **개선**
  * 마이크 입력 품질을 높이기 위해 에코 제거, 소음 억제, 자동 게인 조절을 적용했습니다.
  * 임시 자막은 점선 박스와 진행 표시로 구분됩니다.
  * 회의 종료 안내와 백그라운드 요약 상태 알림을 간결하게 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->