### PR TITLE
[FEAT] 인수인계서 신청 화면 /app/handover #230

### DIFF
--- a/src/app/(shell)/app/handover/error.tsx
+++ b/src/app/(shell)/app/handover/error.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { ScreenError } from "@/components/common/screen-error";
+
+export default function Error({ reset }: { reset: () => void }) {
+  return <ScreenError title="인수인계서 정보를 불러오지 못했습니다" reset={reset} isInsideShell />;
+}

--- a/src/app/(shell)/app/handover/layout.tsx
+++ b/src/app/(shell)/app/handover/layout.tsx
@@ -1,0 +1,14 @@
+import { ClipboardCheck } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { PageHeader } from "@/features/shell/components/page-header";
+
+/** 인수인계서 신청 상단바 — 사이드바에서 바로 닿는 화면이라 backTo는 두지 않는다. */
+export default function HandoverLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <PageHeader title="인수인계서" icon={ClipboardCheck} />
+      {children}
+    </>
+  );
+}

--- a/src/app/(shell)/app/handover/loading.tsx
+++ b/src/app/(shell)/app/handover/loading.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
+      <div className="mx-auto flex w-full max-w-[720px] flex-col gap-5">
+        <Skeleton className="h-24 w-full rounded-lg" />
+        <Skeleton className="h-24 w-full rounded-2xl" />
+        <Skeleton className="h-48 w-full rounded-2xl" />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/app/handover/page.tsx
+++ b/src/app/(shell)/app/handover/page.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from "next";
+
+import { HANDOVER_TYPE } from "@/constants/domain";
+import { HandoverControls } from "@/features/handover/components/handover-controls";
+import { OffboardingForm } from "@/features/handover/components/offboarding-form";
+import { VacationForm } from "@/features/handover/components/vacation-form";
+import { parseHandoverPreview, parseHandoverType } from "@/features/handover/lib";
+import { getHandoverContext } from "@/features/handover/server";
+
+export const metadata: Metadata = {
+  title: "인수인계서",
+};
+
+interface HandoverPageProps {
+  searchParams: Promise<{ as?: string; type?: string }>;
+}
+
+/**
+ * 인수인계서 신청 — 휴직/오프보딩(WORKFLOW.md §7).
+ * ⚠️ Owner는 이 화면에 안 온다(`canWriteHandover`) — 지금은 로그인 세션이 없어 실제 가드
+ *    대신 미리보기 토글로 인물을 바꾼다(`HandoverControls` 주석 참고).
+ */
+export default async function HandoverPage({ searchParams }: HandoverPageProps) {
+  const params = await searchParams;
+  const preview = parseHandoverPreview(params.as);
+  const type = parseHandoverType(params.type);
+  const context = await getHandoverContext(preview);
+
+  return (
+    <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
+      <div className="mx-auto flex w-full max-w-[720px] flex-col gap-5">
+        <HandoverControls activePreview={preview} activeType={type} />
+
+        {type === HANDOVER_TYPE.VACATION ? (
+          <VacationForm context={context} />
+        ) : (
+          <OffboardingForm context={context} />
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/features/handover/actions.ts
+++ b/src/features/handover/actions.ts
@@ -1,0 +1,40 @@
+"use server";
+
+import { HANDOVER_STATUS, HANDOVER_TYPE, type HandoverStatus } from "@/constants/domain";
+import { isMock } from "@/mocks/config";
+
+/** 휴직 신청 — 팀장이면 액션마다 담당자를 지정해 함께 보낸다(자가 재할당). */
+export interface SubmitVacationHandoverPayload {
+  type: typeof HANDOVER_TYPE.VACATION;
+  startDate: string;
+  endDate: string;
+  actionIds: number[];
+  /** 액션 id → 배정받을 팀원 id. 팀장 신청이 아니면 빈 객체. */
+  assignments: Record<number, string>;
+}
+
+export interface SubmitOffboardingHandoverPayload {
+  type: typeof HANDOVER_TYPE.OFFBOARDING;
+  description: string;
+  actionIds: number[];
+}
+
+export type SubmitHandoverPayload =
+  SubmitVacationHandoverPayload | SubmitOffboardingHandoverPayload;
+
+/**
+ * [인수인계서 신청] — 접수만 한다.
+ * ⚠️ `/team/handover`·`/owner/leader-handovers`(승인·재분배·귀속 화면)가 아직 없어
+ *    이어줄 대상이 없다(별도 이슈) — 지금은 신청이 접수됐다는 결과만 mock으로 돌려준다.
+ *    실제 저장·팀장 상신은 그 이슈에서 mock 스토어와 함께 연결한다.
+ */
+export async function submitHandoverAction(
+  payload: SubmitHandoverPayload,
+): Promise<{ status: HandoverStatus }> {
+  if (!isMock) {
+    throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
+  }
+
+  void payload;
+  return { status: HANDOVER_STATUS.SUBMITTED };
+}

--- a/src/features/handover/components/handover-action-list-card.tsx
+++ b/src/features/handover/components/handover-action-list-card.tsx
@@ -1,0 +1,104 @@
+import { Checkbox } from "@/components/ui/checkbox";
+import { ACTION_DELAYED_LABEL, ACTION_STATUS_LABEL, isDelayed } from "@/constants/domain";
+import { formatMonthDayWeekday } from "@/lib/date";
+import { pickPaletteColor } from "@/lib/palette";
+import { cn } from "@/lib/utils";
+
+import type { HandoverActionItem } from "../types";
+
+interface HandoverActionListCardProps {
+  actions: HandoverActionItem[];
+  selectedIds: Set<number>;
+  /** 휴직 기간과 마감일이 겹치는 항목 — 숨기지 않고 배지로만 표시(§lib 절충안). */
+  highlightedIds?: Set<number>;
+  /** 오프보딩 — 전체 선택 고정, 체크박스는 보여주되 못 바꾼다. */
+  locked?: boolean;
+  onToggle?: (id: number) => void;
+}
+
+/**
+ * "내 담당 액션" 체크리스트 카드 — 휴직·오프보딩 두 탭이 같이 쓴다.
+ * ⚠️ 완료 액션은 여기 오기 전에 이미 걸러졌다(`server.ts`) — 이 컴포넌트는 필터링을
+ *    다시 하지 않는다.
+ */
+export function HandoverActionListCard({
+  actions,
+  selectedIds,
+  highlightedIds,
+  locked,
+  onToggle,
+}: HandoverActionListCardProps) {
+  return (
+    <section className="border-border bg-card overflow-hidden rounded-2xl border">
+      <div className="flex items-baseline justify-between gap-3 px-7 pt-6 pb-3">
+        <h2 className="flex items-center gap-2 text-[15px] leading-6 font-semibold tracking-[-0.2px]">
+          <span className="bg-foreground size-2 rounded-full" aria-hidden />내 담당 액션
+        </h2>
+        <p className="text-muted-foreground text-[12px] leading-4 tabular-nums">
+          {selectedIds.size}/{actions.length}건 선택
+        </p>
+      </div>
+
+      {actions.length === 0 ? (
+        <p className="text-muted-foreground border-border border-t px-7 py-8 text-center text-[13px] leading-5">
+          완료하지 않은 담당 액션이 없습니다.
+        </p>
+      ) : (
+        <ul className="border-border border-t">
+          {actions.map((action) => {
+            const checked = selectedIds.has(action.id);
+            const tagColor = pickPaletteColor(action.projectTag);
+            const delayed = isDelayed(action);
+
+            return (
+              <li
+                key={action.id}
+                className="border-border flex items-center gap-3 border-b px-7 py-3 last:border-b-0"
+              >
+                <Checkbox
+                  checked={checked}
+                  disabled={locked}
+                  onCheckedChange={() => onToggle?.(action.id)}
+                  aria-label={`${action.title} 인수인계 대상 선택`}
+                />
+                <span
+                  className="w-fit shrink-0 rounded px-1.5 py-0.5 font-mono text-[10px] font-semibold"
+                  style={{ backgroundColor: tagColor.bgColor, color: tagColor.textColor }}
+                >
+                  {action.projectTag}
+                </span>
+                <span className="text-muted-foreground hidden w-[120px] shrink-0 truncate text-[12px] leading-4 sm:inline">
+                  {action.parentTeamActionName}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-[13px] leading-5">
+                  {action.title}
+                </span>
+                {highlightedIds?.has(action.id) && (
+                  <span className="border-border text-muted-foreground shrink-0 rounded border px-1.5 py-0.5 text-[10px] leading-4">
+                    기간 중 마감
+                  </span>
+                )}
+                <span
+                  className={cn(
+                    "w-[52px] shrink-0 rounded border px-1.5 py-0.5 text-center text-[11px] leading-4",
+                    delayed
+                      ? "border-destructive/40 text-destructive"
+                      : "border-border text-muted-foreground",
+                  )}
+                >
+                  {delayed ? ACTION_DELAYED_LABEL : ACTION_STATUS_LABEL[action.status]}
+                </span>
+                <time
+                  dateTime={action.dueDate}
+                  className="text-muted-foreground w-20 shrink-0 text-right text-[12px] leading-4 whitespace-nowrap tabular-nums"
+                >
+                  {formatMonthDayWeekday(action.dueDate)}
+                </time>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/features/handover/components/handover-controls.tsx
+++ b/src/features/handover/components/handover-controls.tsx
@@ -1,0 +1,79 @@
+import Link from "next/link";
+
+import type { HandoverType } from "@/constants/domain";
+import { cn } from "@/lib/utils";
+
+import {
+  DEFAULT_HANDOVER_PREVIEW,
+  DEFAULT_HANDOVER_TYPE,
+  HANDOVER_PREVIEW_TABS,
+  HANDOVER_TYPE_TABS,
+  type HandoverPreview,
+} from "../lib";
+
+interface HandoverControlsProps {
+  activePreview: HandoverPreview;
+  activeType: HandoverType;
+}
+
+function buildHref(preview: HandoverPreview, type: HandoverType): string {
+  const params = new URLSearchParams();
+  if (preview !== DEFAULT_HANDOVER_PREVIEW) params.set("as", preview);
+  if (type !== DEFAULT_HANDOVER_TYPE) params.set("type", type);
+  const query = params.toString();
+  return query ? `/app/handover?${query}` : "/app/handover";
+}
+
+/**
+ * 미리보기 토글 + 휴직/오프보딩 탭 — 둘 다 **서버우선 `<Link>`**(team/members 컨트롤과
+ * 같은 결). 한쪽을 바꿀 때 다른 쪽 값은 유지해야 해서 항상 같이 넘긴다.
+ */
+export function HandoverControls({ activePreview, activeType }: HandoverControlsProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="border-warning/40 bg-warning/5 flex items-center gap-3 rounded-lg border px-3 py-2">
+        <span className="text-warning shrink-0 text-[12px] leading-4 font-medium">
+          임시 미리보기
+        </span>
+        <div role="group" aria-label="미리보기 인물" className="flex items-center gap-1">
+          {HANDOVER_PREVIEW_TABS.map((tab) => (
+            <Link
+              key={tab.preview}
+              href={buildHref(tab.preview, activeType)}
+              aria-pressed={activePreview === tab.preview}
+              className={cn(
+                "rounded-md px-2 py-1 text-[12px] leading-4 transition-colors",
+                activePreview === tab.preview
+                  ? "bg-foreground text-background font-medium"
+                  : "text-muted-foreground hover:bg-muted",
+              )}
+            >
+              {tab.label}
+            </Link>
+          ))}
+        </div>
+        <span className="text-muted-foreground text-[11px] leading-4">
+          — 로그인 연동 전까지만 쓰는 화면 확인용입니다.
+        </span>
+      </div>
+
+      <nav aria-label="인수인계 종류" className="border-border flex gap-4 border-b">
+        {HANDOVER_TYPE_TABS.map((tab) => (
+          <Link
+            key={tab.type}
+            href={buildHref(activePreview, tab.type)}
+            aria-current={activeType === tab.type ? "page" : undefined}
+            className={cn(
+              "-mb-px border-b-2 px-1 pb-2 text-sm font-medium transition-colors",
+              activeType === tab.type
+                ? "border-foreground text-foreground"
+                : "text-muted-foreground hover:text-foreground border-transparent",
+            )}
+          >
+            {tab.label}
+          </Link>
+        ))}
+      </nav>
+    </div>
+  );
+}

--- a/src/features/handover/components/offboarding-form.tsx
+++ b/src/features/handover/components/offboarding-form.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+
+import { ConfirmDialog } from "@/components/common/confirm-dialog";
+import { ResultDialog } from "@/components/common/result-dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { HANDOVER_TYPE } from "@/constants/domain";
+
+import { submitHandoverAction } from "../actions";
+import type { HandoverContext } from "../types";
+import { HandoverActionListCard } from "./handover-action-list-card";
+
+const DESCRIPTION_MAX_LENGTH = 1000;
+
+interface OffboardingFormProps {
+  context: HandoverContext;
+}
+
+/**
+ * 오프보딩 신청 — 전체 액션 자동 선택(해제 불가) + 인수인계 상세 설명(WORKFLOW.md §7).
+ * ⚠️ 팀장 오프보딩도 신청 화면 자체는 똑같다 — 다른 건 신청 뒤 라우팅(바로 오너에게)뿐이고
+ *    그건 승인 화면(`/team/handover`·`/owner/leader-handovers`, 별도 이슈) 쪽 일이다.
+ */
+export function OffboardingForm({ context }: OffboardingFormProps) {
+  const { actions } = context;
+  const selectedIds = useMemo(() => new Set(actions.map((action) => action.id)), [actions]);
+
+  const [description, setDescription] = useState("");
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [confirmError, setConfirmError] = useState<string | null>(null);
+  const [resultOpen, setResultOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  const canSubmit = description.trim().length > 0 && actions.length > 0;
+
+  function handleConfirm() {
+    setConfirmError(null);
+    startTransition(async () => {
+      try {
+        await submitHandoverAction({
+          type: HANDOVER_TYPE.OFFBOARDING,
+          description: description.trim(),
+          actionIds: actions.map((action) => action.id),
+        });
+        setConfirmOpen(false);
+        setResultOpen(true);
+      } catch {
+        setConfirmError("인수인계서 신청에 실패했습니다. 잠시 후 다시 시도해 주세요.");
+      }
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      <section className="border-border bg-card flex flex-col gap-1.5 rounded-2xl border p-7">
+        <Label htmlFor="offboarding-description">
+          담당 업무 및 인수인계 상세 설명 <span className="text-destructive">*</span>
+        </Label>
+        <textarea
+          id="offboarding-description"
+          rows={4}
+          value={description}
+          onChange={(event) => setDescription(event.target.value.slice(0, DESCRIPTION_MAX_LENGTH))}
+          placeholder="담당했던 업무, 진행 맥락, 인수받을 사람이 알아야 할 사항을 작성해 주세요. PDF에도 함께 포함됩니다."
+          maxLength={DESCRIPTION_MAX_LENGTH}
+          className="border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 w-full resize-none rounded-lg border bg-transparent px-2.5 py-2 text-sm transition-colors outline-none focus-visible:ring-3"
+        />
+        <p className="text-muted-foreground text-right text-xs tabular-nums">
+          {description.length}/{DESCRIPTION_MAX_LENGTH}
+        </p>
+      </section>
+
+      <HandoverActionListCard actions={actions} selectedIds={selectedIds} locked />
+
+      <div className="flex justify-end">
+        <Button
+          type="button"
+          disabled={!canSubmit}
+          className="bg-foreground text-background hover:bg-foreground/90"
+          onClick={() => setConfirmOpen(true)}
+        >
+          인수인계서 신청
+        </Button>
+      </div>
+
+      <ConfirmDialog
+        isOpen={confirmOpen}
+        onOpenChange={(open) => {
+          setConfirmOpen(open);
+          if (!open) setConfirmError(null);
+        }}
+        title="인수인계서를 신청할까요?"
+        description={`담당 액션 ${actions.length}건 전체가 인수인계서에 담겨 신청됩니다. 신청 뒤에는 이 화면에서 되돌릴 수 없습니다.`}
+        confirmLabel="신청"
+        isDestructive
+        isPending={isPending}
+        pendingLabel="신청 중"
+        error={confirmError}
+        onConfirm={handleConfirm}
+      />
+
+      <ResultDialog
+        isOpen={resultOpen}
+        onOpenChange={setResultOpen}
+        title="인수인계서를 신청했습니다."
+        description="담당자 승인을 기다려 주세요."
+        action={
+          <Button
+            type="button"
+            className="bg-foreground text-background hover:bg-foreground/90 w-full"
+            onClick={() => setResultOpen(false)}
+          >
+            확인
+          </Button>
+        }
+      />
+    </div>
+  );
+}

--- a/src/features/handover/components/vacation-form.tsx
+++ b/src/features/handover/components/vacation-form.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+
+import { ConfirmDialog } from "@/components/common/confirm-dialog";
+import { ResultDialog } from "@/components/common/result-dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { AUTHORITY, HANDOVER_TYPE } from "@/constants/domain";
+import { pickPaletteColor } from "@/lib/palette";
+
+import { submitHandoverAction } from "../actions";
+import { sortActionsForVacation } from "../lib";
+import type { HandoverContext } from "../types";
+import { HandoverActionListCard } from "./handover-action-list-card";
+
+interface VacationFormProps {
+  context: HandoverContext;
+}
+
+/**
+ * 휴직 신청 — 시작일·종료일 + 인계할 액션 선택.
+ * ⚠️ **팀장 본인 휴직만 다르다**(WORKFLOW.md §7 "팀장 본인 휴직"): 위에 상위 리더가
+ *    없어 본인이 신청과 재할당을 동시에 한다. [다음]으로 2단계(팀원 배정)를 거친 뒤에야
+ *    [인수인계서 신청]이 뜬다. 일반 팀원은 1단계에서 바로 신청한다.
+ */
+export function VacationForm({ context }: VacationFormProps) {
+  const { applicant, actions, teammates } = context;
+  const isLeader = applicant.role === AUTHORITY.LEADER;
+
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [assignments, setAssignments] = useState<Record<number, string>>({});
+  const [step, setStep] = useState<1 | 2>(1);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [confirmError, setConfirmError] = useState<string | null>(null);
+  const [resultOpen, setResultOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  const { sorted, inRangeIds } = useMemo(
+    () => sortActionsForVacation(actions, startDate, endDate),
+    [actions, startDate, endDate],
+  );
+
+  function handleDateChange(next: { startDate?: string; endDate?: string }) {
+    setStartDate(next.startDate ?? startDate);
+    setEndDate(next.endDate ?? endDate);
+  }
+
+  function toggleAction(id: number) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  const selectedActions = sorted.filter((action) => selectedIds.has(action.id));
+  const canProceed = Boolean(startDate) && Boolean(endDate) && selectedActions.length > 0;
+  const canAssignSubmit = selectedActions.every((action) => assignments[action.id]);
+
+  function handleConfirm() {
+    setConfirmError(null);
+    startTransition(async () => {
+      try {
+        await submitHandoverAction({
+          type: HANDOVER_TYPE.VACATION,
+          startDate,
+          endDate,
+          actionIds: selectedActions.map((action) => action.id),
+          assignments: isLeader ? assignments : {},
+        });
+        setConfirmOpen(false);
+        setResultOpen(true);
+      } catch {
+        setConfirmError("인수인계서 신청에 실패했습니다. 잠시 후 다시 시도해 주세요.");
+      }
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      {step === 1 && (
+        <>
+          <section className="border-border bg-card flex flex-col gap-4 rounded-2xl border p-7">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="vacation-start">
+                  휴직 시작 날짜 <span className="text-destructive">*</span>
+                </Label>
+                <Input
+                  id="vacation-start"
+                  type="date"
+                  value={startDate}
+                  max={endDate || undefined}
+                  onChange={(event) => handleDateChange({ startDate: event.target.value })}
+                />
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="vacation-end">
+                  휴직 종료 날짜 <span className="text-destructive">*</span>
+                </Label>
+                <Input
+                  id="vacation-end"
+                  type="date"
+                  value={endDate}
+                  min={startDate || undefined}
+                  onChange={(event) => handleDateChange({ endDate: event.target.value })}
+                />
+              </div>
+            </div>
+          </section>
+
+          <HandoverActionListCard
+            actions={sorted}
+            selectedIds={selectedIds}
+            highlightedIds={inRangeIds}
+            onToggle={toggleAction}
+          />
+
+          <div className="flex justify-end">
+            {isLeader ? (
+              <Button
+                type="button"
+                disabled={!canProceed}
+                className="bg-foreground text-background hover:bg-foreground/90"
+                onClick={() => setStep(2)}
+              >
+                다음
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                disabled={!canProceed}
+                className="bg-foreground text-background hover:bg-foreground/90"
+                onClick={() => setConfirmOpen(true)}
+              >
+                인수인계서 신청
+              </Button>
+            )}
+          </div>
+        </>
+      )}
+
+      {step === 2 && (
+        <>
+          <section className="border-border bg-card flex flex-col rounded-2xl border">
+            <div className="px-7 pt-6 pb-3">
+              <h2 className="flex items-center gap-2 text-[15px] leading-6 font-semibold tracking-[-0.2px]">
+                <span className="bg-foreground size-2 rounded-full" aria-hidden />
+                선택한 액션에 담당자를 지정해 주세요
+              </h2>
+              <p className="text-muted-foreground mt-1 text-[12px] leading-4">
+                본인 개인 액션이라 팀원에게 바로 나눠 줄 수 있어요. 부담되는 액션은 1단계로 돌아가
+                선택을 해제해 주세요.
+              </p>
+            </div>
+            <ul className="border-border border-t">
+              {selectedActions.map((action) => {
+                const tagColor = pickPaletteColor(action.projectTag);
+                return (
+                  <li
+                    key={action.id}
+                    className="border-border flex items-center gap-3 border-b px-7 py-3 last:border-b-0"
+                  >
+                    <span
+                      className="w-fit shrink-0 rounded px-1.5 py-0.5 font-mono text-[10px] font-semibold"
+                      style={{ backgroundColor: tagColor.bgColor, color: tagColor.textColor }}
+                    >
+                      {action.projectTag}
+                    </span>
+                    <span className="min-w-0 flex-1 truncate text-[13px] leading-5">
+                      {action.title}
+                    </span>
+                    <Select
+                      value={assignments[action.id] ?? ""}
+                      onValueChange={(value) =>
+                        setAssignments((prev) => ({ ...prev, [action.id]: value ?? "" }))
+                      }
+                    >
+                      <SelectTrigger aria-label={`${action.title} 담당자 선택`} className="w-40">
+                        <SelectValue placeholder="담당자 선택" />
+                      </SelectTrigger>
+                      <SelectContent side="bottom" alignItemWithTrigger={false}>
+                        {teammates.map((teammate) => (
+                          <SelectItem key={teammate.id} value={teammate.id}>
+                            {teammate.name} {teammate.position}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+
+          <div className="flex justify-between">
+            <Button type="button" variant="outline" onClick={() => setStep(1)}>
+              이전
+            </Button>
+            <Button
+              type="button"
+              disabled={!canAssignSubmit}
+              className="bg-foreground text-background hover:bg-foreground/90"
+              onClick={() => setConfirmOpen(true)}
+            >
+              인수인계서 신청
+            </Button>
+          </div>
+        </>
+      )}
+
+      <ConfirmDialog
+        isOpen={confirmOpen}
+        onOpenChange={(open) => {
+          setConfirmOpen(open);
+          if (!open) setConfirmError(null);
+        }}
+        title="인수인계서를 신청할까요?"
+        description={
+          isLeader
+            ? `선택한 액션 ${selectedActions.length}건이 지정한 팀원에게 바로 배정되고, 오너의 최종 승인 대기로 올라갑니다.`
+            : `선택한 액션 ${selectedActions.length}건과 함께 팀장에게 인수인계서가 올라갑니다.`
+        }
+        confirmLabel="신청"
+        isPending={isPending}
+        pendingLabel="신청 중"
+        error={confirmError}
+        onConfirm={handleConfirm}
+      />
+
+      <ResultDialog
+        isOpen={resultOpen}
+        onOpenChange={setResultOpen}
+        title="인수인계서를 신청했습니다."
+        description={
+          isLeader ? "오너의 최종 승인을 기다려 주세요." : "팀장의 승인을 기다려 주세요."
+        }
+        action={
+          <Button
+            type="button"
+            className="bg-foreground text-background hover:bg-foreground/90 w-full"
+            onClick={() => setResultOpen(false)}
+          >
+            확인
+          </Button>
+        }
+      />
+    </div>
+  );
+}

--- a/src/features/handover/lib.ts
+++ b/src/features/handover/lib.ts
@@ -1,0 +1,78 @@
+import { HANDOVER_TYPE, type HandoverType } from "@/constants/domain";
+
+import type { HandoverActionItem } from "./types";
+
+/**
+ * ⚠️ **임시 미리보기 토글**(사용자 요청, 2026-08-08) — 로그인이 아직 없어 "지금 보고
+ *    있는 사람"을 화면에서 바로 바꿔볼 수 있게 둔 것. 실제 세션이 붙으면 이 토글과
+ *    `?as=`는 걷어내고 `getViewer()`가 그 자리를 대신한다.
+ */
+export const HANDOVER_PREVIEW = {
+  MEMBER: "member",
+  LEADER: "leader",
+} as const;
+export type HandoverPreview = (typeof HANDOVER_PREVIEW)[keyof typeof HANDOVER_PREVIEW];
+
+export const HANDOVER_PREVIEW_LABEL: Record<HandoverPreview, string> = {
+  member: "팀원(이하윤)",
+  leader: "팀장(김서준)",
+};
+
+export const HANDOVER_PREVIEW_TABS: { preview: HandoverPreview; label: string }[] = [
+  HANDOVER_PREVIEW.MEMBER,
+  HANDOVER_PREVIEW.LEADER,
+].map((preview) => ({ preview, label: HANDOVER_PREVIEW_LABEL[preview] }));
+
+export const DEFAULT_HANDOVER_PREVIEW: HandoverPreview = HANDOVER_PREVIEW.MEMBER;
+
+export function parseHandoverPreview(value: string | undefined): HandoverPreview {
+  return (
+    HANDOVER_PREVIEW_TABS.find((t) => t.preview === value)?.preview ?? DEFAULT_HANDOVER_PREVIEW
+  );
+}
+
+export const HANDOVER_TYPE_TABS: { type: HandoverType; label: string }[] = [
+  HANDOVER_TYPE.VACATION,
+  HANDOVER_TYPE.OFFBOARDING,
+].map((type) => ({
+  type,
+  label: type === HANDOVER_TYPE.VACATION ? "휴직" : "오프보딩",
+}));
+
+export const DEFAULT_HANDOVER_TYPE: HandoverType = HANDOVER_TYPE.VACATION;
+
+export function parseHandoverType(value: string | undefined): HandoverType {
+  return HANDOVER_TYPE_TABS.find((t) => t.type === value)?.type ?? DEFAULT_HANDOVER_TYPE;
+}
+
+/** 마감일이 휴직 기간(양끝 포함) 안에 드는지 — `YYYY-MM-DD` 문자열 비교로 충분하다. */
+export function isDueWithinRange(dueDate: string, startDate: string, endDate: string): boolean {
+  if (!startDate || !endDate) return false;
+  return dueDate >= startDate && dueDate <= endDate;
+}
+
+/**
+ * 절충안(사용자 확정, 2026-08-08): 기간 밖 액션도 **숨기지 않는다** — 목록은 항상 전체를
+ * 보여주고, 기간과 겹치는 것만 위로 정렬 + 배지로 표시한다. 필터로 감추면 "마감일은
+ * 아니어도 자리를 비우면 인계가 필요한" 액션을 사용자가 잊어버릴 수 있다(§정직성).
+ * ⚠️ **기본 체크는 안 한다**(2026-08-08 정정) — 인계할 생각이 없던 액션까지 체크돼
+ *    있으면 오히려 하나씩 해제해야 해서 번거롭다. 정렬·배지까지만 돕고 선택은 전부
+ *    사용자 몫으로 둔다.
+ */
+export function sortActionsForVacation(
+  actions: HandoverActionItem[],
+  startDate: string,
+  endDate: string,
+): { sorted: HandoverActionItem[]; inRangeIds: Set<number> } {
+  const inRangeIds = new Set(
+    actions
+      .filter((action) => isDueWithinRange(action.dueDate, startDate, endDate))
+      .map((a) => a.id),
+  );
+  const sorted = [...actions].sort((a, b) => {
+    const aIn = inRangeIds.has(a.id) ? 0 : 1;
+    const bIn = inRangeIds.has(b.id) ? 0 : 1;
+    return aIn - bIn;
+  });
+  return { sorted, inRangeIds };
+}

--- a/src/features/handover/server.ts
+++ b/src/features/handover/server.ts
@@ -1,0 +1,72 @@
+import { ACTION_STATUS, AUTHORITY } from "@/constants/domain";
+import {
+  TEAM_ACTION_DETAIL_MOCK,
+  TEAM_ACTION_PERSONAL_ITEMS_MOCK,
+} from "@/features/project/mock/team-action-detail";
+import { TEAM_MEMBER_ROSTER_MOCK } from "@/features/team/members/mock/roster";
+
+import { HANDOVER_PREVIEW, type HandoverPreview } from "./lib";
+import type { HandoverActionItem, HandoverApplicant, HandoverContext } from "./types";
+
+/**
+ * ⚠️ 새 mock 데이터를 만들지 않는다 — `TEAM_ACTION_PERSONAL_ITEMS_MOCK`(project 피처)이
+ * 담당자별 개인 액션의 정본이고(보드·팀원 관리도 이걸 쓴다), 팀원 명단은
+ * `TEAM_MEMBER_ROSTER_MOCK`(team/members 피처)을 그대로 쓴다. 두 벌을 따로 두면
+ * 화면마다 같은 사람의 액션·명단이 어긋난다.
+ */
+const APPLICANT_NAME_BY_PREVIEW: Record<HandoverPreview, string> = {
+  member: "이하윤",
+  leader: "김서준",
+};
+
+function buildActions(memberName: string): HandoverActionItem[] {
+  const actions: HandoverActionItem[] = [];
+  for (const [teamActionId, items] of Object.entries(TEAM_ACTION_PERSONAL_ITEMS_MOCK)) {
+    const parent = TEAM_ACTION_DETAIL_MOCK[Number(teamActionId)];
+    if (!parent) continue;
+    for (const item of items) {
+      if (item.assigneeName !== memberName) continue;
+      // ⚠️ 완료 액션은 인계 대상이 아니다(WORKFLOW.md §7) — 조회 단계에서 아예 뺀다.
+      if (item.status === ACTION_STATUS.DONE) continue;
+      actions.push({
+        id: item.id,
+        projectTag: parent.projectTag,
+        parentTeamActionName: parent.name,
+        title: item.title,
+        status: item.status,
+        dueDate: item.dueDate,
+      });
+    }
+  }
+  return actions;
+}
+
+export async function getHandoverContext(preview: HandoverPreview): Promise<HandoverContext> {
+  const applicantName = APPLICANT_NAME_BY_PREVIEW[preview];
+  const roster = TEAM_MEMBER_ROSTER_MOCK.find((member) => member.name === applicantName);
+  if (!roster) throw new Error("mock 데이터 오류 — 로스터에 없는 미리보기 인물입니다.");
+
+  const applicant: HandoverApplicant = {
+    id: roster.id,
+    name: roster.name,
+    role: preview === HANDOVER_PREVIEW.LEADER ? AUTHORITY.LEADER : AUTHORITY.MEMBER,
+    teamName: roster.teamName,
+  };
+
+  const actions = buildActions(applicant.name);
+
+  // ⚠️ 팀장 본인 휴직의 자가 재할당 대상 — 본인 제외 같은 팀원(WORKFLOW.md §7 "팀장 본인 휴직").
+  const teammates =
+    applicant.role === AUTHORITY.LEADER
+      ? TEAM_MEMBER_ROSTER_MOCK.filter((member) => member.name !== applicant.name).map(
+          (member) => ({
+            id: member.id,
+            name: member.name,
+            position: member.position,
+            role: member.role,
+          }),
+        )
+      : [];
+
+  return { applicant, actions, teammates };
+}

--- a/src/features/handover/types.ts
+++ b/src/features/handover/types.ts
@@ -1,0 +1,38 @@
+import type { ActionStatus, Authority } from "@/constants/domain";
+
+/**
+ * 인수인계서 신청 화면(`/app/handover`)의 **UI 계약**(CLAUDE.md §Mock 격리막).
+ * WORKFLOW.md §7 인수인계서.
+ */
+
+/** 체크리스트 한 줄 — 완료 상태는 애초에 조회 단계에서 제외된다. */
+export interface HandoverActionItem {
+  id: number;
+  projectTag: string;
+  parentTeamActionName: string;
+  title: string;
+  status: ActionStatus;
+  dueDate: string;
+}
+
+/** 신청자 — 화면이 role로 팀장 자가 재할당 분기를 튼다. */
+export interface HandoverApplicant {
+  id: string;
+  name: string;
+  role: Authority;
+  teamName: string;
+}
+
+/** 팀장 본인 휴직 재할당 대상 — 본인 제외 팀원. */
+export interface HandoverTeammateOption {
+  id: string;
+  name: string;
+  position: string;
+  role: string;
+}
+
+export interface HandoverContext {
+  applicant: HandoverApplicant;
+  actions: HandoverActionItem[];
+  teammates: HandoverTeammateOption[];
+}


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [x] LEADER (팀장)
- [x] MEMBER (사원)
- [ ] OWNER (대표) — 접근 제외 대상
- [ ] ADMIN (관리자)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

WORKFLOW.md §7 인수인계서 스펙대로 휴직/오프보딩 신청 화면입니다. 본인 담당 액션(완료 제외) 체크리스트에서 인계할 항목을 골라 신청합니다.

- **휴직**: 시작일·종료일 + 액션 선택. 기간·마감일이 겹치는 액션은 숨기지 않고 정렬 우선순위 + "기간 중 마감" 배지로만 도와줍니다(필터로 감추면 위험하다는 사용자 판단으로 절충)
- **팀장 본인 휴직**: [다음] → 선택한 액션마다 팀원 담당자 지정 → 신청, 중간 승인 없이 곧바로 오너 최종 승인 대기(WORKFLOW §7 "자가 선택적 재할당")
- **오프보딩**: 전체 액션 자동 선택(해제 불가) + 인수인계 상세 설명 필수
- 임시 미리보기 토글(`?as=member|leader`)로 로그인 연동 전까지 두 흐름을 바로 바꿔볼 수 있게 했습니다

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [x] 🔐 권한 2축 검사 — Owner 제외 전원, 본인 담당 액션만 대상
- [ ] 🧬 zod — 해당 없음
- [x] 🕵️ 정직성 — 신청이 mock으로 접수만 되고 실제 저장·상신은 안 됨을 명시. 임시 미리보기 토글은 로그인 연동 전까지만 쓰는 임시 UI임을 주석으로 명시
- [x] 🎨 디자인 토큰 사용 · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [x] ♿ a11y — 체크리스트·날짜 선택·확인 창 접근성 확인
- [x] ♻️ 재사용 확인 — `ConfirmDialog`·`ResultDialog` 공용 컴포넌트, 팀원 로스터는 `team/members` mock 재사용
- [x] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API 미사용

---

## 🔗 연관 이슈

Closes #230

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

**알려진 한계**

- `/team/handover`·`/owner/leader-handovers`(승인·재분배·귀속 화면)는 범위 밖 — 신청은 mock으로 접수만 되고 실제 저장·상신은 안 됩니다(별도 이슈)
- 재분석 API·회의 목록 필터 등과 마찬가지로 인수인계서 생성 API 경로 미확정

---

## 📝 추가 메모

⚠️ **스태킹 PR** — base가 develop이 아니라 `feature/team-members#228`이었습니다(팀원 로스터 mock을 재사용해서 의존). #228이 머지되며 base가 자동으로 develop으로 리타겟됐습니다.

확인법 —

- `/app/handover` — 상단 "임시 미리보기"에서 팀원(이하윤) ↔ 팀장(김서준) 전환 확인
- 휴직 탭: 날짜 선택 후 기간 겹치는 액션에 "기간 중 마감" 배지 + 정렬 우선순위 확인(자동 체크는 안 됨 — 사용자가 직접 선택)
- 팀원(이하윤) 휴직: 액션 선택 후 [인수인계서 신청] 바로 노출
- 팀장(김서준) 휴직: 액션 선택 후 [다음] → 담당자 지정 안 하면 [인수인계서 신청] 비활성 확인 → 전부 지정하면 활성화
- 오프보딩 탭: 체크박스 전부 잠김 + 설명 안 쓰면 신청 버튼 비활성 확인
- 신청 → ConfirmDialog → ResultDialog 흐름 확인

`npx tsc --noEmit` / lint 통과 확인됨(커밋·푸시 훅에서 자동 실행).
