### PR TITLE
[DESIGN] 날짜 입력을 네이티브 input에서 커스텀 달력으로 통일 #261

### DIFF
--- a/src/components/common/date-picker-field.tsx
+++ b/src/components/common/date-picker-field.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { format, parse } from "date-fns";
+import { ko } from "date-fns/locale";
+import { CalendarIcon } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+const VALUE_FORMAT = "yyyy-MM-dd";
+const DISPLAY_FORMAT = "yyyy년 M월 d일(EEE)";
+
+function parseValue(value: string): Date | undefined {
+  if (!value) return undefined;
+  const parsed = parse(value, VALUE_FORMAT, new Date());
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+interface DatePickerFieldProps {
+  id?: string;
+  /** `<form action={formAction}>` 네이티브 제출용 — 넘기면 숨은 `<input>`으로 같이 낸다. */
+  name?: string;
+  /** `YYYY-MM-DD`. 아직 안 골랐으면 빈 문자열. */
+  value: string;
+  onChange: (value: string) => void;
+  /** `YYYY-MM-DD` — 이 날짜 이전은 고를 수 없다. */
+  min?: string;
+  /** `YYYY-MM-DD` — 이 날짜 이후는 고를 수 없다. */
+  max?: string;
+  placeholder?: string;
+  "aria-label"?: string;
+  "aria-invalid"?: boolean;
+  disabled?: boolean;
+  /** 트리거 버튼에 붙는 클래스 — 표에 나란히 넣을 때 폭을 좁히는 용도. */
+  className?: string;
+}
+
+/**
+ * 날짜 하나를 고르는 팝오버 달력 — 네이티브 `<input type="date">` 대체
+ * (2026-08-10 디자인 통일: 캘린더 화면의 Todo 추가 모달과 같은 모양으로 맞춘다,
+ * `add-todo-dialog.tsx` 참고). 브라우저마다 다르게 생기는 기본 달력 UI 대신
+ * 이 서비스 톤(먹색 선택)으로 고정된 모습을 쓴다.
+ * ⚠️ `min`/`max`는 문자열 비교가 아니라 **달력에서 그 범위 밖 날짜를 고를 수 없게** 막는다
+ *    — 네이티브 input의 `min`/`max`와 같은 역할이지만 팝오버 안에서 시각적으로도 드러난다.
+ */
+export function DatePickerField({
+  id,
+  name,
+  value,
+  onChange,
+  min,
+  max,
+  placeholder = "날짜 선택",
+  "aria-label": ariaLabel,
+  "aria-invalid": ariaInvalid,
+  disabled,
+  className,
+}: DatePickerFieldProps) {
+  const [open, setOpen] = useState(false);
+  const selected = parseValue(value);
+  const minDate = min ? parseValue(min) : undefined;
+  const maxDate = max ? parseValue(max) : undefined;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      {/* ⚠️ 네이티브 제출용 — 화면엔 안 보이지만 `FormData`엔 `name`으로 잡힌다. */}
+      {name && <input type="hidden" name={name} value={value} />}
+      <PopoverTrigger
+        render={
+          <Button
+            id={id}
+            type="button"
+            variant="outline"
+            disabled={disabled}
+            aria-label={ariaLabel}
+            aria-invalid={ariaInvalid}
+            className={cn("h-10 justify-start gap-2 font-normal", className)}
+          />
+        }
+      >
+        <CalendarIcon aria-hidden className="size-4 shrink-0 text-current" />
+        <span className={cn("truncate", !selected && "text-muted-foreground")}>
+          {selected ? format(selected, DISPLAY_FORMAT, { locale: ko }) : placeholder}
+        </span>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-auto p-3 [--cell-size:--spacing(9)]">
+        <Calendar
+          className="[&_[data-selected-single=true]]:bg-foreground [&_[data-selected-single=true]]:text-background [&_[data-selected-single=true]]:hover:bg-foreground"
+          mode="single"
+          locale={ko}
+          selected={selected}
+          disabled={[minDate && { before: minDate }, maxDate && { after: maxDate }].filter(
+            (matcher) => matcher !== undefined,
+          )}
+          onSelect={(next) => {
+            if (!next) return;
+            onChange(format(next, VALUE_FORMAT));
+            setOpen(false);
+          }}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/features/handover/components/vacation-form.tsx
+++ b/src/features/handover/components/vacation-form.tsx
@@ -3,9 +3,9 @@
 import { useMemo, useState, useTransition } from "react";
 
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
+import { DatePickerField } from "@/components/common/date-picker-field";
 import { ResultDialog } from "@/components/common/result-dialog";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -98,24 +98,24 @@ export function VacationForm({ context }: VacationFormProps) {
                 <Label htmlFor="vacation-start">
                   휴직 시작 날짜 <span className="text-destructive">*</span>
                 </Label>
-                <Input
+                <DatePickerField
                   id="vacation-start"
-                  type="date"
                   value={startDate}
                   max={endDate || undefined}
-                  onChange={(event) => handleDateChange({ startDate: event.target.value })}
+                  onChange={(next) => handleDateChange({ startDate: next })}
+                  className="w-full"
                 />
               </div>
               <div className="flex flex-col gap-1.5">
                 <Label htmlFor="vacation-end">
                   휴직 종료 날짜 <span className="text-destructive">*</span>
                 </Label>
-                <Input
+                <DatePickerField
                   id="vacation-end"
-                  type="date"
                   value={endDate}
                   min={startDate || undefined}
-                  onChange={(event) => handleDateChange({ endDate: event.target.value })}
+                  onChange={(next) => handleDateChange({ endDate: next })}
+                  className="w-full"
                 />
               </div>
             </div>

--- a/src/features/meeting/review/components/action-review-row.tsx
+++ b/src/features/meeting/review/components/action-review-row.tsx
@@ -2,8 +2,8 @@
 
 import { X } from "lucide-react";
 
+import { DatePickerField } from "@/components/common/date-picker-field";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -80,20 +80,18 @@ export function ActionReviewRow({
           </SelectContent>
         </Select>
 
-        <Input
-          type="date"
+        <DatePickerField
           aria-label="시작일"
           value={draft.startDate}
           max={draft.dueDate}
-          onChange={(event) => onStartDateChange(event.target.value)}
+          onChange={onStartDateChange}
           className="w-[150px]"
         />
-        <Input
-          type="date"
+        <DatePickerField
           aria-label="마감일"
           value={draft.dueDate}
           min={draft.startDate}
-          onChange={(event) => onDueDateChange(event.target.value)}
+          onChange={onDueDateChange}
           className="w-[150px]"
         />
 

--- a/src/features/meeting/review/components/manual-draft-form.tsx
+++ b/src/features/meeting/review/components/manual-draft-form.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 
+import { DatePickerField } from "@/components/common/date-picker-field";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -76,20 +77,18 @@ export function ManualDraftForm({
             ))}
           </SelectContent>
         </Select>
-        <Input
-          type="date"
+        <DatePickerField
           aria-label="시작일"
           value={startDate}
           max={dueDate || undefined}
-          onChange={(event) => setStartDate(event.target.value)}
+          onChange={setStartDate}
           className="w-[150px]"
         />
-        <Input
-          type="date"
+        <DatePickerField
           aria-label="마감일"
           value={dueDate}
           min={startDate || undefined}
-          onChange={(event) => setDueDate(event.target.value)}
+          onChange={setDueDate}
           className="w-[150px]"
         />
       </div>

--- a/src/features/project/components/project-form.tsx
+++ b/src/features/project/components/project-form.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import type { CSSProperties } from "react";
 import { useActionState, useRef, useState } from "react";
 
+import { DatePickerField } from "@/components/common/date-picker-field";
 import { FieldError } from "@/components/common/field-error";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -231,14 +232,14 @@ export function ProjectForm({ action, teamOptions, cancelHref }: ProjectFormProp
           <Label htmlFor="project-start-date">
             시작일 <span className="text-destructive">*</span>
           </Label>
-          <Input
+          <DatePickerField
             id="project-start-date"
             name="startDate"
-            type="date"
             value={startDate}
-            onChange={(event) => setStartDate(event.target.value)}
+            onChange={setStartDate}
             max={dueDate || undefined}
             aria-invalid={Boolean(state.errors.startDate)}
+            className="w-full"
           />
           <FieldError message={state.errors.startDate} />
         </div>
@@ -247,14 +248,14 @@ export function ProjectForm({ action, teamOptions, cancelHref }: ProjectFormProp
           <Label htmlFor="project-due-date">
             마감 기한 <span className="text-destructive">*</span>
           </Label>
-          <Input
+          <DatePickerField
             id="project-due-date"
             name="dueDate"
-            type="date"
             value={dueDate}
-            onChange={(event) => setDueDate(event.target.value)}
+            onChange={setDueDate}
             min={startDate || undefined}
             aria-invalid={Boolean(state.errors.dueDate)}
+            className="w-full"
           />
           <FieldError message={state.errors.dueDate} />
         </div>


### PR DESCRIPTION
## 📋 PR 타입

- [ ] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [x] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

- `src/components/common/date-picker-field.tsx` 신규 — 캘린더 화면 Todo 추가 모달(`add-todo-dialog.tsx`)이 쓰던 Popover+Calendar 조합을 공용 컴포넌트로 추출(같은 톤: 먹색 선택, `date-fns`+`ko` 로케일)
- 아래 4개 화면의 네이티브 `<input type="date">`를 이 컴포넌트로 교체: `vacation-form.tsx`(휴직 시작·종료일), `project-form.tsx`(프로젝트 시작일·마감 기한, `name` prop으로 네이티브 form 제출 그대로 유지), `action-review-row.tsx`(AI 리뷰 시작일·마감일), `manual-draft-form.tsx`(액션 직접 추가 시작일·마감일)
- `min`/`max` 제약은 그대로 유지하되, 달력 안에서 범위 밖 날짜가 실제로 비활성화되도록(react-day-picker `disabled` matcher) 구현

---

## ✅ 작업 체크리스트

**기본**

- [ ] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [ ] 불필요한 `console` · 주석 처리된 코드 제거
- [ ] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**(회의 담당자 등), 그리고 **서버(Server Action/BFF)에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [ ] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시 (조용히 "되는 척" 금지)
- [ ] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그)
- [ ] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [ ] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인)
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음

---

## 🔗 연관 이슈

Closes #261

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- `/app/handover`에서 휴직 시작·종료일을 팝오버 달력으로 고를 수 있고 서로 범위를 벗어난 날짜는 비활성화되는지 확인
- `/app/projects/new`에서 시작일·마감 기한 선택 후 실제로 폼 제출(FormData)에 값이 반영되는지 확인
- AI 리뷰 화면(`/app/meeting/:id/review`)에서 액션별 시작일·마감일 수정 확인
- CI(typecheck/lint/test/build) 통과 확인

---

## 📝 추가 메모
