### PR TITLE
[FIX] 인수인계 API 실코드 대조 반영 — 에러봉투·엔드포인트 경로·요청바디·마지막근무일 #298

### DIFF
--- a/src/features/handover/components/offboarding-form.tsx
+++ b/src/features/handover/components/offboarding-form.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState, useTransition } from "react";
 
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
+import { DatePickerField } from "@/components/common/date-picker-field";
 import { ResultDialog } from "@/components/common/result-dialog";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
@@ -28,12 +29,13 @@ export function OffboardingForm({ context }: OffboardingFormProps) {
   const selectedIds = useMemo(() => new Set(actions.map((action) => action.id)), [actions]);
 
   const [description, setDescription] = useState("");
+  const [lastWorkingDay, setLastWorkingDay] = useState("");
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [confirmError, setConfirmError] = useState<string | null>(null);
   const [resultOpen, setResultOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
 
-  const canSubmit = description.trim().length > 0 && actions.length > 0;
+  const canSubmit = description.trim().length > 0 && Boolean(lastWorkingDay) && actions.length > 0;
 
   function handleConfirm() {
     setConfirmError(null);
@@ -43,6 +45,7 @@ export function OffboardingForm({ context }: OffboardingFormProps) {
           type: HANDOVER_TYPE.OFFBOARDING,
           description: description.trim(),
           actionIds: actions.map((action) => action.id),
+          lastWorkingDay,
         });
         setConfirmOpen(false);
         setResultOpen(true);
@@ -54,6 +57,18 @@ export function OffboardingForm({ context }: OffboardingFormProps) {
 
   return (
     <div className="flex flex-col gap-5">
+      <section className="border-border bg-card flex flex-col gap-1.5 rounded-2xl border p-7">
+        <Label htmlFor="offboarding-last-working-day">
+          마지막 근무일 <span className="text-destructive">*</span>
+        </Label>
+        <DatePickerField
+          id="offboarding-last-working-day"
+          value={lastWorkingDay}
+          onChange={setLastWorkingDay}
+          className="w-full"
+        />
+      </section>
+
       <section className="border-border bg-card flex flex-col gap-1.5 rounded-2xl border p-7">
         <Label htmlFor="offboarding-description">
           담당 업무 및 인수인계 상세 설명 <span className="text-destructive">*</span>

--- a/src/features/handover/lib.ts
+++ b/src/features/handover/lib.ts
@@ -22,6 +22,8 @@ export interface SubmitOffboardingHandoverPayload {
   type: typeof HANDOVER_TYPE.OFFBOARDING;
   description: string;
   actionIds: number[];
+  /** 마지막 근무일 `YYYY-MM-DD` — BE 필수(없으면 `HO-011`, BE 인수인계 문서 §2·§5). */
+  lastWorkingDay: string;
 }
 
 export type SubmitHandoverPayload =
@@ -30,21 +32,24 @@ export type SubmitHandoverPayload =
 /**
  * FE 내부 payload → BE 생성 요청 바디. 경계에서만 이름을 바꾼다 — FE 내부 필드명(위 두 타입)은
  * 그대로 두고 fetch 직전에만 변환해 BE 계약을 흡수한다(BE 인수인계 문서, 2026-08-10).
- * `startDate`/`endDate`→`leaveStartAt`/`leaveEndAt`(자정 시각 붙임), `description`→`note`,
- * `actionIds`→`selectedActionIds`.
+ * `type`→`handoverType`, `startDate`/`endDate`→`leaveStartAt`/`leaveEndAt`(자정 시각 붙임),
+ * `description`→`note`, `actionIds`→`selectedActionIds`.
+ * ⚠️ `assignments`(팀장 본인 휴직의 자가 재배정)는 **생성 바디에 안 실린다** — BE POST 바디엔
+ *    그런 필드가 없다. 생성 뒤 건별 `PATCH .../items/{actionId}/reassign`으로 따로 보내야
+ *    한다(§4 재배정 오케스트레이션, 아직 미구현 — 별도 작업).
  */
 export function toHandoverCreateRequestBody(payload: SubmitHandoverPayload) {
   if (payload.type === HANDOVER_TYPE.VACATION) {
     return {
-      type: payload.type,
+      handoverType: payload.type,
       leaveStartAt: `${payload.startDate}T00:00:00`,
       leaveEndAt: `${payload.endDate}T00:00:00`,
       selectedActionIds: payload.actionIds,
-      assignments: payload.assignments,
     };
   }
   return {
-    type: payload.type,
+    handoverType: payload.type,
+    lastWorkingDay: payload.lastWorkingDay,
     note: payload.description,
     selectedActionIds: payload.actionIds,
   };

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -6,11 +6,13 @@ import "server-only";
  * 브라우저는 Next 서버(Server Action·Route Handler)에만 말을 걸고, BE와의 대화는 여기가 대신한다.
  * 토큰은 httpOnly 쿠키에서 읽어 헤더로 붙이므로 **브라우저 JS는 토큰을 못 본다.**
  *
- * ⚠️ **봉투를 벗기는 일은 여기 한 곳에서만 한다.** BE는 성공·실패 모두
- *    `{ httpStatus, message, data }`로 답한다(`global/response/ApiResponse.java`) —
+ * ⚠️ **봉투를 벗기는 일은 여기 한 곳에서만 한다.** 성공·실패 봉투 모양이 **서로 다르다**
+ *    (인수인계 API 연동 가이드, 2026-08-10로 실코드 대조 확인):
+ *    성공 = `{ httpStatus, message, data }`, 실패 = `{ errorCode, message, timestamp, path,
+ *    traceId, details }` — 실패 쪽엔 `data`가 없고 코드는 **top-level `errorCode`**다.
  *    컴포넌트가 봉투를 알면 모양이 바뀔 때 전 화면을 고쳐야 한다(§연동 검증).
  * ⚠️ `message`는 **화면에 그대로 띄울 한국어 문장**이다. 코드로 문구를 조립하지 않는다.
- * ⚠️ 실패의 `data.code`(`AU-035` 등)는 **분기용**이다 — 사람에게 보여 주는 건 `message`다.
+ * ⚠️ 실패의 `errorCode`(`HO-016` 등)는 **분기용**이다 — 사람에게 보여 주는 건 `message`다.
  */
 
 /** BE 주소. 서버에서만 읽으므로 `NEXT_PUBLIC_`을 붙이지 않는다 — 브라우저에 나갈 값이 아니다. */
@@ -88,19 +90,13 @@ function toApiError(status: number, raw: unknown): ApiError {
     return new ApiError(status, "요청을 처리하지 못했습니다. 잠시 후 다시 시도해 주세요.");
   }
 
-  const envelope = raw as { message?: unknown; data?: unknown };
+  const envelope = raw as { message?: unknown; errorCode?: unknown };
   const message =
     typeof envelope.message === "string" && envelope.message.trim().length > 0
       ? envelope.message
       : "요청을 처리하지 못했습니다. 잠시 후 다시 시도해 주세요.";
 
-  const data = envelope.data;
-  const code =
-    typeof data === "object" &&
-    data !== null &&
-    typeof (data as { code?: unknown }).code === "string"
-      ? (data as { code: string }).code
-      : undefined;
+  const code = typeof envelope.errorCode === "string" ? envelope.errorCode : undefined;
 
   return new ApiError(status, message, code);
 }

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -76,10 +76,10 @@ export const ep = {
   /* 인수인계 */
   handovers: () => "/api/handovers",
   handover: (id: number) => `/api/handovers/${id}`,
-  /** 팀장급 인수인계(귀속) 목록 — BE 인수인계 문서(2026-08-10) §package. */
-  handoverPackage: () => "/api/handovers/package",
-  /** 팀장급 인수인계 통계·요약 — BE 인수인계 문서(2026-08-10) §insights. */
-  handoverInsights: () => "/api/handovers/insights",
+  /** 상세 리치뷰(타임라인·회의맥락·수신자별 그룹) — BE 인수인계 문서(2026-08-10) §2. */
+  handoverPackage: (id: number) => `/api/handovers/${id}/package`,
+  /** 레거시 컴파일러 파생 인사이트 — 오프보딩 최종승인 뒤에만 채워짐(BE 인수인계 문서 §2). */
+  handoverInsights: (id: number) => `/api/handovers/${id}/insights`,
   /** 건별 재배정 — 일괄 반영 엔드포인트가 아니다(락·멱등, §team-handover/actions.ts). */
   handoverReassignItem: (id: number, actionId: number) =>
     `/api/handovers/${id}/items/${actionId}/reassign`,


### PR DESCRIPTION
## 📋 PR 타입

- [ ] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

#274/#275(머지 완료) 이후 백엔드 담당자가 실코드 대조로 작성한 "인수인계 API 연동 가이드"(2026-08-10) 대조 결과 반영입니다.

- `lib/api.ts`: **버그 수정** — `toApiError`가 실패 봉투의 `data.code`를 읽고 있었는데, 실제 실패 봉투엔 `data`가 없고 코드는 top-level `errorCode`. 전 도메인에 영향 있는 공용 버그라 같이 고침.
- `lib/endpoints.ts`: **버그 수정** — `handoverPackage`/`handoverInsights`가 `{id}` 파라미터 없이 선언돼 있었음. 실제 경로는 `/api/handovers/{id}/package`, `/api/handovers/{id}/insights`.
- `features/handover/lib.ts`: 생성 요청 바디 `type`→`handoverType`로 정정, `assignments`는 생성 바디에 없는 필드라 제거(재배정은 별도 건별 API — 후속 이슈에서 오케스트레이션 구현 예정). 오프보딩 payload에 `lastWorkingDay` 추가(BE 필수, 없으면 `HO-011`).
- `handover/components/offboarding-form.tsx`: "마지막 근무일" 입력칸 추가.

BE가 실제로 배포·검증한 스펙과 우리 코드가 어긋난 부분(특히 에러 처리 버그)을 실연동 전에 미리 맞춰두기 위함입니다.

---

## ✅ 작업 체크리스트

**기본**

- [ ] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [ ] 불필요한 `console` · 주석 처리된 코드 제거
- [ ] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**(회의 담당자 등), 그리고 **서버(Server Action/BFF)에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [x] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시 (조용히 "되는 척" 금지)
- [ ] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그)
- [ ] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [ ] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인)
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음

---

## 🔗 연관 이슈

Closes #298

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- [x] `npx tsc --noEmit` 0 에러
- [x] `npx jest` 75 suites / 870 tests 전부 통과
- 동작 변화 없음(아직 mock 그대로) — 화면 확인 불필요

---

## 📝 추가 메모

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 오프보딩 신청 시 필수 마지막 근무일을 선택할 수 있습니다.
  * 인수인계 패키지와 인사이트를 특정 인수인계 건별로 조회할 수 있습니다.

* **개선 사항**
  * 오프보딩 및 인수인계 요청 정보가 새로운 형식으로 전송됩니다.
  * API 오류 응답 처리가 변경된 오류 코드 형식을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
