### PR TITLE
[FEAT] 기업 설정 연동 — 기본 정보·팀·직급 #288

### DIFF
--- a/src/features/company/actions.ts
+++ b/src/features/company/actions.ts
@@ -186,7 +186,19 @@ export async function saveDepartmentsAction(
        액션은 직접 부를 수 있다(§권한). 지금 저장된 트리와 견줘야 무엇이 바뀌었는지 알 수 있다 —
        클라이언트가 보낸 값만 보면 "무엇이 사라졌는지"를 모른다.
   */
-  const current = await getCompanySetting();
+  /*
+    ⚠️ **여기서 던지면 카드가 아니라 페이지가 죽는다.** `getCompanySetting()`은 서버를
+       세 번 부르므로 얼마든지 실패할 수 있는데, `try` 밖에 두면 그 예외가 그대로 올라가
+       error boundary가 화면을 통째로 갈아치운다 — 방금 짠 팀 구조가 다 날아간다.
+       이 파일이 세 번 적어 둔 "던지지 않는다"를 스스로 깨는 자리였다.
+  */
+  let current: Awaited<ReturnType<typeof getCompanySetting>>;
+  try {
+    current = await getCompanySetting();
+  } catch (error) {
+    return { isSuccess: false, message: toUserMessage(error) };
+  }
+
   const blocked = findBlockedTeamChange(current.departments, departments, current.teamMemberCounts);
   if (blocked) {
     return {
@@ -215,20 +227,21 @@ export async function saveDepartmentsAction(
          `roleLabel` 관리 경로 0건) — 팀만 저장하고 성공이라고 말하면 **역할을 고친 사람이
          저장됐다고 믿는다**(§정직성). 바뀐 게 있으면 그 사실을 말하고 멈춘다.
     */
-    const roleSignature = (nodes: DepartmentNode[]) =>
+    /*
+      ⚠️ **이름 변경 여부와 무관하게 막는다.** 처음엔 "이름도 같이 바뀌었으면 통과"로 뒀는데,
+         보내는 본문은 `{ name }`뿐이라 그때도 역할은 안 저장된다 — 이름만 바뀌고 역할은
+         사라진 채 **성공**이라고 말하게 된다. 역할은 팀과 따로 세어야 한다.
+    */
+    const rolesOf = (nodes: DepartmentNode[]) =>
       nodes
-        .map((node) => `${node.name}:${node.children.map((child) => child.name).join(",")}`)
+        .map((node) => `${node.id}:${node.children.map((child) => child.name).join(",")}`)
+        .sort()
         .join("|");
-    if (roleSignature(current.departments) !== roleSignature(departments)) {
-      const namesChanged =
-        current.departments.map((n) => n.name).join("|") !==
-        departments.map((n) => n.name).join("|");
-      if (!namesChanged) {
-        return {
-          isSuccess: false,
-          message: "팀 안 역할은 아직 저장할 수 없습니다. 팀 이름만 바꿔 주세요",
-        };
-      }
+    if (rolesOf(current.departments) !== rolesOf(departments)) {
+      return {
+        isSuccess: false,
+        message: "팀 안 역할은 아직 저장할 수 없습니다. 팀 이름만 바꿔 주세요",
+      };
     }
 
     const before = new Map(current.departments.map((node) => [node.id, node.name]));
@@ -283,8 +296,14 @@ export async function savePositionsAction(positions: Position[]): Promise<Compan
 
   // ⚠️ 던지지 않는다 — 저장 실패는 화면 전체 실패가 아니다
   if (!isMock) {
-    /* 팀과 같은 이유로 차이를 계산해 한 건씩 부른다 — 지우기는 마지막이다 */
-    const current = await getCompanySetting();
+    /* 팀과 같은 이유로 차이를 계산해 한 건씩 부른다. 지우기가 먼저다 */
+    let current: Awaited<ReturnType<typeof getCompanySetting>>;
+    try {
+      current = await getCompanySetting();
+    } catch (error) {
+      /* 팀 저장과 같은 이유 — 던지면 카드가 아니라 페이지가 죽는다 */
+      return { isSuccess: false, message: toUserMessage(error) };
+    }
     const before = new Map(current.positions.map((item) => [item.id, item]));
     const after = new Map(positions.map((item) => [item.id, item]));
 

--- a/src/features/company/actions.ts
+++ b/src/features/company/actions.ts
@@ -2,7 +2,10 @@
 
 import { revalidatePath } from "next/cache";
 
+import { requireAccessToken } from "@/features/auth/session";
 import { getViewer } from "@/features/shell/viewer";
+import { serverApi, toUserMessage } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
 import { canManageCompany } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
@@ -38,7 +41,6 @@ const SETTING_PATH = "/owner/setting";
 
 const FORBIDDEN = "기업 설정을 바꿀 권한이 없습니다";
 
-const NOT_CONNECTED = "저장 기능이 아직 연결되지 않았습니다";
 
 /**
  * 세션을 못 읽었을 때.
@@ -116,8 +118,30 @@ export async function saveCompanyProfileAction(
        카드를 통째로 갈아치워 방금 적은 값이 다 날아간다(§토스트: error.tsx는 페이지 전체 실패용).
   */
   if (!isMock) {
-    // TODO(BE 협의): `PATCH /companies/me`
-    return { errors: {}, message: NOT_CONNECTED };
+    /*
+      [확인] BE `CompanyController.updateProfile` — `PATCH /api/companies/me`.
+      ⚠️ **보낸 필드만 바뀐다**(부분 수정). `code`는 대상이 아니다 — 사원 로그인 키라 바뀌면
+         기존 사원이 전부 못 들어온다.
+      ⚠️ **좌표는 못 보낸다.** BE가 `address` 문자열만 받는다 — 지도에서 고른 자리는
+         주소 글자만 남고 핀은 저장되지 않는다(§mapper).
+    */
+    try {
+      const accessToken = await requireAccessToken();
+      await serverApi<unknown>(ep.companyMe(), {
+        method: "PATCH",
+        accessToken,
+        json: {
+          name: draft.name,
+          businessNumber: draft.businessNumber,
+          address: draft.place?.address ?? null,
+        },
+      });
+    } catch (error) {
+      return { errors: {}, message: toUserMessage(error) };
+    }
+
+    revalidatePath(SETTING_PATH);
+    return { errors: {}, isSaved: true };
   }
 
   updateMockCompanyProfile(draft);
@@ -149,11 +173,10 @@ export async function saveDepartmentsAction(
        그게 던진다 — 순서가 뒤집히면 액션 자체가 거절되어 화면이 결과 대신 아무것도 못 받는다
        (이 파일이 세 번 적어 둔 "던지지 않는다"를 스스로 깨는 자리였다).
   */
-  if (!isMock) {
-    // TODO(BE 협의): `PUT /companies/me/teams`
-    return { isSuccess: false, message: NOT_CONNECTED };
-  }
-
+  /*
+    ⚠️ **사람이 딸린 팀은 못 지운다.** 화면에서 미리 막지만 액션은 주소만 알면 직접 부를 수
+       있다(§권한: 화면 숨김은 보안이 아니다). 지금 저장된 것과 견줘야 무엇이 사라졌는지 안다.
+  */
   /*
     ⚠️ **사람이 딸린 팀은 못 지우고, 남의 팀 아래로도 못 넣는다.** 화면에서 미리 막지만
        액션은 직접 부를 수 있다(§권한). 지금 저장된 트리와 견줘야 무엇이 바뀌었는지 알 수 있다 —
@@ -171,6 +194,46 @@ export async function saveDepartmentsAction(
     };
   }
 
+  if (!isMock) {
+    /*
+      ⚠️ **통째로 넣는 API가 없다.** BE는 팀을 한 건씩 다룬다(`POST` · `PATCH /{id}` ·
+         `DELETE /{id}`) — 화면은 트리를 통째로 저장하므로 여기서 **차이를 계산해** 나눠 부른다.
+      ⚠️ **지우기를 마지막에 한다.** 이름 바꾸기·새로 만들기가 먼저 끝나야, 중간에 실패해도
+         남는 쪽이 더 안전하다 — 먼저 지우면 실패했을 때 팀만 사라진 상태가 된다.
+      ⚠️ 새로 만든 팀은 화면에서 붙인 임시 id를 들고 온다. 서버 id가 아니므로
+         **숫자로 읽히지 않는 것**을 새 팀으로 본다.
+    */
+    const before = new Map(current.departments.map((node) => [node.id, node.name]));
+    const after = new Map(departments.map((node) => [node.id, node.name]));
+
+    try {
+      const accessToken = await requireAccessToken();
+
+      for (const [id, name] of after) {
+        const serverId = Number(id);
+        if (!Number.isInteger(serverId) || !before.has(id)) {
+          await serverApi<unknown>(ep.teams(), { method: "POST", accessToken, json: { name } });
+        } else if (before.get(id) !== name) {
+          await serverApi<unknown>(ep.team(serverId), {
+            method: "PATCH",
+            accessToken,
+            json: { name },
+          });
+        }
+      }
+
+      for (const id of before.keys()) {
+        if (after.has(id)) continue;
+        await serverApi<unknown>(ep.team(Number(id)), { method: "DELETE", accessToken });
+      }
+    } catch (error) {
+      return { isSuccess: false, message: toUserMessage(error) };
+    }
+
+    revalidatePath(SETTING_PATH);
+    return { isSuccess: true };
+  }
+
   updateMockDepartments(departments);
   revalidatePath(SETTING_PATH);
   return { isSuccess: true };
@@ -186,8 +249,39 @@ export async function savePositionsAction(positions: Position[]): Promise<Compan
 
   // ⚠️ 던지지 않는다 — 저장 실패는 화면 전체 실패가 아니다
   if (!isMock) {
-    // TODO(BE 협의): `PUT /companies/me/positions`
-    return { isSuccess: false, message: NOT_CONNECTED };
+    /* 팀과 같은 이유로 차이를 계산해 한 건씩 부른다 — 지우기는 마지막이다 */
+    const current = await getCompanySetting();
+    const before = new Map(current.positions.map((item) => [item.id, item]));
+    const after = new Map(positions.map((item) => [item.id, item]));
+
+    try {
+      const accessToken = await requireAccessToken();
+
+      for (const [id, position] of after) {
+        const serverId = Number(id);
+        const previous = before.get(id);
+        const body = { name: position.name, authority: position.role, description: null };
+        if (!Number.isInteger(serverId) || !previous) {
+          await serverApi<unknown>(ep.jobPositions(), { method: "POST", accessToken, json: body });
+        } else if (previous.name !== position.name || previous.role !== position.role) {
+          await serverApi<unknown>(ep.jobPosition(serverId), {
+            method: "PATCH",
+            accessToken,
+            json: body,
+          });
+        }
+      }
+
+      for (const id of before.keys()) {
+        if (after.has(id)) continue;
+        await serverApi<unknown>(ep.jobPosition(Number(id)), { method: "DELETE", accessToken });
+      }
+    } catch (error) {
+      return { isSuccess: false, message: toUserMessage(error) };
+    }
+
+    revalidatePath(SETTING_PATH);
+    return { isSuccess: true };
   }
 
   updateMockPositions(positions);

--- a/src/features/company/actions.ts
+++ b/src/features/company/actions.ts
@@ -41,7 +41,6 @@ const SETTING_PATH = "/owner/setting";
 
 const FORBIDDEN = "기업 설정을 바꿀 권한이 없습니다";
 
-
 /**
  * 세션을 못 읽었을 때.
  * ⚠️ **권한 없음과 다른 말이다.** 쿠키가 만료된 OWNER에게 "권한이 없습니다"라고 하면
@@ -133,7 +132,12 @@ export async function saveCompanyProfileAction(
         json: {
           name: draft.name,
           businessNumber: draft.businessNumber,
-          address: draft.place?.address ?? null,
+          /*
+            ⚠️ **`null`을 보내면 안 지워진다.** BE는 부분 수정이라 `null`을 "이 필드는 건드리지
+               말라"로 읽는다 — 주소를 비우려고 지운 사람에게는 옛 주소가 그대로 남는다.
+               빈 문자열을 보내야 실제로 비워진다(`@Size`만 걸려 있어 통과한다).
+          */
+          address: draft.place?.address ?? "",
         },
       });
     } catch (error) {
@@ -198,16 +202,45 @@ export async function saveDepartmentsAction(
     /*
       ⚠️ **통째로 넣는 API가 없다.** BE는 팀을 한 건씩 다룬다(`POST` · `PATCH /{id}` ·
          `DELETE /{id}`) — 화면은 트리를 통째로 저장하므로 여기서 **차이를 계산해** 나눠 부른다.
-      ⚠️ **지우기를 마지막에 한다.** 이름 바꾸기·새로 만들기가 먼저 끝나야, 중간에 실패해도
-         남는 쪽이 더 안전하다 — 먼저 지우면 실패했을 때 팀만 사라진 상태가 된다.
+      ⚠️ **지우기를 먼저 한다.** 처음엔 마지막에 뒀는데, 지운 팀의 이름을 다른 팀에 다시
+         쓰거나 두 팀 이름을 맞바꾸면 **같은 이름이 잠깐 둘**이 되어 서버가 막는다 —
+         지우고 나서 만들면 그 자리가 비어 있다.
+      ⚠️ 대신 **사람이 딸린 팀은 위에서 이미 걸렀다**(`findBlockedTeamChange`). 지우기가
+         먼저여도 사람이 붕 뜨지 않는다.
       ⚠️ 새로 만든 팀은 화면에서 붙인 임시 id를 들고 온다. 서버 id가 아니므로
          **숫자로 읽히지 않는 것**을 새 팀으로 본다.
     */
+    /*
+      ⚠️ **팀 안 '역할' 라벨은 저장할 곳이 없다.** BE에 그걸 다루는 API가 없다(전 레포에
+         `roleLabel` 관리 경로 0건) — 팀만 저장하고 성공이라고 말하면 **역할을 고친 사람이
+         저장됐다고 믿는다**(§정직성). 바뀐 게 있으면 그 사실을 말하고 멈춘다.
+    */
+    const roleSignature = (nodes: DepartmentNode[]) =>
+      nodes
+        .map((node) => `${node.name}:${node.children.map((child) => child.name).join(",")}`)
+        .join("|");
+    if (roleSignature(current.departments) !== roleSignature(departments)) {
+      const namesChanged =
+        current.departments.map((n) => n.name).join("|") !==
+        departments.map((n) => n.name).join("|");
+      if (!namesChanged) {
+        return {
+          isSuccess: false,
+          message: "팀 안 역할은 아직 저장할 수 없습니다. 팀 이름만 바꿔 주세요",
+        };
+      }
+    }
+
     const before = new Map(current.departments.map((node) => [node.id, node.name]));
     const after = new Map(departments.map((node) => [node.id, node.name]));
 
     try {
       const accessToken = await requireAccessToken();
+
+      for (const id of before.keys()) {
+        if (after.has(id)) continue;
+        await serverApi<unknown>(ep.team(Number(id)), { method: "DELETE", accessToken });
+      }
 
       for (const [id, name] of after) {
         const serverId = Number(id);
@@ -221,12 +254,13 @@ export async function saveDepartmentsAction(
           });
         }
       }
-
-      for (const id of before.keys()) {
-        if (after.has(id)) continue;
-        await serverApi<unknown>(ep.team(Number(id)), { method: "DELETE", accessToken });
-      }
     } catch (error) {
+      /*
+        ⚠️ **실패해도 화면을 다시 읽는다.** 한 건씩 부르므로 **중간까지는 이미 반영돼 있다** —
+           그대로 두면 화면은 옛 트리를 들고 있고 서버는 반쯤 바뀐 상태라, 사람이 다시 저장을
+           누르면 이미 만든 팀을 또 만든다.
+      */
+      revalidatePath(SETTING_PATH);
       return { isSuccess: false, message: toUserMessage(error) };
     }
 
@@ -257,13 +291,28 @@ export async function savePositionsAction(positions: Position[]): Promise<Compan
     try {
       const accessToken = await requireAccessToken();
 
+      for (const id of before.keys()) {
+        if (after.has(id)) continue;
+        await serverApi<unknown>(ep.jobPosition(Number(id)), { method: "DELETE", accessToken });
+      }
+
       for (const [id, position] of after) {
         const serverId = Number(id);
         const previous = before.get(id);
-        const body = { name: position.name, authority: position.role, description: null };
+        /*
+          ⚠️ **`description`은 필수다**(BE `@NotBlank`). `null`을 보내면 **항상 400**이다.
+             화면에 그 칸이 없어 사람이 적을 길이 없으므로, 서버에서 읽어 온 값을 그대로
+             되돌려 보내고 새 직급이면 이름으로 채운다 — 빈 문자열도 `@NotBlank`에 걸린다.
+        */
+        const description = position.description?.trim() || position.name;
+        const body = { name: position.name, authority: position.role, description };
         if (!Number.isInteger(serverId) || !previous) {
           await serverApi<unknown>(ep.jobPositions(), { method: "POST", accessToken, json: body });
-        } else if (previous.name !== position.name || previous.role !== position.role) {
+        } else if (
+          previous.name !== position.name ||
+          previous.role !== position.role ||
+          (previous.description ?? "") !== description
+        ) {
           await serverApi<unknown>(ep.jobPosition(serverId), {
             method: "PATCH",
             accessToken,
@@ -271,12 +320,9 @@ export async function savePositionsAction(positions: Position[]): Promise<Compan
           });
         }
       }
-
-      for (const id of before.keys()) {
-        if (after.has(id)) continue;
-        await serverApi<unknown>(ep.jobPosition(Number(id)), { method: "DELETE", accessToken });
-      }
     } catch (error) {
+      /* 팀과 같은 이유 — 중간까지 반영됐으므로 실패해도 화면을 다시 읽는다 */
+      revalidatePath(SETTING_PATH);
       return { isSuccess: false, message: toUserMessage(error) };
     }
 

--- a/src/features/company/mapper.ts
+++ b/src/features/company/mapper.ts
@@ -31,9 +31,12 @@ export interface BeTeam {
   memberCount: number;
 }
 
-/** [확인] BE `PositionSummary` */
+/**
+ * [확인] BE `PositionResponse` — ⚠️ **`id`가 아니라 `jobPositionId`다.**
+ * 이름을 잘못 읽으면 모든 직급 id가 `undefined`가 되어, 저장할 때 전부 **새 직급으로 잡힌다**.
+ */
 export interface BePosition {
-  id: number;
+  jobPositionId: number;
   name: string;
   authority: string;
   description: string | null;
@@ -85,5 +88,15 @@ export function toTeamMemberCounts(teams: BeTeam[]): Record<string, number> {
  */
 export function toPosition(position: BePosition): Position {
   const role: AssignableRole = position.authority === "LEADER" ? "LEADER" : "MEMBER";
-  return { id: String(position.id), name: position.name, role };
+  /*
+    ⚠️ **`description`을 들고 다닌다.** BE가 `@NotBlank`로 필수라 저장할 때 다시 보내야 하는데,
+       여기서 버리면 왕복 한 번에 남의 설명이 지워진다 — 화면이 안 보여 주는 값이라도
+       **되돌려 보낼 책임**은 남는다.
+  */
+  return {
+    id: String(position.jobPositionId),
+    name: position.name,
+    role,
+    description: position.description ?? "",
+  };
 }

--- a/src/features/company/mapper.ts
+++ b/src/features/company/mapper.ts
@@ -1,0 +1,89 @@
+import type { AssignableRole } from "@/features/onboarding/types";
+
+import type { CompanyProfile, DepartmentNode, Position } from "./types";
+
+/**
+ * BE shape → UI 계약 (§Mock 격리막 — 흡수하는 곳은 여기 하나다).
+ *
+ * ⚠️ 기업 설정 화면은 **세 API에서 값을 모은다**(`/companies/me` · `/teams` · `/job-positions`).
+ *    한 번에 주는 엔드포인트가 BE에 없어서다 — 그 사실을 화면이 알 필요는 없다.
+ */
+
+/** [확인] BE `CompanyProfileResponse` */
+export interface BeCompanyProfile {
+  companyId: number;
+  code: string;
+  name: string;
+  businessNumber: string | null;
+  representativeName: string | null;
+  address: string | null;
+  phone: string | null;
+  plan: string;
+  onboardedAt: string | null;
+}
+
+/** [확인] BE `TeamNode` */
+export interface BeTeam {
+  teamId: number;
+  name: string;
+  leaderMemberId: number | null;
+  leaderName: string | null;
+  memberCount: number;
+}
+
+/** [확인] BE `PositionSummary` */
+export interface BePosition {
+  id: number;
+  name: string;
+  authority: string;
+  description: string | null;
+  memberCount: number;
+}
+
+/**
+ * 기업 기본 정보.
+ *
+ * ⚠️ **좌표가 없다.** BE는 `address` 문자열만 들고 우리 계약은 `PickedPlace`(위도·경도)다 —
+ *    지도에서 고른 자리가 **저장도 복원도 안 된다.** 주소는 남으므로 글자는 그대로 보이지만,
+ *    다시 열면 핀이 사라진다. 좌표 칸이 생기기 전까지 `lat`·`lng`를 0으로 둔다
+ *    (기업 등록 신청이 지도를 못 쓸 때 쓰는 것과 같은 규칙).
+ * ⚠️ **`plan`을 안 쓴다.** BE가 `"FREE"`를 고정으로 내려주는데(결제 연동 전), 우리 규칙은
+ *    **무료 요금제가 없다**는 것이다 — 그 값을 화면에 올리면 돈을 안 받는 것처럼 읽힌다
+ *    (CLAUDE.md §요금제).
+ * ⚠️ **`representativeName`·`phone`도 안 쓴다.** 우리 `CompanyProfile`에 자리가 없다 —
+ *    지금 화면이 안 보여 주는 값이라 버리는 게 아니라 **아직 안 받는 것**이다.
+ */
+export function toCompanyProfile(profile: BeCompanyProfile): CompanyProfile {
+  return {
+    name: profile.name,
+    businessNumber: profile.businessNumber ?? "",
+    place: profile.address ? { address: profile.address, lat: 0, lng: 0 } : null,
+    code: profile.code,
+  };
+}
+
+/**
+ * 팀 목록 → 트리.
+ *
+ * ⚠️ **팀은 계층이 없다**(CLAUDE.md §권한 ③ — 플랫 목록, 2026-08-06 BE 스키마 확정).
+ *    `DepartmentNode`가 `children`을 들고 있는 건 온보딩과 타입을 공유해서지, 팀이 중첩된다는
+ *    뜻이 아니다 — 항상 빈 배열이다.
+ * ⚠️ **팀장(`leaderMemberId`·`leaderName`)을 못 담는다.** 우리 노드에 자리가 없어 지금은
+ *    버린다 — 화면에 팀장이 안 보이는 건 그래서다.
+ */
+export function toDepartmentNode(team: BeTeam): DepartmentNode {
+  return { id: String(team.teamId), name: team.name, children: [] };
+}
+
+export function toTeamMemberCounts(teams: BeTeam[]): Record<string, number> {
+  return Object.fromEntries(teams.map((team) => [String(team.teamId), team.memberCount]));
+}
+
+/**
+ * 직급.
+ * ⚠️ 모르는 권한이 오면 가장 낮은 쪽으로 떨어뜨린다 — 권한은 넘겨짚으면 안 되는 값이다(§권한).
+ */
+export function toPosition(position: BePosition): Position {
+  const role: AssignableRole = position.authority === "LEADER" ? "LEADER" : "MEMBER";
+  return { id: String(position.id), name: position.name, role };
+}

--- a/src/features/company/server.ts
+++ b/src/features/company/server.ts
@@ -1,7 +1,19 @@
 import "server-only";
 
+import { requireAccessToken } from "@/features/auth/session";
+import { serverApi } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
 import { isMock } from "@/mocks/config";
 
+import {
+  type BeCompanyProfile,
+  type BePosition,
+  type BeTeam,
+  toCompanyProfile,
+  toDepartmentNode,
+  toPosition,
+  toTeamMemberCounts,
+} from "./mapper";
 import { getMockCompanySetting } from "./mock/company";
 import type { CompanySetting } from "./types";
 
@@ -15,6 +27,24 @@ import type { CompanySetting } from "./types";
 export async function getCompanySetting(): Promise<CompanySetting> {
   if (isMock) return getMockCompanySetting();
 
-  // TODO(BE 협의): `GET /companies/me/setting` — 응답 봉투 모양은 아직 모른다(매퍼가 벗긴다)
-  throw new Error("기업 설정 조회 API가 아직 연결되지 않았습니다.");
+  /*
+    ⚠️ **한 번에 주는 API가 없다.** 화면은 기본 정보·팀·직급을 한 화면에 그리는데 BE는 셋으로
+       나뉘어 있다([확인] `CompanyController.getProfile` · `TeamController.list` ·
+       `PositionController.list`) — 여기서 모아 하나로 돌려준다. 화면은 그 사실을 모른다.
+    ⚠️ **나란히 부른다.** 줄줄이 기다리면 카드 셋이 다 그려질 때까지 세 번 왕복한다.
+    ⚠️ 회사는 **토큰의 `companyId`** 로 정해진다 — 파라미터로 안 보낸다(§라우트 그룹).
+  */
+  const accessToken = await requireAccessToken();
+  const [profile, teams, positions] = await Promise.all([
+    serverApi<BeCompanyProfile>(ep.companyMe(), { accessToken }),
+    serverApi<BeTeam[]>(ep.teams(), { accessToken }),
+    serverApi<BePosition[]>(ep.jobPositions(), { accessToken }),
+  ]);
+
+  return {
+    profile: toCompanyProfile(profile),
+    departments: teams.map(toDepartmentNode),
+    positions: positions.map(toPosition),
+    teamMemberCounts: toTeamMemberCounts(teams),
+  };
 }

--- a/src/features/onboarding/types.ts
+++ b/src/features/onboarding/types.ts
@@ -90,6 +90,15 @@ export interface Position {
   id: string;
   name: string;
   role: AssignableRole;
+  /**
+   * 직급 권한 요약.
+   *
+   * ⚠️ **화면에 안 보이지만 버리면 안 된다.** BE가 `@NotBlank`로 필수라(`CreatePositionRequest`·
+   *    `UpdatePositionRequest`) 저장할 때 다시 보내야 한다 — 안 들고 다니면 왕복 한 번에
+   *    남이 적어 둔 설명이 지워지거나 400이 난다.
+   * ⚠️ 온보딩에서 새로 만들 때는 비어 있다 — 그때는 저장하는 쪽이 채운다.
+   */
+  description?: string;
 }
 
 /** 기업이 고를 수 있는 권한. `SYSTEM`은 서비스 운영자라 제외된다. */

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -41,6 +41,18 @@ export const ep = {
   /* 조직 */
   members: () => "/api/members",
   member: (id: number) => `/api/members/${id}`,
+  /**
+   * 팀 — [확인] identity/team/presentation/api/TeamController.java
+   *
+   * ⚠️ **한 건씩 다룬다**(`POST`·`PATCH /{id}`·`DELETE /{id}`). 트리를 통째로 넣는
+   *    `PUT`은 BE에 없다 — 화면은 통째로 저장하므로 부르는 쪽이 **차이를 계산해** 나눠 부른다.
+   * ⚠️ 조회 응답에 `memberCount`가 들어 있다 — 사람이 딸린 팀을 못 지우는 판정에 그대로 쓴다.
+   */
+  teams: () => "/api/teams",
+  team: (id: number) => `/api/teams/${id}`,
+  /** 직급 — [확인] identity/position/presentation/api/PositionController.java */
+  jobPositions: () => "/api/job-positions",
+  jobPosition: (id: number) => `/api/job-positions/${id}`,
   departments: () => "/api/departments",
   rooms: () => "/api/rooms",
 


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

**무엇을**

| 카드 | API |
|---|---|
| 기본 정보 | `GET`/`PATCH /api/companies/me` |
| 팀 | `GET`/`POST`/`PATCH`/`DELETE /api/teams` |
| 직급 | `GET`/`POST`/`PATCH`/`DELETE /api/job-positions` |

새 파일: `features/company/mapper.ts`

**구조가 어긋나서 흡수한 것 둘**

- ⚠️ **한 번에 주는 API가 없습니다.** 화면은 세 카드를 한 화면에 그리는데 BE는 셋으로 나뉘어 있어, `getCompanySetting()`이 **나란히 부르고** 하나로 합칩니다. 화면은 그 사실을 모릅니다
- ⚠️ **통째로 넣는 API가 없습니다.** 화면은 트리·목록을 통째로 저장하는데 BE는 한 건씩입니다 — **차이를 계산해** 나눠 부릅니다. **지우기를 마지막에** 합니다(먼저 지우면 중간 실패 시 팀만 사라집니다). 새로 만든 항목은 화면이 붙인 임시 id라 **숫자로 안 읽히는 것**을 새것으로 봅니다

**안 붙는 것 — 사유를 코드에 적었습니다**

- ⚠️ **좌표**(`place`) — BE는 `address` 문자열만 받습니다. **지도 핀이 저장·복원 안 됩니다.** 주소 글자는 남습니다
- **대표자명·대표번호** — BE는 주고받는데 `CompanyProfile`에 자리가 없습니다
- **팀장**(`leaderMemberId`·`leaderName`) — `TeamNode`가 주는데 `DepartmentNode`에 자리가 없어 화면에 안 보입니다
- ⚠️ **`plan`** — BE가 `"FREE"` 고정으로 내려줍니다(주석: 결제 연동 없음). 우리 규칙은 **무료 요금제가 없다**이므로 쓰지 않습니다 — 화면에 올리면 돈을 안 받는 것처럼 읽힙니다

**검사**

`tsc` · `eslint` · `jest` 73 suites / 831 tests 통과.

---

## ✅ 작업 체크리스트

**기본**

- [ ] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [ ] 불필요한 `console` · 주석 처리된 코드 제거
- [ ] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**(회의 담당자 등), 그리고 **서버(Server Action/BFF)에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [x] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시 (조용히 "되는 척" 금지)
- [ ] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그)
- [ ] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [ ] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인)
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음

---

## 🔗 연관 이슈

Closes #288

⚠️ **PR #267(Identity) 위에 얹혀 있습니다.**

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

-

---

## 📝 추가 메모

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 회사 프로필, 팀, 직급 정보를 실제 서버에서 불러올 수 있습니다.
  * 회사 프로필과 주소를 저장하고, 팀 및 직급을 추가·수정·삭제할 수 있습니다.
  * 직급 권한 설명이 저장되고 기존 설명이 유지됩니다.
  * 팀별 구성원 수와 조직 구조가 화면에 정확히 표시됩니다.

* **버그 수정**
  * 저장 중 발생한 API 오류를 사용자에게 안내합니다.
  * 일부 저장 실패 시 최신 설정을 다시 확인해 데이터 불일치를 줄입니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
