### PR TITLE
[FIX] 화면 문구의 조사 자리표시자 정리 #252

### DIFF
--- a/src/features/meeting/review/components/meeting-review-view.tsx
+++ b/src/features/meeting/review/components/meeting-review-view.tsx
@@ -33,6 +33,15 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
   const [drafts, setDrafts] = useState<AiActionDraft[]>(review.drafts);
   const [rejectedReasons, setRejectedReasons] = useState<Record<string, ActionRejectReason>>({});
   const [rejectTargetId, setRejectTargetId] = useState<string | null>(null);
+  /*
+    ⚠️ **제목은 베껴 두고 열림 깃발만 내린다**(2026-08-10). 전에는 제목을 `rejectTargetId`에서
+       그때그때 찾아 썼는데, 닫을 때 id가 먼저 비어서 **닫힘 애니메이션이 도는 동안**
+       창에 `''이 확정 대상에서 제외됩니다`가 스쳤다 — 방금 보던 제목이 빈 따옴표로 바뀐다.
+       창이 아직 화면에 있는 동안에는 마지막에 보던 값이 그대로 있어야 한다
+       (기업 상세 확인창이 같은 이유로 쓰는 방식 — `system/company-detail-dialog.tsx`).
+  */
+  const [isRejectOpen, setIsRejectOpen] = useState(false);
+  const [rejectTitle, setRejectTitle] = useState("");
   const [pendingReason, setPendingReason] = useState<ActionRejectReason | null>(null);
   const [isAddingManual, setIsAddingManual] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -43,23 +52,21 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
   const visibleDrafts = drafts.filter((draft) => !(draft.id in rejectedReasons));
   const highConfidence = visibleDrafts.filter((d) => d.confidence === AI_CONFIDENCE.HIGH);
   const needsReview = visibleDrafts.filter((d) => d.confidence === AI_CONFIDENCE.NEEDS_REVIEW);
-  const rejectTarget = rejectTargetId
-    ? (drafts.find((d) => d.id === rejectTargetId) ?? null)
-    : null;
-
   function updateDraft(id: string, patch: Partial<AiActionDraft>) {
     setDrafts((prev) => prev.map((draft) => (draft.id === id ? { ...draft, ...patch } : draft)));
   }
 
   function openRejectDialog(id: string) {
     setRejectTargetId(id);
+    setRejectTitle(drafts.find((d) => d.id === id)?.title ?? "");
     setPendingReason(null);
+    setIsRejectOpen(true);
   }
 
   function confirmReject() {
     if (!rejectTargetId || !pendingReason) return;
     setRejectedReasons((prev) => ({ ...prev, [rejectTargetId]: pendingReason }));
-    setRejectTargetId(null);
+    setIsRejectOpen(false);
   }
 
   function addManualDraft(input: ManualDraftInput) {
@@ -226,9 +233,9 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
       </div>
 
       <RejectReasonDialog
-        isOpen={rejectTarget !== null}
-        onOpenChange={(open) => !open && setRejectTargetId(null)}
-        actionTitle={rejectTarget?.title ?? ""}
+        isOpen={isRejectOpen}
+        onOpenChange={(open) => !open && setIsRejectOpen(false)}
+        actionTitle={rejectTitle}
         reason={pendingReason}
         onReasonChange={setPendingReason}
         onConfirm={confirmReject}

--- a/src/features/meeting/review/components/reject-reason-dialog.tsx
+++ b/src/features/meeting/review/components/reject-reason-dialog.tsx
@@ -6,6 +6,7 @@ import {
   ACTION_REJECT_REASON_LABEL,
   type ActionRejectReason,
 } from "@/constants/meeting";
+import { subjectParticle } from "@/lib/korean";
 import { cn } from "@/lib/utils";
 
 const REASONS = Object.values(ACTION_REJECT_REASON);
@@ -38,7 +39,9 @@ export function RejectReasonDialog({
       title="이 액션을 반려할까요?"
       description={
         <>
-          &lsquo;{actionTitle}&rsquo;이(가) 확정 대상에서 제외됩니다.
+          {/* 조사는 받침을 보고 고른다(`lib/korean.ts`) — `이(가)`로 두면 괄호가 그대로 보인다 */}
+          &lsquo;{actionTitle}&rsquo;
+          {subjectParticle(actionTitle)} 확정 대상에서 제외됩니다.
           <br />
           사유를 골라 주세요.
         </>

--- a/src/features/shell/components/page-header.tsx
+++ b/src/features/shell/components/page-header.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import type { ReactNode } from "react";
 
 import { ThemeToggle } from "@/components/common/theme-toggle";
+import { directionParticle } from "@/lib/korean";
 
 interface PageHeaderProps {
   /** 화면 제목. 페이지마다 `h1`은 하나뿐이다(CLAUDE.md §SEO·a11y) */
@@ -59,7 +60,11 @@ export function PageHeader({ title, icon: Icon, meta, backTo, action }: PageHead
         {backTo ? (
           <Link
             href={backTo.href}
-            aria-label={`${backTo.label}(으)로 돌아가기`}
+            /*
+              조사는 **받침을 보고 고른다**(`lib/korean.ts`). `(으)로`로 박아 두면
+              스크린리더가 괄호까지 읽어 `회의 상세(으)로 돌아가기`가 된다.
+            */
+            aria-label={`${backTo.label}${directionParticle(backTo.label)} 돌아가기`}
             className="text-muted-foreground hover:text-foreground hover:bg-foreground/5 focus-visible:ring-ring absolute top-1/2 right-full flex size-8 shrink-0 -translate-y-1/2 items-center justify-center rounded-md transition-colors focus-visible:ring-2 focus-visible:outline-hidden"
           >
             <ArrowLeft className="size-[18px]" />

--- a/src/features/system/components/company-detail-dialog.tsx
+++ b/src/features/system/components/company-detail-dialog.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/dialog";
 import { COMPANY_STATUS, COMPANY_STATUS_LABEL } from "@/constants/domain";
 import { formatDate } from "@/lib/date";
+import { objectParticle } from "@/lib/korean";
 
 import { suspendCompanyAction, unsuspendCompanyAction } from "../actions";
 import type { ManagedCompany } from "../types";
@@ -221,7 +222,7 @@ export function CompanyDetailDialog({ company, closeHref, currentPath }: Company
         title={
           confirmed?.isSuspended
             ? `'${confirmed.name}' 정지를 해제할까요?`
-            : `'${confirmed?.name}'을(를) 정지할까요?`
+            : `'${confirmed?.name}'${objectParticle(confirmed?.name ?? "")} 정지할까요?`
         }
         description={
           confirmed?.isSuspended

--- a/src/lib/korean.test.ts
+++ b/src/lib/korean.test.ts
@@ -1,4 +1,4 @@
-import { objectParticle, subjectParticle, topicParticle } from "./korean";
+import { directionParticle, objectParticle, subjectParticle, topicParticle } from "./korean";
 
 /**
  * 조사 고르기 — **사이드바 라벨이 실제로 지나가는 값**으로 묶는다.
@@ -43,5 +43,33 @@ describe("나머지 조사", () => {
   it("목적격 — 받침 유무로 갈린다", () => {
     expect(objectParticle("프로젝트")).toBe("를");
     expect(objectParticle("검색")).toBe("을");
+  });
+});
+
+/**
+ * 방향 조사 — **받침 `ㄹ`만 예외**라 다른 조사와 같이 묶을 수 없다.
+ * 실제로 지나가는 값은 뒤로가기 라벨(화면 이름)이다.
+ */
+describe("directionParticle", () => {
+  it.each(["회의", "공지", "회의 상세", "프로젝트", "대시보드", "저장소 관리"])(
+    "받침 없는 `%s`에는 `로`",
+    (word) => {
+      expect(directionParticle(word)).toBe("로");
+    },
+  );
+
+  it.each(["회의실", "메일", "프로필"])("받침 `ㄹ`도 `로`다 — `%s`", (word) => {
+    expect(directionParticle(word)).toBe("로");
+  });
+
+  it.each(["기업 가입 승인", "검색", "인수인계 목록"])("그 밖의 받침에는 `으로` — `%s`", (word) => {
+    expect(directionParticle(word)).toBe("으로");
+  });
+
+  it("괄호가 문구에 남지 않는다 — 이 조사가 없어서 `(으)로`가 박혀 있었다", () => {
+    expect(`회의 상세${directionParticle("회의 상세")} 돌아가기`).toBe("회의 상세로 돌아가기");
+    expect(`기업 가입 승인${directionParticle("기업 가입 승인")} 돌아가기`).toBe(
+      "기업 가입 승인으로 돌아가기",
+    );
   });
 });

--- a/src/lib/korean.ts
+++ b/src/lib/korean.ts
@@ -13,6 +13,8 @@ const SYLLABLE_START = 0xac00;
 const SYLLABLE_END = 0xd7a3;
 /** 한 초성·중성 묶음이 갖는 종성 가짓수(받침 없음 포함) */
 const FINAL_COUNT = 28;
+/** 종성 `ㄹ`의 자리 — 방향 조사는 이 받침만 예외다(`회의실로`) */
+const RIEUL_FINAL = 8;
 
 /**
  * 마지막 글자에 받침이 있는지.
@@ -43,4 +45,23 @@ export function subjectParticle(word: string): "이" | "가" {
 /** 목적격 조사 — `프로젝트`+`를`, `검색`+`을` */
 export function objectParticle(word: string): "을" | "를" {
   return hasFinalConsonant(word) ? "을" : "를";
+}
+
+/**
+ * 방향 조사 — `회의 상세`+`로`, `기업 가입 승인`+`으로`.
+ *
+ * ⚠️ **받침 `ㄹ`은 예외다.** 받침이 있으면 `으로`인데 `ㄹ`만 `로`를 쓴다 —
+ *    `회의실으로`가 아니라 `회의실로`다. 다른 조사엔 없는 규칙이라 여기서만 따로 본다.
+ * ⚠️ 한글이 아니면 다른 조사와 같은 쪽(`으로`)으로 둔다 — 이 자리를 지나는 값은
+ *    화면 이름(`회의`·`공지`·`기업 가입 승인`)이라 한글이다.
+ */
+export function directionParticle(word: string): "로" | "으로" {
+  const last = word.trim().at(-1);
+  if (!last) return "으로";
+
+  const code = last.charCodeAt(0);
+  if (code < SYLLABLE_START || code > SYLLABLE_END) return "으로";
+
+  const final = (code - SYLLABLE_START) % FINAL_COUNT;
+  return final === 0 || final === RIEUL_FINAL ? "로" : "으로";
 }


### PR DESCRIPTION
## 📋 PR 타입

- [ ] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [x] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

**무엇**

화면 문구에 남아 있던 **조사 자리표시자**(`(으)로`·`이(가)`)를 걷어냅니다.

**왜**

레포에는 이미 조사를 받침으로 고르는 헬퍼가 있고(`src/lib/korean.ts`), 그 파일이 이 문제를 못 박아 뒀습니다 — "문구에 조사를 박아 두면 안 된다 … 넣는 자리에서 고르게 한다". 그런데 **방향 조사(`로`/`으로`)만 헬퍼에 없어서** 그 자리만 자리표시자로 남아 있었습니다.

| 자리 | 전 | 후 |
| --- | --- | --- |
| 셸 상단바 뒤로가기(`aria-label`) | `회의 상세(으)로 돌아가기` | `회의 상세로 돌아가기` |
| 〃 | `기업 가입 승인(으)로 돌아가기` | `기업 가입 승인으로 돌아가기` |
| 액션 반려 확인 창 | `'…검토'이(가) 제외됩니다` | `'…검토'가 제외됩니다` |

뒤로가기는 셸 공용이라 뒤로가기가 있는 화면 **전부**에 해당합니다. 눈에 보이는 글자는 아니지만 스크린리더는 괄호까지 읽습니다.

**어떻게**

- `korean.ts`에 `directionParticle`을 더했습니다. **받침 `ㄹ`만 예외**라 기존 `hasFinalConsonant`로는 안 됩니다 — `회의실으로`가 아니라 `회의실로`입니다. 종성 자리를 직접 보고 고릅니다.
- `PageHeader`와 반려 사유 창이 헬퍼를 부르게 했습니다.

---

## ✅ 작업 체크리스트

**기본**

- [ ] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [ ] 불필요한 `console` · 주석 처리된 코드 제거
- [ ] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**(회의 담당자 등), 그리고 **서버(Server Action/BFF)에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [ ] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시 (조용히 "되는 척" 금지)
- [ ] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그)
- [x] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [x] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인)
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음

---

## 🔗 연관 이슈

Closes #252

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

```bash
npx jest src/lib/korean.test.ts
```

뒤로가기가 있는 화면에서 화살표의 접근성 이름을 확인합니다. 실제로 읽어 본 값입니다.

| 경로 | 읽히는 말 |
| --- | --- |
| `/app/notice/:id` | 공지**로** 돌아가기 |
| `/app/meeting/:id` | 회의**로** 돌아가기 |
| `/app/meeting/:id/review` | 회의 상세**로** 돌아가기 |
| `/team/handover/:id` | 인수인계서 관리**로** 돌아가기 |

---

## 📝 추가 메모

테스트 833개 통과(방향 조사 사례 4묶음 추가).

**남은 것**

`이(가)`·`을(를)` 같은 자리표시자가 새로 들어오는 것은 이 PR이 막지 못합니다. 린트 규칙으로 막는 편이 확실한데, 규칙 하나를 새로 만드는 일이라 별도로 봐야 합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 반려 확인 안내 문구가 액션 제목의 받침에 맞춰 '이' 또는 '가'로 자연스럽게 표시됩니다.
  * 뒤로가기 링크의 접근성 안내 문구가 대상 이름의 받침에 따라 '로' 또는 '으로'로 올바르게 표시됩니다.
  * 받침이 없는 경우와 'ㄹ' 받침을 포함한 다양한 한글 표현을 지원해 문법적으로 자연스러운 안내를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
