### PR TITLE
[FEAT] 회의실 예약 참석자 필터(전체/팀장급만/내 부서만) 추가 #256 #257

### DIFF
--- a/src/app/(shell)/app/rooms/page.tsx
+++ b/src/app/(shell)/app/rooms/page.tsx
@@ -56,6 +56,7 @@ export default async function RoomsPage({ searchParams }: RoomsPageProps) {
           projects={projects}
           showParentTeamAction={requiresParentTeamAction(viewer)}
           teamActions={teamActions}
+          viewerTeamName={viewer.teamName ?? null}
           week={format(week, "yyyy-MM-dd")}
         />
       </div>

--- a/src/features/calendar/mock/events.ts
+++ b/src/features/calendar/mock/events.ts
@@ -25,7 +25,7 @@ const INITIAL: PersonalCalendarEvent[] = [
     id: "action-1",
     title: "회의실 예약 정책 공유",
     start: new Date("2026-08-05T14:00:00"),
-    end: new Date("2026-08-05T15:00:00"),
+    end: new Date("2026-08-08T15:00:00"),
     tag: CALENDAR_ITEM_TAG.PERSONAL_ACTION,
     isCompleted: false,
   },

--- a/src/features/rooms/components/room-attendee-picker.test.tsx
+++ b/src/features/rooms/components/room-attendee-picker.test.tsx
@@ -1,18 +1,27 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+import { AUTHORITY } from "@/constants/authority";
+
 import type { RoomMember } from "../types";
 import { RoomAttendeePicker } from "./room-attendee-picker";
 
 const MEMBERS: RoomMember[] = [
-  { id: 1, name: "박대표" },
-  { id: 2, name: "김서준" },
-  { id: 3, name: "이하윤" },
+  { id: 1, name: "박대표", teamName: null, authority: AUTHORITY.OWNER },
+  { id: 2, name: "김서준", teamName: "개발팀", authority: AUTHORITY.LEADER },
+  { id: 3, name: "이하윤", teamName: "개발팀", authority: AUTHORITY.MEMBER },
 ];
 
 describe("RoomAttendeePicker", () => {
   it("검색 전에는 전체 목록을 보여준다", () => {
-    render(<RoomAttendeePicker members={MEMBERS} selectedIds={[]} onChange={jest.fn()} />);
+    render(
+      <RoomAttendeePicker
+        members={MEMBERS}
+        selectedIds={[]}
+        onChange={jest.fn()}
+        viewerTeamName="개발팀"
+      />,
+    );
 
     expect(screen.getByText("박대표")).toBeInTheDocument();
     expect(screen.getByText("김서준")).toBeInTheDocument();
@@ -21,7 +30,14 @@ describe("RoomAttendeePicker", () => {
 
   it("이름을 검색하면 그 이름만 남는다", async () => {
     const user = userEvent.setup();
-    render(<RoomAttendeePicker members={MEMBERS} selectedIds={[]} onChange={jest.fn()} />);
+    render(
+      <RoomAttendeePicker
+        members={MEMBERS}
+        selectedIds={[]}
+        onChange={jest.fn()}
+        viewerTeamName="개발팀"
+      />,
+    );
 
     await user.type(screen.getByRole("textbox", { name: "참석자 검색" }), "김");
 
@@ -32,7 +48,14 @@ describe("RoomAttendeePicker", () => {
   it("체크하면 onChange에 추가된 id를 실어 보낸다", async () => {
     const user = userEvent.setup();
     const onChange = jest.fn();
-    render(<RoomAttendeePicker members={MEMBERS} selectedIds={[]} onChange={onChange} />);
+    render(
+      <RoomAttendeePicker
+        members={MEMBERS}
+        selectedIds={[]}
+        onChange={onChange}
+        viewerTeamName="개발팀"
+      />,
+    );
 
     await user.click(screen.getByRole("checkbox", { name: "김서준" }));
 
@@ -42,7 +65,14 @@ describe("RoomAttendeePicker", () => {
   it("이미 선택된 사람의 체크를 풀면 목록에서 뺀다", async () => {
     const user = userEvent.setup();
     const onChange = jest.fn();
-    render(<RoomAttendeePicker members={MEMBERS} selectedIds={[1, 2]} onChange={onChange} />);
+    render(
+      <RoomAttendeePicker
+        members={MEMBERS}
+        selectedIds={[1, 2]}
+        onChange={onChange}
+        viewerTeamName="개발팀"
+      />,
+    );
 
     await user.click(screen.getByRole("checkbox", { name: "김서준" }));
 
@@ -50,17 +80,67 @@ describe("RoomAttendeePicker", () => {
   });
 
   it("선택 인원 수를 보여준다", () => {
-    render(<RoomAttendeePicker members={MEMBERS} selectedIds={[1, 2]} onChange={jest.fn()} />);
+    render(
+      <RoomAttendeePicker
+        members={MEMBERS}
+        selectedIds={[1, 2]}
+        onChange={jest.fn()}
+        viewerTeamName="개발팀"
+      />,
+    );
 
     expect(screen.getByText("선택 2명")).toBeInTheDocument();
   });
 
   it("검색 결과가 없으면 안내 문구를 보여준다", async () => {
     const user = userEvent.setup();
-    render(<RoomAttendeePicker members={MEMBERS} selectedIds={[]} onChange={jest.fn()} />);
+    render(
+      <RoomAttendeePicker
+        members={MEMBERS}
+        selectedIds={[]}
+        onChange={jest.fn()}
+        viewerTeamName="개발팀"
+      />,
+    );
 
     await user.type(screen.getByRole("textbox", { name: "참석자 검색" }), "존재하지않는이름");
 
     expect(screen.getByText("검색 결과가 없어요")).toBeInTheDocument();
+  });
+
+  it("'팀장급만'을 고르면 LEADER만 남는다", async () => {
+    const user = userEvent.setup();
+    render(
+      <RoomAttendeePicker
+        members={MEMBERS}
+        selectedIds={[]}
+        onChange={jest.fn()}
+        viewerTeamName="개발팀"
+      />,
+    );
+
+    await user.click(screen.getByRole("radio", { name: "팀장급만" }));
+
+    expect(screen.getByText("김서준")).toBeInTheDocument();
+    expect(screen.queryByText("박대표")).not.toBeInTheDocument();
+    expect(screen.queryByText("이하윤")).not.toBeInTheDocument();
+  });
+
+  it("'내 부서만'을 고르면 같은 부서만 남는다", async () => {
+    const user = userEvent.setup();
+    render(
+      <RoomAttendeePicker
+        members={MEMBERS}
+        selectedIds={[]}
+        onChange={jest.fn()}
+        viewerTeamName="개발팀"
+      />,
+    );
+
+    await user.click(screen.getByRole("radio", { name: "내 부서만" }));
+
+    expect(screen.getByText("김서준")).toBeInTheDocument();
+    expect(screen.getByText("이하윤")).toBeInTheDocument();
+    expect(screen.queryByText("박대표")).not.toBeInTheDocument();
   });
 });

--- a/src/features/rooms/components/room-attendee-picker.tsx
+++ b/src/features/rooms/components/room-attendee-picker.tsx
@@ -5,14 +5,58 @@ import { useMemo, useState } from "react";
 
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { AUTHORITY } from "@/constants/authority";
 import { useProfileAvatar } from "@/hooks/use-profile-avatar";
+import { cn } from "@/lib/utils";
 
+import {
+  ROOM_ATTENDEE_FILTER,
+  ROOM_ATTENDEE_FILTER_LABEL,
+  type RoomAttendeeFilter,
+} from "../constants";
 import type { RoomMember } from "../types";
 
 interface RoomAttendeePickerProps {
   members: RoomMember[];
   selectedIds: number[];
   onChange: (ids: number[]) => void;
+  /** 지금 보고 있는 사람의 부서 — "내 부서만" 필터 기준(`null`이면 Owner처럼 부서가 없는 사람). */
+  viewerTeamName: string | null;
+}
+
+const FILTER_OPTIONS = Object.values(ROOM_ATTENDEE_FILTER);
+
+interface AttendeeFilterGroupProps {
+  value: RoomAttendeeFilter;
+  onChange: (value: RoomAttendeeFilter) => void;
+}
+
+/** 참석자 필터 3종 — 서로 배타적이라 체크박스 모양이어도 동작은 라디오다(`RoomPickerList`와 같은 패턴). */
+function AttendeeFilterGroup({ value, onChange }: AttendeeFilterGroupProps) {
+  return (
+    <div className="flex items-center gap-1" role="radiogroup" aria-label="참석자 필터">
+      {FILTER_OPTIONS.map((option) => {
+        const selected = option === value;
+        return (
+          <button
+            key={option}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            onClick={() => onChange(option)}
+            className={cn(
+              "rounded-full border px-2.5 py-1 text-[11px] transition-colors",
+              selected
+                ? "border-foreground bg-foreground/5 font-medium"
+                : "border-input text-muted-foreground hover:bg-muted",
+            )}
+          >
+            {ROOM_ATTENDEE_FILTER_LABEL[option]}
+          </button>
+        );
+      })}
+    </div>
+  );
 }
 
 const AVATAR_SIZE = 20;
@@ -49,14 +93,27 @@ function AttendeeRow({
  * 회의실 예약 "참석자" 선택 — 검색으로 좁히되, 결과는 **전체 목록을 체크박스로** 보여준다
  * (디자인 반영). 검색 전에는 전체가 다 보이고, 검색하면 이름이 걸리는 사람만 남는다.
  */
-export function RoomAttendeePicker({ members, selectedIds, onChange }: RoomAttendeePickerProps) {
+export function RoomAttendeePicker({
+  members,
+  selectedIds,
+  onChange,
+  viewerTeamName,
+}: RoomAttendeePickerProps) {
   const [keyword, setKeyword] = useState("");
+  const [filter, setFilter] = useState<RoomAttendeeFilter>(ROOM_ATTENDEE_FILTER.ALL);
 
   const visible = useMemo(() => {
     const query = keyword.trim().toLowerCase();
-    if (!query) return members;
-    return members.filter((member) => member.name.toLowerCase().includes(query));
-  }, [members, keyword]);
+    return members
+      .filter((member) => {
+        if (filter === ROOM_ATTENDEE_FILTER.LEADER) return member.authority === AUTHORITY.LEADER;
+        if (filter === ROOM_ATTENDEE_FILTER.MY_TEAM) {
+          return viewerTeamName !== null && member.teamName === viewerTeamName;
+        }
+        return true;
+      })
+      .filter((member) => !query || member.name.toLowerCase().includes(query));
+  }, [members, keyword, filter, viewerTeamName]);
 
   function toggle(id: number) {
     onChange(
@@ -66,7 +123,10 @@ export function RoomAttendeePicker({ members, selectedIds, onChange }: RoomAtten
 
   return (
     <div className="flex h-full flex-col gap-2">
-      <Label>참석자</Label>
+      <div className="flex items-center justify-between">
+        <Label>참석자</Label>
+        <AttendeeFilterGroup value={filter} onChange={setFilter} />
+      </div>
 
       <div className="relative">
         <Search

--- a/src/features/rooms/components/room-reservation-dialog.test.tsx
+++ b/src/features/rooms/components/room-reservation-dialog.test.tsx
@@ -20,7 +20,9 @@ const ROOMS: MeetingRoom[] = [
     closeTime: "18:00",
   },
 ];
-const MEMBERS: RoomMember[] = [{ id: 1, name: "박대표" }];
+const MEMBERS: RoomMember[] = [
+  { id: 1, name: "박대표", teamName: null, authority: AUTHORITY.OWNER },
+];
 const PROJECTS: RoomProjectOption[] = [{ id: "1", name: "굿즈 프로젝트", tag: "GOODS" }];
 const TEAM_ACTIONS: RoomTeamActionOption[] = [];
 
@@ -38,6 +40,7 @@ function renderDialog(overrides: Partial<React.ComponentProps<typeof RoomReserva
       projects={PROJECTS}
       showParentTeamAction={false}
       teamActions={TEAM_ACTIONS}
+      viewerTeamName={null}
       onCreated={onCreated}
       {...overrides}
     />,
@@ -56,6 +59,7 @@ describe("RoomReservationDialog", () => {
         projects={PROJECTS}
         showParentTeamAction={false}
         teamActions={TEAM_ACTIONS}
+        viewerTeamName={null}
         onCreated={jest.fn()}
       />,
     );
@@ -92,12 +96,36 @@ describe("RoomReservationDialog", () => {
     expect(screen.getByRole("combobox", { name: "상위 팀 액션" })).toBeInTheDocument();
   });
 
-  it("필수값을 안 채우고 등록을 누르면 필드별 오류를 보여주고 onCreated는 안 부른다", async () => {
+  it("즉시 예약을 누르면 바로 등록하지 않고 확인 모달을 먼저 띄운다", async () => {
+    const user = userEvent.setup();
+    const { onCreated } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: "즉시 예약" }));
+
+    expect(screen.getByText("이대로 등록하시겠습니까?")).toBeInTheDocument();
+    expect(onCreated).not.toHaveBeenCalled();
+  });
+
+  it("확인 모달에서 취소하면 등록하지 않는다", async () => {
+    const user = userEvent.setup();
+    const { onCreated } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: "즉시 예약" }));
+    // ⚠️ 본 다이얼로그의 [취소]와 이름이 같다 — 나중에(위에) 뜬 확인 모달 쪽을 고른다.
+    const cancelButtons = screen.getAllByRole("button", { name: "취소" });
+    await user.click(cancelButtons.at(-1)!);
+
+    expect(screen.queryByText("이대로 등록하시겠습니까?")).not.toBeInTheDocument();
+    expect(onCreated).not.toHaveBeenCalled();
+  });
+
+  it("필수값을 안 채우고 확인 모달에서 예약을 누르면 필드별 오류를 보여주고 onCreated는 안 부른다", async () => {
     const user = userEvent.setup();
     const { onCreated } = renderDialog();
 
     await user.type(screen.getByLabelText("회의 제목"), "새 회의");
     await user.click(screen.getByRole("button", { name: "즉시 예약" }));
+    await user.click(screen.getByRole("button", { name: "예약" }));
 
     await waitFor(() => {
       const roomError = screen.getByText(

--- a/src/features/rooms/components/room-reservation-dialog.tsx
+++ b/src/features/rooms/components/room-reservation-dialog.tsx
@@ -3,9 +3,10 @@
 import { format } from "date-fns";
 import { ko } from "date-fns/locale";
 import { Bell } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useFormStatus } from "react-dom";
 
+import { ConfirmDialog } from "@/components/common/confirm-dialog";
 import { FieldError } from "@/components/common/field-error";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
@@ -35,6 +36,8 @@ interface RoomReservationDialogProps {
    *  직접 못 부른다. */
   showParentTeamAction: boolean;
   teamActions: RoomTeamActionOption[];
+  /** 참석자 "내 부서만" 필터 기준 — `RoomAttendeePicker`로 그대로 흘려보낸다. */
+  viewerTeamName: string | null;
   /** 생성 성공 시 호출 — 재조회 없이 부모 화면에 바로 얹는다(§최적화: action 리턴값 그대로 반영). */
   onCreated: (created: RoomReservation) => void;
 }
@@ -62,13 +65,18 @@ function SlotSummary({ slotStart }: { slotStart: Date }) {
 
 interface DialogActionsProps {
   onCancel: () => void;
+  /** "즉시 예약" 클릭 — 여기서 바로 제출하지 않고 확인 모달을 먼저 띄운다. */
+  onRequestSubmit: () => void;
 }
 
 /**
  * 취소·제출 버튼 — `useFormStatus`는 `<form>`의 **자손** 컴포넌트에서만 호출할 수 있어서
  * `RoomReservationDialog`(그 `<form>`을 직접 그리는 컴포넌트) 안이 아니라 여기로 뺐다.
+ * ⚠️ "즉시 예약"은 `type="submit"`이 아니다 — 눌러도 바로 제출하지 않고 확인 모달을 먼저
+ *    띄운다. 실제 제출은 확인 모달의 [예약]에서 `form.requestSubmit()`으로 한다
+ *    (`RoomReservationDialog` 참고).
  */
-function DialogActions({ onCancel }: DialogActionsProps) {
+function DialogActions({ onCancel, onRequestSubmit }: DialogActionsProps) {
   const { pending } = useFormStatus();
 
   return (
@@ -76,7 +84,7 @@ function DialogActions({ onCancel }: DialogActionsProps) {
       <Button type="button" variant="outline" disabled={pending} onClick={onCancel}>
         취소
       </Button>
-      <Button type="submit" variant="ink" disabled={pending}>
+      <Button type="button" variant="ink" disabled={pending} onClick={onRequestSubmit}>
         {pending ? "예약 중" : "즉시 예약"}
       </Button>
     </div>
@@ -125,6 +133,7 @@ export function RoomReservationDialog({
   projects,
   showParentTeamAction,
   teamActions,
+  viewerTeamName,
   onCreated,
 }: RoomReservationDialogProps) {
   const { state, formAction, form, setForm, handleOpenChange } = useRoomReservationForm({
@@ -136,6 +145,14 @@ export function RoomReservationDialog({
   const [isPending, setIsPending] = useState(false);
   // ⚠️ `PendingReporter`의 effect 의존성이라 참조를 고정한다 — 안 그러면 매 렌더 다시 돈다.
   const handlePendingChange = useCallback((next: boolean) => setIsPending(next), []);
+
+  /**
+   * "즉시 예약" 확인 모달 — 실제 등록은 이 창의 [예약]에서 `formRef.requestSubmit()`으로
+   * 진짜 제출을 건다(§DialogActions). 폼 자체의 값(제목·회의실 등)은 그대로 있으니 두 번
+   * 입력할 필요는 없다.
+   */
+  const formRef = useRef<HTMLFormElement>(null);
+  const [showConfirm, setShowConfirm] = useState(false);
 
   return (
     <Dialog
@@ -152,7 +169,7 @@ export function RoomReservationDialog({
           <DialogTitle>회의실 예약</DialogTitle>
         </DialogHeader>
 
-        <form action={formAction}>
+        <form ref={formRef} action={formAction}>
           <PendingReporter onChange={handlePendingChange} />
           <input
             type="hidden"
@@ -187,6 +204,7 @@ export function RoomReservationDialog({
                   members={members}
                   selectedIds={form.attendeeIds}
                   onChange={(attendeeIds) => setForm((prev) => ({ ...prev, attendeeIds }))}
+                  viewerTeamName={viewerTeamName}
                 />
                 <FieldError reserveSpace message={state.errors.attendeeIds} />
               </div>
@@ -202,10 +220,25 @@ export function RoomReservationDialog({
           </div>
 
           <div className="border-border flex items-center justify-end gap-4 border-t px-6 py-4">
-            <DialogActions onCancel={() => handleOpenChange(false)} />
+            <DialogActions
+              onCancel={() => handleOpenChange(false)}
+              onRequestSubmit={() => setShowConfirm(true)}
+            />
           </div>
         </form>
       </DialogContent>
+
+      <ConfirmDialog
+        isOpen={showConfirm}
+        onOpenChange={setShowConfirm}
+        title="이대로 등록하시겠습니까?"
+        description="등록하면 참석자에게 알림이 전송되고, 곧바로 회의실이 예약됩니다."
+        confirmLabel="예약"
+        onConfirm={() => {
+          setShowConfirm(false);
+          formRef.current?.requestSubmit();
+        }}
+      />
     </Dialog>
   );
 }

--- a/src/features/rooms/components/rooms-board.test.tsx
+++ b/src/features/rooms/components/rooms-board.test.tsx
@@ -1,0 +1,54 @@
+import { AUTHORITY } from "@/constants/authority";
+
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/lib/mock-actor", () => ({
+  getMockActor: jest.fn(() => ({ id: 1, role: AUTHORITY.OWNER })),
+}));
+// ⚠️ 실제 주간 캘린더는 `react-big-calendar` + `next/dynamic`을 물고 있어 무겁다 — 이 테스트는
+//    "예약하기" 버튼이 모달을 여는지만 본다(그 캘린더 렌더링은 `weekly-room-calendar.test.tsx`가 맡는다).
+jest.mock("./weekly-room-calendar-loader", () => ({
+  WeeklyRoomCalendarLoader: () => null,
+}));
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import type { MeetingRoom, RoomProjectOption, RoomTeamActionOption } from "../types";
+import { RoomsBoard } from "./rooms-board";
+
+const ROOMS: MeetingRoom[] = [
+  {
+    id: "room-large",
+    name: "대회의실",
+    location: "3층 A동",
+    openTime: "09:00",
+    closeTime: "18:00",
+  },
+];
+const MEMBERS = [{ id: 1, name: "박대표", teamName: null, authority: AUTHORITY.OWNER }];
+const PROJECTS: RoomProjectOption[] = [{ id: "1", name: "굿즈 프로젝트", tag: "GOODS" }];
+const TEAM_ACTIONS: RoomTeamActionOption[] = [];
+
+describe("RoomsBoard", () => {
+  it("우측 상단 [예약하기]를 누르면 예약 모달이 뜬다", async () => {
+    const user = userEvent.setup();
+    render(
+      <RoomsBoard
+        initialReservations={[]}
+        rooms={ROOMS}
+        members={MEMBERS}
+        projects={PROJECTS}
+        showParentTeamAction={false}
+        teamActions={TEAM_ACTIONS}
+        viewerTeamName={null}
+        week="2026-08-10"
+      />,
+    );
+
+    expect(screen.queryByText("회의실 예약")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "예약하기" }));
+
+    expect(screen.getByText("회의실 예약")).toBeInTheDocument();
+  });
+});

--- a/src/features/rooms/components/rooms-board.tsx
+++ b/src/features/rooms/components/rooms-board.tsx
@@ -1,7 +1,11 @@
 "use client";
 
+import { Plus } from "lucide-react";
 import { useState } from "react";
 
+import { Button } from "@/components/ui/button";
+
+import { getNextAvailableSlot } from "../next-available-slot";
 import type {
   MeetingRoom,
   RoomMember,
@@ -23,6 +27,8 @@ interface RoomsBoardProps {
    *  못 부른다(여기·`RoomReservationDialog`가 전부 client). */
   showParentTeamAction: boolean;
   teamActions: RoomTeamActionOption[];
+  /** 참석자 "내 부서만" 필터 기준 — `RoomReservationDialog`로 그대로 흘려보낸다. */
+  viewerTeamName: string | null;
   /** "YYYY-MM-DD" — 이 주의 월요일. 서버 컴포넌트가 이 주 기준으로 `initialReservations`를 내려준다. */
   week: string;
 }
@@ -42,6 +48,7 @@ export function RoomsBoard({
   projects,
   showParentTeamAction,
   teamActions,
+  viewerTeamName,
   week,
 }: RoomsBoardProps) {
   const [reservations, setReservations] = useState(initialReservations);
@@ -49,6 +56,21 @@ export function RoomsBoard({
 
   return (
     <div className="flex flex-col gap-6">
+      {/* ⚠️ `/app/notice`의 "새 공지"와 같은 자리·같은 패턴이다(우측 정렬, `ink` 버튼) — 캘린더
+          칸을 직접 클릭하는 대신 바로 예약을 시작하는 진입점이다. 여는 시각은
+          `getNextAvailableSlot`이 "지금"을 30분 단위로 올려 계산한다. */}
+      <div className="flex justify-end">
+        <Button
+          type="button"
+          size="sm"
+          variant="ink"
+          onClick={() => setSlotStart(getNextAvailableSlot(new Date()))}
+        >
+          <Plus aria-hidden />
+          예약하기
+        </Button>
+      </div>
+
       <WeeklyRoomCalendarLoader
         reservations={reservations}
         members={members}
@@ -65,6 +87,7 @@ export function RoomsBoard({
         projects={projects}
         showParentTeamAction={showParentTeamAction}
         teamActions={teamActions}
+        viewerTeamName={viewerTeamName}
         onCreated={(created) => setReservations((prev) => [...prev, created])}
       />
     </div>

--- a/src/features/rooms/components/weekly-room-calendar.css
+++ b/src/features/rooms/components/weekly-room-calendar.css
@@ -85,8 +85,13 @@
   transition: background-color 100ms;
 }
 
+/*
+  ⚠️ 6% → 10%로 올렸다(2026-08-10) — 6%는 밝은 화면에서 커서만 바뀌고 배경 변화가 거의
+     안 보인다는 피드백이 있었다. 굵은 색 대신 그대로 `--foreground` 믹스 비율만 올려서
+     토큰은 그대로 유지한다(§디자인 토큰: 하드코딩 금지).
+*/
 .rbc-day-slot .rbc-time-slot:hover {
-  background-color: color-mix(in srgb, var(--foreground) 6%, transparent);
+  background-color: color-mix(in srgb, var(--foreground) 10%, transparent);
 }
 
 .rbc-day-slot .rbc-time-slot {

--- a/src/features/rooms/constants.ts
+++ b/src/features/rooms/constants.ts
@@ -7,3 +7,27 @@
 
 /** 예약 길이 — 팀 확정: 30분 한 타임, 연장하지 않는다(CLAUDE.md §브라우저 API). */
 export const RESERVATION_DURATION_MINUTES = 30;
+
+/**
+ * 회의실 운영 시간(분 단위, 09:00~18:00) — `validate.ts`(서버·폼 검증)와 "예약하기" 버튼의
+ * 기본 슬롯 계산(`next-available-slot.ts`)이 같은 값을 쓴다. 한쪽만 고치면 어긋난다.
+ */
+export const ROOM_OPERATING_START_MINUTES = 9 * 60;
+export const ROOM_OPERATING_END_MINUTES = 18 * 60;
+
+/**
+ * 참석자 피커 필터 3종 — `RoomAttendeePicker`가 쓴다.
+ * ⚠️ 세 값은 서로 배타적이라 라디오그룹으로 짠다(`role="radiogroup"`, `RoomPickerList`와 같은 패턴).
+ */
+export const ROOM_ATTENDEE_FILTER = {
+  ALL: "all",
+  LEADER: "leader",
+  MY_TEAM: "myTeam",
+} as const;
+export type RoomAttendeeFilter = (typeof ROOM_ATTENDEE_FILTER)[keyof typeof ROOM_ATTENDEE_FILTER];
+
+export const ROOM_ATTENDEE_FILTER_LABEL: Record<RoomAttendeeFilter, string> = {
+  all: "전체",
+  leader: "팀장급만",
+  myTeam: "내 부서만",
+};

--- a/src/features/rooms/mock/members.ts
+++ b/src/features/rooms/mock/members.ts
@@ -1,21 +1,25 @@
+import { AUTHORITY } from "@/constants/authority";
+
 import type { RoomMember } from "../types";
 
 /**
  * ⚠️ 목 데이터 — BE 연동 전. 참석자 검색 대상이 되는 사원 목록(전사 공용, 부서 무관).
- * 사원 도메인(`/manage/members`)과 별도로 이 화면 전용 경량 목록만 둔다 — 필요한 필드가
- * id·이름뿐이라 사원 도메인 전체 타입을 끌어오지 않는다.
+ * 사원 도메인(`/manage/members`)과 별도로 이 화면 전용 경량 목록만 둔다 — 필요한 필드가 필터용
+ * `teamName`·`authority`까지 셋뿐이라 사원 도메인 전체 타입을 끌어오지 않는다.
+ * ⚠️ 팀·권한은 여기서 새로 지어내지 않는다 — `features/member/mock/managed.ts`의 같은 id와
+ *    같은 값이다(§정직한 목업: 화면을 오갈 때 같은 사람의 소속이 달라 보이면 안 된다).
  */
 export const MEETING_MEMBERS: RoomMember[] = [
-  { id: 1, name: "박대표" },
-  { id: 2, name: "김서준" },
-  { id: 3, name: "이하윤" },
-  { id: 4, name: "박도현" },
-  { id: 5, name: "최유진" },
-  { id: 6, name: "정민석" },
-  { id: 7, name: "강서연" },
-  { id: 8, name: "임지안" },
-  { id: 9, name: "오현우" },
-  { id: 10, name: "한소율" },
+  { id: 1, name: "박대표", teamName: null, authority: AUTHORITY.OWNER },
+  { id: 2, name: "김서준", teamName: "개발팀", authority: AUTHORITY.LEADER },
+  { id: 3, name: "이하윤", teamName: "개발팀", authority: AUTHORITY.MEMBER },
+  { id: 4, name: "박도현", teamName: "개발팀", authority: AUTHORITY.MEMBER },
+  { id: 5, name: "최유진", teamName: "마케팅팀", authority: AUTHORITY.LEADER },
+  { id: 6, name: "정민석", teamName: "마케팅팀", authority: AUTHORITY.MEMBER },
+  { id: 7, name: "강서연", teamName: "디자인팀", authority: AUTHORITY.LEADER },
+  { id: 8, name: "임지안", teamName: "마케팅팀", authority: AUTHORITY.MEMBER },
+  { id: 9, name: "오현우", teamName: "전략기획팀", authority: AUTHORITY.LEADER },
+  { id: 10, name: "한소율", teamName: "디자인팀", authority: AUTHORITY.MEMBER },
 ];
 
 export function listMockMembers(): RoomMember[] {

--- a/src/features/rooms/next-available-slot.test.ts
+++ b/src/features/rooms/next-available-slot.test.ts
@@ -1,0 +1,28 @@
+import { getNextAvailableSlot } from "./next-available-slot";
+
+describe("getNextAvailableSlot", () => {
+  it("30분 단위가 아니면 다음 30분 경계로 올린다", () => {
+    const slot = getNextAvailableSlot(new Date("2026-08-11T10:12:00"));
+    expect(slot).toEqual(new Date("2026-08-11T10:30:00"));
+  });
+
+  it("이미 30분 경계면 그대로 둔다", () => {
+    const slot = getNextAvailableSlot(new Date("2026-08-11T10:30:00"));
+    expect(slot).toEqual(new Date("2026-08-11T10:30:00"));
+  });
+
+  it("운영 시간 전이면 같은 날 09:00으로 당긴다", () => {
+    const slot = getNextAvailableSlot(new Date("2026-08-11T07:40:00"));
+    expect(slot).toEqual(new Date("2026-08-11T09:00:00"));
+  });
+
+  it("마감 30분을 못 채우면 다음 날 09:00으로 넘긴다", () => {
+    const slot = getNextAvailableSlot(new Date("2026-08-11T17:45:00"));
+    expect(slot).toEqual(new Date("2026-08-12T09:00:00"));
+  });
+
+  it("운영 종료 시각이면 다음 날로 넘긴다", () => {
+    const slot = getNextAvailableSlot(new Date("2026-08-11T18:00:00"));
+    expect(slot).toEqual(new Date("2026-08-12T09:00:00"));
+  });
+});

--- a/src/features/rooms/next-available-slot.ts
+++ b/src/features/rooms/next-available-slot.ts
@@ -1,0 +1,36 @@
+import {
+  RESERVATION_DURATION_MINUTES,
+  ROOM_OPERATING_END_MINUTES,
+  ROOM_OPERATING_START_MINUTES,
+} from "./constants";
+
+/**
+ * 우측 상단 "예약하기" 버튼이 여는 기본 슬롯 — 지금 시각을 30분 단위로 올려 잡는다.
+ * ⚠️ 회의실·요일별 예약 현황은 안 본다 — 그건 예약 모달을 연 뒤 캘린더에서 이미 확인할 수 있고,
+ *    이 계산은 "언제 열지"만 정한다(어느 회의실인지는 모달에서 고른다).
+ * ⚠️ 운영 시간(09:00~18:00) 밖이면 다음 날 09:00으로 넘긴다 — `validateRoomReservationDraft`가
+ *    막는 값을 미리 열어주지 않는다.
+ */
+export function getNextAvailableSlot(now: Date): Date {
+  const slot = new Date(now);
+  slot.setSeconds(0, 0);
+
+  const remainder = slot.getMinutes() % RESERVATION_DURATION_MINUTES;
+  if (remainder !== 0) {
+    slot.setMinutes(slot.getMinutes() + (RESERVATION_DURATION_MINUTES - remainder));
+  }
+
+  const dayMinutes = slot.getHours() * 60 + slot.getMinutes();
+  if (dayMinutes < ROOM_OPERATING_START_MINUTES) {
+    setTimeOfDay(slot, ROOM_OPERATING_START_MINUTES);
+  } else if (dayMinutes + RESERVATION_DURATION_MINUTES > ROOM_OPERATING_END_MINUTES) {
+    slot.setDate(slot.getDate() + 1);
+    setTimeOfDay(slot, ROOM_OPERATING_START_MINUTES);
+  }
+
+  return slot;
+}
+
+function setTimeOfDay(date: Date, minutesFromMidnight: number): void {
+  date.setHours(Math.floor(minutesFromMidnight / 60), minutesFromMidnight % 60, 0, 0);
+}

--- a/src/features/rooms/types.ts
+++ b/src/features/rooms/types.ts
@@ -3,6 +3,8 @@
  * 컴포넌트는 이 타입만 알고, 목/실서버 분기는 `server.ts`가 끝낸다.
  */
 
+import type { Authority } from "@/constants/authority";
+
 /**
  * 회의실 한 곳.
  * ⚠️ **"수용 인원" 필드는 없다**(WORKFLOW.md §10-A 확정 — 전면 폐기). 화면·모달·데이터 구조
@@ -34,10 +36,17 @@ export interface MeetingRoomDraft {
 
 export type MeetingRoomFormErrors = Partial<Record<keyof MeetingRoomDraft, string>>;
 
-/** 참석자 검색 대상 — 예약 폼의 "참석자" 피커가 쓴다. */
+/**
+ * 참석자 검색 대상 — 예약 폼의 "참석자" 피커가 쓴다.
+ * ⚠️ `teamName`·`authority`는 "팀장급만"·"내 부서만" 필터(`RoomAttendeePicker`)를 위해서만
+ *    쓴다 — 사원 도메인 전체 타입은 여전히 안 끌어온다(§경량 항목).
+ */
 export interface RoomMember {
   id: number;
   name: string;
+  /** Owner는 팀이 없다(`null`, CLAUDE.md §조직 계층). */
+  teamName: string | null;
+  authority: Authority;
 }
 
 /** 예약 폼의 "프로젝트" select가 쓰는 경량 항목 — 프로젝트 도메인 전체 타입을 끌어오지 않는다. */

--- a/src/features/rooms/validate.ts
+++ b/src/features/rooms/validate.ts
@@ -3,7 +3,11 @@ import { isValid, parse } from "date-fns";
 import type { Authority } from "@/constants/authority";
 import { requiresParentTeamAction } from "@/lib/permission";
 
-import { RESERVATION_DURATION_MINUTES } from "./constants";
+import {
+  RESERVATION_DURATION_MINUTES,
+  ROOM_OPERATING_END_MINUTES,
+  ROOM_OPERATING_START_MINUTES,
+} from "./constants";
 import type {
   MeetingRoomDraft,
   MeetingRoomFormErrors,
@@ -15,9 +19,6 @@ const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 const TIME_PATTERN = /^([01]\d|2[0-3]):(00|30)$/;
 /** 회의실 운영 시작·종료 시각용 — 예약 슬롯(`TIME_PATTERN`)과 달리 30분 단위 제약이 없다. */
 const GENERAL_TIME_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/;
-
-const OPERATING_START_MINUTES = 9 * 60;
-const OPERATING_END_MINUTES = 18 * 60;
 
 function isValidCalendarDate(value: string): boolean {
   if (!DATE_PATTERN.test(value)) return false;
@@ -58,8 +59,8 @@ export function validateRoomReservationDraft(
   } else {
     const startMinutes = toMinutes(draft.startTime);
     if (
-      startMinutes < OPERATING_START_MINUTES ||
-      startMinutes + RESERVATION_DURATION_MINUTES > OPERATING_END_MINUTES
+      startMinutes < ROOM_OPERATING_START_MINUTES ||
+      startMinutes + RESERVATION_DURATION_MINUTES > ROOM_OPERATING_END_MINUTES
     ) {
       errors.startTime = "회의실 운영 시간(09:00~18:00) 안에서 선택해 주세요";
     }


### PR DESCRIPTION
## 📋 PR 타입
- [x] feature
- [x] style

## 🗂 작업 영역
- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실

## 🙋 관련 역할
- [x] 공통

## 📝 작업 내용
- 참석자 피커에 "전체/팀장급만/내 부서만" 라디오그룹 필터 추가 — `RoomMember`에 `teamName`·`authority` 추가(mock 값은 사원 도메인 목과 동일하게 맞춤), viewer.teamName을 page → RoomsBoard → RoomReservationDialog → RoomAttendeePicker로 전달 (#256)
- [즉시 예약] 클릭 시 곧바로 등록하지 않고 `ConfirmDialog`("이대로 등록하시겠습니까?")를 먼저 띄우도록 변경 — 확인 후 `formRef.requestSubmit()`으로 실제 제출 (#257)
- 주간 캘린더 빈 슬롯 hover 배경을 6%→10%로 올려 클릭 가능 영역이 더 잘 드러나게 보강(cursor: pointer는 기존에도 있었음) (#258)
- `RoomsBoard` 우측 상단에 "예약하기" 버튼 추가(`/app/notice`의 "새 공지"와 같은 배치·톤) — `getNextAvailableSlot()`으로 "지금"을 30분 단위로 올려 기본 슬롯 계산(운영시간 09:00~18:00 밖이면 다음 날 09:00), 이 상수를 `validate.ts`와 공유하도록 `constants.ts`로 이동 (#259)

## ✅ 작업 체크리스트
**기본**
- [x] 브랜치 명명 규칙 준수 (`feature/room-memberfilter`)
- [x] 커밋 컨벤션 준수
- [x] 아래 Closes # 기입
- [x] 불필요한 console·주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**
- [x] 🔐 권한 2축 검사 — 신규 서버 액션·소유권 로직 없음(기존 예약 생성 액션·검증을 그대로 사용). 참석자 필터는 조회 전용 UI라 참석자 지정 권한 자체엔 영향 없음
- [x] 🧬 zod — `validateRoomReservationDraft` 로직·스키마 변경 없음(운영시간 상수 위치만 `validate.ts` ↔ `constants.ts`로 이동, 값은 동일)
- [x] 🕵️ 정직성 — mock 참석자의 팀·권한 값은 `features/member/mock/managed.ts`와 동일하게 맞췄다는 주석을 남김. 그 외 목/미구현/폴백 없음
- [x] 🎨 디자인 토큰 사용 — hover 강화는 기존 `color-mix(in srgb, var(--foreground) …)` 토큰 믹스 비율만 조정(생 hex 없음), 새 버튼은 기존 `Button ink` 변형 재사용

**품질**
- [x] ⚡ 최적화 — 무거운 캘린더는 기존 `next/dynamic` 그대로, 이번 변경으로 새로 추가된 무거운 리소스 없음
- [x] ♿ a11y — 참석자 필터는 `role="radiogroup"`/`role="radio"`로 구현(3개 값이 서로 배타적이라 라디오 시맨틱 사용)
- [x] ♻️ 재사용 확인 — 확인 모달은 기존 `ConfirmDialog`(NoticeCreateDialog와 같은 패턴), 예약하기 버튼은 `/app/notice`의 헤더 배치 그대로, 필터 그룹은 `RoomPickerList`의 라디오 패턴 재사용
- [x] 🧪 loading/error/empty — 참석자 검색 결과 없음 상태 그대로 유지, 그 외 3상태 영향 없음
- [x] 브라우저 전용 API 사용 없음(해당 없음)

## 🔗 연관 이슈
Closes #256
Closes #257
Closes #258
Closes #259

## 📸 스크린샷 (선택)
| Before | After |
| ------ | ----- |
|        |       |

## 💬 리뷰 포인트
- 참석자 필터는 스펙에 "checkbox"라고 적혀 있었지만 세 값(전체/팀장급만/내 부서만)이 서로 배타적이라 `role="radio"` 그룹으로 구현했습니다 — 의도와 맞는지 확인해 주세요.
- 확인 모달 통과 후에야 서버 액션이 실행되므로, 필드 검증 오류는 확인 모달을 한 번 더 거친 뒤 보여집니다.
- "예약하기"의 기본 슬롯은 회의실별 실제 예약 현황과 대조하지 않고 시간만으로 계산합니다(회의실은 모달에서 고른 뒤 확인).
- 뷰어가 Owner(팀 없음)일 때 "내 부서만" 필터는 빈 목록이 됩니다 — 조직 계층 규칙(Owner는 팀이 없음)에 따른 의도된 동작입니다.

## 📝 추가 메모
- 브라우저 프리뷰가 이 작업 중 계속 로딩 상태로 멈춰 있어 시각 확인은 못 했습니다 — 병합 전 로컬에서 한 번 봐주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 회의실 화면에서 현재 시각 기준 다음 예약 가능 시간으로 예약을 시작할 수 있습니다.
  * 예약 전 확인 모달이 표시되어 내용을 검토한 뒤 확정할 수 있습니다.
  * 참석자를 전체, 리더, 내 부서 기준으로 필터링하고 이름으로 검색할 수 있습니다.
  * 참석자 필터에 사용자의 소속 팀 정보가 반영됩니다.
* **개선**
  * 운영 시간 외 예약 시작 시간이 다음 운영일의 첫 시간으로 조정됩니다.
  * 시간 슬롯 호버 상태의 가시성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->