### PR TITLE
[FEAT] 회의실 관리 CRUD 검증(테스트·빌드) #276

### DIFF
--- a/src/features/rooms/actions.test.ts
+++ b/src/features/rooms/actions.test.ts
@@ -16,8 +16,10 @@ import { getMockActor } from "@/lib/mock-actor";
 import {
   createMeetingRoomAction,
   createRoomReservationAction,
+  deleteMeetingRoomAction,
   updateMeetingRoomAction,
 } from "./actions";
+import { findMockRoom } from "./mock/rooms";
 
 const revalidatePathMock = revalidatePath as unknown as jest.Mock;
 const getMockActorMock = getMockActor as unknown as jest.Mock;
@@ -112,6 +114,37 @@ describe("회의실 추가·수정", () => {
     );
 
     expect(result.errors.name).toBe("수정할 회의실을 찾을 수 없습니다");
+  });
+});
+
+describe("회의실 삭제", () => {
+  it("Admin이 아니면 삭제를 막는다(OWNER도 예외 없음)", async () => {
+    getMockActorMock.mockReturnValue({ id: 1, role: "OWNER" });
+
+    await expect(deleteMeetingRoomAction(roomForm({ id: "room-large" }))).rejects.toThrow(
+      "회의실을 삭제할 권한이 없습니다",
+    );
+    expect(revalidatePathMock).not.toHaveBeenCalled();
+  });
+
+  it("Admin 겸직자면 삭제할 수 있고, 목록에서 사라진다", async () => {
+    getMockActorMock.mockReturnValue({ id: 2, role: "MEMBER", isAdmin: true });
+    const created = await createMeetingRoomAction({ errors: {} }, roomForm(VALID_ROOM_ENTRIES));
+    revalidatePathMock.mockClear();
+
+    await deleteMeetingRoomAction(roomForm({ id: created.room!.id }));
+
+    expect(findMockRoom(created.room!.id)).toBeNull();
+    expect(revalidatePathMock).toHaveBeenCalledWith("/manage/rooms");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/app/rooms");
+  });
+
+  it("없는 id를 삭제해도 조용히 넘어간다(중복 삭제 요청 방어)", async () => {
+    getMockActorMock.mockReturnValue({ id: 2, role: "MEMBER", isAdmin: true });
+
+    await expect(
+      deleteMeetingRoomAction(roomForm({ id: "존재하지-않음" })),
+    ).resolves.toBeUndefined();
   });
 });
 

--- a/src/features/rooms/actions.ts
+++ b/src/features/rooms/actions.ts
@@ -11,7 +11,7 @@ import { isMock } from "@/mocks/config";
 import { RESERVATION_DURATION_MINUTES } from "./constants";
 import { findMockMember } from "./mock/members";
 import { addMockReservation, listMockReservationsByRoom } from "./mock/reservations";
-import { addMockRoom, findMockRoom, updateMockRoom } from "./mock/rooms";
+import { addMockRoom, deleteMockRoom, findMockRoom, updateMockRoom } from "./mock/rooms";
 import type {
   MeetingRoom,
   MeetingRoomDraft,
@@ -188,4 +188,26 @@ export async function updateMeetingRoomAction(
   revalidatePath(MANAGE_ROOMS_PATH);
   revalidatePath(ROOMS_PATH);
   return { errors: {}, room };
+}
+
+/**
+ * 회의실 삭제 — 추가·수정과 같은 규칙(권한·`isMock` 분기). 되돌릴 수 없는 조작이라 화면
+ * (`RoomDeleteDialog`)에서 확인 Dialog를 먼저 띄운 뒤에만 이 액션이 실행된다(§토스트: 파괴적
+ * 작업은 Dialog). 같은 화면에 머무르므로 `deleteNoticeAction`과 달리 `redirect`는 없다.
+ */
+export async function deleteMeetingRoomAction(formData: FormData): Promise<void> {
+  if (!canManageRooms(getMockActor())) {
+    throw new Error("회의실을 삭제할 권한이 없습니다");
+  }
+
+  if (!isMock) {
+    // ⚠️ 미구현 — API 스펙 확정 후 BFF 경로로 회의실 삭제 요청을 보낸다.
+    throw new Error("회의실 삭제 API가 아직 연결되지 않았습니다.");
+  }
+
+  const id = String(formData.get("id") ?? "");
+  deleteMockRoom(id);
+
+  revalidatePath(MANAGE_ROOMS_PATH);
+  revalidatePath(ROOMS_PATH);
 }

--- a/src/features/rooms/components/room-delete-dialog.tsx
+++ b/src/features/rooms/components/room-delete-dialog.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useTransition } from "react";
+import { toast } from "sonner";
+
+import { ConfirmDialog } from "@/components/common/confirm-dialog";
+
+import { deleteMeetingRoomAction } from "../actions";
+import { ROOM_DELETE_CONFIRM } from "../constants";
+import type { MeetingRoom } from "../types";
+
+interface RoomDeleteDialogProps {
+  room: MeetingRoom;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * 삭제 확인 모달 — 트리거는 표 행의 "⋯" 메뉴(`room-row-actions.tsx`)에 있다.
+ * ⚠️ `notice-delete-button.tsx`와 같은 골격(`useTransition` + 서버 액션 직접 호출) — 다만
+ *    삭제 뒤 같은 화면에 머무르므로 `redirect` 대신 `router.refresh()`로 목록을 다시 받아온다.
+ */
+export function RoomDeleteDialog({ room, open, onOpenChange }: RoomDeleteDialogProps) {
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+
+  function handleConfirm() {
+    const formData = new FormData();
+    formData.set("id", room.id);
+    // ⚠️ 콜백이 Promise를 반환해야 한다 — 반환하지 않으면 React가 삭제가 끝나기 전에
+    //    전환을 "완료"로 보고 `isPending`이 너무 일찍 꺼져 버튼이 풀린다.
+    startTransition(async () => {
+      await deleteMeetingRoomAction(formData);
+      onOpenChange(false);
+      router.refresh();
+      toast.success("회의실을 삭제했습니다");
+    });
+  }
+
+  return (
+    <ConfirmDialog
+      isOpen={open}
+      onOpenChange={(next) => {
+        if (!next && isPending) return;
+        onOpenChange(next);
+      }}
+      title={ROOM_DELETE_CONFIRM.title(room.name)}
+      description={ROOM_DELETE_CONFIRM.description}
+      confirmLabel={ROOM_DELETE_CONFIRM.confirmLabel}
+      pendingLabel={ROOM_DELETE_CONFIRM.pendingLabel}
+      isDestructive
+      isPending={isPending}
+      onConfirm={handleConfirm}
+    />
+  );
+}

--- a/src/features/rooms/components/room-edit-dialog.tsx
+++ b/src/features/rooms/components/room-edit-dialog.tsx
@@ -1,12 +1,10 @@
 "use client";
 
-import { Pencil } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
-import { Button } from "@/components/ui/button";
 
 import { updateMeetingRoomAction } from "../actions";
 import type { MeetingRoom } from "../types";
@@ -15,47 +13,45 @@ import { RoomForm } from "./room-form";
 interface RoomEditDialogProps {
   /** 목록(서버 컴포넌트)이 이미 받아 온 값 — 모달을 위해 다시 조회하지 않는다 */
   room: MeetingRoom;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
 }
 
-/** "수정" 트리거 + 수정 모달 — `room-create-dialog.tsx`와 같은 골격이다. */
-export function RoomEditDialog({ room }: RoomEditDialogProps) {
-  const [open, setOpen] = useState(false);
+/**
+ * 수정 모달 — `room-create-dialog.tsx`와 같은 골격이다.
+ * ⚠️ **외부에서 열림 상태를 받는다**(2026-08-10 정리) — 트리거가 표 행의 "⋯" 메뉴
+ *    (`room-row-actions.tsx`)로 옮겨서 이 컴포넌트가 직접 버튼을 그릴 필요가 없다.
+ */
+export function RoomEditDialog({ room, open, onOpenChange }: RoomEditDialogProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const formRef = useRef<HTMLFormElement>(null);
   const router = useRouter();
 
   return (
-    <>
-      <Button type="button" variant="outline" size="xs" onClick={() => setOpen(true)}>
-        <Pencil aria-hidden />
-        수정
-      </Button>
-
-      <ConfirmDialog
-        isOpen={open}
-        onOpenChange={(next) => {
-          if (!next && isSubmitting) return;
-          setOpen(next);
+    <ConfirmDialog
+      isOpen={open}
+      onOpenChange={(next) => {
+        if (!next && isSubmitting) return;
+        onOpenChange(next);
+      }}
+      title="회의실 정보를 수정할까요?"
+      description="바뀐 정보가 예약 화면에 바로 반영됩니다."
+      confirmLabel="저장"
+      pendingLabel="저장 중"
+      isPending={isSubmitting}
+      onConfirm={() => formRef.current?.requestSubmit()}
+    >
+      <RoomForm
+        action={updateMeetingRoomAction}
+        room={room}
+        formRef={formRef}
+        onPendingChange={setIsSubmitting}
+        onSuccess={() => {
+          onOpenChange(false);
+          router.refresh();
+          toast.success("회의실 정보를 수정했습니다");
         }}
-        title="회의실 정보를 수정할까요?"
-        description="바뀐 정보가 예약 화면에 바로 반영됩니다."
-        confirmLabel="저장"
-        pendingLabel="저장 중"
-        isPending={isSubmitting}
-        onConfirm={() => formRef.current?.requestSubmit()}
-      >
-        <RoomForm
-          action={updateMeetingRoomAction}
-          room={room}
-          formRef={formRef}
-          onPendingChange={setIsSubmitting}
-          onSuccess={() => {
-            setOpen(false);
-            router.refresh();
-            toast.success("회의실 정보를 수정했습니다");
-          }}
-        />
-      </ConfirmDialog>
-    </>
+      />
+    </ConfirmDialog>
   );
 }

--- a/src/features/rooms/components/room-form.tsx
+++ b/src/features/rooms/components/room-form.tsx
@@ -5,8 +5,16 @@ import { useActionState, useEffect, useRef, useState } from "react";
 import { FieldError } from "@/components/common/field-error";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 import type { MeetingRoomFormState } from "../actions";
+import { TIME_OPTIONS } from "../constants";
 import type { MeetingRoom } from "../types";
 
 interface RoomFormProps {
@@ -27,8 +35,10 @@ interface RoomFormProps {
 }
 
 /**
- * 회의실 추가·수정 폼 — `notice-form.tsx`와 같은 골격(실제 `<form action={formAction}>`,
- * 필드가 전부 plain input이라 shadcn `Select` 우회 없이 그대로 쓴다).
+ * 회의실 추가·수정 폼 — `notice-form.tsx`와 같은 골격(실제 `<form action={formAction}>`).
+ * ⚠️ 이용 시작·종료는 공용 `Select`로 고른다 — base-ui `Select`는 네이티브 폼 필드가 아니라서
+ *    `room-reservation-dialog.tsx`의 `projectId`와 같은 방식으로 `input type="hidden"`을
+ *    같이 둬서 `formData.get("openTime"/"closeTime")`이 그대로 읽히게 한다.
  */
 export function RoomForm({ action, room, onSuccess, onPendingChange, formRef }: RoomFormProps) {
   const [state, formAction, isPending] = useActionState(action, { errors: {} });
@@ -82,27 +92,45 @@ export function RoomForm({ action, room, onSuccess, onPendingChange, formRef }: 
       <div className="grid grid-cols-2 gap-3">
         <div className="flex flex-col gap-1.5">
           <Label htmlFor="room-open-time">이용 시작</Label>
-          <Input
-            id="room-open-time"
-            name="openTime"
-            type="time"
-            value={openTime}
-            onChange={(event) => setOpenTime(event.target.value)}
-            aria-invalid={Boolean(state.errors.openTime)}
-          />
+          <input type="hidden" name="openTime" value={openTime} />
+          <Select value={openTime} onValueChange={(value) => setOpenTime(value ?? "")}>
+            <SelectTrigger
+              id="room-open-time"
+              aria-invalid={Boolean(state.errors.openTime)}
+              className="w-full"
+            >
+              <SelectValue placeholder="시작 시간 선택" />
+            </SelectTrigger>
+            <SelectContent>
+              {TIME_OPTIONS.map((time) => (
+                <SelectItem key={time} value={time}>
+                  {time}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
           <FieldError reserveSpace message={state.errors.openTime} />
         </div>
 
         <div className="flex flex-col gap-1.5">
           <Label htmlFor="room-close-time">이용 종료</Label>
-          <Input
-            id="room-close-time"
-            name="closeTime"
-            type="time"
-            value={closeTime}
-            onChange={(event) => setCloseTime(event.target.value)}
-            aria-invalid={Boolean(state.errors.closeTime)}
-          />
+          <input type="hidden" name="closeTime" value={closeTime} />
+          <Select value={closeTime} onValueChange={(value) => setCloseTime(value ?? "")}>
+            <SelectTrigger
+              id="room-close-time"
+              aria-invalid={Boolean(state.errors.closeTime)}
+              className="w-full"
+            >
+              <SelectValue placeholder="종료 시간 선택" />
+            </SelectTrigger>
+            <SelectContent>
+              {TIME_OPTIONS.map((time) => (
+                <SelectItem key={time} value={time}>
+                  {time}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
           <FieldError reserveSpace message={state.errors.closeTime} />
         </div>
       </div>

--- a/src/features/rooms/components/room-row-actions.tsx
+++ b/src/features/rooms/components/room-row-actions.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+import type { MeetingRoom } from "../types";
+import { RoomDeleteDialog } from "./room-delete-dialog";
+import { RoomEditDialog } from "./room-edit-dialog";
+
+interface RoomRowActionsProps {
+  room: MeetingRoom;
+}
+
+/**
+ * 회의실 목록 한 행의 "⋯" 메뉴 — 수정·삭제.
+ * ⚠️ 두 모달(`RoomEditDialog`·`RoomDeleteDialog`)은 외부에서 열림 상태를 받는다 — 트리거가
+ *    메뉴 항목이라 각 모달이 자기 버튼을 그리면 "⋯" 메뉴와 모달이 동시에 뜬다.
+ */
+export function RoomRowActions({ room }: RoomRowActionsProps) {
+  const [editOpen, setEditOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <Button type="button" variant="ghost" size="icon-xs" aria-label={`${room.name} 관리`}>
+              <MoreHorizontal aria-hidden />
+            </Button>
+          }
+        />
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={() => setEditOpen(true)}>
+            <Pencil aria-hidden />
+            수정
+          </DropdownMenuItem>
+          <DropdownMenuItem variant="destructive" onClick={() => setDeleteOpen(true)}>
+            <Trash2 aria-hidden />
+            삭제
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <RoomEditDialog room={room} open={editOpen} onOpenChange={setEditOpen} />
+      <RoomDeleteDialog room={room} open={deleteOpen} onOpenChange={setDeleteOpen} />
+    </>
+  );
+}

--- a/src/features/rooms/components/rooms-manage-table.tsx
+++ b/src/features/rooms/components/rooms-manage-table.tsx
@@ -1,5 +1,5 @@
 import type { MeetingRoom } from "../types";
-import { RoomEditDialog } from "./room-edit-dialog";
+import { RoomRowActions } from "./room-row-actions";
 
 interface RoomsManageTableProps {
   rooms: MeetingRoom[];
@@ -58,7 +58,7 @@ export function RoomsManageTable({ rooms, canManage }: RoomsManageTableProps) {
                     {room.openTime} - {room.closeTime}
                   </td>
                   <td className="px-4 py-3.5 text-center">
-                    {canManage && <RoomEditDialog room={room} />}
+                    {canManage && <RoomRowActions room={room} />}
                   </td>
                 </tr>
               ))}

--- a/src/features/rooms/constants.ts
+++ b/src/features/rooms/constants.ts
@@ -18,3 +18,13 @@ export const TIME_OPTIONS = Array.from({ length: 48 }, (_, index) => {
   const minute = index % 2 === 0 ? "00" : "30";
   return `${hour}:${minute}`;
 });
+
+/** 회의실 삭제 확인창 문구 — `room-delete-dialog.tsx` 하나만 쓰지만, 카피 하드코딩 금지
+ * 원칙(CLAUDE.md §도메인 상수)에 맞춰 컴포넌트 밖으로 뺐다(`NOTICE_DELETE_CONFIRM`과 같은 자리). */
+export const ROOM_DELETE_CONFIRM = {
+  /** 확인창 제목 — 회의실 이름을 끼워 넣는다 */
+  title: (roomName: string) => `'${roomName}'을 삭제할까요?`,
+  description: "삭제하면 예약 화면 목록에서도 사라집니다. 되돌릴 수 없습니다.",
+  confirmLabel: "삭제",
+  pendingLabel: "삭제 중",
+} as const;

--- a/src/features/rooms/constants.ts
+++ b/src/features/rooms/constants.ts
@@ -7,3 +7,14 @@
 
 /** 예약 길이 — 팀 확정: 30분 한 타임, 연장하지 않는다(CLAUDE.md §브라우저 API). */
 export const RESERVATION_DURATION_MINUTES = 30;
+
+/**
+ * 회의실 이용 가능 시간(운영시간) select용 30분 단위 옵션 — "00:00"~"23:30", 48개.
+ * ⚠️ 검증(`GENERAL_TIME_PATTERN`)은 분 단위 제약이 없지만, 예약 슬롯과 같은 30분 단위로
+ *    보여 주는 게 고르기 쉽고 실제로 쓰는 시각도 대개 이 격자 위에 있다.
+ */
+export const TIME_OPTIONS = Array.from({ length: 48 }, (_, index) => {
+  const hour = String(Math.floor(index / 2)).padStart(2, "0");
+  const minute = index % 2 === 0 ? "00" : "30";
+  return `${hour}:${minute}`;
+});

--- a/src/features/rooms/mock/rooms.test.ts
+++ b/src/features/rooms/mock/rooms.test.ts
@@ -1,4 +1,4 @@
-import { addMockRoom, findMockRoom, listMockRooms, updateMockRoom } from "./rooms";
+import { addMockRoom, deleteMockRoom, findMockRoom, listMockRooms, updateMockRoom } from "./rooms";
 
 const DRAFT = {
   name: "  신관 세미나실  ",
@@ -39,5 +39,25 @@ describe("회의실 mock 스토어", () => {
 
   it("없는 id는 조회 시 null을 돌려준다", () => {
     expect(findMockRoom("존재하지-않음")).toBeNull();
+  });
+
+  it("회의실을 삭제하면 목록에서 사라지고 true를 돌려준다", () => {
+    const created = addMockRoom(DRAFT);
+    const before = listMockRooms().length;
+
+    const existed = deleteMockRoom(created.id);
+
+    expect(existed).toBe(true);
+    expect(listMockRooms()).toHaveLength(before - 1);
+    expect(findMockRoom(created.id)).toBeNull();
+  });
+
+  it("없는 id를 삭제하려 하면 false를 돌려주고 목록은 그대로다", () => {
+    const before = listMockRooms().length;
+
+    const existed = deleteMockRoom("존재하지-않음");
+
+    expect(existed).toBe(false);
+    expect(listMockRooms()).toHaveLength(before);
   });
 });

--- a/src/features/rooms/mock/rooms.ts
+++ b/src/features/rooms/mock/rooms.ts
@@ -85,3 +85,10 @@ export function updateMockRoom(id: string, draft: MeetingRoomDraft): MeetingRoom
   store.rooms = [...store.rooms.slice(0, index), updated, ...store.rooms.slice(index + 1)];
   return updated;
 }
+
+/** 회의실 삭제 — 있던 회의실이면 지우고 true, 이미 없으면 false(중복 삭제 요청도 조용히 넘어간다). */
+export function deleteMockRoom(id: string): boolean {
+  const existed = store.rooms.some((room) => room.id === id);
+  store.rooms = store.rooms.filter((room) => room.id !== id);
+  return existed;
+}


### PR DESCRIPTION
## 📋 PR 타입

> 해당하는 타입을 선택해 주세요 (복수 선택 가능)

- [ ] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [x] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [x] OWNER (대표)
- [x] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- 회의실 삭제 액션(#{이슈1})·「⋯」 메뉴/삭제 확인 모달(#{이슈2}) 작업 마무리 검증
- 코드 변경 없음 — `npx jest`(820개 전체) · `npm run build` · `npx tsc --noEmit` · `npx eslint` 통과만 확인

---

## ✅ 작업 체크리스트

**기본**

- [ ] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [ ] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**(회의 담당자 등), 그리고 **서버(Server Action/BFF)에서 재검사** (해당 없음 — 코드 변경 없음)
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse` (해당 없음)
- [x] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시 (조용히 "되는 척" 금지) — 브라우저 클릭 검증 못 한 부분을 아래 추가 메모에 명시
- [ ] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨 (해당 없음)

**품질**

- [ ] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그) (해당 없음)
- [ ] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로 (해당 없음 — 접근성 트리로만 재확인)
- [ ] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인) (해당 없음)
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 기존 3상태 화면(`loading.tsx`/`error.tsx`) 회귀 없음을 빌드로 확인
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음 (해당 없음)

---

## 🔗 연관 이슈

Closes #276

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

---

## 📝 추가 메모

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 회의실 관리 화면에서 회의실을 수정하거나 삭제할 수 있는 행별 작업 메뉴를 추가했습니다.
  * 회의실 삭제 전 확인 대화상자와 삭제 완료 알림을 제공합니다.
* **개선**
  * 회의실 운영 시간을 30분 단위 선택 목록에서 간편하게 지정할 수 있습니다.
  * 회의실 수정 대화상자의 상태 관리와 제출 중 동작을 개선했습니다.
  * 수정·삭제 후 관리 목록과 예약 화면이 자동으로 최신 상태로 갱신됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->