### PR TITLE
[CHORE] 인수인계 API 연동 준비 — 상태 매퍼·요청 필드·재배정 구조·엔드포인트 등록 #274

### DIFF
--- a/src/constants/handover.ts
+++ b/src/constants/handover.ts
@@ -22,6 +22,32 @@ export const HANDOVER_STATUS_LABEL: Record<HandoverStatus, string> = {
   REJECTED: "반려",
 };
 
+/**
+ * BE가 실제로 내려주는 상태 원본값(BE 인수인계 문서, 2026-08-10) — `REASSIGNED`·`FINALIZED`는
+ * FE 이름과 달라 매퍼에서만 변환한다. `SUBMITTED`·`REJECTED`는 이름이 같아 그대로 통과.
+ * ⚠️ BE enum은 DB·테스트까지 굳어 있어 이름을 안 바꾼다 — 경계(`mapHandoverStatusFromBe`)에서만
+ *    흡수하고 UI·기존 화면(`MID_APPROVED` 등 사용)은 손대지 않는다.
+ */
+export const HANDOVER_STATUS_BE = {
+  SUBMITTED: "SUBMITTED",
+  REASSIGNED: "REASSIGNED",
+  FINALIZED: "FINALIZED",
+  REJECTED: "REJECTED",
+} as const;
+export type HandoverStatusBe = (typeof HANDOVER_STATUS_BE)[keyof typeof HANDOVER_STATUS_BE];
+
+/** 응답 매퍼 경계 — BE 상태 원본값을 FE `HandoverStatus`로 바꾼다. */
+export function mapHandoverStatusFromBe(status: HandoverStatusBe): HandoverStatus {
+  switch (status) {
+    case HANDOVER_STATUS_BE.REASSIGNED:
+      return HANDOVER_STATUS.MID_APPROVED;
+    case HANDOVER_STATUS_BE.FINALIZED:
+      return HANDOVER_STATUS.FINAL_APPROVED;
+    default:
+      return status;
+  }
+}
+
 export const HANDOVER_TYPE = {
   VACATION: "VACATION",
   OFFBOARDING: "OFFBOARDING",

--- a/src/features/handover/actions.ts
+++ b/src/features/handover/actions.ts
@@ -1,26 +1,15 @@
 "use server";
 
-import { HANDOVER_STATUS, HANDOVER_TYPE, type HandoverStatus } from "@/constants/domain";
+import { HANDOVER_STATUS, type HandoverStatus } from "@/constants/domain";
 import { isMock } from "@/mocks/config";
 
-/** 휴직 신청 — 팀장이면 액션마다 담당자를 지정해 함께 보낸다(자가 재할당). */
-export interface SubmitVacationHandoverPayload {
-  type: typeof HANDOVER_TYPE.VACATION;
-  startDate: string;
-  endDate: string;
-  actionIds: number[];
-  /** 액션 id → 배정받을 팀원 id. 팀장 신청이 아니면 빈 객체. */
-  assignments: Record<number, string>;
-}
+import type { SubmitHandoverPayload } from "./lib";
 
-export interface SubmitOffboardingHandoverPayload {
-  type: typeof HANDOVER_TYPE.OFFBOARDING;
-  description: string;
-  actionIds: number[];
-}
-
-export type SubmitHandoverPayload =
-  SubmitVacationHandoverPayload | SubmitOffboardingHandoverPayload;
+export type {
+  SubmitHandoverPayload,
+  SubmitOffboardingHandoverPayload,
+  SubmitVacationHandoverPayload,
+} from "./lib";
 
 /**
  * [인수인계서 신청] — 접수만 한다.

--- a/src/features/handover/lib.ts
+++ b/src/features/handover/lib.ts
@@ -2,6 +2,54 @@ import { HANDOVER_TYPE, type HandoverType } from "@/constants/domain";
 
 import type { HandoverActionItem } from "./types";
 
+/** 휴직 신청 — 팀장이면 액션마다 담당자를 지정해 함께 보낸다(자가 재할당). */
+export interface SubmitVacationHandoverPayload {
+  type: typeof HANDOVER_TYPE.VACATION;
+  startDate: string;
+  endDate: string;
+  actionIds: number[];
+  /**
+   * 액션 id → 배정받을 팀원 id. 팀장 신청이 아니면 빈 객체.
+   * ⚠️ 지금은 로스터 mock(`TEAM_MEMBER_ROSTER_MOCK`)의 문자열 슬러그 id(`"member-lee"`)다.
+   *    실 멤버 API가 붙으면 로스터 자체가 처음부터 숫자 id로 오므로 별도 변환 함수가 아니라
+   *    **로스터 mock을 숫자 id로 바꾸는 쪽**이 맞는 해결책이다 — 지금 값으로는 이름 매칭 없이
+   *    숫자로 캐스팅할 수 없다(BE 인수인계 문서 §5, 백엔드 담당자 별도 확인 예정).
+   */
+  assignments: Record<number, string>;
+}
+
+export interface SubmitOffboardingHandoverPayload {
+  type: typeof HANDOVER_TYPE.OFFBOARDING;
+  description: string;
+  actionIds: number[];
+}
+
+export type SubmitHandoverPayload =
+  SubmitVacationHandoverPayload | SubmitOffboardingHandoverPayload;
+
+/**
+ * FE 내부 payload → BE 생성 요청 바디. 경계에서만 이름을 바꾼다 — FE 내부 필드명(위 두 타입)은
+ * 그대로 두고 fetch 직전에만 변환해 BE 계약을 흡수한다(BE 인수인계 문서, 2026-08-10).
+ * `startDate`/`endDate`→`leaveStartAt`/`leaveEndAt`(자정 시각 붙임), `description`→`note`,
+ * `actionIds`→`selectedActionIds`.
+ */
+export function toHandoverCreateRequestBody(payload: SubmitHandoverPayload) {
+  if (payload.type === HANDOVER_TYPE.VACATION) {
+    return {
+      type: payload.type,
+      leaveStartAt: `${payload.startDate}T00:00:00`,
+      leaveEndAt: `${payload.endDate}T00:00:00`,
+      selectedActionIds: payload.actionIds,
+      assignments: payload.assignments,
+    };
+  }
+  return {
+    type: payload.type,
+    note: payload.description,
+    selectedActionIds: payload.actionIds,
+  };
+}
+
 /**
  * ⚠️ **임시 미리보기 토글**(사용자 요청, 2026-08-08) — 로그인이 아직 없어 "지금 보고
  *    있는 사람"을 화면에서 바로 바꿔볼 수 있게 둔 것. 실제 세션이 붙으면 이 토글과

--- a/src/features/team-handover/actions.ts
+++ b/src/features/team-handover/actions.ts
@@ -11,7 +11,7 @@ import { todayIso } from "@/lib/date";
 import { isMock } from "@/mocks/config";
 
 import { FIXED_LEADER_NAME, getTeamHandoverDetail } from "./server";
-import type { TeamHandoverAssignment } from "./types";
+import type { TeamHandoverAssignment, TeamMemberOption } from "./types";
 
 const LIST_PATH = "/team/handover";
 const MANAGE_PATH = "/manage/members";
@@ -22,6 +22,23 @@ function findPersonalItem(actionId: number) {
     if (found) return found;
   }
   return null;
+}
+
+/**
+ * 액션 하나를 재배정한다 — BE는 건별 `PATCH /api/handovers/{id}/items/{actionId}/reassign`로
+ * 락·멱등을 강제한다(BE 인수인계 문서, 2026-08-10; 일괄 반영 엔드포인트가 아니다).
+ * 지금은 mock이라 로컬 mutate 한 건이지만, **실연동 시 이 함수 내부만 실 API 호출로 바꾸면**
+ * `completeTeamHandoverAction`의 순회 구조는 그대로 쓴다.
+ */
+function reassignHandoverItem(
+  assignment: TeamHandoverAssignment,
+  teammateById: Map<number, TeamMemberOption>,
+): void {
+  const teammate = teammateById.get(assignment.assigneeId);
+  const item = findPersonalItem(assignment.actionId);
+  if (!teammate || !item) return;
+  item.assigneeName = teammate.name;
+  item.assigneeRoleLabel = teammate.roleLabel ?? undefined;
 }
 
 /**
@@ -68,12 +85,8 @@ export async function completeTeamHandoverAction(
     seenActionIds.add(actionId);
   }
 
-  for (const { actionId, assigneeId } of assignments) {
-    const teammate = teammateById.get(assigneeId);
-    const item = findPersonalItem(actionId);
-    if (!teammate || !item) continue;
-    item.assigneeName = teammate.name;
-    item.assigneeRoleLabel = teammate.roleLabel ?? undefined;
+  for (const assignment of assignments) {
+    reassignHandoverItem(assignment, teammateById);
   }
 
   completeMockHandoverMidApproval(memberId, FIXED_LEADER_NAME, todayIso());

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -30,6 +30,16 @@ export const ep = {
   /* 인수인계 */
   handovers: () => "/api/handovers",
   handover: (id: number) => `/api/handovers/${id}`,
+  /** 팀장급 인수인계(귀속) 목록 — BE 인수인계 문서(2026-08-10) §package. */
+  handoverPackage: () => "/api/handovers/package",
+  /** 팀장급 인수인계 통계·요약 — BE 인수인계 문서(2026-08-10) §insights. */
+  handoverInsights: () => "/api/handovers/insights",
+  /** 건별 재배정 — 일괄 반영 엔드포인트가 아니다(락·멱등, §team-handover/actions.ts). */
+  handoverReassignItem: (id: number, actionId: number) =>
+    `/api/handovers/${id}/items/${actionId}/reassign`,
+  handoverComplete: (id: number) => `/api/handovers/${id}/complete`,
+  handoverFinalize: (id: number) => `/api/handovers/${id}/finalize`,
+  handoverReject: (id: number) => `/api/handovers/${id}/reject`,
 
   /* 조직 */
   members: () => "/api/members",


### PR DESCRIPTION
## 📋 PR 타입

- [ ] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [x] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

백엔드 담당자(김민섭)가 전달한 인수인계 도메인 매퍼링 표(2026-08-10) 기준, 실 API 연동 전 매퍼/상수 레벨 준비 작업입니다. mock 동작은 그대로, 실연동 시 경계(매퍼)만 채우면 되도록 구조만 미리 잡았습니다.

- `constants/handover.ts`: `HANDOVER_STATUS_BE`(BE 원본 enum) + `mapHandoverStatusFromBe()` 경계 매퍼 추가 (`REASSIGNED`→`MID_APPROVED`, `FINALIZED`→`FINAL_APPROVED`)
- `features/handover/lib.ts`: `toHandoverCreateRequestBody()` 추가 — FE 내부 payload(`startDate`/`endDate`/`description`/`actionIds`) → BE 요청 바디(`leaveStartAt`/`leaveEndAt`/`note`/`selectedActionIds`) 변환. (순수 함수라 `"use server"` 파일인 `actions.ts`가 아니라 여기 둠 — Server Action은 async 함수여야 해서 build error 났던 것 수정)
- `features/team-handover/actions.ts`: 재배정 루프를 `reassignHandoverItem()` 건별 헬퍼로 분리 — BE가 `PATCH /{id}/items/{actionId}/reassign` 건별(락·멱등)을 강제하기 때문. 실연동 시 이 함수 내부만 API 호출로 바꾸면 순회 구조는 그대로.
- `lib/endpoints.ts`: `handoverPackage`·`handoverInsights`·`handoverReassignItem`·`handoverComplete`·`handoverFinalize`·`handoverReject` URL 빌더 추가.

멤버 id 문자열→숫자 변환(BE 매퍼링 표 원래 항목 4)은 범위에서 제외 — 로스터 mock이 실연동 시 처음부터 숫자 id로 교체되면 되는 거라 별도 변환 로직 불필요(2026-08-10 확인).

API 연동 실작업 들어가기 전에, 이미 확정된 매핑 규칙을 지금 반영해두면 연동 시 매퍼 내부만 채우면 됩니다(컴포넌트·화면 로직 0줄 수정).

---

## ✅ 작업 체크리스트

**기본**

- [ ] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [ ] 불필요한 `console` · 주석 처리된 코드 제거
- [ ] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**(회의 담당자 등), 그리고 **서버(Server Action/BFF)에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [x] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시 (조용히 "되는 척" 금지)
- [ ] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그)
- [ ] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [ ] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인)
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음

---

## 🔗 연관 이슈

Closes #274

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- [x] `npx tsc --noEmit` 0 에러
- [x] `npx jest` 72 suites / 820 tests 전부 통과
- 동작 변화 없음(mock 그대로) — 화면 확인 불필요

---

## 📝 추가 메모

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 휴직 및 오프보딩 인수인계 요청을 제출할 수 있습니다.
  - 인수인계 항목별 담당자를 재배정할 수 있습니다.
  - 인수인계 패키지와 인사이트를 조회할 수 있습니다.
  - 인수인계를 완료, 최종 확정 또는 거절할 수 있습니다.

- **개선 사항**
  - 서버와 화면 간 인수인계 상태가 올바르게 표시되도록 상태 변환을 지원합니다.
  - 휴직 기간, 작업 목록, 담당자 배정 정보가 요청에 맞게 처리됩니다.
  - 오프보딩 설명이 인수인계 메모로 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
