### PR TITLE
[FEAT] 팀장급 인수인계서 관리 화면 구현 #237

### DIFF
--- a/src/app/(shell)/(authority)/owner/leader-handovers/[handoverId]/error.tsx
+++ b/src/app/(shell)/(authority)/owner/leader-handovers/[handoverId]/error.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { ScreenError } from "@/components/common/screen-error";
+
+export default function Error({ reset }: { reset: () => void }) {
+  return <ScreenError title="인수인계서를 불러오지 못했습니다" reset={reset} isInsideShell />;
+}

--- a/src/app/(shell)/(authority)/owner/leader-handovers/[handoverId]/loading.tsx
+++ b/src/app/(shell)/(authority)/owner/leader-handovers/[handoverId]/loading.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
+      <div className="mx-auto flex w-full max-w-[960px] flex-col gap-5">
+        <Skeleton className="h-10 w-72 rounded-lg" />
+        <Skeleton className="h-24 w-full rounded-2xl" />
+        <Skeleton className="h-48 w-full rounded-2xl" />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/(authority)/owner/leader-handovers/[handoverId]/page.tsx
+++ b/src/app/(shell)/(authority)/owner/leader-handovers/[handoverId]/page.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { LeaderHandoverActionList } from "@/features/leader-handover/components/leader-handover-action-list";
+import { LeaderHandoverAssignForm } from "@/features/leader-handover/components/leader-handover-assign-form";
+import { getLeaderHandoverDetail } from "@/features/leader-handover/server";
+import { getViewer } from "@/features/shell/viewer";
+import { canManageLeaderHandovers } from "@/lib/permission";
+
+export const metadata: Metadata = {
+  title: "인수인계서 상세",
+};
+
+interface LeaderHandoverDetailPageProps {
+  params: Promise<{ handoverId: string }>;
+}
+
+export default async function LeaderHandoverDetailPage({ params }: LeaderHandoverDetailPageProps) {
+  const viewer = await getViewer();
+  if (!canManageLeaderHandovers(viewer)) notFound();
+
+  const { handoverId } = await params;
+  const handover = await getLeaderHandoverDetail(handoverId);
+  if (!handover) notFound();
+
+  return (
+    <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
+      <div className="mx-auto flex w-full max-w-[960px] flex-col gap-5">
+        <div>
+          <h2 className="text-[22px] leading-[30px] font-semibold tracking-[-0.4px]">
+            {handover.title}
+          </h2>
+          <p className="text-muted-foreground mt-1 text-[13px] leading-5">
+            {handover.formerLeaderName} · {handover.teamName}
+          </p>
+        </div>
+
+        <LeaderHandoverAssignForm handover={handover} />
+        <LeaderHandoverActionList actions={handover.actions} />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/(authority)/owner/leader-handovers/error.tsx
+++ b/src/app/(shell)/(authority)/owner/leader-handovers/error.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { ScreenError } from "@/components/common/screen-error";
+
+export default function Error({ reset }: { reset: () => void }) {
+  return <ScreenError title="인수인계서 목록을 불러오지 못했습니다" reset={reset} isInsideShell />;
+}

--- a/src/app/(shell)/(authority)/owner/leader-handovers/layout.tsx
+++ b/src/app/(shell)/(authority)/owner/leader-handovers/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+
+import { LeaderHandoversPageHeader } from "@/features/leader-handover/components/leader-handovers-page-header";
+
+/** 상세도 이 레이아웃 아래다 — 헤더가 한 번만 마운트돼야 뒤로가기 화살표가 안 덜컥거린다. */
+export default function LeaderHandoversLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <LeaderHandoversPageHeader />
+      {children}
+    </>
+  );
+}

--- a/src/app/(shell)/(authority)/owner/leader-handovers/loading.tsx
+++ b/src/app/(shell)/(authority)/owner/leader-handovers/loading.tsx
@@ -1,0 +1,12 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
+      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-5">
+        <Skeleton className="h-8 w-64 rounded-lg" />
+        <Skeleton className="h-40 w-full rounded-2xl" />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/(authority)/owner/leader-handovers/page.tsx
+++ b/src/app/(shell)/(authority)/owner/leader-handovers/page.tsx
@@ -1,0 +1,120 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import {
+  LEADER_HANDOVER_CUSTODY_STATUS,
+  LEADER_HANDOVER_CUSTODY_STATUS_LABEL,
+} from "@/constants/domain";
+import {
+  LEADER_HANDOVER_FILTER_TABS,
+  parseCustodyFilter,
+  toCustodyStatus,
+} from "@/features/leader-handover/lib";
+import { listLeaderHandovers } from "@/features/leader-handover/server";
+import { getViewer } from "@/features/shell/viewer";
+import { formatMonthDayWeekday } from "@/lib/date";
+import { canManageLeaderHandovers } from "@/lib/permission";
+import { cn } from "@/lib/utils";
+
+export const metadata: Metadata = {
+  title: "팀장급 인수인계서 관리",
+};
+
+interface LeaderHandoversPageProps {
+  searchParams: Promise<{ status?: string }>;
+}
+
+/**
+ * 팀장급 인수인계서 관리 — 오프보딩 최종 승인이 끝난 뒤 담당자 없이 남는 개인 액션
+ * 뭉치를 새 팀장에게 넘길 때까지 모아 보여준다(WORKFLOW.md §7).
+ * ⚠️ **오프보딩만** 올라온다 — 팀장 휴직은 본인이 재할당을 마치고 올라가 여기 없다.
+ * ⚠️ 사원 관리 최종 승인과의 실제 연동은 범위 밖이다(고정 mock, 2026-08-08 사용자 확인).
+ */
+export default async function LeaderHandoversPage({ searchParams }: LeaderHandoversPageProps) {
+  const viewer = await getViewer();
+  if (!canManageLeaderHandovers(viewer)) notFound();
+
+  const params = await searchParams;
+  const activeFilter = parseCustodyFilter(params.status);
+  const items = await listLeaderHandovers(toCustodyStatus(activeFilter));
+
+  return (
+    <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
+      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-5">
+        <nav aria-label="귀속 상태 필터" className="flex items-center gap-1">
+          {LEADER_HANDOVER_FILTER_TABS.map((tab) => (
+            <Link
+              key={tab.value}
+              href={
+                tab.value === "all"
+                  ? "/owner/leader-handovers"
+                  : `/owner/leader-handovers?status=${tab.value}`
+              }
+              aria-pressed={activeFilter === tab.value}
+              className={cn(
+                "rounded-lg px-2.5 py-1.5 text-[13px] leading-5 transition-colors",
+                activeFilter === tab.value
+                  ? "bg-foreground text-background font-medium"
+                  : "text-muted-foreground hover:bg-muted",
+              )}
+            >
+              {tab.label}
+            </Link>
+          ))}
+        </nav>
+
+        <div className="border-border bg-card overflow-hidden rounded-2xl border">
+          <div className="border-border text-muted-foreground flex items-center gap-4 border-b px-6 py-3 text-[12px] leading-4">
+            <span className="min-w-0 flex-1">인수인계서명</span>
+            <span className="w-28 shrink-0">퇴사 팀장</span>
+            <span className="w-28 shrink-0">팀</span>
+            <span className="w-32 shrink-0">오프보딩 승인일</span>
+            <span className="w-20 shrink-0 text-right">상태</span>
+          </div>
+
+          {items.length === 0 ? (
+            <p className="text-muted-foreground px-6 py-10 text-center text-[13px] leading-5">
+              해당하는 인수인계서가 없습니다.
+            </p>
+          ) : (
+            <ul>
+              {items.map((item) => {
+                const isAssigned = item.custodyStatus === LEADER_HANDOVER_CUSTODY_STATUS.ASSIGNED;
+                return (
+                  <li key={item.id} className="border-border border-b last:border-b-0">
+                    <Link
+                      href={`/owner/leader-handovers/${item.id}`}
+                      className="hover:bg-muted/50 flex items-center gap-4 px-6 py-3.5 text-[13px] leading-5 transition-colors"
+                    >
+                      <span className="min-w-0 flex-1 truncate font-medium">{item.title}</span>
+                      <span className="text-muted-foreground w-28 shrink-0 truncate">
+                        {item.formerLeaderName}
+                      </span>
+                      <span className="text-muted-foreground w-28 shrink-0 truncate">
+                        {item.teamName}
+                      </span>
+                      <span className="text-muted-foreground w-32 shrink-0 tabular-nums">
+                        {formatMonthDayWeekday(item.offboardingApprovedAt)}
+                      </span>
+                      <span
+                        className={cn(
+                          "w-20 shrink-0 rounded border px-2 py-0.5 text-center text-[11px] leading-4",
+                          isAssigned
+                            ? "border-border/50 text-muted-foreground/60"
+                            : "border-foreground/35 bg-foreground/[0.06] text-foreground font-medium",
+                        )}
+                      >
+                        {LEADER_HANDOVER_CUSTODY_STATUS_LABEL[item.custodyStatus]}
+                      </span>
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/(authority)/owner/leader-handovers/page.tsx
+++ b/src/app/(shell)/(authority)/owner/leader-handovers/page.tsx
@@ -51,7 +51,7 @@ export default async function LeaderHandoversPage({ searchParams }: LeaderHandov
                   ? "/owner/leader-handovers"
                   : `/owner/leader-handovers?status=${tab.value}`
               }
-              aria-pressed={activeFilter === tab.value}
+              aria-current={activeFilter === tab.value ? "page" : undefined}
               className={cn(
                 "rounded-lg px-2.5 py-1.5 text-[13px] leading-5 transition-colors",
                 activeFilter === tab.value

--- a/src/constants/handover.ts
+++ b/src/constants/handover.ts
@@ -42,3 +42,21 @@ export const HANDOVER_TYPE_LABEL: Record<HandoverType, string> = {
   */
   OFFBOARDING: "오프보딩",
 };
+
+/**
+ * "팀장급 인수인계서 관리"(`/owner/leader-handovers`)의 상태 — **오프보딩 최종 승인
+ * 뒤에만** 생긴다(WORKFLOW.md §7). `HANDOVER_STATUS`와 다른 축이다: 저건 신청→승인
+ * 흐름이고, 이건 승인이 끝난 뒤 "담당자 없는 액션 뭉치를 누구에게 넘길지"의 흐름이다.
+ * ⚠️ 팀장 **휴직**은 여기 안 온다 — 휴직은 본인이 재할당을 마치고 올라간다(§7).
+ */
+export const LEADER_HANDOVER_CUSTODY_STATUS = {
+  PENDING: "PENDING",
+  ASSIGNED: "ASSIGNED",
+} as const;
+export type LeaderHandoverCustodyStatus =
+  (typeof LEADER_HANDOVER_CUSTODY_STATUS)[keyof typeof LEADER_HANDOVER_CUSTODY_STATUS];
+
+export const LEADER_HANDOVER_CUSTODY_STATUS_LABEL: Record<LeaderHandoverCustodyStatus, string> = {
+  PENDING: "귀속 대기",
+  ASSIGNED: "귀속 완료",
+};

--- a/src/features/leader-handover/actions.ts
+++ b/src/features/leader-handover/actions.ts
@@ -1,0 +1,37 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { isMock } from "@/mocks/config";
+
+import { findMockLeaderHandover, markMockLeaderHandoverAssigned } from "./mock/leader-handovers";
+
+/**
+ * [OOO에게 귀속] — 이 인수인계서에 담긴 액션 전체의 담당자를 새 팀장에게 일괄 이전한다
+ * (WORKFLOW.md §7).
+ * ⚠️ 실제 액션 도메인(보드·내 액션 등)에 담당자를 반영하는 매퍼는 ERD 확정 후 연결한다
+ *    (CLAUDE.md §Mock 격리막) — 지금은 이 화면의 귀속 상태 전환만 담당한다.
+ * ⚠️ 사원 관리 승인 흐름과의 실제 연동(승인 시 이 목록에 새로 생기는 것)은 범위 밖이다
+ *    (별도 이슈, 2026-08-08 사용자 확인).
+ */
+export async function assignLeaderHandoverAction(
+  handoverId: string,
+  newLeaderId: string,
+): Promise<{ isSuccess: boolean }> {
+  if (!isMock) {
+    throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
+  }
+
+  const handover = findMockLeaderHandover(handoverId);
+  if (!handover) return { isSuccess: false };
+  if (!handover.candidates.some((candidate) => candidate.id === newLeaderId)) {
+    return { isSuccess: false };
+  }
+
+  markMockLeaderHandoverAssigned(handoverId);
+
+  revalidatePath("/owner/leader-handovers");
+  revalidatePath(`/owner/leader-handovers/${handoverId}`);
+
+  return { isSuccess: true };
+}

--- a/src/features/leader-handover/actions.ts
+++ b/src/features/leader-handover/actions.ts
@@ -2,6 +2,9 @@
 
 import { revalidatePath } from "next/cache";
 
+import { LEADER_HANDOVER_CUSTODY_STATUS } from "@/constants/domain";
+import { getViewer } from "@/features/shell/viewer";
+import { canManageLeaderHandovers } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
 import { findMockLeaderHandover, markMockLeaderHandoverAssigned } from "./mock/leader-handovers";
@@ -13,17 +16,26 @@ import { findMockLeaderHandover, markMockLeaderHandoverAssigned } from "./mock/l
  *    (CLAUDE.md §Mock 격리막) — 지금은 이 화면의 귀속 상태 전환만 담당한다.
  * ⚠️ 사원 관리 승인 흐름과의 실제 연동(승인 시 이 목록에 새로 생기는 것)은 범위 밖이다
  *    (별도 이슈, 2026-08-08 사용자 확인).
+ * ⚠️ **화면 권한 체크는 페이지가 하지만 이 Action은 따로 재검사한다**(§권한: 화면 숨김은
+ *    보안이 아니다) — 주소만 알면 페이지를 거치지 않고 이 Action을 직접 부를 수 있다.
+ *    이미 귀속 완료(`ASSIGNED`)된 건도 다시 못 돌린다 — 일괄 이전은 한 번뿐이다.
  */
 export async function assignLeaderHandoverAction(
   handoverId: string,
   newLeaderId: string,
 ): Promise<{ isSuccess: boolean }> {
+  const viewer = await getViewer();
+  if (!canManageLeaderHandovers(viewer)) return { isSuccess: false };
+
   if (!isMock) {
     throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
   }
 
   const handover = findMockLeaderHandover(handoverId);
   if (!handover) return { isSuccess: false };
+  if (handover.custodyStatus !== LEADER_HANDOVER_CUSTODY_STATUS.PENDING) {
+    return { isSuccess: false };
+  }
   if (!handover.candidates.some((candidate) => candidate.id === newLeaderId)) {
     return { isSuccess: false };
   }

--- a/src/features/leader-handover/components/leader-handover-action-list.tsx
+++ b/src/features/leader-handover/components/leader-handover-action-list.tsx
@@ -1,0 +1,71 @@
+import { ACTION_DELAYED_LABEL, ACTION_STATUS_LABEL, isDelayed } from "@/constants/domain";
+import { formatMonthDayWeekday } from "@/lib/date";
+import { pickPaletteColor } from "@/lib/palette";
+import { cn } from "@/lib/utils";
+
+import type { LeaderHandoverAction } from "../types";
+
+/** 담긴 액션 전체 — 읽기만 한다(WORKFLOW.md §7). 담당자 변경은 [귀속]이 한 번에 한다. */
+export function LeaderHandoverActionList({ actions }: { actions: LeaderHandoverAction[] }) {
+  return (
+    <section className="border-border bg-card overflow-hidden rounded-2xl border">
+      <div className="flex items-baseline justify-between gap-3 px-7 pt-6 pb-3">
+        <h2 className="flex items-center gap-2 text-[15px] leading-6 font-semibold tracking-[-0.2px]">
+          <span className="bg-foreground size-2 rounded-full" aria-hidden />
+          담긴 액션
+        </h2>
+        <p className="text-muted-foreground text-[12px] leading-4 tabular-nums">
+          {actions.length}건
+        </p>
+      </div>
+
+      {actions.length === 0 ? (
+        <p className="text-muted-foreground border-border border-t px-7 py-8 text-center text-[13px] leading-5">
+          담긴 액션이 없습니다.
+        </p>
+      ) : (
+        <ul className="border-border border-t">
+          {actions.map((action) => {
+            const tagColor = pickPaletteColor(action.projectTag);
+            const delayed = isDelayed(action);
+            return (
+              <li
+                key={action.id}
+                className="border-border flex items-center gap-3 border-b px-7 py-3 last:border-b-0"
+              >
+                <span
+                  className="w-fit shrink-0 rounded px-1.5 py-0.5 font-mono text-[10px] font-semibold"
+                  style={{ backgroundColor: tagColor.bgColor, color: tagColor.textColor }}
+                >
+                  {action.projectTag}
+                </span>
+                <span className="text-muted-foreground hidden w-[140px] shrink-0 truncate text-[12px] leading-4 sm:inline">
+                  {action.parentTeamActionName}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-[13px] leading-5">
+                  {action.title}
+                </span>
+                <span
+                  className={cn(
+                    "w-[52px] shrink-0 rounded border px-1.5 py-0.5 text-center text-[11px] leading-4",
+                    delayed
+                      ? "border-destructive/40 text-destructive"
+                      : "border-border text-muted-foreground",
+                  )}
+                >
+                  {delayed ? ACTION_DELAYED_LABEL : ACTION_STATUS_LABEL[action.status]}
+                </span>
+                <time
+                  dateTime={action.dueDate}
+                  className="text-muted-foreground w-20 shrink-0 text-right text-[12px] leading-4 whitespace-nowrap tabular-nums"
+                >
+                  {formatMonthDayWeekday(action.dueDate)}
+                </time>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/features/leader-handover/components/leader-handover-assign-form.tsx
+++ b/src/features/leader-handover/components/leader-handover-assign-form.tsx
@@ -41,13 +41,22 @@ export function LeaderHandoverAssignForm({ handover }: LeaderHandoverAssignFormP
   function handleConfirm() {
     setError(null);
     startTransition(async () => {
-      const result = await assignLeaderHandoverAction(handover.id, selectedId);
-      if (!result.isSuccess) {
+      /*
+        ⚠️ **던질 수 있는 호출이다.** `isMock`이 꺼지면 Action이 예외를 던지는데, 여기서
+           안 잡으면 이 창이 아니라 페이지 전체 error.tsx로 넘어가 확인 창이 통째로
+           사라진다(§토스트: 페이지 전체 실패는 error.tsx, 이건 그 자리가 아니다).
+      */
+      try {
+        const result = await assignLeaderHandoverAction(handover.id, selectedId);
+        if (!result.isSuccess) {
+          setError("귀속 처리에 실패했습니다. 잠시 후 다시 시도해 주세요.");
+          return;
+        }
+        setConfirmOpen(false);
+        toast.success(`${selectedCandidate?.name} 님에게 귀속했습니다`);
+      } catch {
         setError("귀속 처리에 실패했습니다. 잠시 후 다시 시도해 주세요.");
-        return;
       }
-      setConfirmOpen(false);
-      toast.success(`${selectedCandidate?.name} 님에게 귀속했습니다`);
     });
   }
 

--- a/src/features/leader-handover/components/leader-handover-assign-form.tsx
+++ b/src/features/leader-handover/components/leader-handover-assign-form.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { Download } from "lucide-react";
+import Link from "next/link";
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+
+import { ConfirmDialog } from "@/components/common/confirm-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { LEADER_HANDOVER_CUSTODY_STATUS } from "@/constants/domain";
+
+import { assignLeaderHandoverAction } from "../actions";
+import type { LeaderHandoverDetail } from "../types";
+
+interface LeaderHandoverAssignFormProps {
+  handover: LeaderHandoverDetail;
+}
+
+/**
+ * 수신자(신규 팀장) 선택 + [OOO에게 귀속](WORKFLOW.md §7).
+ * ⚠️ 이미 귀속 완료된 건은 다시 못 바꾼다 — 일괄 이전은 한 번뿐이다.
+ * ⚠️ 실제 PDF 생성 API는 아직 BE와 경로가 확정 전이다(§연동 검증) — 버튼만 두고
+ *    눌렀을 때 "연동 전"임을 그대로 알린다(§정직성).
+ */
+export function LeaderHandoverAssignForm({ handover }: LeaderHandoverAssignFormProps) {
+  const isAssigned = handover.custodyStatus === LEADER_HANDOVER_CUSTODY_STATUS.ASSIGNED;
+  const [selectedId, setSelectedId] = useState("");
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const selectedCandidate = handover.candidates.find((candidate) => candidate.id === selectedId);
+
+  function handleConfirm() {
+    setError(null);
+    startTransition(async () => {
+      const result = await assignLeaderHandoverAction(handover.id, selectedId);
+      if (!result.isSuccess) {
+        setError("귀속 처리에 실패했습니다. 잠시 후 다시 시도해 주세요.");
+        return;
+      }
+      setConfirmOpen(false);
+      toast.success(`${selectedCandidate?.name} 님에게 귀속했습니다`);
+    });
+  }
+
+  return (
+    <section className="border-border bg-card flex flex-col gap-4 rounded-2xl border p-7">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="flex items-center gap-2 text-[15px] leading-6 font-semibold tracking-[-0.2px]">
+          <span className="bg-foreground size-2 rounded-full" aria-hidden />새 팀장에게 귀속
+        </h2>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          onClick={() => toast("PDF 생성은 아직 연동되지 않았습니다")}
+        >
+          <Download />
+          인수인계서 PDF 다운로드
+        </Button>
+      </div>
+
+      {isAssigned ? (
+        <p className="text-muted-foreground text-[13px] leading-5">
+          이미 귀속이 완료된 인수인계서입니다.
+        </p>
+      ) : handover.candidates.length === 0 ? (
+        /*
+          ⚠️ **타 부서 팀장은 후보에 안 넣는다**(팀 정정, 2026-08-08) — 그 팀에 새 팀장이
+             생기기 전까지는 넘길 곳이 없다는 뜻이라, 빈 셀렉트 대신 다음 할 일을 알려준다.
+        */
+        <p className="text-muted-foreground text-[13px] leading-5 break-keep">
+          {handover.teamName}에 아직 새 팀장이 지정되지 않았습니다. 먼저{" "}
+          <Link href="/manage/members" className="text-foreground underline underline-offset-2">
+            사원 관리
+          </Link>
+          에서 그 팀 소속 사원을 팀장으로 승급해 주세요.
+        </p>
+      ) : (
+        <div className="flex items-center gap-3">
+          <Select value={selectedId} onValueChange={(value) => setSelectedId(value ?? "")}>
+            <SelectTrigger aria-label="수신자 선택" className="w-56">
+              {/* 원본 값(id)이 아니라 이름·팀 라벨을 보여준다(다른 화면의 담당자 선택과 같은 패턴) */}
+              <SelectValue placeholder="수신자(신규 팀장) 선택">
+                {(value) => {
+                  const candidate = handover.candidates.find((c) => c.id === value);
+                  return candidate ? `${candidate.name} · ${candidate.teamName}` : value;
+                }}
+              </SelectValue>
+            </SelectTrigger>
+            <SelectContent side="bottom" alignItemWithTrigger={false}>
+              {handover.candidates.map((candidate) => (
+                <SelectItem key={candidate.id} value={candidate.id}>
+                  {candidate.name} · {candidate.teamName}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button
+            type="button"
+            disabled={!selectedId}
+            className="bg-foreground text-background hover:bg-foreground/90"
+            onClick={() => setConfirmOpen(true)}
+          >
+            {selectedCandidate ? `${selectedCandidate.name}에게 귀속` : "귀속"}
+          </Button>
+        </div>
+      )}
+
+      <ConfirmDialog
+        isOpen={confirmOpen}
+        onOpenChange={(open) => {
+          setConfirmOpen(open);
+          if (!open) setError(null);
+        }}
+        title={`${selectedCandidate?.name} 님에게 귀속할까요?`}
+        description={`담긴 액션 ${handover.actionCount}건 전체의 담당자가 ${selectedCandidate?.name} 님으로 한 번에 바뀝니다. 되돌릴 수 없습니다.`}
+        confirmLabel="귀속"
+        isPending={isPending}
+        pendingLabel="귀속 중"
+        error={error}
+        onConfirm={handleConfirm}
+      />
+    </section>
+  );
+}

--- a/src/features/leader-handover/components/leader-handovers-page-header.tsx
+++ b/src/features/leader-handover/components/leader-handovers-page-header.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { ClipboardCheck } from "lucide-react";
+import { usePathname } from "next/navigation";
+
+import { PageHeader } from "@/features/shell/components/page-header";
+
+/** 목록 경로 — 이 경로면 뒤로가기 없음, 더 깊으면(상세) 뒤로가기를 붙인다. */
+const LIST_PATH = "/owner/leader-handovers";
+
+/**
+ * "팀장급 인수인계서 관리" 목록·상세가 함께 쓰는 상단바.
+ * ⚠️ **목록·상세를 각자 레이아웃으로 나누지 않는다** — 나누면 라우트를 옮길 때마다
+ *    상단바가 통째로 다시 마운트돼 헤더가 두 번 겹쳐 뜬다(`members-page-header.tsx`와
+ *    같은 이유로 정정, 2026-08-08). 여기 한 곳에서만 그리고 경로만 보고 토글한다.
+ */
+export function LeaderHandoversPageHeader() {
+  const pathname = usePathname();
+  const isDetail = pathname !== LIST_PATH;
+
+  return (
+    <PageHeader
+      title="팀장급 인수인계서 관리"
+      icon={ClipboardCheck}
+      backTo={isDetail ? { href: LIST_PATH, label: "팀장급 인수인계서 관리" } : undefined}
+    />
+  );
+}

--- a/src/features/leader-handover/lib.ts
+++ b/src/features/leader-handover/lib.ts
@@ -1,0 +1,30 @@
+import {
+  LEADER_HANDOVER_CUSTODY_STATUS,
+  LEADER_HANDOVER_CUSTODY_STATUS_LABEL,
+  type LeaderHandoverCustodyStatus,
+} from "@/constants/domain";
+
+export const CUSTODY_FILTER_ALL = "all";
+
+export const LEADER_HANDOVER_FILTER_TABS: { value: string; label: string }[] = [
+  { value: CUSTODY_FILTER_ALL, label: "전체" },
+  {
+    value: LEADER_HANDOVER_CUSTODY_STATUS.PENDING,
+    label: LEADER_HANDOVER_CUSTODY_STATUS_LABEL.PENDING,
+  },
+  {
+    value: LEADER_HANDOVER_CUSTODY_STATUS.ASSIGNED,
+    label: LEADER_HANDOVER_CUSTODY_STATUS_LABEL.ASSIGNED,
+  },
+];
+
+/** URL의 `?status=` 값을 안전하게 필터로 — 모르는 값이면 기본(전체). */
+export function parseCustodyFilter(value: string | undefined): string {
+  return LEADER_HANDOVER_FILTER_TABS.some((tab) => tab.value === value)
+    ? (value as string)
+    : CUSTODY_FILTER_ALL;
+}
+
+export function toCustodyStatus(filter: string): LeaderHandoverCustodyStatus | null {
+  return filter === CUSTODY_FILTER_ALL ? null : (filter as LeaderHandoverCustodyStatus);
+}

--- a/src/features/leader-handover/mock/leader-handovers.ts
+++ b/src/features/leader-handover/mock/leader-handovers.ts
@@ -1,0 +1,93 @@
+import { ACTION_STATUS, LEADER_HANDOVER_CUSTODY_STATUS } from "@/constants/domain";
+import {
+  TEAM_ACTION_DETAIL_MOCK,
+  TEAM_ACTION_PERSONAL_ITEMS_MOCK,
+} from "@/features/project/mock/team-action-detail";
+
+import type { LeaderCandidate, LeaderHandoverAction, LeaderHandoverDetail } from "../types";
+
+/**
+ * ⚠️ 목 데이터 — BE 연동 전. 사원 관리(`/manage/members`)의 오프보딩 최종 승인과는
+ * 아직 연동하지 않는다(별도 이슈, 사용자 확인 2026-08-08) — 이 화면만 확인할 수 있게
+ * 고정 항목 하나를 둔다.
+ * ⚠️ 액션은 새로 만들지 않는다 — `TEAM_ACTION_PERSONAL_ITEMS_MOCK`(project 피처)에서
+ * 김서준 담당 항목을 그대로 걸러 쓴다(다른 화면과 같은 정본).
+ */
+function buildFormerLeaderActions(memberName: string): LeaderHandoverAction[] {
+  const actions: LeaderHandoverAction[] = [];
+  for (const [teamActionId, items] of Object.entries(TEAM_ACTION_PERSONAL_ITEMS_MOCK)) {
+    const parent = TEAM_ACTION_DETAIL_MOCK[Number(teamActionId)];
+    if (!parent) continue;
+    for (const item of items) {
+      if (item.assigneeName !== memberName) continue;
+      if (item.status === ACTION_STATUS.DONE) continue;
+      actions.push({
+        id: item.id,
+        projectTag: parent.projectTag,
+        parentTeamActionName: parent.name,
+        title: item.title,
+        status: item.status,
+        dueDate: item.dueDate,
+      });
+    }
+  }
+  return actions;
+}
+
+/**
+ * ⚠️ **같은 팀에 새로 지정된 팀장만** 후보다(2026-08-08 팀 정정) — 타 부서 팀장에게
+ *    넘기지 않는다. 사원 관리(`/manage/members`)에서 먼저 그 팀 소속 사원을 팀장으로
+ *    승급해야 여기 후보로 뜬다. 지금 데모는 개발팀이 아직 공석이라 후보가 없다 —
+ *    실제로 누군가 승급되면 그 사람만 담는다(빈 배열을 채우지 않는다, §정직성).
+ */
+const CANDIDATES: Record<string, LeaderCandidate[]> = {
+  개발팀: [],
+};
+
+interface LeaderHandoverStore {
+  items: Record<string, LeaderHandoverDetail>;
+}
+
+const globalStore = globalThis as typeof globalThis & {
+  __leaderHandoverStore?: LeaderHandoverStore;
+};
+
+function seedStore(): LeaderHandoverStore {
+  const actions = buildFormerLeaderActions("김서준");
+  return {
+    items: {
+      "leader-handover-1": {
+        id: "leader-handover-1",
+        title: "김서준 개발팀장 오프보딩 인수인계서",
+        formerLeaderName: "김서준",
+        teamName: "개발팀",
+        offboardingApprovedAt: "2026-08-12",
+        actionCount: actions.length,
+        custodyStatus: LEADER_HANDOVER_CUSTODY_STATUS.PENDING,
+        actions,
+        candidates: CANDIDATES["개발팀"] ?? [],
+      },
+    },
+  };
+}
+
+function getStore(): LeaderHandoverStore {
+  if (!globalStore.__leaderHandoverStore) {
+    globalStore.__leaderHandoverStore = seedStore();
+  }
+  return globalStore.__leaderHandoverStore;
+}
+
+export function listMockLeaderHandovers(): LeaderHandoverDetail[] {
+  return Object.values(getStore().items);
+}
+
+export function findMockLeaderHandover(id: string): LeaderHandoverDetail | null {
+  return getStore().items[id] ?? null;
+}
+
+/** [OOO에게 귀속] — mock에선 상태만 바꾼다. */
+export function markMockLeaderHandoverAssigned(id: string): void {
+  const item = getStore().items[id];
+  if (item) item.custodyStatus = LEADER_HANDOVER_CUSTODY_STATUS.ASSIGNED;
+}

--- a/src/features/leader-handover/server.ts
+++ b/src/features/leader-handover/server.ts
@@ -1,0 +1,24 @@
+import type { LeaderHandoverCustodyStatus } from "@/constants/domain";
+
+import { findMockLeaderHandover, listMockLeaderHandovers } from "./mock/leader-handovers";
+import type { LeaderHandoverDetail, LeaderHandoverListItem } from "./types";
+
+export async function listLeaderHandovers(
+  filter: LeaderHandoverCustodyStatus | null,
+): Promise<LeaderHandoverListItem[]> {
+  const items = listMockLeaderHandovers();
+  const filtered = filter ? items.filter((item) => item.custodyStatus === filter) : items;
+  return filtered.map((item) => ({
+    id: item.id,
+    title: item.title,
+    formerLeaderName: item.formerLeaderName,
+    teamName: item.teamName,
+    offboardingApprovedAt: item.offboardingApprovedAt,
+    actionCount: item.actionCount,
+    custodyStatus: item.custodyStatus,
+  }));
+}
+
+export async function getLeaderHandoverDetail(id: string): Promise<LeaderHandoverDetail | null> {
+  return findMockLeaderHandover(id);
+}

--- a/src/features/leader-handover/types.ts
+++ b/src/features/leader-handover/types.ts
@@ -1,0 +1,43 @@
+import type { ActionStatus, LeaderHandoverCustodyStatus } from "@/constants/domain";
+
+/**
+ * "팀장급 인수인계서 관리"(`/owner/leader-handovers`)의 **UI 계약**(CLAUDE.md §Mock 격리막).
+ * WORKFLOW.md §7 — 팀장 오프보딩이 최종 승인된 뒤 담당자 없이 남는 개인 액션 뭉치를
+ * 새 팀장이 정해질 때까지 붙들고 있다가 일괄 이전한다.
+ */
+
+export interface LeaderHandoverAction {
+  id: number;
+  projectTag: string;
+  parentTeamActionName: string;
+  title: string;
+  status: ActionStatus;
+  dueDate: string;
+}
+
+/** 목록 한 줄. */
+export interface LeaderHandoverListItem {
+  id: string;
+  title: string;
+  formerLeaderName: string;
+  teamName: string;
+  /** 오프보딩 최종 승인일 `YYYY-MM-DD`. */
+  offboardingApprovedAt: string;
+  actionCount: number;
+  custodyStatus: LeaderHandoverCustodyStatus;
+}
+
+/**
+ * 귀속 대상 후보 — **같은 팀에 새로 지정된 팀장만**(2026-08-08 팀 정정). 타 부서
+ * 팀장에게는 넘기지 않는다 — 그 팀에 새 팀장이 생기기 전까지 후보는 비어 있다.
+ */
+export interface LeaderCandidate {
+  id: string;
+  name: string;
+  teamName: string;
+}
+
+export interface LeaderHandoverDetail extends LeaderHandoverListItem {
+  actions: LeaderHandoverAction[];
+  candidates: LeaderCandidate[];
+}

--- a/src/features/member/manage-actions.ts
+++ b/src/features/member/manage-actions.ts
@@ -179,6 +179,10 @@ export async function changeMemberGradeAction(
  * ⚠️ 올릴 때는 **그 팀에 이미 리더가 있나**, 내릴 때는 **그 팀의 마지막 리더인가**를 본다.
  *    한쪽만 막으면 리더가 둘이 되거나 아예 없어진다.
  * ⚠️ 팀이 없는 사람(Owner)은 해당 없다 — 여기 오기 전에 이미 걸러진다.
+ * ⚠️ **퇴사자는 리더 수에서 뺀다**(2026-08-08 정정) — 팀장이 오프보딩 최종 승인되면
+ *    그 팀은 실제로 공석이어야 한다(WORKFLOW §7 "리더 공석 중에도... 막히지 않음").
+ *    `approveMockHandover`가 그 사람의 `authority`도 같이 내리지만, 혹시 놓치는 경로가
+ *    생겨도 여기서 한 번 더 걸러야 유령 팀장 때문에 승급이 영영 막히지 않는다.
  */
 async function findTeamLeaderClash(
   target: ManagedMember,
@@ -194,7 +198,10 @@ async function findTeamLeaderClash(
   const members = await listManagedMembers();
   const leaders = members.filter(
     (member) =>
-      member.teamName === team && member.authority === AUTHORITY.LEADER && member.id !== target.id,
+      member.teamName === team &&
+      member.authority === AUTHORITY.LEADER &&
+      member.status !== MEMBER_STATUS.RESIGNED &&
+      member.id !== target.id,
   );
 
   const existing = leaders[0];

--- a/src/features/member/mock/managed.ts
+++ b/src/features/member/mock/managed.ts
@@ -290,16 +290,23 @@ export function updateMockMemberGrade(
  * 최종 승인 — 신청을 치우고 사람 상태를 옮긴다.
  * ⚠️ 휴직은 `VACATION`, 오프보딩은 `RESIGNED`다. 끝난 뒤의 사람 상태는 흐름 이름과 다르다
  *    (§도메인 상수: 오프보딩 ↔ 퇴사).
+ * ⚠️ **팀장이 오프보딩되면 `authority`도 같이 내린다**(2026-08-08 정정) — 안 내리면
+ *    이 사람은 퇴사했는데도 시스템엔 여전히 그 팀 LEADER로 남아, 후임을 승급하려 하면
+ *    "이미 팀장이 있다"로 막히고 본인을 내리려 해도 "유일한 팀장"이라 막혀 순환 잠금에
+ *    빠진다(WORKFLOW §7 "리더 공석"은 실제로 비어 있어야 다음 사람을 앉힐 수 있다).
+ *    휴직은 복귀를 전제로 하므로 권한을 안 건드린다 — 휴직 중에도 팀장 자리는 그대로다.
  */
 export function approveMockHandover(id: number): void {
   store = store.map((entry) => {
     if (entry.member.id !== id || !entry.pendingHandover) return entry;
     const isVacation = entry.pendingHandover.type === HANDOVER_TYPE.VACATION;
+    const wasLeader = entry.member.authority === AUTHORITY.LEADER;
     return {
       ...entry,
       member: {
         ...entry.member,
         status: isVacation ? MEMBER_STATUS.VACATION : MEMBER_STATUS.RESIGNED,
+        authority: !isVacation && wasLeader ? AUTHORITY.MEMBER : entry.member.authority,
       },
       pendingHandover: null,
     };

--- a/src/lib/permission.ts
+++ b/src/lib/permission.ts
@@ -85,6 +85,15 @@ export function canManageCompany(actor: Actor): boolean {
 }
 
 /**
+ * 팀장급 인수인계서 관리(`/owner/leader-handovers`) — **OWNER 전용, Admin도 불가**
+ * (CLAUDE.md §라우트 그룹). 다른 팀장급의 오프보딩을 처리하는 일이라 위계상 Admin
+ * 겸직으로는 성립하지 않는다 — `canManageBilling`처럼 Admin을 끼워 주지 않는다.
+ */
+export function canManageLeaderHandovers(actor: Actor): boolean {
+  return actor.role === AUTHORITY.OWNER;
+}
+
+/**
  * 구독·결제 — OWNER이거나 Admin을 겸한 사람.
  *
  * ⚠️ 이 판정 때문에 관리 기능이 `/owner/*`가 아니라 **`/manage/*`** 하나로 모여 있다


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [x] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

- 오프보딩 최종 승인 후 담당자 없는 액션 뭉치를 재귀속하는 "팀장급 인수인계서 관리"(`/owner/leader-handovers`) 화면 신규 구현
- `LEADER_HANDOVER_CUSTODY_STATUS`(귀속 대기/완료) 상수 추가, `canManageLeaderHandovers`(OWNER 전용) 권한 함수 추가
- `src/features/leader-handover/` 신규: types/server/actions/lib/mock + 목록·상세 페이지, 액션 리스트, 배정 폼 컴포넌트
- BE 미연동으로 목데이터 사용 중

---

## ✅ 작업 체크리스트

**기본**

- [ ] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [ ] 아래 `Closes #` 에 이슈 번호 기입
- [ ] 불필요한 `console` · 주석 처리된 코드 제거
- [ ] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**(회의 담당자 등), 그리고 **서버(Server Action/BFF)에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [x] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시 (조용히 "되는 척" 금지)
- [ ] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그)
- [ ] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [ ] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인)
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음

---

## 🔗 연관 이슈

Closes #237

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- `/owner/leader-handovers` 목록 진입 및 권한(OWNER 전용) 확인
- 상세 페이지에서 담당자 없는 액션 배정 플로우 확인
- CI(typecheck/lint/test/build) 통과 확인

---

## 📝 추가 메모

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 팀장급 인수인계서 관리 목록과 상세 페이지를 추가했습니다.
  - 상태별 필터, 인수인계 정보, 담당 액션 목록을 확인할 수 있습니다.
  - 후임 팀장을 선택해 인수인계 항목을 배정할 수 있습니다.
  - 로딩 화면과 오류 발생 시 재시도 기능을 제공합니다.

- **개선 사항**
  - 인수인계 상태와 담당자 배정 결과를 명확한 메시지와 토스트로 안내합니다.
  - 퇴사한 팀장은 리더 충돌 및 마지막 리더 판단에서 제외됩니다.
  - 오프보딩 승인 시 팀장 권한이 자동으로 조정됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
