### PR TITLE
[FIX] 인수인계 승인 카드 — 팀장/사원 구분 + PDF 다운로드 #235

### DIFF
--- a/src/app/(shell)/(authority)/manage/members/[memberId]/page.tsx
+++ b/src/app/(shell)/(authority)/manage/members/[memberId]/page.tsx
@@ -98,6 +98,7 @@ export default async function ManageMemberDetailPage({
               <HandoverApprovalCard
                 memberId={detail.member.id}
                 memberName={detail.member.name}
+                memberAuthority={detail.member.authority}
                 handover={detail.pendingHandover}
                 canApprove={canApproveFinal(viewer)}
               />

--- a/src/constants/handover.ts
+++ b/src/constants/handover.ts
@@ -42,3 +42,13 @@ export const HANDOVER_TYPE_LABEL: Record<HandoverType, string> = {
   */
   OFFBOARDING: "오프보딩",
 };
+
+/**
+ * 승인 카드 제목에 붙는 신청자 서술어 — **권한 배지(Leader/Member, 영문)가 아니라
+ * 한글 서술어다**(`handover-approval-card.tsx` 참고). 신청은 OWNER 제외 전원이 할 수
+ * 있지만(`canWriteHandover`) 제목에서 가르는 건 팀장 본인 신청인지 여부뿐이라 둘로 충분하다.
+ */
+export const HANDOVER_APPLICANT_TYPE_LABEL = {
+  LEADER: "팀장",
+  MEMBER: "사원",
+} as const;

--- a/src/features/member/components/handover-approval-card.tsx
+++ b/src/features/member/components/handover-approval-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CircleAlert } from "lucide-react";
+import { CircleAlert, Download } from "lucide-react";
 import Link from "next/link";
 import { useEffect, useRef, useState, useTransition } from "react";
 import { toast } from "sonner";
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
+import { AUTHORITY, type Authority } from "@/constants/authority";
 import { HANDOVER_TYPE, HANDOVER_TYPE_LABEL } from "@/constants/handover";
 import { formatMonthDayWeekday } from "@/lib/date";
 import { cn } from "@/lib/utils";
@@ -39,11 +40,14 @@ const REASON_MAX = 200;
 export function HandoverApprovalCard({
   memberId,
   memberName,
+  memberAuthority,
   handover,
   canApprove,
 }: {
   memberId: number;
   memberName: string;
+  /** 제목에 "팀장/사원"을 붙이는 데만 쓴다 — 승인 판정과는 무관하다(그건 `canApprove`). */
+  memberAuthority: Authority;
   handover: PendingHandover;
   /** OWNER만 참이다 — Admin 겸직자는 화면엔 들어와도 이 버튼이 없다(WORKFLOW §11) */
   canApprove: boolean;
@@ -78,6 +82,13 @@ export function HandoverApprovalCard({
 
   const isVacation = handover.type === HANDOVER_TYPE.VACATION;
   const typeLabel = HANDOVER_TYPE_LABEL[handover.type];
+  /*
+    ⚠️ **제목에 팀장/사원을 박아 넣는다**(사용자 확정, 2026-08-08) — 전에는 본문을 읽어야만
+       팀장 본인 신청인지 알 수 있었다. "팀장 휴직"·"사원 오프보딩"처럼 넷을 한눈에
+       가르는 게 목적이라 여기 값은 권한 배지(Leader/Member, 영문)가 아니라 그 옆에서
+       쓰는 한글 서술어다 — `이 화면 제목`이지 `권한 라벨`이 아니다.
+  */
+  const applicantTypeLabel = memberAuthority === AUTHORITY.LEADER ? "팀장" : "사원";
 
   const run = (task: () => Promise<{ isSuccess: boolean; message?: string }>, done: string) =>
     startTransition(async () => {
@@ -101,7 +112,7 @@ export function HandoverApprovalCard({
       <div className="flex items-center justify-between gap-3 px-7 pt-6 pb-5">
         <h2 className="flex items-center gap-2 text-[15px] leading-6 font-semibold tracking-[-0.2px]">
           <span className="bg-foreground size-2 rounded-full" aria-hidden />
-          {typeLabel} 최종 승인 대기
+          {applicantTypeLabel} {typeLabel} 최종 승인 대기
         </h2>
         <span className="border-warning/40 text-warning shrink-0 rounded border px-2 py-0.5 text-[11px] leading-4">
           검토 필요
@@ -167,6 +178,27 @@ export function HandoverApprovalCard({
           >
             팀장급 인수인계서 관리로 가기
           </Link>
+        )}
+
+        {/*
+          ⚠️ **오프보딩만** PDF를 준다 — 휴직은 재직 상태로 되돌아오는 일이라 문서로 남길
+             필요가 없다고 정리했다(§7). 승인 여부와 무관하게 보인다 — Admin 겸직자도
+             내용은 몰라도 되지만(WORKFLOW §11) 파일을 미리 받아 둘 수는 있어야 한다.
+          ⚠️ 실제 PDF 생성 API는 아직 BE와 경로가 확정 전이다(§연동 검증) — 지금은 버튼만
+             두고 눌렀을 때 "연동 전"임을 그대로 알린다. 조용히 아무 일도 안 일어나면
+             고장 난 것처럼 보인다(§정직성).
+        */}
+        {!isVacation && (
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="w-fit"
+            onClick={() => toast("PDF 생성은 아직 연동되지 않았습니다")}
+          >
+            <Download />
+            인수인계서 PDF 다운로드
+          </Button>
         )}
 
         {canApprove && (

--- a/src/features/member/components/handover-approval-card.tsx
+++ b/src/features/member/components/handover-approval-card.tsx
@@ -9,12 +9,26 @@ import { ConfirmDialog } from "@/components/common/confirm-dialog";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { AUTHORITY, type Authority } from "@/constants/authority";
-import { HANDOVER_TYPE, HANDOVER_TYPE_LABEL } from "@/constants/handover";
+import {
+  HANDOVER_APPLICANT_TYPE_LABEL,
+  HANDOVER_TYPE,
+  HANDOVER_TYPE_LABEL,
+} from "@/constants/handover";
 import { formatMonthDayWeekday } from "@/lib/date";
 import { cn } from "@/lib/utils";
 
 import { approveHandoverAction, rejectHandoverAction } from "../manage-actions";
 import type { PendingHandover } from "../manage-types";
+
+interface HandoverApprovalCardProps {
+  memberId: number;
+  memberName: string;
+  /** 제목에 "팀장/사원"을 붙이는 데만 쓴다 — 승인 판정과는 무관하다(그건 `canApprove`). */
+  memberAuthority: Authority;
+  handover: PendingHandover;
+  /** OWNER만 참이다 — Admin 겸직자는 화면엔 들어와도 이 버튼이 없다(WORKFLOW §11) */
+  canApprove: boolean;
+}
 
 /**
  * 최종 승인 카드 — 인수인계의 **마지막 관문**.
@@ -43,15 +57,7 @@ export function HandoverApprovalCard({
   memberAuthority,
   handover,
   canApprove,
-}: {
-  memberId: number;
-  memberName: string;
-  /** 제목에 "팀장/사원"을 붙이는 데만 쓴다 — 승인 판정과는 무관하다(그건 `canApprove`). */
-  memberAuthority: Authority;
-  handover: PendingHandover;
-  /** OWNER만 참이다 — Admin 겸직자는 화면엔 들어와도 이 버튼이 없다(WORKFLOW §11) */
-  canApprove: boolean;
-}) {
+}: HandoverApprovalCardProps) {
   const [reason, setReason] = useState("");
   /**
    * 지금 확인을 기다리는 일.
@@ -86,9 +92,14 @@ export function HandoverApprovalCard({
     ⚠️ **제목에 팀장/사원을 박아 넣는다**(사용자 확정, 2026-08-08) — 전에는 본문을 읽어야만
        팀장 본인 신청인지 알 수 있었다. "팀장 휴직"·"사원 오프보딩"처럼 넷을 한눈에
        가르는 게 목적이라 여기 값은 권한 배지(Leader/Member, 영문)가 아니라 그 옆에서
-       쓰는 한글 서술어다 — `이 화면 제목`이지 `권한 라벨`이 아니다.
+       쓰는 한글 서술어다 — `이 화면 제목`이지 `권한 라벨`이 아니다. `AUTHORITY_LABEL`(영문)을
+       재사용하지 않는 것도 같은 이유 — 라벨 하드코딩 금지는 지키되 값은 `constants/handover.ts`
+       (이 서술어를 쓰는 도메인)에 둔다.
   */
-  const applicantTypeLabel = memberAuthority === AUTHORITY.LEADER ? "팀장" : "사원";
+  const applicantTypeLabel =
+    memberAuthority === AUTHORITY.LEADER
+      ? HANDOVER_APPLICANT_TYPE_LABEL.LEADER
+      : HANDOVER_APPLICANT_TYPE_LABEL.MEMBER;
 
   const run = (task: () => Promise<{ isSuccess: boolean; message?: string }>, done: string) =>
     startTransition(async () => {


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

사원 상세(`/manage/members/:id`)의 인수인계 최종 승인 카드가 "휴직 최종 승인 대기"처럼 유형만 보여줘서, 팀장 본인 신청인지 팀원 신청인지 본문을 읽어야만 알 수 있었습니다. 제목에 "팀장"/"사원"을 붙여 네 조합(팀장 휴직·팀장 오프보딩·사원 휴직·사원 오프보딩)이 한눈에 구분되게 했습니다.

오프보딩 건에는 PDF 다운로드 버튼도 추가했습니다 — 오너가 실무 내용은 몰라도 최소 PDF는 받아 둘 수 있어야 한다는 요구사항(BE와 PDF 생성 협의 완료).

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [x] 🔐 권한 2축 검사 — 해당 없음. 기존 `canApproveFinal`/`canManageMembers` 판정 그대로 사용
- [ ] 🧬 zod — 해당 없음
- [x] 🕵️ 정직성 — PDF 생성 API 미연동임을 명시, 클릭 시 "PDF 생성은 아직 연동되지 않았습니다" 안내
- [x] 🎨 디자인 토큰 사용 · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [x] ♿ a11y — 버튼 이름·안내 토스트 접근성 확인
- [x] ♻️ 재사용 확인 — 기존 `HandoverApprovalCard`에 prop만 추가, 새로 안 만듦
- [ ] 🧪 3상태 — 해당 없음(카드 표시 보강)
- [ ] 브라우저 전용 API 미사용

---

## 🔗 연관 이슈

Closes #235

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
| "휴직 최종 승인 대기" | "사원 휴직 최종 승인 대기" + PDF 버튼(오프보딩) |

---

## 💬 리뷰 포인트

**알려진 한계**

PDF 다운로드는 실제 파일을 안 줍니다 — BE 생성 API 경로 확정 후 연결 필요합니다.

---

## 📝 추가 메모

확인법 —

- `/manage/members/3`(이하윤, 휴직) — 제목이 "사원 휴직 최종 승인 대기"로 뜨는지, PDF 버튼이 없는지 확인
- `/manage/members/8`(임지안, 오프보딩) — 제목이 "사원 오프보딩 최종 승인 대기"로 뜨는지, "인수인계서 PDF 다운로드" 버튼이 뜨는지, 클릭 시 "PDF 생성은 아직 연동되지 않았습니다" 토스트가 뜨는지 확인

`npx tsc --noEmit` / lint 통과 확인됨(커밋·푸시 훅에서 자동 실행).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 인수인계 승인 카드에서 신청자를 팀장 또는 사원으로 구분해 표시합니다.
  * 오프보딩 인수인계 건에 PDF 다운로드 버튼을 추가했습니다.
* **개선 사항**
  * PDF 다운로드 기능이 준비 중인 경우 안내 토스트를 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
