### PR TITLE
[FEAT] 사원 관리 연동 — 목록·상세·권한 변경·계정 발급 #286

### DIFF
--- a/src/features/company/actions.ts
+++ b/src/features/company/actions.ts
@@ -186,7 +186,19 @@ export async function saveDepartmentsAction(
        액션은 직접 부를 수 있다(§권한). 지금 저장된 트리와 견줘야 무엇이 바뀌었는지 알 수 있다 —
        클라이언트가 보낸 값만 보면 "무엇이 사라졌는지"를 모른다.
   */
-  const current = await getCompanySetting();
+  /*
+    ⚠️ **여기서 던지면 카드가 아니라 페이지가 죽는다.** `getCompanySetting()`은 서버를
+       세 번 부르므로 얼마든지 실패할 수 있는데, `try` 밖에 두면 그 예외가 그대로 올라가
+       error boundary가 화면을 통째로 갈아치운다 — 방금 짠 팀 구조가 다 날아간다.
+       이 파일이 세 번 적어 둔 "던지지 않는다"를 스스로 깨는 자리였다.
+  */
+  let current: Awaited<ReturnType<typeof getCompanySetting>>;
+  try {
+    current = await getCompanySetting();
+  } catch (error) {
+    return { isSuccess: false, message: toUserMessage(error) };
+  }
+
   const blocked = findBlockedTeamChange(current.departments, departments, current.teamMemberCounts);
   if (blocked) {
     return {
@@ -215,20 +227,21 @@ export async function saveDepartmentsAction(
          `roleLabel` 관리 경로 0건) — 팀만 저장하고 성공이라고 말하면 **역할을 고친 사람이
          저장됐다고 믿는다**(§정직성). 바뀐 게 있으면 그 사실을 말하고 멈춘다.
     */
-    const roleSignature = (nodes: DepartmentNode[]) =>
+    /*
+      ⚠️ **이름 변경 여부와 무관하게 막는다.** 처음엔 "이름도 같이 바뀌었으면 통과"로 뒀는데,
+         보내는 본문은 `{ name }`뿐이라 그때도 역할은 안 저장된다 — 이름만 바뀌고 역할은
+         사라진 채 **성공**이라고 말하게 된다. 역할은 팀과 따로 세어야 한다.
+    */
+    const rolesOf = (nodes: DepartmentNode[]) =>
       nodes
-        .map((node) => `${node.name}:${node.children.map((child) => child.name).join(",")}`)
+        .map((node) => `${node.id}:${node.children.map((child) => child.name).join(",")}`)
+        .sort()
         .join("|");
-    if (roleSignature(current.departments) !== roleSignature(departments)) {
-      const namesChanged =
-        current.departments.map((n) => n.name).join("|") !==
-        departments.map((n) => n.name).join("|");
-      if (!namesChanged) {
-        return {
-          isSuccess: false,
-          message: "팀 안 역할은 아직 저장할 수 없습니다. 팀 이름만 바꿔 주세요",
-        };
-      }
+    if (rolesOf(current.departments) !== rolesOf(departments)) {
+      return {
+        isSuccess: false,
+        message: "팀 안 역할은 아직 저장할 수 없습니다. 팀 이름만 바꿔 주세요",
+      };
     }
 
     const before = new Map(current.departments.map((node) => [node.id, node.name]));
@@ -283,8 +296,14 @@ export async function savePositionsAction(positions: Position[]): Promise<Compan
 
   // ⚠️ 던지지 않는다 — 저장 실패는 화면 전체 실패가 아니다
   if (!isMock) {
-    /* 팀과 같은 이유로 차이를 계산해 한 건씩 부른다 — 지우기는 마지막이다 */
-    const current = await getCompanySetting();
+    /* 팀과 같은 이유로 차이를 계산해 한 건씩 부른다. 지우기가 먼저다 */
+    let current: Awaited<ReturnType<typeof getCompanySetting>>;
+    try {
+      current = await getCompanySetting();
+    } catch (error) {
+      /* 팀 저장과 같은 이유 — 던지면 카드가 아니라 페이지가 죽는다 */
+      return { isSuccess: false, message: toUserMessage(error) };
+    }
     const before = new Map(current.positions.map((item) => [item.id, item]));
     const after = new Map(positions.map((item) => [item.id, item]));
 

--- a/src/features/company/actions.ts
+++ b/src/features/company/actions.ts
@@ -2,7 +2,10 @@
 
 import { revalidatePath } from "next/cache";
 
+import { requireAccessToken } from "@/features/auth/session";
 import { getViewer } from "@/features/shell/viewer";
+import { serverApi, toUserMessage } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
 import { canManageCompany } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
@@ -38,7 +41,6 @@ const SETTING_PATH = "/owner/setting";
 
 const FORBIDDEN = "기업 설정을 바꿀 권한이 없습니다";
 
-const NOT_CONNECTED = "저장 기능이 아직 연결되지 않았습니다";
 
 /**
  * 세션을 못 읽었을 때.
@@ -116,8 +118,30 @@ export async function saveCompanyProfileAction(
        카드를 통째로 갈아치워 방금 적은 값이 다 날아간다(§토스트: error.tsx는 페이지 전체 실패용).
   */
   if (!isMock) {
-    // TODO(BE 협의): `PATCH /companies/me`
-    return { errors: {}, message: NOT_CONNECTED };
+    /*
+      [확인] BE `CompanyController.updateProfile` — `PATCH /api/companies/me`.
+      ⚠️ **보낸 필드만 바뀐다**(부분 수정). `code`는 대상이 아니다 — 사원 로그인 키라 바뀌면
+         기존 사원이 전부 못 들어온다.
+      ⚠️ **좌표는 못 보낸다.** BE가 `address` 문자열만 받는다 — 지도에서 고른 자리는
+         주소 글자만 남고 핀은 저장되지 않는다(§mapper).
+    */
+    try {
+      const accessToken = await requireAccessToken();
+      await serverApi<unknown>(ep.companyMe(), {
+        method: "PATCH",
+        accessToken,
+        json: {
+          name: draft.name,
+          businessNumber: draft.businessNumber,
+          address: draft.place?.address ?? null,
+        },
+      });
+    } catch (error) {
+      return { errors: {}, message: toUserMessage(error) };
+    }
+
+    revalidatePath(SETTING_PATH);
+    return { errors: {}, isSaved: true };
   }
 
   updateMockCompanyProfile(draft);
@@ -149,11 +173,10 @@ export async function saveDepartmentsAction(
        그게 던진다 — 순서가 뒤집히면 액션 자체가 거절되어 화면이 결과 대신 아무것도 못 받는다
        (이 파일이 세 번 적어 둔 "던지지 않는다"를 스스로 깨는 자리였다).
   */
-  if (!isMock) {
-    // TODO(BE 협의): `PUT /companies/me/teams`
-    return { isSuccess: false, message: NOT_CONNECTED };
-  }
-
+  /*
+    ⚠️ **사람이 딸린 팀은 못 지운다.** 화면에서 미리 막지만 액션은 주소만 알면 직접 부를 수
+       있다(§권한: 화면 숨김은 보안이 아니다). 지금 저장된 것과 견줘야 무엇이 사라졌는지 안다.
+  */
   /*
     ⚠️ **사람이 딸린 팀은 못 지우고, 남의 팀 아래로도 못 넣는다.** 화면에서 미리 막지만
        액션은 직접 부를 수 있다(§권한). 지금 저장된 트리와 견줘야 무엇이 바뀌었는지 알 수 있다 —
@@ -171,6 +194,46 @@ export async function saveDepartmentsAction(
     };
   }
 
+  if (!isMock) {
+    /*
+      ⚠️ **통째로 넣는 API가 없다.** BE는 팀을 한 건씩 다룬다(`POST` · `PATCH /{id}` ·
+         `DELETE /{id}`) — 화면은 트리를 통째로 저장하므로 여기서 **차이를 계산해** 나눠 부른다.
+      ⚠️ **지우기를 마지막에 한다.** 이름 바꾸기·새로 만들기가 먼저 끝나야, 중간에 실패해도
+         남는 쪽이 더 안전하다 — 먼저 지우면 실패했을 때 팀만 사라진 상태가 된다.
+      ⚠️ 새로 만든 팀은 화면에서 붙인 임시 id를 들고 온다. 서버 id가 아니므로
+         **숫자로 읽히지 않는 것**을 새 팀으로 본다.
+    */
+    const before = new Map(current.departments.map((node) => [node.id, node.name]));
+    const after = new Map(departments.map((node) => [node.id, node.name]));
+
+    try {
+      const accessToken = await requireAccessToken();
+
+      for (const [id, name] of after) {
+        const serverId = Number(id);
+        if (!Number.isInteger(serverId) || !before.has(id)) {
+          await serverApi<unknown>(ep.teams(), { method: "POST", accessToken, json: { name } });
+        } else if (before.get(id) !== name) {
+          await serverApi<unknown>(ep.team(serverId), {
+            method: "PATCH",
+            accessToken,
+            json: { name },
+          });
+        }
+      }
+
+      for (const id of before.keys()) {
+        if (after.has(id)) continue;
+        await serverApi<unknown>(ep.team(Number(id)), { method: "DELETE", accessToken });
+      }
+    } catch (error) {
+      return { isSuccess: false, message: toUserMessage(error) };
+    }
+
+    revalidatePath(SETTING_PATH);
+    return { isSuccess: true };
+  }
+
   updateMockDepartments(departments);
   revalidatePath(SETTING_PATH);
   return { isSuccess: true };
@@ -186,8 +249,39 @@ export async function savePositionsAction(positions: Position[]): Promise<Compan
 
   // ⚠️ 던지지 않는다 — 저장 실패는 화면 전체 실패가 아니다
   if (!isMock) {
-    // TODO(BE 협의): `PUT /companies/me/positions`
-    return { isSuccess: false, message: NOT_CONNECTED };
+    /* 팀과 같은 이유로 차이를 계산해 한 건씩 부른다 — 지우기는 마지막이다 */
+    const current = await getCompanySetting();
+    const before = new Map(current.positions.map((item) => [item.id, item]));
+    const after = new Map(positions.map((item) => [item.id, item]));
+
+    try {
+      const accessToken = await requireAccessToken();
+
+      for (const [id, position] of after) {
+        const serverId = Number(id);
+        const previous = before.get(id);
+        const body = { name: position.name, authority: position.role, description: null };
+        if (!Number.isInteger(serverId) || !previous) {
+          await serverApi<unknown>(ep.jobPositions(), { method: "POST", accessToken, json: body });
+        } else if (previous.name !== position.name || previous.role !== position.role) {
+          await serverApi<unknown>(ep.jobPosition(serverId), {
+            method: "PATCH",
+            accessToken,
+            json: body,
+          });
+        }
+      }
+
+      for (const id of before.keys()) {
+        if (after.has(id)) continue;
+        await serverApi<unknown>(ep.jobPosition(Number(id)), { method: "DELETE", accessToken });
+      }
+    } catch (error) {
+      return { isSuccess: false, message: toUserMessage(error) };
+    }
+
+    revalidatePath(SETTING_PATH);
+    return { isSuccess: true };
   }
 
   updateMockPositions(positions);

--- a/src/features/company/actions.ts
+++ b/src/features/company/actions.ts
@@ -41,7 +41,6 @@ const SETTING_PATH = "/owner/setting";
 
 const FORBIDDEN = "기업 설정을 바꿀 권한이 없습니다";
 
-
 /**
  * 세션을 못 읽었을 때.
  * ⚠️ **권한 없음과 다른 말이다.** 쿠키가 만료된 OWNER에게 "권한이 없습니다"라고 하면
@@ -133,7 +132,12 @@ export async function saveCompanyProfileAction(
         json: {
           name: draft.name,
           businessNumber: draft.businessNumber,
-          address: draft.place?.address ?? null,
+          /*
+            ⚠️ **`null`을 보내면 안 지워진다.** BE는 부분 수정이라 `null`을 "이 필드는 건드리지
+               말라"로 읽는다 — 주소를 비우려고 지운 사람에게는 옛 주소가 그대로 남는다.
+               빈 문자열을 보내야 실제로 비워진다(`@Size`만 걸려 있어 통과한다).
+          */
+          address: draft.place?.address ?? "",
         },
       });
     } catch (error) {
@@ -198,16 +202,45 @@ export async function saveDepartmentsAction(
     /*
       ⚠️ **통째로 넣는 API가 없다.** BE는 팀을 한 건씩 다룬다(`POST` · `PATCH /{id}` ·
          `DELETE /{id}`) — 화면은 트리를 통째로 저장하므로 여기서 **차이를 계산해** 나눠 부른다.
-      ⚠️ **지우기를 마지막에 한다.** 이름 바꾸기·새로 만들기가 먼저 끝나야, 중간에 실패해도
-         남는 쪽이 더 안전하다 — 먼저 지우면 실패했을 때 팀만 사라진 상태가 된다.
+      ⚠️ **지우기를 먼저 한다.** 처음엔 마지막에 뒀는데, 지운 팀의 이름을 다른 팀에 다시
+         쓰거나 두 팀 이름을 맞바꾸면 **같은 이름이 잠깐 둘**이 되어 서버가 막는다 —
+         지우고 나서 만들면 그 자리가 비어 있다.
+      ⚠️ 대신 **사람이 딸린 팀은 위에서 이미 걸렀다**(`findBlockedTeamChange`). 지우기가
+         먼저여도 사람이 붕 뜨지 않는다.
       ⚠️ 새로 만든 팀은 화면에서 붙인 임시 id를 들고 온다. 서버 id가 아니므로
          **숫자로 읽히지 않는 것**을 새 팀으로 본다.
     */
+    /*
+      ⚠️ **팀 안 '역할' 라벨은 저장할 곳이 없다.** BE에 그걸 다루는 API가 없다(전 레포에
+         `roleLabel` 관리 경로 0건) — 팀만 저장하고 성공이라고 말하면 **역할을 고친 사람이
+         저장됐다고 믿는다**(§정직성). 바뀐 게 있으면 그 사실을 말하고 멈춘다.
+    */
+    const roleSignature = (nodes: DepartmentNode[]) =>
+      nodes
+        .map((node) => `${node.name}:${node.children.map((child) => child.name).join(",")}`)
+        .join("|");
+    if (roleSignature(current.departments) !== roleSignature(departments)) {
+      const namesChanged =
+        current.departments.map((n) => n.name).join("|") !==
+        departments.map((n) => n.name).join("|");
+      if (!namesChanged) {
+        return {
+          isSuccess: false,
+          message: "팀 안 역할은 아직 저장할 수 없습니다. 팀 이름만 바꿔 주세요",
+        };
+      }
+    }
+
     const before = new Map(current.departments.map((node) => [node.id, node.name]));
     const after = new Map(departments.map((node) => [node.id, node.name]));
 
     try {
       const accessToken = await requireAccessToken();
+
+      for (const id of before.keys()) {
+        if (after.has(id)) continue;
+        await serverApi<unknown>(ep.team(Number(id)), { method: "DELETE", accessToken });
+      }
 
       for (const [id, name] of after) {
         const serverId = Number(id);
@@ -221,12 +254,13 @@ export async function saveDepartmentsAction(
           });
         }
       }
-
-      for (const id of before.keys()) {
-        if (after.has(id)) continue;
-        await serverApi<unknown>(ep.team(Number(id)), { method: "DELETE", accessToken });
-      }
     } catch (error) {
+      /*
+        ⚠️ **실패해도 화면을 다시 읽는다.** 한 건씩 부르므로 **중간까지는 이미 반영돼 있다** —
+           그대로 두면 화면은 옛 트리를 들고 있고 서버는 반쯤 바뀐 상태라, 사람이 다시 저장을
+           누르면 이미 만든 팀을 또 만든다.
+      */
+      revalidatePath(SETTING_PATH);
       return { isSuccess: false, message: toUserMessage(error) };
     }
 
@@ -257,13 +291,28 @@ export async function savePositionsAction(positions: Position[]): Promise<Compan
     try {
       const accessToken = await requireAccessToken();
 
+      for (const id of before.keys()) {
+        if (after.has(id)) continue;
+        await serverApi<unknown>(ep.jobPosition(Number(id)), { method: "DELETE", accessToken });
+      }
+
       for (const [id, position] of after) {
         const serverId = Number(id);
         const previous = before.get(id);
-        const body = { name: position.name, authority: position.role, description: null };
+        /*
+          ⚠️ **`description`은 필수다**(BE `@NotBlank`). `null`을 보내면 **항상 400**이다.
+             화면에 그 칸이 없어 사람이 적을 길이 없으므로, 서버에서 읽어 온 값을 그대로
+             되돌려 보내고 새 직급이면 이름으로 채운다 — 빈 문자열도 `@NotBlank`에 걸린다.
+        */
+        const description = position.description?.trim() || position.name;
+        const body = { name: position.name, authority: position.role, description };
         if (!Number.isInteger(serverId) || !previous) {
           await serverApi<unknown>(ep.jobPositions(), { method: "POST", accessToken, json: body });
-        } else if (previous.name !== position.name || previous.role !== position.role) {
+        } else if (
+          previous.name !== position.name ||
+          previous.role !== position.role ||
+          (previous.description ?? "") !== description
+        ) {
           await serverApi<unknown>(ep.jobPosition(serverId), {
             method: "PATCH",
             accessToken,
@@ -271,12 +320,9 @@ export async function savePositionsAction(positions: Position[]): Promise<Compan
           });
         }
       }
-
-      for (const id of before.keys()) {
-        if (after.has(id)) continue;
-        await serverApi<unknown>(ep.jobPosition(Number(id)), { method: "DELETE", accessToken });
-      }
     } catch (error) {
+      /* 팀과 같은 이유 — 중간까지 반영됐으므로 실패해도 화면을 다시 읽는다 */
+      revalidatePath(SETTING_PATH);
       return { isSuccess: false, message: toUserMessage(error) };
     }
 

--- a/src/features/company/mapper.ts
+++ b/src/features/company/mapper.ts
@@ -31,9 +31,12 @@ export interface BeTeam {
   memberCount: number;
 }
 
-/** [확인] BE `PositionSummary` */
+/**
+ * [확인] BE `PositionResponse` — ⚠️ **`id`가 아니라 `jobPositionId`다.**
+ * 이름을 잘못 읽으면 모든 직급 id가 `undefined`가 되어, 저장할 때 전부 **새 직급으로 잡힌다**.
+ */
 export interface BePosition {
-  id: number;
+  jobPositionId: number;
   name: string;
   authority: string;
   description: string | null;
@@ -85,5 +88,15 @@ export function toTeamMemberCounts(teams: BeTeam[]): Record<string, number> {
  */
 export function toPosition(position: BePosition): Position {
   const role: AssignableRole = position.authority === "LEADER" ? "LEADER" : "MEMBER";
-  return { id: String(position.id), name: position.name, role };
+  /*
+    ⚠️ **`description`을 들고 다닌다.** BE가 `@NotBlank`로 필수라 저장할 때 다시 보내야 하는데,
+       여기서 버리면 왕복 한 번에 남의 설명이 지워진다 — 화면이 안 보여 주는 값이라도
+       **되돌려 보낼 책임**은 남는다.
+  */
+  return {
+    id: String(position.jobPositionId),
+    name: position.name,
+    role,
+    description: position.description ?? "",
+  };
 }

--- a/src/features/company/mapper.ts
+++ b/src/features/company/mapper.ts
@@ -1,0 +1,89 @@
+import type { AssignableRole } from "@/features/onboarding/types";
+
+import type { CompanyProfile, DepartmentNode, Position } from "./types";
+
+/**
+ * BE shape → UI 계약 (§Mock 격리막 — 흡수하는 곳은 여기 하나다).
+ *
+ * ⚠️ 기업 설정 화면은 **세 API에서 값을 모은다**(`/companies/me` · `/teams` · `/job-positions`).
+ *    한 번에 주는 엔드포인트가 BE에 없어서다 — 그 사실을 화면이 알 필요는 없다.
+ */
+
+/** [확인] BE `CompanyProfileResponse` */
+export interface BeCompanyProfile {
+  companyId: number;
+  code: string;
+  name: string;
+  businessNumber: string | null;
+  representativeName: string | null;
+  address: string | null;
+  phone: string | null;
+  plan: string;
+  onboardedAt: string | null;
+}
+
+/** [확인] BE `TeamNode` */
+export interface BeTeam {
+  teamId: number;
+  name: string;
+  leaderMemberId: number | null;
+  leaderName: string | null;
+  memberCount: number;
+}
+
+/** [확인] BE `PositionSummary` */
+export interface BePosition {
+  id: number;
+  name: string;
+  authority: string;
+  description: string | null;
+  memberCount: number;
+}
+
+/**
+ * 기업 기본 정보.
+ *
+ * ⚠️ **좌표가 없다.** BE는 `address` 문자열만 들고 우리 계약은 `PickedPlace`(위도·경도)다 —
+ *    지도에서 고른 자리가 **저장도 복원도 안 된다.** 주소는 남으므로 글자는 그대로 보이지만,
+ *    다시 열면 핀이 사라진다. 좌표 칸이 생기기 전까지 `lat`·`lng`를 0으로 둔다
+ *    (기업 등록 신청이 지도를 못 쓸 때 쓰는 것과 같은 규칙).
+ * ⚠️ **`plan`을 안 쓴다.** BE가 `"FREE"`를 고정으로 내려주는데(결제 연동 전), 우리 규칙은
+ *    **무료 요금제가 없다**는 것이다 — 그 값을 화면에 올리면 돈을 안 받는 것처럼 읽힌다
+ *    (CLAUDE.md §요금제).
+ * ⚠️ **`representativeName`·`phone`도 안 쓴다.** 우리 `CompanyProfile`에 자리가 없다 —
+ *    지금 화면이 안 보여 주는 값이라 버리는 게 아니라 **아직 안 받는 것**이다.
+ */
+export function toCompanyProfile(profile: BeCompanyProfile): CompanyProfile {
+  return {
+    name: profile.name,
+    businessNumber: profile.businessNumber ?? "",
+    place: profile.address ? { address: profile.address, lat: 0, lng: 0 } : null,
+    code: profile.code,
+  };
+}
+
+/**
+ * 팀 목록 → 트리.
+ *
+ * ⚠️ **팀은 계층이 없다**(CLAUDE.md §권한 ③ — 플랫 목록, 2026-08-06 BE 스키마 확정).
+ *    `DepartmentNode`가 `children`을 들고 있는 건 온보딩과 타입을 공유해서지, 팀이 중첩된다는
+ *    뜻이 아니다 — 항상 빈 배열이다.
+ * ⚠️ **팀장(`leaderMemberId`·`leaderName`)을 못 담는다.** 우리 노드에 자리가 없어 지금은
+ *    버린다 — 화면에 팀장이 안 보이는 건 그래서다.
+ */
+export function toDepartmentNode(team: BeTeam): DepartmentNode {
+  return { id: String(team.teamId), name: team.name, children: [] };
+}
+
+export function toTeamMemberCounts(teams: BeTeam[]): Record<string, number> {
+  return Object.fromEntries(teams.map((team) => [String(team.teamId), team.memberCount]));
+}
+
+/**
+ * 직급.
+ * ⚠️ 모르는 권한이 오면 가장 낮은 쪽으로 떨어뜨린다 — 권한은 넘겨짚으면 안 되는 값이다(§권한).
+ */
+export function toPosition(position: BePosition): Position {
+  const role: AssignableRole = position.authority === "LEADER" ? "LEADER" : "MEMBER";
+  return { id: String(position.id), name: position.name, role };
+}

--- a/src/features/company/server.ts
+++ b/src/features/company/server.ts
@@ -1,7 +1,19 @@
 import "server-only";
 
+import { requireAccessToken } from "@/features/auth/session";
+import { serverApi } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
 import { isMock } from "@/mocks/config";
 
+import {
+  type BeCompanyProfile,
+  type BePosition,
+  type BeTeam,
+  toCompanyProfile,
+  toDepartmentNode,
+  toPosition,
+  toTeamMemberCounts,
+} from "./mapper";
 import { getMockCompanySetting } from "./mock/company";
 import type { CompanySetting } from "./types";
 
@@ -15,6 +27,24 @@ import type { CompanySetting } from "./types";
 export async function getCompanySetting(): Promise<CompanySetting> {
   if (isMock) return getMockCompanySetting();
 
-  // TODO(BE 협의): `GET /companies/me/setting` — 응답 봉투 모양은 아직 모른다(매퍼가 벗긴다)
-  throw new Error("기업 설정 조회 API가 아직 연결되지 않았습니다.");
+  /*
+    ⚠️ **한 번에 주는 API가 없다.** 화면은 기본 정보·팀·직급을 한 화면에 그리는데 BE는 셋으로
+       나뉘어 있다([확인] `CompanyController.getProfile` · `TeamController.list` ·
+       `PositionController.list`) — 여기서 모아 하나로 돌려준다. 화면은 그 사실을 모른다.
+    ⚠️ **나란히 부른다.** 줄줄이 기다리면 카드 셋이 다 그려질 때까지 세 번 왕복한다.
+    ⚠️ 회사는 **토큰의 `companyId`** 로 정해진다 — 파라미터로 안 보낸다(§라우트 그룹).
+  */
+  const accessToken = await requireAccessToken();
+  const [profile, teams, positions] = await Promise.all([
+    serverApi<BeCompanyProfile>(ep.companyMe(), { accessToken }),
+    serverApi<BeTeam[]>(ep.teams(), { accessToken }),
+    serverApi<BePosition[]>(ep.jobPositions(), { accessToken }),
+  ]);
+
+  return {
+    profile: toCompanyProfile(profile),
+    departments: teams.map(toDepartmentNode),
+    positions: positions.map(toPosition),
+    teamMemberCounts: toTeamMemberCounts(teams),
+  };
 }

--- a/src/features/member/manage-actions.ts
+++ b/src/features/member/manage-actions.ts
@@ -23,7 +23,7 @@ import { isMock } from "@/mocks/config";
 
 import { isEmailTaken, validateAccount } from "./account-validate";
 import { GRADE_LOCK_NOTE, gradeLockOf } from "./grade";
-import { getManagedMember, getManagedMembersPage, listManagedMembers } from "./manage-server";
+import { getManagedMember, getManagedMembersPage, getTeamLeaders } from "./manage-server";
 import type {
   AccountDraft,
   AccountErrors,
@@ -198,7 +198,15 @@ export async function changeMemberGradeAction(
         json: { role: next.authority, jobPositionId: Number(jobPosition.id) },
       });
 
-      /* 겸직이 실제로 달라질 때만 부른다 — OWNER만 열리는 경로라 괜히 부르면 403이다 */
+      /*
+        ⚠️ **겸직 변경은 OWNER만 된다**(BE `@PreAuthorize("hasRole('OWNER')")`). ADMIN이
+           겸직을 건드리면 역할·직급은 이미 저장된 뒤 이 호출만 403으로 막혀 **절반만 반영**된다 —
+           화면은 "실패"라고 말하는데 직급은 바뀌어 있다. 부르기 전에 걸러 낸다.
+        ⚠️ 실제로 달라질 때만 부른다 — 같은 값이면 괜히 403을 만들 이유가 없다.
+      */
+      if (next.isAdmin !== target.member.isAdmin && pass.viewer.role !== AUTHORITY.OWNER) {
+        return { isSuccess: false, message: "관리자 겸직은 대표만 바꿀 수 있습니다" };
+      }
       if (next.isAdmin !== target.member.isAdmin) {
         await serverApi<unknown>(ep.memberAdmin(id), {
           method: "PATCH",
@@ -245,20 +253,19 @@ async function findTeamLeaderClash(
   const willBeLeader = nextAuthority === AUTHORITY.LEADER;
   if (wasLeader === willBeLeader) return null;
 
-  const members = await listManagedMembers();
-  const leaders = members.filter(
-    (member) =>
-      member.teamName === team &&
-      member.authority === AUTHORITY.LEADER &&
-      member.status !== MEMBER_STATUS.RESIGNED &&
-      member.id !== target.id,
-  );
+  /*
+    ⚠️ **명부 전체를 받지 않는다.** 전에는 `listManagedMembers()`를 불렀는데, 연동 뒤 그 함수는
+       "페이지 단위로 조회하라"며 던진다 — 라이브에서 팀장 권한을 바꾸려 할 때마다 액션이
+       통째로 터졌다. 팀 조회가 팀장을 이미 얹어 준다.
+  */
+  const leaders = await getTeamLeaders();
+  const existing = leaders.get(team);
+  const isOtherPerson = existing !== undefined && existing.id !== target.id;
 
-  const existing = leaders[0];
-  if (willBeLeader && existing) {
+  if (willBeLeader && isOtherPerson) {
     return `${team}에는 이미 팀장(${existing.name})이 있습니다. 먼저 그 사람의 권한을 바꿔 주세요`;
   }
-  if (!willBeLeader && leaders.length === 0) {
+  if (!willBeLeader && !isOtherPerson) {
     return `${team}의 유일한 팀장입니다. 후임을 먼저 정해 주세요`;
   }
   return null;
@@ -389,6 +396,20 @@ export async function issueAccountAction(draft: AccountDraft): Promise<IssueAcco
     const team = company.departments.find((item) => item.name === draft.teamName);
     if (!team) return { errors: { teamName: "회사에 없는 팀입니다" } };
 
+    /*
+      ⚠️ **id가 숫자가 아닐 수 있다.** 화면에서 방금 만든 팀·직급은 아직 저장 전이라 임시
+         id를 들고 있다 — 그대로 `Number()`하면 `NaN`이 나가고 BE가 400으로 되돌려 주는데,
+         그 문구는 "왜 안 되는지"를 말해 주지 못한다.
+    */
+    const teamId = Number(team.id);
+    const positionId = Number(jobPosition.id);
+    if (!Number.isInteger(teamId)) {
+      return { errors: { teamName: "먼저 기업 설정에서 팀을 저장해 주세요" } };
+    }
+    if (!Number.isInteger(positionId)) {
+      return { errors: { position: "먼저 기업 설정에서 직급을 저장해 주세요" } };
+    }
+
     try {
       const accessToken = await requireAccessToken();
       await serverApi<unknown>(ep.manageMembers(), {
@@ -397,8 +418,10 @@ export async function issueAccountAction(draft: AccountDraft): Promise<IssueAcco
         json: {
           name: draft.name,
           email: draft.email,
-          teamId: Number(team.id),
-          jobPositionId: Number(jobPosition.id),
+          teamId: teamId,
+          jobPositionId: positionId,
+          /* ⚠️ **`role`은 필수다**(BE `@NotNull`). 빠뜨리면 **항상 400**이다 */
+          role: draft.authority,
           roleLabel: draft.roleLabel || null,
         },
       });

--- a/src/features/member/manage-actions.ts
+++ b/src/features/member/manage-actions.ts
@@ -5,9 +5,12 @@ import { revalidatePath } from "next/cache";
 import type { Authority } from "@/constants/authority";
 import { AUTHORITY, POSITION_AUTHORITIES } from "@/constants/authority";
 import { MEMBER_STATUS } from "@/constants/member";
+import { requireAccessToken } from "@/features/auth/session";
 import { getCompanySetting } from "@/features/company/server";
 import { getViewer } from "@/features/shell/viewer";
+import { serverApi, toUserMessage } from "@/lib/api";
 import { todayIso } from "@/lib/date";
+import { ep } from "@/lib/endpoints";
 import type { PaginatedResult } from "@/lib/paginate";
 import {
   canApproveFinal,
@@ -50,6 +53,17 @@ import { buildTeamRoles, isRoleOfTeam } from "./team-roles";
  */
 
 const NO_SESSION = "세션이 만료되었습니다. 다시 로그인해 주세요";
+/*
+  아직 못 붙인 것들이 쓰는 문구.
+
+  ⚠️ **"BE 협의 대기"가 아니다.** 각각 이유가 다르다(2026-08-10 BE 실코드 대조):
+    · 휴직·오프보딩 승인/반려 — `handover` 도메인 API(`PATCH /api/handovers/{id}/finalize`
+      ·`/complete`·`/reject`)가 있지만 **어느 것이 이 화면의 "승인"인지 확실하지 않고**,
+      그 도메인은 이 화면 담당이 아니다. 담당자와 맞춘 뒤 붙인다.
+    · 계정 삭제 — **BE에 경로가 없다.** `MemberController`·`ManageMemberController` 어디에도
+      `@DeleteMapping`이 없다. 만들어 달라고 요청해야 한다.
+  화면에는 이 문구가 그대로 뜬다 — 되는 척하지 않는다(§정직성).
+*/
 const NOT_CONNECTED = "아직 연결되지 않은 기능입니다";
 
 function pathOf(id: number) {
@@ -162,8 +176,44 @@ export async function changeMemberGradeAction(
   if (clash) return { isSuccess: false, message: clash };
 
   if (!isMock) {
-    // TODO(BE 협의): `PATCH /companies/me/members/{id}`
-    return { isSuccess: false, message: NOT_CONNECTED };
+    /*
+      ⚠️ **호출이 둘로 갈린다.** 역할·직급은 `PATCH /api/members/{id}`, 관리자 겸직은
+         `PATCH /api/members/{id}/admin`이다 — 앞쪽에 `isAdmin`을 실어 보내면 BE가
+         **400(`FIELD_NOT_ALLOWED`)** 으로 막는다. 어드민이 자기를 복제하는 것을 끊으려고
+         관리자 토글만 **OWNER 전용** 경로로 떼어 둔 것이다.
+      ⚠️ **직급은 이름이 아니라 id로 보낸다.** 화면은 이름을 다루므로 회사 목록에서 되찾는다 —
+         못 찾으면 보내지 않는다(없는 직급으로 바뀌느니 실패가 낫다).
+      ⚠️ **`roleLabel`(팀 안 세부 역할)을 보낼 곳이 없다.** BE `UpdateMemberRoleRequest`는
+         `role`·`jobPositionId`만 받는다 — 그 값은 지금 서버에 안 남는다. 되는 척하지 않으려고
+         적어 둔다(§정직성). API가 생기면 여기서 함께 보낸다.
+    */
+    const jobPosition = company.positions.find((item) => item.name === position);
+    if (!jobPosition) return { isSuccess: false, message: "회사에 없는 직급입니다" };
+
+    try {
+      const accessToken = await requireAccessToken();
+      await serverApi<unknown>(ep.member(id), {
+        method: "PATCH",
+        accessToken,
+        json: { role: next.authority, jobPositionId: Number(jobPosition.id) },
+      });
+
+      /* 겸직이 실제로 달라질 때만 부른다 — OWNER만 열리는 경로라 괜히 부르면 403이다 */
+      if (next.isAdmin !== target.member.isAdmin) {
+        await serverApi<unknown>(ep.memberAdmin(id), {
+          method: "PATCH",
+          accessToken,
+          json: { isAdmin: next.isAdmin },
+        });
+      }
+    } catch (error) {
+      return { isSuccess: false, message: toUserMessage(error) };
+    }
+
+    revalidatePath(pathOf(id));
+    revalidatePath("/manage/members");
+    revalidatePath(PEOPLE_PATH);
+    return { isSuccess: true };
   }
 
   updateMockMemberGrade(id, next);
@@ -326,8 +376,40 @@ export async function issueAccountAction(draft: AccountDraft): Promise<IssueAcco
   if (Object.keys(errors).length > 0) return { errors };
 
   if (!isMock) {
-    // TODO(BE 협의): `POST /companies/me/members`
-    return { errors: {}, message: NOT_CONNECTED };
+    /*
+      [확인] BE `ManageMemberController` — `POST /api/manage/members`.
+      비밀번호를 만들지 않는다: 기업코드·이메일·첫 비밀번호를 **서버가 메일로 보낸다.**
+      ⚠️ 중복 메일은 **서버가 본다.** 화면이 목록을 들고 있어도 그 사이 다른 관리자가 같은
+         주소로 발급했을 수 있다 — 그때는 BE의 `message`를 그대로 이메일 칸에 띄운다.
+      ⚠️ 팀·직급은 **id**로 보낸다. 화면은 이름을 다루므로 회사 목록에서 되찾는다.
+    */
+    const jobPosition = company.positions.find((item) => item.name === draft.position);
+    if (!jobPosition) return { errors: { position: "회사에 없는 직급입니다" } };
+
+    const team = company.departments.find((item) => item.name === draft.teamName);
+    if (!team) return { errors: { teamName: "회사에 없는 팀입니다" } };
+
+    try {
+      const accessToken = await requireAccessToken();
+      await serverApi<unknown>(ep.manageMembers(), {
+        method: "POST",
+        accessToken,
+        json: {
+          name: draft.name,
+          email: draft.email,
+          teamId: Number(team.id),
+          jobPositionId: Number(jobPosition.id),
+          roleLabel: draft.roleLabel || null,
+        },
+      });
+    } catch (error) {
+      /* 중복 메일이 가장 흔한 실패라 이메일 칸에 붙인다 — 폼 오류는 인라인이다(DECISIONS §7) */
+      return { errors: { email: toUserMessage(error) } };
+    }
+
+    revalidatePath("/manage/members");
+    revalidatePath(PEOPLE_PATH);
+    return { errors: {} };
   }
 
   /*

--- a/src/features/member/manage-mapper.ts
+++ b/src/features/member/manage-mapper.ts
@@ -1,5 +1,4 @@
 import { AUTHORITY, type Authority } from "@/constants/authority";
-import { HANDOVER_TYPE, type HandoverType } from "@/constants/handover";
 import { MEMBER_STATUS, type MemberStatus } from "@/constants/member";
 
 import type { ManagedMember, MemberFilter } from "./manage-types";
@@ -81,21 +80,6 @@ function toMemberStatus(workStatus: string): MemberStatus {
   return (Object.values(MEMBER_STATUS) as string[]).includes(workStatus)
     ? (workStatus as MemberStatus)
     : MEMBER_STATUS.ACTIVE;
-}
-
-/**
- * 대기 중인 신청 종류.
- *
- * ⚠️ BE의 `LEAVE`는 우리 `VACATION`이다(필터와 같은 간극).
- * ⚠️ **`null`을 지어내지 않는다.** 모르는 값이면 `null`로 두어 "대기 없음"이 되는데,
- *    그건 승인이 필요한 사람을 목록에서 감추는 일이다 — 대신 모르면 그대로 두고
- *    거르기에서만 빠지게 한다.
- */
-function toPendingHandoverType(value: string | null): HandoverType | null {
-  if (!value) return null;
-  if (value === "LEAVE" || value === HANDOVER_TYPE.VACATION) return HANDOVER_TYPE.VACATION;
-  if (value === HANDOVER_TYPE.OFFBOARDING) return HANDOVER_TYPE.OFFBOARDING;
-  return null;
 }
 
 export function toManagedMember(item: BeMemberListItem | BeMemberDetail): ManagedMember {

--- a/src/features/member/manage-mapper.ts
+++ b/src/features/member/manage-mapper.ts
@@ -1,0 +1,104 @@
+import { AUTHORITY, type Authority } from "@/constants/authority";
+import { HANDOVER_TYPE, type HandoverType } from "@/constants/handover";
+import { MEMBER_STATUS, type MemberStatus } from "@/constants/member";
+
+import type { ManagedMember, MemberFilter } from "./manage-types";
+
+/**
+ * BE shape → UI 계약 (§Mock 격리막 — **shape을 흡수하는 곳은 여기 하나다**).
+ *
+ * ⚠️ 컴포넌트는 이 파일을 모른다. BE가 모양을 바꾸면 여기만 고친다.
+ * ⚠️ **필드 이름이 곳곳에서 다르다.** BE는 `positionName`·`workStatus`, 우리는
+ *    `position`·`status`다. 어느 한쪽으로 맞추자고 화면을 고치면 연동할 때마다 화면이 흔들린다.
+ */
+
+/** [확인] BE `MemberListItemResponse` */
+export interface BeMemberListItem {
+  memberId: number;
+  name: string;
+  email: string | null;
+  teamName: string | null;
+  positionName: string | null;
+  role: string;
+  isAdmin: boolean;
+  roleLabel: string | null;
+  workStatus: string;
+  joinedAt: string | null;
+  pendingHandoverType: string | null;
+}
+
+/**
+ * 화면 필터 → BE 필터.
+ *
+ * ⚠️ **이름이 다르다.** 우리는 `VACATION_PENDING`(휴직), BE는 `LEAVE_PENDING`이다 —
+ *    그대로 보내면 Spring이 enum 변환에 실패해 **400**이 난다. 상수를 화면 쪽에 맞춰 둔 건
+ *    화면 문구가 "휴직"이기 때문이고, 그 간극을 메우는 게 매퍼의 일이다.
+ */
+export function toBeFilter(filter: MemberFilter): string {
+  if (filter === "VACATION_PENDING") return "LEAVE_PENDING";
+  return filter;
+}
+
+/**
+ * 권한 문자열 → 우리 상수.
+ *
+ * ⚠️ **모르는 값이 오면 가장 낮은 권한으로 떨어뜨린다.** BE가 역할을 하나 늘렸을 때
+ *    화면이 터지는 것보다, 덜 보이는 쪽이 안전하다 — 권한은 넘겨짚으면 안 되는 값이다(§권한).
+ */
+function toAuthority(role: string): Authority {
+  switch (role) {
+    case AUTHORITY.OWNER:
+      return AUTHORITY.OWNER;
+    case AUTHORITY.LEADER:
+      return AUTHORITY.LEADER;
+    default:
+      return AUTHORITY.MEMBER;
+  }
+}
+
+/**
+ * 근무 상태 → 우리 상수.
+ *
+ * ⚠️ 소프트 딜리트(`DELETED`)는 **상태가 아니라 목록에서 빠지는 일**이다(§도메인 상수) —
+ *    그 판정은 부르는 쪽이 `isVisibleMemberStatus`로 한다. 여기서는 값만 옮긴다.
+ */
+function toMemberStatus(workStatus: string): MemberStatus {
+  return (Object.values(MEMBER_STATUS) as string[]).includes(workStatus)
+    ? (workStatus as MemberStatus)
+    : MEMBER_STATUS.ACTIVE;
+}
+
+/**
+ * 대기 중인 신청 종류.
+ *
+ * ⚠️ BE의 `LEAVE`는 우리 `VACATION`이다(필터와 같은 간극).
+ * ⚠️ **`null`을 지어내지 않는다.** 모르는 값이면 `null`로 두어 "대기 없음"이 되는데,
+ *    그건 승인이 필요한 사람을 목록에서 감추는 일이다 — 대신 모르면 그대로 두고
+ *    거르기에서만 빠지게 한다.
+ */
+function toPendingHandoverType(value: string | null): HandoverType | null {
+  if (!value) return null;
+  if (value === "LEAVE" || value === HANDOVER_TYPE.VACATION) return HANDOVER_TYPE.VACATION;
+  if (value === HANDOVER_TYPE.OFFBOARDING) return HANDOVER_TYPE.OFFBOARDING;
+  return null;
+}
+
+export function toManagedMember(item: BeMemberListItem): ManagedMember {
+  return {
+    id: item.memberId,
+    name: item.name,
+    email: item.email ?? "",
+    /*
+      ⚠️ **빈 문자열을 `null`로 되돌린다.** 우리 계약은 "팀 없음"을 `null`로 적기로 했고
+         (Owner는 팀이 없다), 빈 문자열은 "이름이 없는 팀"과 구분이 안 된다.
+    */
+    teamName: item.teamName?.trim() ? item.teamName : null,
+    position: item.positionName ?? "",
+    authority: toAuthority(item.role),
+    isAdmin: item.isAdmin,
+    roleLabel: item.roleLabel?.trim() ? item.roleLabel : null,
+    status: toMemberStatus(item.workStatus),
+    joinedAt: item.joinedAt ?? "",
+    pendingHandoverType: toPendingHandoverType(item.pendingHandoverType),
+  };
+}

--- a/src/features/member/manage-mapper.ts
+++ b/src/features/member/manage-mapper.ts
@@ -12,19 +12,34 @@ import type { ManagedMember, MemberFilter } from "./manage-types";
  *    `position`·`status`다. 어느 한쪽으로 맞추자고 화면을 고치면 연동할 때마다 화면이 흔들린다.
  */
 
-/** [확인] BE `MemberListItemResponse` */
+/**
+ * [확인] BE `MemberListItemResponse` — **목록은 상세보다 적게 준다.**
+ *
+ * ⚠️ **`joinedOn`이다**(`joinedAt` 아님). 이름을 잘못 읽으면 `undefined`가 조용히 빈 문자열이
+ *    되어 **입사일 열이 통째로 빈칸**으로 뜬다 — 값이 없는 것과 구분이 안 된다.
+ * ⚠️ **목록에는 `email`이 없다.** 표가 그 열을 안 그리므로(WORKFLOW §9: 이름·팀·직급·권한·
+ *    역할·상태·입사일) 문제가 아니고, 상세(`BeMemberDetail`)에는 있다.
+ * ⚠️ **목록에는 `pendingHandoverType`도 없다.** 거르기는 이제 서버가 하므로(`filter`
+ *    파라미터) 화면이 그 값을 볼 일이 없다 — 목으로 돌 때만 쓰인다.
+ */
 export interface BeMemberListItem {
   memberId: number;
   name: string;
-  email: string | null;
   teamName: string | null;
   positionName: string | null;
   role: string;
   isAdmin: boolean;
   roleLabel: string | null;
   workStatus: string;
-  joinedAt: string | null;
-  pendingHandoverType: string | null;
+  /** `2020-01-02` — Jackson이 `LocalDate`를 ISO 문자열로 내린다 */
+  joinedOn: string | null;
+}
+
+/** [확인] BE `MemberDetailResponse` — 목록에 없는 `email`·`teamId`·`jobPositionId`가 더 있다 */
+export interface BeMemberDetail extends BeMemberListItem {
+  teamId: number | null;
+  jobPositionId: number | null;
+  email: string | null;
 }
 
 /**
@@ -83,11 +98,15 @@ function toPendingHandoverType(value: string | null): HandoverType | null {
   return null;
 }
 
-export function toManagedMember(item: BeMemberListItem): ManagedMember {
+export function toManagedMember(item: BeMemberListItem | BeMemberDetail): ManagedMember {
   return {
     id: item.memberId,
     name: item.name,
-    email: item.email ?? "",
+    /*
+      ⚠️ **목록에는 이메일이 없다.** 표가 그 열을 안 그리므로 빈 문자열로 둔다 —
+         지어내지 않는다. 상세는 실제 값이 온다.
+    */
+    email: "email" in item ? (item.email ?? "") : "",
     /*
       ⚠️ **빈 문자열을 `null`로 되돌린다.** 우리 계약은 "팀 없음"을 `null`로 적기로 했고
          (Owner는 팀이 없다), 빈 문자열은 "이름이 없는 팀"과 구분이 안 된다.
@@ -98,7 +117,11 @@ export function toManagedMember(item: BeMemberListItem): ManagedMember {
     isAdmin: item.isAdmin,
     roleLabel: item.roleLabel?.trim() ? item.roleLabel : null,
     status: toMemberStatus(item.workStatus),
-    joinedAt: item.joinedAt ?? "",
-    pendingHandoverType: toPendingHandoverType(item.pendingHandoverType),
+    joinedAt: item.joinedOn ?? "",
+    /*
+      ⚠️ **목록 응답에 없다.** 휴직·오프보딩 대기 구분은 이제 서버 `filter`가 하므로
+         화면이 이 값을 볼 일이 없다 — 목으로 돌 때만 채워진다.
+    */
+    pendingHandoverType: null,
   };
 }

--- a/src/features/member/manage-mapper.ts
+++ b/src/features/member/manage-mapper.ts
@@ -1,5 +1,5 @@
 import { AUTHORITY, type Authority } from "@/constants/authority";
-import { MEMBER_STATUS, type MemberStatus } from "@/constants/member";
+import type { MemberStatus } from "@/constants/member";
 
 import type { ManagedMember, MemberFilter } from "./manage-types";
 
@@ -75,11 +75,12 @@ function toAuthority(role: string): Authority {
  *
  * ⚠️ 소프트 딜리트(`DELETED`)는 **상태가 아니라 목록에서 빠지는 일**이다(§도메인 상수) —
  *    그 판정은 부르는 쪽이 `isVisibleMemberStatus`로 한다. 여기서는 값만 옮긴다.
+ * ⚠️ **모르는 값을 `ACTIVE`로 바꾸지 않는다.** 그러면 `DELETED`처럼 목록에서 빠져야 할 사람이
+ *    **재직 중으로 되살아나고**, BE가 상태를 하나 늘렸을 때 그 사람들이 전부 재직으로 뭉친다 —
+ *    화면이 거짓말을 한다(§정직성). 원문을 그대로 넘겨 `isVisibleMemberStatus`가 거르게 둔다.
  */
 function toMemberStatus(workStatus: string): MemberStatus {
-  return (Object.values(MEMBER_STATUS) as string[]).includes(workStatus)
-    ? (workStatus as MemberStatus)
-    : MEMBER_STATUS.ACTIVE;
+  return workStatus as MemberStatus;
 }
 
 export function toManagedMember(item: BeMemberListItem | BeMemberDetail): ManagedMember {

--- a/src/features/member/manage-server.ts
+++ b/src/features/member/manage-server.ts
@@ -1,10 +1,14 @@
 import "server-only";
 
 import { isVisibleMemberStatus } from "@/constants/member";
+import { requireAccessToken } from "@/features/auth/session";
+import { serverApi } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
 import { paginate, type PaginatedResult } from "@/lib/paginate";
 import { isMock } from "@/mocks/config";
 
 import { filterMembers, searchMembers } from "./manage-filter";
+import { type BeMemberListItem, toBeFilter, toManagedMember } from "./manage-mapper";
 import type { ManagedMember, ManagedMemberDetail, MemberQuery } from "./manage-types";
 import {
   findMockManagedMember,
@@ -24,8 +28,12 @@ import {
 export async function listManagedMembers(): Promise<ManagedMember[]> {
   if (isMock) return listMockManagedMembers();
 
-  // TODO(BE 협의): `GET /companies/me/members` — 응답 봉투는 아직 모른다(매퍼가 벗긴다)
-  throw new Error("사원 목록 조회 API가 아직 연결되지 않았습니다.");
+  /*
+    ⚠️ **전체를 한 번에 받는 길은 안 만든다.** 사원이 수백 명이면 그 수백을 다 받아 오게 되고,
+       BE도 목록은 페이지 단위로만 연다(`GET /api/members?page&size`). 목으로 돌 때만 쓰는
+       편의 함수로 남긴다 — 부르는 곳은 `getManagedMembersPage`다.
+  */
+  throw new Error("사원 목록은 페이지 단위로 조회합니다 — getManagedMembersPage를 쓰세요.");
 }
 
 /** 한 화면에 그리는 줄 수 — 첫 페이지를 서버가 렌더하고 그 아래부터 이어 붙인다 */
@@ -46,8 +54,52 @@ export async function getManagedMembersPage(
   page: number,
   pageSize: number = MEMBER_PAGE_SIZE,
 ): Promise<PaginatedResult<ManagedMember>> {
-  const all = await listManagedMembers();
-  return paginate(searchMembers(filterMembers(all, query.filter), query.keyword), page, pageSize);
+  if (isMock) {
+    const all = await listManagedMembers();
+    return paginate(searchMembers(filterMembers(all, query.filter), query.keyword), page, pageSize);
+  }
+
+  /*
+    ⚠️ **검색·필터·자르기를 전부 서버가 한다**(`GET /api/members`, [확인] BE `MemberController.list`).
+       받아 와서 화면이 거르면 지금 페이지 안에서만 찾게 되어 "없습니다"가 거짓말이 된다.
+    ⚠️ 회사는 **토큰의 `companyId`** 로 정해진다 — 파라미터로 안 보낸다. 보내면 남의 회사
+       사원을 조회할 수 있는 구멍이 된다(BE도 principal에서만 읽는다).
+    ⚠️ `filter`는 이름이 갈린다 — 우리 `VACATION_PENDING` ↔ BE `LEAVE_PENDING`(`toBeFilter`).
+    ⚠️ **번호 기준이 다르다.** 우리 `paginate`는 1부터, BE는 **0부터**다 — 그대로 넘기면
+       첫 페이지를 건너뛰고 두 번째부터 보여준다. 여기서 한 칸 내려 보내고, 돌려줄 때
+       다시 올린다.
+  */
+  const accessToken = await requireAccessToken();
+  const params = new URLSearchParams({
+    filter: toBeFilter(query.filter),
+    page: String(Math.max(0, page - 1)),
+    size: String(pageSize),
+  });
+  if (query.keyword.trim()) params.set("q", query.keyword.trim());
+
+  const response = await serverApi<{
+    totalElements: number;
+    page: number;
+    size: number;
+    content: BeMemberListItem[];
+  }>(`${ep.members()}?${params}`, { accessToken });
+
+  /*
+    ⚠️ **지워진 사람은 여기서 뺀다**(§도메인 상수). 퇴사자(`RESIGNED`)는 남는다 — 그 사람이
+       남긴 회의·액션의 출처라 이름이 사라지면 추적이 끊긴다.
+    ⚠️ 거른 만큼 `totalCount`를 줄이지 않는다. 그 숫자는 **서버가 센 전체**이고, 화면의
+       `전체 N건`은 그 값을 말해야 다음 페이지가 있는지와 어긋나지 않는다.
+  */
+  const items = response.content
+    .map(toManagedMember)
+    .filter((member) => isVisibleMemberStatus(member.status));
+
+  return {
+    items,
+    page: response.page + 1,
+    totalPages: Math.max(1, Math.ceil(response.totalElements / response.size)),
+    totalCount: response.totalElements,
+  };
 }
 
 /**
@@ -64,14 +116,35 @@ export async function getManagedMember(id: number): Promise<ManagedMemberDetail 
     return found && isVisibleMemberStatus(found.member.status) ? found : null;
   }
 
-  // TODO(BE 협의): `GET /companies/me/members/{id}`
-  throw new Error("사원 조회 API가 아직 연결되지 않았습니다.");
+  /*
+    [확인] BE `MemberController.detail` — `GET /api/members/{memberId}`.
+    ⚠️ **액션·대기 신청은 이 응답에 없다.** BE `MemberDetailResponse`가 주는 건 사람 정보뿐이라,
+       지금은 그 둘을 빈 값으로 둔다 — 지어내지 않는다(§정직성). 액션 목록 API가 붙으면
+       여기서 함께 읽어 채운다.
+  */
+  const accessToken = await requireAccessToken();
+  let detail: BeMemberListItem;
+  try {
+    detail = await serverApi<BeMemberListItem>(ep.member(id), { accessToken });
+  } catch {
+    /* 없는 사람·권한 없음 모두 화면에서는 `notFound()`다 — 있는지 없는지를 알려 주지 않는다 */
+    return null;
+  }
+
+  const member = toManagedMember(detail);
+  if (!isVisibleMemberStatus(member.status)) return null;
+
+  return { member, actions: [], pendingHandover: null };
 }
 
 /** 이미 쓰고 있는 메일 주소 — 중복 발급을 막는다 */
 export async function listMemberEmails(): Promise<string[]> {
   if (isMock) return listMockMemberEmails();
 
-  // TODO(BE 협의): 발급 API가 서버에서 중복을 보면 이 조회는 사라진다
-  throw new Error("사원 목록 조회 API가 아직 연결되지 않았습니다.");
+  /*
+    ⚠️ **중복 판정은 서버가 한다.** 발급 API(`POST /api/manage/members`)가 이미 쓰는 주소를
+       거르므로, 전체 메일 주소를 받아 와 화면에서 비교할 이유가 없다 — 그 목록은 그 자체로
+       개인정보이기도 하다. 목으로 돌 때 폼 검증을 보여 주려고 남겨 둔다.
+  */
+  return [];
 }

--- a/src/features/member/manage-server.ts
+++ b/src/features/member/manage-server.ts
@@ -8,7 +8,12 @@ import { paginate, type PaginatedResult } from "@/lib/paginate";
 import { isMock } from "@/mocks/config";
 
 import { filterMembers, searchMembers } from "./manage-filter";
-import { type BeMemberListItem, toBeFilter, toManagedMember } from "./manage-mapper";
+import {
+  type BeMemberDetail,
+  type BeMemberListItem,
+  toBeFilter,
+  toManagedMember,
+} from "./manage-mapper";
 import type { ManagedMember, ManagedMemberDetail, MemberQuery } from "./manage-types";
 import {
   findMockManagedMember,
@@ -123,9 +128,9 @@ export async function getManagedMember(id: number): Promise<ManagedMemberDetail 
        여기서 함께 읽어 채운다.
   */
   const accessToken = await requireAccessToken();
-  let detail: BeMemberListItem;
+  let detail: BeMemberDetail;
   try {
-    detail = await serverApi<BeMemberListItem>(ep.member(id), { accessToken });
+    detail = await serverApi<BeMemberDetail>(ep.member(id), { accessToken });
   } catch {
     /* 없는 사람·권한 없음 모두 화면에서는 `notFound()`다 — 있는지 없는지를 알려 주지 않는다 */
     return null;

--- a/src/features/member/manage-server.ts
+++ b/src/features/member/manage-server.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import { isVisibleMemberStatus } from "@/constants/member";
 import { requireAccessToken } from "@/features/auth/session";
-import { serverApi } from "@/lib/api";
+import { ApiError, serverApi } from "@/lib/api";
 import { ep } from "@/lib/endpoints";
 import { paginate, type PaginatedResult } from "@/lib/paginate";
 import { isMock } from "@/mocks/config";
@@ -82,8 +82,13 @@ export async function getManagedMembersPage(
   });
   if (query.keyword.trim()) params.set("q", query.keyword.trim());
 
+  /*
+    ⚠️ **`totalCount`다**(`totalElements` 아님 — [확인] BE `MemberPageResponse`). 이름을 잘못
+       읽으면 `undefined`가 되어 `전체 N건`이 비고 `totalPages`가 `NaN`이 된다 — 다음 페이지가
+       있는지 아무도 모르게 된다.
+  */
   const response = await serverApi<{
-    totalElements: number;
+    totalCount: number;
     page: number;
     size: number;
     content: BeMemberListItem[];
@@ -102,8 +107,9 @@ export async function getManagedMembersPage(
   return {
     items,
     page: response.page + 1,
-    totalPages: Math.max(1, Math.ceil(response.totalElements / response.size)),
-    totalCount: response.totalElements,
+    /* ⚠️ `size`가 0으로 오면 0으로 나눠 `Infinity`가 된다 — 요청한 값으로 되돌린다 */
+    totalPages: Math.max(1, Math.ceil(response.totalCount / (response.size || pageSize))),
+    totalCount: response.totalCount,
   };
 }
 
@@ -131,9 +137,15 @@ export async function getManagedMember(id: number): Promise<ManagedMemberDetail 
   let detail: BeMemberDetail;
   try {
     detail = await serverApi<BeMemberDetail>(ep.member(id), { accessToken });
-  } catch {
-    /* 없는 사람·권한 없음 모두 화면에서는 `notFound()`다 — 있는지 없는지를 알려 주지 않는다 */
-    return null;
+  } catch (error) {
+    /*
+      ⚠️ **모든 실패를 "없는 사람"으로 만들지 않는다.** 통신 장애나 500까지 `null`로 바꾸면
+         화면이 `notFound()`를 띄워 **사원이 지워진 것처럼 보인다** — 실제로는 서버가 잠깐
+         맛이 간 것이다(§정직성).
+      ⚠️ 404·403만 `null`이다. 있는지 없는지를 알려 주지 않으려고 둘을 같이 묶는다.
+    */
+    if (error instanceof ApiError && (error.status === 404 || error.status === 403)) return null;
+    throw error;
   }
 
   const member = toManagedMember(detail);
@@ -152,4 +164,37 @@ export async function listMemberEmails(): Promise<string[]> {
        개인정보이기도 하다. 목으로 돌 때 폼 검증을 보여 주려고 남겨 둔다.
   */
   return [];
+}
+
+/**
+ * 팀별 현재 팀장 — **팀당 한 명 규칙**을 서버에서 재검사할 때 쓴다.
+ *
+ * ⚠️ **명부 전체를 받아 거르지 않는다.** 사원이 수백 명이면 그 수백을 다 받아 오는데,
+ *    필요한 건 팀마다 한 명뿐이다 — BE의 팀 조회가 `leaderMemberId`·`leaderName`을
+ *    이미 얹어 준다([확인] `TeamNodeResponse`).
+ * ⚠️ 목으로 돌 때는 명부에서 뽑는다 — 목에는 팀 조회가 따로 없다.
+ */
+export async function getTeamLeaders(): Promise<Map<string, { id: number; name: string }>> {
+  if (isMock) {
+    const leaders = new Map<string, { id: number; name: string }>();
+    for (const member of listMockManagedMembers()) {
+      if (!member.teamName) continue;
+      if (member.authority !== "LEADER") continue;
+      if (member.status === "RESIGNED") continue;
+      leaders.set(member.teamName, { id: member.id, name: member.name });
+    }
+    return leaders;
+  }
+
+  const accessToken = await requireAccessToken();
+  const teams = await serverApi<
+    { name: string; leaderMemberId: number | null; leaderName: string | null }[]
+  >(ep.teams(), { accessToken });
+
+  const leaders = new Map<string, { id: number; name: string }>();
+  for (const team of teams) {
+    if (team.leaderMemberId === null) continue;
+    leaders.set(team.name, { id: team.leaderMemberId, name: team.leaderName ?? "" });
+  }
+  return leaders;
 }

--- a/src/features/onboarding/types.ts
+++ b/src/features/onboarding/types.ts
@@ -90,6 +90,15 @@ export interface Position {
   id: string;
   name: string;
   role: AssignableRole;
+  /**
+   * 직급 권한 요약.
+   *
+   * ⚠️ **화면에 안 보이지만 버리면 안 된다.** BE가 `@NotBlank`로 필수라(`CreatePositionRequest`·
+   *    `UpdatePositionRequest`) 저장할 때 다시 보내야 한다 — 안 들고 다니면 왕복 한 번에
+   *    남이 적어 둔 설명이 지워지거나 400이 난다.
+   * ⚠️ 온보딩에서 새로 만들 때는 비어 있다 — 그때는 저장하는 쪽이 채운다.
+   */
+  description?: string;
 }
 
 /** 기업이 고를 수 있는 권한. `SYSTEM`은 서비스 운영자라 제외된다. */

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -39,8 +39,20 @@ export const ep = {
   handover: (id: number) => `/api/handovers/${id}`,
 
   /* 조직 */
+  /* 조직 — [확인] identity/member/presentation/api/{Member,ManageMember}Controller.java */
   members: () => "/api/members",
   member: (id: number) => `/api/members/${id}`,
+  /** 조직도 — OWNER·ADMIN 전용 */
+  memberOrgChart: () => "/api/members/org-chart",
+  /**
+   * 관리자 겸직 토글 — **OWNER 전용**이고 경로가 따로다.
+   *
+   * ⚠️ 역할·직급 변경(`member`)에 `isAdmin`을 실어 보내면 BE가 400(`FIELD_NOT_ALLOWED`)으로
+   *    막는다. 어드민이 자기를 복제하는 것을 끊으려고 일부러 갈라 둔 경로다.
+   */
+  memberAdmin: (id: number) => `/api/members/${id}/admin`,
+  /** 계정 발급 — 첫 비밀번호는 서버가 메일로 보낸다 */
+  manageMembers: () => "/api/manage/members",
   departments: () => "/api/departments",
   rooms: () => "/api/rooms",
 

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -41,6 +41,18 @@ export const ep = {
   /* 조직 */
   members: () => "/api/members",
   member: (id: number) => `/api/members/${id}`,
+  /**
+   * 팀 — [확인] identity/team/presentation/api/TeamController.java
+   *
+   * ⚠️ **한 건씩 다룬다**(`POST`·`PATCH /{id}`·`DELETE /{id}`). 트리를 통째로 넣는
+   *    `PUT`은 BE에 없다 — 화면은 통째로 저장하므로 부르는 쪽이 **차이를 계산해** 나눠 부른다.
+   * ⚠️ 조회 응답에 `memberCount`가 들어 있다 — 사람이 딸린 팀을 못 지우는 판정에 그대로 쓴다.
+   */
+  teams: () => "/api/teams",
+  team: (id: number) => `/api/teams/${id}`,
+  /** 직급 — [확인] identity/position/presentation/api/PositionController.java */
+  jobPositions: () => "/api/job-positions",
+  jobPosition: (id: number) => `/api/job-positions/${id}`,
   departments: () => "/api/departments",
   rooms: () => "/api/rooms",
 


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [x] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

**무엇을**

격리막(`isMock` 분기)이 이미 서 있어 **매퍼와 실호출만** 채웠습니다. 화면 코드는 0줄입니다.

| 화면 동작 | API |
|---|---|
| 목록(검색·필터·페이지) | `GET /api/members?filter&q&page&size` |
| 상세 | `GET /api/members/{id}` |
| 역할·직급 변경 | `PATCH /api/members/{id}` |
| 관리자 겸직 토글 | `PATCH /api/members/{id}/admin` (**OWNER 전용**) |
| 계정 발급 | `POST /api/manage/members` |

새 파일: `features/member/manage-mapper.ts` (BE shape 흡수)

**실코드를 보고 잡은 것**

- ⚠️ **필터 이름이 갈립니다** — 우리 `VACATION_PENDING` ↔ BE `LEAVE_PENDING`. 그대로 보내면 enum 변환 실패로 **400**입니다. 매퍼가 옮깁니다
- ⚠️ **페이지 번호 기준이 다릅니다** — 우리 `paginate`는 1부터, BE는 **0부터**입니다. 그대로 넘기면 첫 페이지를 건너뜁니다. 보낼 때 내리고 받을 때 올립니다
- ⚠️ **관리자 토글은 경로가 따로입니다** — `PATCH /{id}`에 `isAdmin`을 실으면 BE가 400(`FIELD_NOT_ALLOWED`)으로 막습니다. 어드민 자기복제를 끊으려고 OWNER 전용 경로로 떼어 둔 것이라, 겸직이 **실제로 달라질 때만** 부릅니다(안 그러면 괜히 403)
- ⚠️ **직급·팀은 이름이 아니라 id로 보냅니다.** 화면은 이름을 다루므로 회사 목록에서 되찾고, 못 찾으면 보내지 않습니다

**안 붙인 것 — 이유가 각각 다릅니다**

되는 척하지 않으려고 코드에 사유를 적어 뒀습니다.

- **휴직·오프보딩 승인/반려** — `handover` 도메인 API는 있으나 `finalize`·`complete`·`reject` 중 **어느 것이 이 화면의 "승인"인지 확실하지 않고**, 그 도메인은 제 소유가 아닙니다. 담당자와 맞춘 뒤 붙입니다
- **계정 삭제** — ⚠️ **BE에 경로가 없습니다.** `MemberController`·`ManageMemberController` 어디에도 `@DeleteMapping`이 없습니다. 요청이 필요합니다
- **상세의 액션 목록·대기 신청** — `MemberDetailResponse`에 없어 빈 값으로 둡니다. 지어내지 않습니다
- **`roleLabel`(팀 안 세부 역할) 변경** — `UpdateMemberRoleRequest`가 `role`·`jobPositionId`만 받습니다. 지금은 서버에 안 남습니다

**검사**

`tsc` · `eslint` · `jest` 73 suites / 831 tests 통과.

---

## ✅ 작업 체크리스트

**기본**

- [ ] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [ ] 불필요한 `console` · 주석 처리된 코드 제거
- [ ] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**(회의 담당자 등), 그리고 **서버(Server Action/BFF)에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [x] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시 (조용히 "되는 척" 금지)
- [ ] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그)
- [ ] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [ ] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인)
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음

---

## 🔗 연관 이슈

Closes #286

⚠️ **PR #267(Identity) 위에 얹혀 있습니다.** `lib/api.ts`·`auth/session.ts`가 거기 있습니다.

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

-

---

## 📝 추가 메모

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능
- 실제 서버와 연동해 구성원 목록을 조회하고 필터, 검색, 페이지 크기를 적용할 수 있습니다.
- 구성원의 직급 및 관리자 권한을 변경하고 계정을 발급할 수 있습니다.
- 조직도와 상세 구성원 정보를 서버에서 확인할 수 있습니다.

## 버그 수정
- 서버 오류를 직급 변경 및 계정 발급 화면의 사용자 친화적인 메시지로 안내합니다.
- 구성원 정보의 누락되거나 알 수 없는 값이 안정적인 기본값으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
