### PR TITLE
[FEAT] 개인 Todo 데이터 모델에 시작~끝 날짜 추가 #278

### DIFF
--- a/src/features/calendar/actions.test.ts
+++ b/src/features/calendar/actions.test.ts
@@ -19,10 +19,10 @@ beforeEach(() => {
 });
 
 describe("개인 Todo 작성", () => {
-  it("제목·날짜가 있으면 성공하고 생성값을 돌려준다", async () => {
+  it("제목·시작·끝 날짜가 있으면 성공하고 생성값을 돌려준다", async () => {
     const result = await createPersonalTodoAction(
       { errors: {} },
-      form({ title: "새 할일", date: "2026-09-01" }),
+      form({ title: "새 할일", date: "2026-09-01", endDate: "2026-09-01" }),
     );
 
     expect(result.errors).toEqual({});
@@ -30,10 +30,21 @@ describe("개인 Todo 작성", () => {
     expect(revalidatePathMock).toHaveBeenCalledWith("/app/calendar");
   });
 
+  it("끝 날짜가 시작 날짜보다 나중이면 여러 날에 걸친 Todo를 만든다", async () => {
+    const result = await createPersonalTodoAction(
+      { errors: {} },
+      form({ title: "여러 날 할일", date: "2026-09-01", endDate: "2026-09-03" }),
+    );
+
+    expect(result.errors).toEqual({});
+    expect(result.created?.start).toEqual(new Date("2026-09-01T00:00:00"));
+    expect(result.created?.end).toEqual(new Date("2026-09-03T00:00:00"));
+  });
+
   it("제목이 비면 막고 revalidatePath를 안 부른다", async () => {
     const result = await createPersonalTodoAction(
       { errors: {} },
-      form({ title: "", date: "2026-09-01" }),
+      form({ title: "", date: "2026-09-01", endDate: "2026-09-01" }),
     );
 
     expect(result.errors.title).toBeDefined();
@@ -41,20 +52,30 @@ describe("개인 Todo 작성", () => {
     expect(revalidatePathMock).not.toHaveBeenCalled();
   });
 
-  it("날짜가 올바르지 않으면 막는다", async () => {
+  it("시작 날짜가 올바르지 않으면 막는다", async () => {
     const result = await createPersonalTodoAction(
       { errors: {} },
-      form({ title: "제목", date: "2026-02-30" }),
+      form({ title: "제목", date: "2026-02-30", endDate: "2026-02-30" }),
     );
 
     expect(result.errors.date).toBeDefined();
+    expect(revalidatePathMock).not.toHaveBeenCalled();
+  });
+
+  it("끝 날짜가 시작 날짜보다 이전이면 막는다", async () => {
+    const result = await createPersonalTodoAction(
+      { errors: {} },
+      form({ title: "제목", date: "2026-09-05", endDate: "2026-09-01" }),
+    );
+
+    expect(result.errors.endDate).toBeDefined();
     expect(revalidatePathMock).not.toHaveBeenCalled();
   });
 });
 
 describe("개인 Todo 완료 토글", () => {
   it("개인 Todo는 토글되고 경로를 재검증한다", async () => {
-    const created = addMockTodo({ title: "토글 대상", date: "2026-09-02" });
+    const created = addMockTodo({ title: "토글 대상", date: "2026-09-02", endDate: "2026-09-02" });
 
     await toggleTodoCompletionAction(created.id);
 

--- a/src/features/calendar/actions.ts
+++ b/src/features/calendar/actions.ts
@@ -27,6 +27,7 @@ function readDraft(formData: FormData): PersonalTodoDraft {
   return {
     title: String(formData.get("title") ?? ""),
     date: String(formData.get("date") ?? ""),
+    endDate: String(formData.get("endDate") ?? ""),
     color: color ? String(color) : undefined,
   };
 }

--- a/src/features/calendar/components/add-todo-dialog.tsx
+++ b/src/features/calendar/components/add-todo-dialog.tsx
@@ -39,9 +39,11 @@ const INITIAL_STATE: PersonalTodoFormState = { errors: {} };
 export function AddTodoDialog({ defaultDate, onCreated }: AddTodoDialogProps) {
   const [open, setOpen] = useState(false);
   const [datePopoverOpen, setDatePopoverOpen] = useState(false);
+  const [endDatePopoverOpen, setEndDatePopoverOpen] = useState(false);
   const [state, formAction, isPending] = useActionState(createPersonalTodoAction, INITIAL_STATE);
   const [title, setTitle] = useState("");
   const [date, setDate] = useState<Date>(defaultDate);
+  const [endDate, setEndDate] = useState<Date>(defaultDate);
   const handledCreatedId = useRef<string | null>(null);
 
   useEffect(() => {
@@ -57,6 +59,7 @@ export function AddTodoDialog({ defaultDate, onCreated }: AddTodoDialogProps) {
   function handleOpen() {
     // 모달을 열 때마다 지금 상세조회 중인 날짜로 다시 맞춘다 — 며칠 전에 열었던 값이 남아있지 않게.
     setDate(defaultDate);
+    setEndDate(defaultDate);
     setOpen(true);
   }
 
@@ -64,6 +67,7 @@ export function AddTodoDialog({ defaultDate, onCreated }: AddTodoDialogProps) {
     const formData = new FormData();
     formData.set("title", title);
     formData.set("date", format(date, DATE_FORMAT));
+    formData.set("endDate", format(endDate, DATE_FORMAT));
     /*
       ⚠️ `startTransition`으로 감싼다. `ConfirmDialog`엔 `<form>`이 없어 버튼 클릭에서
          직접 부르는데, `useActionState`의 액션을 트랜지션 밖에서 부르면 React가
@@ -131,7 +135,7 @@ export function AddTodoDialog({ defaultDate, onCreated }: AddTodoDialogProps) {
           </div>
 
           <div className="flex flex-col gap-1.5">
-            <Label htmlFor="todo-date">날짜</Label>
+            <Label htmlFor="todo-date">시작 날짜</Label>
             <Popover open={datePopoverOpen} onOpenChange={setDatePopoverOpen}>
               <PopoverTrigger
                 render={
@@ -165,12 +169,49 @@ export function AddTodoDialog({ defaultDate, onCreated }: AddTodoDialogProps) {
                   onSelect={(selected) => {
                     if (!selected) return;
                     setDate(selected);
+                    // ⚠️ 끝 날짜가 시작보다 앞서게 되면 시작 날짜로 같이 밀어둔다 — 범위가 뒤집힌 채로 남지 않게.
+                    if (endDate < selected) setEndDate(selected);
                     setDatePopoverOpen(false);
                   }}
                 />
               </PopoverContent>
             </Popover>
             <FieldError reserveSpace message={state.errors.date} />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="todo-end-date">끝 날짜</Label>
+            <Popover open={endDatePopoverOpen} onOpenChange={setEndDatePopoverOpen}>
+              <PopoverTrigger
+                render={
+                  <Button
+                    id="todo-end-date"
+                    type="button"
+                    variant="outline"
+                    className="h-10 w-full justify-start gap-2 font-normal"
+                  />
+                }
+              >
+                <CalendarIcon aria-hidden className="size-4 text-current" />
+                {format(endDate, "yyyy년 M월 d일(EEE)", { locale: ko })}
+              </PopoverTrigger>
+              <PopoverContent align="start" className="w-auto p-3 [--cell-size:--spacing(9)]">
+                <Calendar
+                  className="[&_[data-selected-single=true]]:bg-foreground [&_[data-selected-single=true]]:text-background [&_[data-selected-single=true]]:hover:bg-foreground"
+                  mode="single"
+                  locale={ko}
+                  selected={endDate}
+                  // 시작 날짜 이전은 고를 수 없다 — 범위가 뒤집히는 입력 자체를 막는다.
+                  disabled={{ before: date }}
+                  onSelect={(selected) => {
+                    if (!selected) return;
+                    setEndDate(selected);
+                    setEndDatePopoverOpen(false);
+                  }}
+                />
+              </PopoverContent>
+            </Popover>
+            <FieldError reserveSpace message={state.errors.endDate} />
           </div>
         </div>
       </ConfirmDialog>

--- a/src/features/calendar/mock/events.test.ts
+++ b/src/features/calendar/mock/events.test.ts
@@ -11,7 +11,11 @@ describe("개인 캘린더 mock 스토어", () => {
   it("Todo를 추가하면 앞뒤 공백을 지우고 미완료 상태로 목록에 붙는다", () => {
     const before = listMockEvents().length;
 
-    const created = addMockTodo({ title: "  새 할일  ", date: "2026-09-10" });
+    const created = addMockTodo({
+      title: "  새 할일  ",
+      date: "2026-09-10",
+      endDate: "2026-09-10",
+    });
 
     expect(created.title).toBe("새 할일");
     expect(created.tag).toBe(CALENDAR_ITEM_TAG.PERSONAL_TODO);
@@ -22,8 +26,23 @@ describe("개인 캘린더 mock 스토어", () => {
     expect(findMockEvent(created.id)).toEqual(created);
   });
 
+  it("끝 날짜가 시작 날짜보다 나중이면 여러 날에 걸친 항목으로 만든다", () => {
+    const created = addMockTodo({
+      title: "여러 날 Todo",
+      date: "2026-09-10",
+      endDate: "2026-09-12",
+    });
+
+    expect(created.start).toEqual(new Date("2026-09-10T00:00:00"));
+    expect(created.end).toEqual(new Date("2026-09-12T00:00:00"));
+  });
+
   it("완료 토글은 isCompleted를 뒤집는다", () => {
-    const created = addMockTodo({ title: "토글 테스트", date: "2026-09-11" });
+    const created = addMockTodo({
+      title: "토글 테스트",
+      date: "2026-09-11",
+      endDate: "2026-09-11",
+    });
 
     const toggled = toggleMockCompletion(created.id);
     expect(toggled?.isCompleted).toBe(true);

--- a/src/features/calendar/mock/events.ts
+++ b/src/features/calendar/mock/events.ts
@@ -53,14 +53,13 @@ export function findMockEvent(id: string): PersonalCalendarEvent | null {
   return store.events.find((event) => event.id === id) ?? null;
 }
 
-/** Todo 작성 — 하루 종일 항목으로 취급(시:분 지정 없이 날짜만 받는다). */
+/** Todo 작성 — 하루 종일 항목으로 취급(시:분 지정 없이 날짜만 받는다), 시작~끝 날짜로 기간을 가진다. */
 export function addMockTodo(draft: PersonalTodoDraft): PersonalCalendarEvent {
-  const day = new Date(`${draft.date}T00:00:00`);
   const event: PersonalCalendarEvent = {
     id: `todo-${++store.sequence}`,
     title: draft.title.trim(),
-    start: day,
-    end: day,
+    start: new Date(`${draft.date}T00:00:00`),
+    end: new Date(`${draft.endDate}T00:00:00`),
     tag: CALENDAR_ITEM_TAG.PERSONAL_TODO,
     isCompleted: false,
     color: draft.color,

--- a/src/features/calendar/types.ts
+++ b/src/features/calendar/types.ts
@@ -41,11 +41,17 @@ export interface PersonalCalendarEvent {
   color?: string;
 }
 
-/** 개인 Todo 작성 폼 입력 — 화면과 서버가 같은 스키마(`validate.ts`)로 검증한다. */
+/**
+ * 개인 Todo 작성 폼 입력 — 화면과 서버가 같은 스키마(`validate.ts`)로 검증한다.
+ * ⚠️ `date`~`endDate` 기간으로 캘린더에 연속 막대로 표시된다(2026-08-10) — 끝 날짜가
+ *    시작 날짜와 같으면 기존처럼 하루짜리 항목이 된다.
+ */
 export interface PersonalTodoDraft {
   title: string;
-  /** "YYYY-MM-DD" */
+  /** 시작 날짜 "YYYY-MM-DD" */
   date: string;
+  /** 끝 날짜 "YYYY-MM-DD" — 시작 날짜보다 이전일 수 없다. */
+  endDate: string;
   color?: string;
 }
 

--- a/src/features/calendar/validate.test.ts
+++ b/src/features/calendar/validate.test.ts
@@ -1,12 +1,22 @@
 import { validatePersonalTodoDraft } from "./validate";
 
 describe("개인 Todo 작성 검증", () => {
-  it("제목·날짜가 다 있으면 통과한다", () => {
-    expect(validatePersonalTodoDraft({ title: "보고서 작성", date: "2026-08-05" })).toEqual({});
+  it("제목·시작·끝 날짜가 다 있으면 통과한다", () => {
+    expect(
+      validatePersonalTodoDraft({
+        title: "보고서 작성",
+        date: "2026-08-05",
+        endDate: "2026-08-05",
+      }),
+    ).toEqual({});
   });
 
   it("제목이 비어 있으면 막는다", () => {
-    const errors = validatePersonalTodoDraft({ title: "   ", date: "2026-08-05" });
+    const errors = validatePersonalTodoDraft({
+      title: "   ",
+      date: "2026-08-05",
+      endDate: "2026-08-05",
+    });
     expect(errors.title).toBe("제목을 입력해 주세요");
   });
 
@@ -15,41 +25,104 @@ describe("개인 Todo 작성 검증", () => {
        한 줄에 다 보여줄 수 있는 길이가 20자라, 그 경계를 값으로 고정해 둔다.
   */
   it("제목이 20자를 넘으면 막는다", () => {
-    const errors = validatePersonalTodoDraft({ title: "가".repeat(21), date: "2026-08-05" });
+    const errors = validatePersonalTodoDraft({
+      title: "가".repeat(21),
+      date: "2026-08-05",
+      endDate: "2026-08-05",
+    });
     expect(errors.title).toBe("제목은 20자까지 입력할 수 있습니다");
   });
 
   it("제목이 정확히 20자면 통과한다", () => {
-    expect(validatePersonalTodoDraft({ title: "가".repeat(20), date: "2026-08-05" })).toEqual({});
+    expect(
+      validatePersonalTodoDraft({
+        title: "가".repeat(20),
+        date: "2026-08-05",
+        endDate: "2026-08-05",
+      }),
+    ).toEqual({});
   });
 
-  it("날짜가 비어 있으면 막는다", () => {
-    const errors = validatePersonalTodoDraft({ title: "제목", date: "" });
-    expect(errors.date).toBe("날짜를 선택해 주세요");
+  it("시작 날짜가 비어 있으면 막는다", () => {
+    const errors = validatePersonalTodoDraft({ title: "제목", date: "", endDate: "2026-08-05" });
+    expect(errors.date).toBe("시작 날짜를 선택해 주세요");
   });
 
   it("형식이 YYYY-MM-DD가 아니면 막는다", () => {
-    const errors = validatePersonalTodoDraft({ title: "제목", date: "2026/08/05" });
-    expect(errors.date).toBe("올바른 날짜가 아닙니다");
+    const errors = validatePersonalTodoDraft({
+      title: "제목",
+      date: "2026/08/05",
+      endDate: "2026-08-05",
+    });
+    expect(errors.date).toBe("올바른 시작 날짜가 아닙니다");
   });
 
   // ⚠️ 2월은 30일까지 없다 — 문자열 형식만 보면 통과시켜버리는 실수를 막는 회귀 테스트.
   it("존재하지 않는 날짜(2월 30일)는 막는다", () => {
-    const errors = validatePersonalTodoDraft({ title: "제목", date: "2026-02-30" });
-    expect(errors.date).toBe("올바른 날짜가 아닙니다");
+    const errors = validatePersonalTodoDraft({
+      title: "제목",
+      date: "2026-02-30",
+      endDate: "2026-02-30",
+    });
+    expect(errors.date).toBe("올바른 시작 날짜가 아닙니다");
   });
 
   it("13월처럼 범위를 벗어난 달도 막는다", () => {
-    const errors = validatePersonalTodoDraft({ title: "제목", date: "2026-13-01" });
-    expect(errors.date).toBe("올바른 날짜가 아닙니다");
+    const errors = validatePersonalTodoDraft({
+      title: "제목",
+      date: "2026-13-01",
+      endDate: "2026-13-01",
+    });
+    expect(errors.date).toBe("올바른 시작 날짜가 아닙니다");
   });
 
   it("윤년의 2월 29일은 통과한다", () => {
-    expect(validatePersonalTodoDraft({ title: "제목", date: "2024-02-29" })).toEqual({});
+    expect(
+      validatePersonalTodoDraft({ title: "제목", date: "2024-02-29", endDate: "2024-02-29" }),
+    ).toEqual({});
   });
 
   it("윤년이 아닌 해의 2월 29일은 막는다", () => {
-    const errors = validatePersonalTodoDraft({ title: "제목", date: "2026-02-29" });
-    expect(errors.date).toBe("올바른 날짜가 아닙니다");
+    const errors = validatePersonalTodoDraft({
+      title: "제목",
+      date: "2026-02-29",
+      endDate: "2026-02-29",
+    });
+    expect(errors.date).toBe("올바른 시작 날짜가 아닙니다");
+  });
+
+  it("끝 날짜가 비어 있으면 막는다", () => {
+    const errors = validatePersonalTodoDraft({ title: "제목", date: "2026-08-05", endDate: "" });
+    expect(errors.endDate).toBe("끝 날짜를 선택해 주세요");
+  });
+
+  it("끝 날짜 형식이 올바르지 않으면 막는다", () => {
+    const errors = validatePersonalTodoDraft({
+      title: "제목",
+      date: "2026-08-05",
+      endDate: "2026/08/06",
+    });
+    expect(errors.endDate).toBe("올바른 끝 날짜가 아닙니다");
+  });
+
+  it("끝 날짜가 시작 날짜보다 이전이면 막는다", () => {
+    const errors = validatePersonalTodoDraft({
+      title: "제목",
+      date: "2026-08-10",
+      endDate: "2026-08-05",
+    });
+    expect(errors.endDate).toBe("끝 날짜는 시작 날짜보다 이전일 수 없습니다");
+  });
+
+  it("끝 날짜가 시작 날짜와 같으면 통과한다(하루짜리 Todo)", () => {
+    expect(
+      validatePersonalTodoDraft({ title: "제목", date: "2026-08-05", endDate: "2026-08-05" }),
+    ).toEqual({});
+  });
+
+  it("끝 날짜가 시작 날짜보다 나중이면 통과한다(여러 날 Todo)", () => {
+    expect(
+      validatePersonalTodoDraft({ title: "제목", date: "2026-08-05", endDate: "2026-08-07" }),
+    ).toEqual({});
   });
 });

--- a/src/features/calendar/validate.ts
+++ b/src/features/calendar/validate.ts
@@ -35,7 +35,13 @@ export function validatePersonalTodoDraft(draft: PersonalTodoDraft): PersonalTod
   else if (title.length > PERSONAL_TODO_TITLE_MAX)
     errors.title = `제목은 ${PERSONAL_TODO_TITLE_MAX}자까지 입력할 수 있습니다`;
 
-  if (!draft.date.trim()) errors.date = "날짜를 선택해 주세요";
-  else if (!isValidCalendarDate(draft.date)) errors.date = "올바른 날짜가 아닙니다";
+  if (!draft.date.trim()) errors.date = "시작 날짜를 선택해 주세요";
+  else if (!isValidCalendarDate(draft.date)) errors.date = "올바른 시작 날짜가 아닙니다";
+
+  if (!draft.endDate.trim()) errors.endDate = "끝 날짜를 선택해 주세요";
+  else if (!isValidCalendarDate(draft.endDate)) errors.endDate = "올바른 끝 날짜가 아닙니다";
+  else if (!errors.date && draft.endDate < draft.date)
+    errors.endDate = "끝 날짜는 시작 날짜보다 이전일 수 없습니다";
+
   return errors;
 }


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [x] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

- `PersonalTodoDraft`(`types.ts`)에 `endDate` 필드 추가 — `date`는 시작 날짜로 재정의
- `validatePersonalTodoDraft`(`validate.ts`)에 끝 날짜 필수/형식 검증 + `endDate >= date` 범위 검증 추가
- mock `addMockTodo`(`mock/events.ts`)가 `start`/`end`를 각각 시작/끝 날짜로 채우도록 수정

---

## ✅ 작업 체크리스트

**기본**

- [ ] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 해당 없음 (데이터 모델만 확장, 권한 로직 변경 없음)
- [ ] 🧬 **zod** — 이 레포는 zod 대신 `validate.ts` 수동 검증 패턴을 씀 (기존 컨벤션 유지)
- [x] 🕵️ **정직성** — mock 스토어 사용 명시(기존 주석 유지), 미구현 아님
- [x] 🎨 디자인 토큰 사용 — 해당 없음 (UI 변경 없음)

**품질**

- [x] ⚡ 최적화 — 해당 없음 (로직 레이어만)
- [x] ♿ a11y — 해당 없음 (UI 변경 없음)
- [x] ♻️ 재사용 확인 — 기존 `PersonalTodoDraft`/`validate.ts`/`mock/events.ts` 구조 그대로 확장
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 해당 없음 (UI 변경 없음, 다음 PR에서 확인)
- [ ] 브라우저 전용 API — 해당 없음

---

## 🔗 연관 이슈

Closes #278

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
| 해당 없음 (UI 변경 없음) | 해당 없음 |

---

## 💬 리뷰 포인트

- `actions.ts`의 `readDraft`와 `add-todo-dialog.tsx`는 아직 `endDate`를 안 채운다 — 다음 PR(모달 UI)에서 연결되므로, 이 PR만 머지하면 타입 에러가 남는다. 순서상 다음 PR과 함께 검토 부탁드립니다.

---

## 📝 추가 메모

`src/features/calendar/validate.test.ts`, `src/features/calendar/mock/events.test.ts`에 범위 검증 테스트 추가. `npx jest src/features/calendar/validate.test.ts src/features/calendar/mock/events.test.ts` 통과.

