### PR TITLE
[CHORE] jest 수집 범위를 src로 좁힘 — 워크트리 사본 제외 #248

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -7,6 +7,9 @@ const config: Config = {
   testEnvironment: "jsdom",
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   moduleNameMapper: { "^@/(.*)$": "<rootDir>/src/$1" },
+  // 테스트는 전부 src/ 안에 있다. 수집 범위를 여기로 못박아야
+  // 레포 안에 생기는 체크아웃 사본(.claude/worktrees/* 등)의 테스트를 끌어오지 않는다.
+  roots: ["<rootDir>/src"],
   // Playwright 스펙은 e2e/ 에만 둔다 (CONVENTIONS §18)
   testPathIgnorePatterns: ["<rootDir>/.next/", "<rootDir>/node_modules/", "<rootDir>/e2e/"],
 };


### PR DESCRIPTION
## 📋 PR 타입

- [ ] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [x] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

- `jest.config.ts`에 `roots: ["<rootDir>/src"]` 한 줄을 더해 테스트 수집 범위를 현재 체크아웃 안으로 좁힙니다.
- 배경: 백그라운드 작업이 `.claude/worktrees/<name>/`에 git 워크트리를 만드는데, 그 경로가 `rootDir` 아래라 `npx jest`가 워크트리 사본의 테스트까지 수집했습니다. 그쪽 코드가 작업 중이면 미완성이라 `Test suite failed to run`이 뜨고, 내 브랜치는 멀쩡한데 로컬 테스트가 빨갛게 보입니다.
- 테스트는 전부 `src/` 안에 있어서 범위를 거기로 못박는 쪽이 가장 단순합니다. `testPathIgnorePatterns`에 경로를 하나씩 더하는 방식은 레포 안에 새 사본이 생길 때마다 또 고쳐야 합니다.

---

## ✅ 작업 체크리스트

**기본**

- [ ] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [ ] 불필요한 `console` · 주석 처리된 코드 제거
- [ ] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**(회의 담당자 등), 그리고 **서버(Server Action/BFF)에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [ ] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시 (조용히 "되는 척" 금지)
- [ ] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그)
- [ ] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [ ] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인)
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음

---

## 🔗 연관 이슈

Closes #248

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

워크트리를 둔 상태에서 레포 루트에서 실행합니다.

```bash
npx jest --listTests | wc -l
```

- 전: 216 (워크트리 2개 × 72 포함)
- 후: 72 — `.claude/worktrees` 경로 0건, `72 suites / 815 tests` 전부 통과
- CI는 체크아웃이 하나뿐이라 영향이 없습니다.

---

## 📝 추가 메모

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 테스트 검색 범위를 `src` 디렉터리로 제한했습니다.
  * 테스트 실행 시 불필요한 경로가 검색되지 않도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->