### PR TITLE
[FEAT] 캘린더 여러 날 Todo 연속 막대 렌더링 + 제목별 색상  #306

### DIFF
--- a/src/features/calendar/components/calendar-event-list-item.tsx
+++ b/src/features/calendar/components/calendar-event-list-item.tsx
@@ -1,7 +1,7 @@
 import { Checkbox } from "@/components/ui/checkbox";
 import { cn } from "@/lib/utils";
 
-import { CALENDAR_TAG_DOT_COLOR, calendarStatusDotColor } from "../tag-colors";
+import { CALENDAR_TAG_DOT_COLOR, calendarStatusDotColor, getTodoTitleColor } from "../tag-colors";
 import {
   CALENDAR_ITEM_TAG,
   CALENDAR_ITEM_TAG_LABEL,
@@ -30,7 +30,10 @@ interface CalendarEventListItemProps {
  */
 export function CalendarEventListItem({ event, onToggleCompletion }: CalendarEventListItemProps) {
   const isTodo = event.tag === CALENDAR_ITEM_TAG.PERSONAL_TODO;
-  const tagColor = event.color ?? CALENDAR_TAG_DOT_COLOR[event.tag];
+  // ⚠️ 개인 Todo는 제목마다 색이 갈린다(2026-08-14) — 달력 칩(`month-grid.tsx`)과 같은 규칙.
+  const tagColor =
+    event.color ??
+    (isTodo ? getTodoTitleColor(event.title).solidColor : CALENDAR_TAG_DOT_COLOR[event.tag]);
 
   return (
     <li className="border-border bg-secondary/40 flex items-center gap-3 rounded-lg border px-3.5 py-3">

--- a/src/features/calendar/components/calendar-legend.tsx
+++ b/src/features/calendar/components/calendar-legend.tsx
@@ -1,30 +1,42 @@
-import { CALENDAR_STATUS_DOT_COLOR, CALENDAR_TAG_DOT_COLOR } from "../tag-colors";
+import {
+  CALENDAR_STATUS_DOT_COLOR,
+  CALENDAR_TAG_DOT_COLOR,
+  CALENDAR_TODO_LEGEND_SWATCH,
+} from "../tag-colors";
 import { CALENDAR_ITEM_TAG } from "../types";
+
+interface LegendItem {
+  label: string;
+  /** 콩(dot)에 그대로 얹는 배경 — 단색은 `backgroundColor`, Todo처럼 여러 색이면 `background`(그레이디언트). */
+  swatchStyle: { backgroundColor: string } | { background: string };
+}
 
 /**
  * ⚠️ 라벨은 일부러 `CALENDAR_ITEM_TAG_LABEL`("개인 Todo")과 다르다 — 범례는 "Todo"로 짧게 쓰기로
  *    확정했다(2026-08-05). 색만 `tag-colors.ts`로 공유하고 라벨 문구는 여기서 따로 관리한다.
+ * ⚠️ **Todo는 콩이 아니라 색동 원이다**(2026-08-14) — 제목마다 색이 달라져서 콩 하나로는
+ *    "이 색"을 보여줄 수 없다. 실제로 나올 수 있는 색 풀 전체를 원으로 둘러 "색이 다양하게
+ *    나온다"는 사실만 알린다. 개인 액션은 여전히 fuchsia 고정이라 콩 그대로 둔다.
  */
-const TAG_ITEMS = [
-  { label: "Todo", color: CALENDAR_TAG_DOT_COLOR[CALENDAR_ITEM_TAG.PERSONAL_TODO] },
-  { label: "개인 액션", color: CALENDAR_TAG_DOT_COLOR[CALENDAR_ITEM_TAG.PERSONAL_ACTION] },
-] as const;
+const TAG_ITEMS: LegendItem[] = [
+  { label: "Todo", swatchStyle: { background: CALENDAR_TODO_LEGEND_SWATCH } },
+  {
+    label: "개인 액션",
+    swatchStyle: { backgroundColor: CALENDAR_TAG_DOT_COLOR[CALENDAR_ITEM_TAG.PERSONAL_ACTION] },
+  },
+];
 
-const STATUS_ITEMS = [
-  { label: "진행중", color: CALENDAR_STATUS_DOT_COLOR.IN_PROGRESS },
-  { label: "완료", color: CALENDAR_STATUS_DOT_COLOR.DONE },
-] as const;
+const STATUS_ITEMS: LegendItem[] = [
+  { label: "진행중", swatchStyle: { backgroundColor: CALENDAR_STATUS_DOT_COLOR.IN_PROGRESS } },
+  { label: "완료", swatchStyle: { backgroundColor: CALENDAR_STATUS_DOT_COLOR.DONE } },
+];
 
-function LegendGroup({ items }: { items: readonly { label: string; color: string }[] }) {
+function LegendGroup({ items }: { items: readonly LegendItem[] }) {
   return (
     <ul className="flex items-center gap-3">
       {items.map((item) => (
         <li key={item.label} className="flex items-center gap-1.5">
-          <span
-            aria-hidden
-            className="size-2 shrink-0 rounded-full"
-            style={{ backgroundColor: item.color }}
-          />
+          <span aria-hidden className="size-2 shrink-0 rounded-full" style={item.swatchStyle} />
           {item.label}
         </li>
       ))}

--- a/src/features/calendar/components/month-grid.test.tsx
+++ b/src/features/calendar/components/month-grid.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 
+import { getTodoTitleColor } from "../tag-colors";
 import { CALENDAR_ITEM_TAG, type PersonalCalendarEvent } from "../types";
 import { MonthGrid } from "./month-grid";
 
@@ -63,5 +64,166 @@ describe("MonthGrid — 여러 날에 걸친 Todo", () => {
     expect(screen.getByRole("button", { name: /8월 5일.*일정 1건/ })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /8월 6일(?!.*일정)/ })).toBeInTheDocument();
     expect(screen.getAllByText("여러 날 Todo")).toHaveLength(1);
+  });
+});
+
+describe("MonthGrid — 같은 주 안에서 줄 순서가 안 흔들린다(밤티현상 수정)", () => {
+  it("긴 항목이 항상 위 줄이다 — 입력 배열 순서와 무관하다", () => {
+    const longEvent = buildEvent({
+      id: "long",
+      title: "긴 항목",
+      start: new Date("2026-08-10T00:00:00"),
+      end: new Date("2026-08-12T00:00:00"),
+    });
+    const shortEvent = buildEvent({
+      id: "short",
+      title: "짧은 항목",
+      start: new Date("2026-08-10T00:00:00"),
+      end: new Date("2026-08-10T00:00:00"),
+    });
+
+    // ⚠️ 짧은 항목을 배열 앞에 둔다 — 정렬이 입력 순서에 기대지 않고 기간으로 매기는지 본다.
+    render(
+      <MonthGrid
+        events={[shortEvent, longEvent]}
+        month={new Date("2026-08-01T00:00:00")}
+        selectedDate={new Date("2026-08-01T00:00:00")}
+        onSelectDate={jest.fn()}
+      />,
+    );
+
+    const day10Group = screen.getByRole("group", { name: /8월 10일.*일정/ });
+    const titles = Array.from(day10Group.children).map((child) => child.textContent);
+    expect(titles[0]).toContain("긴 항목");
+    expect(titles[1]).toContain("짧은 항목");
+  });
+
+  it("같은 항목이라도 옆 항목이 사라지는 날엔 빈 줄로 자리를 메워 세로 위치가 유지된다", () => {
+    // A: 8/2~8/3 (row 0), B: 8/3~8/4 (row 1), C: 8/3~8/4 (row 1과 겹쳐 row 2로 밀림).
+    // 8/4에는 A가 없다 — 빈 줄 없이 그리면 C가 2번째 칸으로 올라와 8/3과 세로 위치가 어긋난다.
+    const eventA = buildEvent({
+      id: "event-a",
+      title: "A",
+      start: new Date("2026-08-02T00:00:00"),
+      end: new Date("2026-08-03T00:00:00"),
+    });
+    const eventB = buildEvent({
+      id: "event-b",
+      title: "B",
+      start: new Date("2026-08-03T00:00:00"),
+      end: new Date("2026-08-04T00:00:00"),
+    });
+    const eventC = buildEvent({
+      id: "event-c",
+      title: "C",
+      start: new Date("2026-08-03T00:00:00"),
+      end: new Date("2026-08-04T00:00:00"),
+    });
+
+    render(
+      <MonthGrid
+        events={[eventC, eventA, eventB]}
+        month={new Date("2026-08-01T00:00:00")}
+        selectedDate={new Date("2026-08-01T00:00:00")}
+        onSelectDate={jest.fn()}
+      />,
+    );
+
+    /*
+      ⚠️ `textContent`로는 못 잰다 — 이어지는 칸(`spanEdge` middle/end)은 제목을 안 보여주는 게
+         의도된 디자인이라(연속 막대 규칙, 2026-08-10) 8/3·8/4의 B·C 칩엔 눈에 보이는 글자가
+         없다. 대신 항상 붙는 `title` 속성(툴팁)으로 어떤 항목인지 식별한다.
+    */
+    // 8/3 — A·B·C 다 걸린다: 3줄 다 차 있다.
+    const day3Group = screen.getByRole("group", { name: /8월 3일.*일정/ });
+    const day3Titles = Array.from(day3Group.children).map((child) => child.getAttribute("title"));
+    expect(day3Titles).toEqual(["A", "B", "C"]);
+
+    // 8/4 — A는 빠지지만, C는 여전히 3번째 자리(빈 줄 다음)에 있어야 8/3과 세로로 이어진다.
+    const day4Group = screen.getByRole("group", { name: /8월 4일.*일정/ });
+    expect(day4Group.children).toHaveLength(3);
+    expect(day4Group.children[0]).toHaveAttribute("aria-hidden", "true");
+    expect(day4Group.children[0]).not.toHaveAttribute("title");
+    expect(day4Group.children[1]).toHaveAttribute("title", "B");
+    expect(day4Group.children[2]).toHaveAttribute("title", "C");
+  });
+});
+
+describe("MonthGrid — 개인 Todo는 제목마다 색이 다르다", () => {
+  it("칩 배경이 고정 sky색이 아니라 제목에서 뽑은 팔레트 색이다", () => {
+    const event = buildEvent({ title: "A" });
+    render(
+      <MonthGrid
+        events={[event]}
+        month={new Date("2026-08-01T00:00:00")}
+        selectedDate={new Date("2026-08-01T00:00:00")}
+        onSelectDate={jest.fn()}
+      />,
+    );
+
+    const chip = screen.getByTitle("A");
+    expect(chip.style.backgroundColor).toBe(getTodoTitleColor("A").bgColor);
+  });
+
+  it("제목이 다르면 칩 배경색도 달라질 수 있다", () => {
+    const eventA = buildEvent({
+      id: "todo-a",
+      title: "A",
+      start: new Date("2026-08-10T00:00:00"),
+      end: new Date("2026-08-10T00:00:00"),
+    });
+    const eventB = buildEvent({
+      id: "todo-b",
+      title: "B",
+      start: new Date("2026-08-11T00:00:00"),
+      end: new Date("2026-08-11T00:00:00"),
+    });
+    render(
+      <MonthGrid
+        events={[eventA, eventB]}
+        month={new Date("2026-08-01T00:00:00")}
+        selectedDate={new Date("2026-08-01T00:00:00")}
+        onSelectDate={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByTitle("A").style.backgroundColor).not.toBe(
+      screen.getByTitle("B").style.backgroundColor,
+    );
+  });
+});
+
+describe("MonthGrid — 완료된 여러 날 Todo의 취소선이 칸마다 끊기지 않는다", () => {
+  it("이어지는 쪽 인셋을 0으로 둬서 배경처럼 취소선도 옆 칸까지 맞붙는다", () => {
+    const event = buildEvent({
+      title: "완료된 Todo",
+      start: new Date("2026-08-05T00:00:00"),
+      end: new Date("2026-08-07T00:00:00"),
+      isCompleted: true,
+    });
+
+    render(
+      <MonthGrid
+        events={[event]}
+        month={new Date("2026-08-01T00:00:00")}
+        selectedDate={new Date("2026-08-01T00:00:00")}
+        onSelectDate={jest.fn()}
+      />,
+    );
+
+    const chipOn = (dateLabel: RegExp) =>
+      screen.getByRole("group", { name: dateLabel }).querySelector('[title="완료된 Todo"]');
+
+    // 시작 칸 — 왼쪽은 제 여백(1.5)만큼, 오른쪽은 다음 칸과 맞붙게 0으로 튼다.
+    expect(chipOn(/8월 5일.*일정/)?.className).toContain("after:left-1.5");
+    expect(chipOn(/8월 5일.*일정/)?.className).toContain("after:right-0");
+
+    // 중간 칸 — 양쪽 다 옆 칸과 맞붙어야 하니 둘 다 0.
+    expect(chipOn(/8월 6일.*일정/)?.className).toContain("after:left-0");
+    expect(chipOn(/8월 6일.*일정/)?.className).toContain("after:right-0");
+
+    // 끝 칸 — 왼쪽은 앞 칸과 맞붙게 0, 오른쪽은 제 여백(1.5)으로 마무리.
+    expect(chipOn(/8월 7일.*일정/)?.className).toContain("after:left-0");
+    expect(chipOn(/8월 7일.*일정/)?.className).toContain("after:right-1.5");
   });
 });

--- a/src/features/calendar/components/month-grid.test.tsx
+++ b/src/features/calendar/components/month-grid.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+
+import { CALENDAR_ITEM_TAG, type PersonalCalendarEvent } from "../types";
+import { MonthGrid } from "./month-grid";
+
+function buildEvent(overrides: Partial<PersonalCalendarEvent> = {}): PersonalCalendarEvent {
+  return {
+    id: "todo-1",
+    title: "여러 날 Todo",
+    start: new Date("2026-08-05T00:00:00"),
+    end: new Date("2026-08-05T00:00:00"),
+    tag: CALENDAR_ITEM_TAG.PERSONAL_TODO,
+    isCompleted: false,
+    ...overrides,
+  };
+}
+
+describe("MonthGrid — 여러 날에 걸친 Todo", () => {
+  it("시작~끝 날짜에 걸친 모든 칸에 걸린다", () => {
+    const event = buildEvent({ end: new Date("2026-08-07T00:00:00") });
+    render(
+      <MonthGrid
+        events={[event]}
+        month={new Date("2026-08-01T00:00:00")}
+        selectedDate={new Date("2026-08-01T00:00:00")}
+        onSelectDate={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /8월 5일.*일정 1건/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /8월 6일.*일정 1건/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /8월 7일.*일정 1건/ })).toBeInTheDocument();
+    // 8월 4일·8월 8일은 구간 밖이라 걸리지 않는다.
+    expect(screen.getByRole("button", { name: /8월 4일(?!.*일정)/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /8월 8일(?!.*일정)/ })).toBeInTheDocument();
+  });
+
+  it("이어진 막대에서는 제목·상태 콩이 시작 칸에서만 보인다 — 같은 항목이 반복되지 않는다", () => {
+    const event = buildEvent({ end: new Date("2026-08-07T00:00:00") });
+    render(
+      <MonthGrid
+        events={[event]}
+        month={new Date("2026-08-01T00:00:00")}
+        selectedDate={new Date("2026-08-01T00:00:00")}
+        onSelectDate={jest.fn()}
+      />,
+    );
+
+    expect(screen.getAllByText("여러 날 Todo")).toHaveLength(1);
+  });
+
+  it("하루짜리 Todo는 그 날 칸에만 걸린다(기존 동작)", () => {
+    const event = buildEvent();
+    render(
+      <MonthGrid
+        events={[event]}
+        month={new Date("2026-08-01T00:00:00")}
+        selectedDate={new Date("2026-08-01T00:00:00")}
+        onSelectDate={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /8월 5일.*일정 1건/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /8월 6일(?!.*일정)/ })).toBeInTheDocument();
+    expect(screen.getAllByText("여러 날 Todo")).toHaveLength(1);
+  });
+});

--- a/src/features/calendar/components/month-grid.tsx
+++ b/src/features/calendar/components/month-grid.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  differenceInCalendarDays,
   eachDayOfInterval,
   endOfMonth,
   endOfWeek,
@@ -16,8 +17,13 @@ import { useSyncExternalStore } from "react";
 
 import { cn } from "@/lib/utils";
 
-import { CALENDAR_TAG_BG, CALENDAR_TAG_FG, calendarStatusDotColor } from "../tag-colors";
-import type { PersonalCalendarEvent } from "../types";
+import {
+  CALENDAR_TAG_BG,
+  CALENDAR_TAG_FG,
+  calendarStatusDotColor,
+  getTodoTitleColor,
+} from "../tag-colors";
+import { CALENDAR_ITEM_TAG, type PersonalCalendarEvent } from "../types";
 
 /**
  * 월간 격자 — **직접 그린다.**
@@ -63,6 +69,65 @@ function getEventSpanEdge(event: PersonalCalendarEvent, day: Date): EventSpanEdg
   if (isSameDay(day, event.start)) return "start";
   if (isSameDay(day, event.end)) return "end";
   return "middle";
+}
+
+/** 항목이 걸치는 날수 — 하루짜리는 0. 줄 배정 우선순위(길수록 위)와 정렬에 쓴다. */
+function eventSpanDays(event: PersonalCalendarEvent): number {
+  return differenceInCalendarDays(startOfDay(event.end), startOfDay(event.start));
+}
+
+/**
+ * 같은 주(週) 안에서 항목을 줄 순서로 세운다 — **긴 항목이 항상 위 줄**이다(2026-08-14 확정).
+ * 시작일이 이른 쪽, 그래도 같으면 id로 안정 정렬한다(같은 입력이면 항상 같은 결과가 나와야
+ * 화면을 새로고침해도 줄이 안 흔들린다).
+ */
+function compareEventsForStacking(a: PersonalCalendarEvent, b: PersonalCalendarEvent): number {
+  const spanDiff = eventSpanDays(b) - eventSpanDays(a);
+  if (spanDiff !== 0) return spanDiff;
+  const startDiff = a.start.getTime() - b.start.getTime();
+  if (startDiff !== 0) return startDiff;
+  return a.id.localeCompare(b.id);
+}
+
+/**
+ * 한 주(週, 7일) 안에서 항목마다 **고정 줄 번호**를 매긴다.
+ *
+ * ⚠️ **왜 필요한가.** 하루 칸마다 그날 걸리는 항목만 따로 나열하면, 옆 항목이 있다 없다에 따라
+ *    같은 항목이 어느 날은 2번째, 어느 날은 3번째 줄로 밀려 보인다 — 이어진 막대가 삐뚤어
+ *    보이는 원인이다(§DESIGN 잔버그, 2026-08-14). 줄 번호를 이 항목이 걸치는 **모든 날에
+ *    똑같이** 매겨 두고, 그 줄이 빈 날엔 자리만 채우는 빈 칸을 넣어야 막대가 안 흔들린다.
+ * ⚠️ 탐욕(그리디) 배정이다 — `compareEventsForStacking` 순서로 훑으며, 그 항목이 걸치는
+ *    요일들에서 **아직 아무도 안 쓴 가장 낮은 줄**을 고른다. 달력 라이브러리들이 흔히 쓰는
+ *    "day-of-week 점유표" 방식과 같다.
+ */
+function computeWeekEventRows(
+  weekDays: Date[],
+  events: PersonalCalendarEvent[],
+): Map<string, number> {
+  const relevant = events.filter((event) => weekDays.some((day) => eventOccursOnDay(event, day)));
+  const sorted = [...relevant].sort(compareEventsForStacking);
+
+  const rowOccupancy: boolean[][] = [];
+  const rowByEventId = new Map<string, number>();
+
+  for (const event of sorted) {
+    const dayIndexes = weekDays
+      .map((day, index) => (eventOccursOnDay(event, day) ? index : -1))
+      .filter((index) => index >= 0);
+
+    let row = 0;
+    for (;;) {
+      const occupied = (rowOccupancy[row] ??= new Array(weekDays.length).fill(false));
+      if (dayIndexes.every((index) => !occupied[index])) {
+        dayIndexes.forEach((index) => (occupied[index] = true));
+        rowByEventId.set(event.id, row);
+        break;
+      }
+      row += 1;
+    }
+  }
+
+  return rowByEventId;
 }
 
 /**
@@ -124,21 +189,29 @@ export function MonthGrid({ events, month, selectedDate, onSelectDate }: MonthGr
         className="grid min-h-0 flex-1"
         style={{ gridTemplateRows: `repeat(${weekCount}, minmax(0, 1fr))` }}
       >
-        {Array.from({ length: weekCount }, (_, week) => (
-          <div key={week} className="border-border grid grid-cols-7 not-first:border-t">
-            {days.slice(week * 7, week * 7 + 7).map((day) => (
-              <DayCell
-                key={day.toISOString()}
-                day={day}
-                events={events.filter((event) => eventOccursOnDay(event, day))}
-                isOutside={!isSameMonth(day, month)}
-                isToday={format(day, DAY_KEY) === todayKey}
-                isSelected={isSameDay(day, selectedDate)}
-                onSelect={onSelectDate}
-              />
-            ))}
-          </div>
-        ))}
+        {Array.from({ length: weekCount }, (_, week) => {
+          const weekDays = days.slice(week * 7, week * 7 + 7);
+          // ⚠️ 줄 번호는 **주 단위**로 다시 매긴다 — 주가 바뀌면 이어지는 막대도 새로 시작하는
+          //    모양이라(월간 격자가 주마다 행을 새로 그리므로), 줄도 주마다 새로 세는 게 맞다.
+          const rowByEventId = computeWeekEventRows(weekDays, events);
+
+          return (
+            <div key={week} className="border-border grid grid-cols-7 not-first:border-t">
+              {weekDays.map((day) => (
+                <DayCell
+                  key={day.toISOString()}
+                  day={day}
+                  events={events.filter((event) => eventOccursOnDay(event, day))}
+                  rowByEventId={rowByEventId}
+                  isOutside={!isSameMonth(day, month)}
+                  isToday={format(day, DAY_KEY) === todayKey}
+                  isSelected={isSameDay(day, selectedDate)}
+                  onSelect={onSelectDate}
+                />
+              ))}
+            </div>
+          );
+        })}
       </div>
     </div>
   );
@@ -154,6 +227,7 @@ export function MonthGrid({ events, month, selectedDate, onSelectDate }: MonthGr
 function DayCell({
   day,
   events,
+  rowByEventId,
   isOutside,
   isToday,
   isSelected,
@@ -161,13 +235,27 @@ function DayCell({
 }: {
   day: Date;
   events: PersonalCalendarEvent[];
+  /** 이 주(週) 안에서 항목마다 매긴 고정 줄 번호 — `computeWeekEventRows` 참고. */
+  rowByEventId: Map<string, number>;
   isOutside: boolean;
   isToday: boolean;
   isSelected: boolean;
   onSelect: (date: Date) => void;
 }) {
   const dateLabel = format(day, "M월 d일(EEE)", { locale: ko });
-  const mayOverflow = events.length > MAX_VISIBLE_CHIPS;
+
+  /*
+    ⚠️ **줄 번호만큼 자리를 채운다.** 이 날의 최고 줄 번호까지는 빈 줄도 자리를 차지해야,
+       그 줄을 쓰는 다른 날의 항목과 세로 위치가 맞아 이어진 막대처럼 보인다
+       (`computeWeekEventRows` 주석 — "밤티현상" 수정, 2026-08-14).
+    ⚠️ 최고 줄 **뒤**는 채우지 않는다 — 이 날엔 아무것도 없어 맞출 대상이 없다.
+  */
+  const maxRow = events.reduce((max, event) => Math.max(max, rowByEventId.get(event.id) ?? 0), -1);
+  const slots: (PersonalCalendarEvent | null)[] = Array.from(
+    { length: maxRow + 1 },
+    (_, row) => events.find((event) => rowByEventId.get(event.id) === row) ?? null,
+  );
+  const mayOverflow = slots.length > MAX_VISIBLE_CHIPS;
 
   return (
     /*
@@ -247,9 +335,14 @@ function DayCell({
             mayOverflow ? "pointer-events-auto" : "pointer-events-none",
           )}
         >
-          {events.map((event) => (
-            <EventChip key={event.id} event={event} spanEdge={getEventSpanEdge(event, day)} />
-          ))}
+          {slots.map((event, row) =>
+            event ? (
+              <EventChip key={event.id} event={event} spanEdge={getEventSpanEdge(event, day)} />
+            ) : (
+              // 줄만 비었을 뿐 항목은 없다 — 자리만 채우고 스크린리더엔 아무것도 안 알린다.
+              <div key={`gap-${row}`} aria-hidden className="h-4 shrink-0" />
+            ),
+          )}
         </div>
       )}
     </div>
@@ -277,13 +370,16 @@ function DayCell({
 function EventChip({ event, spanEdge }: { event: PersonalCalendarEvent; spanEdge: EventSpanEdge }) {
   const done = event.isCompleted;
   const showContent = spanEdge === "single" || spanEdge === "start";
+  // ⚠️ 개인 Todo는 제목마다 색이 갈린다(2026-08-14) — 개인 액션은 여전히 fuchsia 고정이다.
+  const isTodo = event.tag === CALENDAR_ITEM_TAG.PERSONAL_TODO;
+  const todoColor = isTodo ? getTodoTitleColor(event.title) : null;
 
   return (
     <span
       title={event.title}
       style={{
-        color: CALENDAR_TAG_FG[event.tag],
-        backgroundColor: event.color ?? CALENDAR_TAG_BG[event.tag],
+        color: todoColor?.textColor ?? CALENDAR_TAG_FG[event.tag],
+        backgroundColor: event.color ?? todoColor?.bgColor ?? CALENDAR_TAG_BG[event.tag],
       }}
       className={cn(
         /*
@@ -303,9 +399,15 @@ function EventChip({ event, spanEdge }: { event: PersonalCalendarEvent; spanEdge
         /*
           ⚠️ 취소선을 **칩 전체**에 긋는다. `line-through`는 글자 위에만 그어져서, 제목이
              짧거나 잘리면 선이 중간에 끊겨 지저분했다 — 가운데를 가로지르는 선 하나로 둔다.
+          ⚠️ 좌우 인셋도 배경 여백(`-ml-1.5`/`-mr-1.5`)과 **같은 규칙**을 따른다(2026-08-14) —
+             안 그러면 이어진 칸끼리 배경은 맞붙어도 취소선만 각 칸 여백(6px)에서 멈춰서,
+             완료된 여러 날 Todo가 하루마다 선이 끊긴 것처럼 보인다.
         */
         done &&
-          "after:absolute after:inset-x-1.5 after:top-1/2 after:h-px after:-translate-y-1/2 after:bg-current after:opacity-70",
+          "after:absolute after:top-1/2 after:h-px after:-translate-y-1/2 after:bg-current after:opacity-70",
+        done && (spanEdge === "middle" || spanEdge === "end" ? "after:left-0" : "after:left-1.5"),
+        done &&
+          (spanEdge === "middle" || spanEdge === "start" ? "after:right-0" : "after:right-1.5"),
       )}
     >
       {showContent ? (

--- a/src/features/calendar/components/month-grid.tsx
+++ b/src/features/calendar/components/month-grid.tsx
@@ -7,6 +7,7 @@ import {
   format,
   isSameDay,
   isSameMonth,
+  startOfDay,
   startOfMonth,
   startOfWeek,
 } from "date-fns";
@@ -42,6 +43,27 @@ const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"] as const;
 const MAX_VISIBLE_CHIPS = 3;
 
 const DAY_KEY = "yyyy-MM-dd";
+
+/** 그 날이 항목의 시작~끝 구간에 걸리는지 — 여러 날에 걸친 Todo도 지나는 날마다 걸린다. */
+function eventOccursOnDay(event: PersonalCalendarEvent, day: Date): boolean {
+  const dayStart = startOfDay(day).getTime();
+  return (
+    startOfDay(event.start).getTime() <= dayStart && dayStart <= startOfDay(event.end).getTime()
+  );
+}
+
+/**
+ * 여러 날 항목을 **연속 막대**로 이어 보이려면 구간 안에서 그 날이 어디쯤인지가 필요하다.
+ * `single`은 하루짜리(기존 디자인 그대로), `start`/`middle`/`end`는 이어진 막대의 한 조각이다.
+ */
+type EventSpanEdge = "single" | "start" | "middle" | "end";
+
+function getEventSpanEdge(event: PersonalCalendarEvent, day: Date): EventSpanEdge {
+  if (isSameDay(event.start, event.end)) return "single";
+  if (isSameDay(day, event.start)) return "start";
+  if (isSameDay(day, event.end)) return "end";
+  return "middle";
+}
 
 /**
  * "오늘"을 **브라우저 기준으로** 잡는다 — 서버 렌더에서는 `null`이다.
@@ -108,7 +130,7 @@ export function MonthGrid({ events, month, selectedDate, onSelectDate }: MonthGr
               <DayCell
                 key={day.toISOString()}
                 day={day}
-                events={events.filter((event) => isSameDay(event.start, day))}
+                events={events.filter((event) => eventOccursOnDay(event, day))}
                 isOutside={!isSameMonth(day, month)}
                 isToday={format(day, DAY_KEY) === todayKey}
                 isSelected={isSameDay(day, selectedDate)}
@@ -226,7 +248,7 @@ function DayCell({
           )}
         >
           {events.map((event) => (
-            <EventChip key={event.id} event={event} />
+            <EventChip key={event.id} event={event} spanEdge={getEventSpanEdge(event, day)} />
           ))}
         </div>
       )}
@@ -245,9 +267,16 @@ function DayCell({
  * ⚠️ 채움/테두리로 상태를 말하던 방식은 걷어냈다 — 콩이 같은 말을 더 분명히 한다.
  * ⚠️ 취소선은 남긴다. 끝난 일은 훑을 때 건너뛸 수 있어야 한다.
  * ⚠️ 제목이 길면 자른다. `min-w-0`이 없으면 flex 자식이 안 줄어들어 칸을 밀어낸다.
+ *
+ * ⚠️ **여러 날에 걸친 항목은 이 칩을 지나는 칸마다 그려 하나의 막대처럼 잇는다**(2026-08-10).
+ *    하루 칸을 격자로 직접 그리는 지금 구조를 바꾸지 않고, 시작~끝 칩 사이의 둥근 모서리와
+ *    칸 사이 여백(`px-1.5`)만 없애 이어 붙인다 — `spanEdge`가 그 위치를 말해 준다.
+ *    제목·상태 콩은 **시작 칸에서만** 보인다. 매 칸에 반복하면 이어진 막대가 아니라
+ *    같은 항목이 여러 개 있는 것처럼 읽힌다.
  */
-function EventChip({ event }: { event: PersonalCalendarEvent }) {
+function EventChip({ event, spanEdge }: { event: PersonalCalendarEvent; spanEdge: EventSpanEdge }) {
   const done = event.isCompleted;
+  const showContent = spanEdge === "single" || spanEdge === "start";
 
   return (
     <span
@@ -263,7 +292,14 @@ function EventChip({ event }: { event: PersonalCalendarEvent }) {
              `scrollHeight`가 안 늘어나 스크롤이 아예 안 생겼다. 안 줄어들어야 넘치고,
              넘쳐야 그 칸만 스크롤한다(이게 라이브러리를 걷어낸 이유다).
         */
-        "relative flex shrink-0 items-center gap-1 rounded px-1.5 text-[11px] leading-[16px] font-medium",
+        "relative flex shrink-0 items-center gap-1 px-1.5 text-[11px] leading-[16px] font-medium",
+        // 하루짜리는 네 모서리 다 둥글게, 이어진 막대는 시작·끝 칸만 그쪽 모서리를 둥글게 둔다.
+        spanEdge === "single" && "rounded",
+        spanEdge === "start" && "rounded-l",
+        spanEdge === "end" && "rounded-r",
+        // 이어지는 쪽은 칸의 좌우 여백(`px-1.5`)만큼 밀어내 옆 칸 칩과 맞붙는다.
+        (spanEdge === "middle" || spanEdge === "end") && "-ml-1.5",
+        (spanEdge === "middle" || spanEdge === "start") && "-mr-1.5",
         /*
           ⚠️ 취소선을 **칩 전체**에 긋는다. `line-through`는 글자 위에만 그어져서, 제목이
              짧거나 잘리면 선이 중간에 끊겨 지저분했다 — 가운데를 가로지르는 선 하나로 둔다.
@@ -272,12 +308,21 @@ function EventChip({ event }: { event: PersonalCalendarEvent }) {
           "after:absolute after:inset-x-1.5 after:top-1/2 after:h-px after:-translate-y-1/2 after:bg-current after:opacity-70",
       )}
     >
-      <span
-        aria-hidden
-        className="size-1.5 shrink-0 rounded-full"
-        style={{ backgroundColor: calendarStatusDotColor(done) }}
-      />
-      <span className="min-w-0 truncate">{event.title}</span>
+      {showContent ? (
+        <>
+          <span
+            aria-hidden
+            className="size-1.5 shrink-0 rounded-full"
+            style={{ backgroundColor: calendarStatusDotColor(done) }}
+          />
+          <span className="min-w-0 truncate">{event.title}</span>
+        </>
+      ) : (
+        // 이어지는 칸도 높이는 같아야 막대가 끊겨 보이지 않는다 — 보이는 글자 없이 자리만 채운다.
+        <span aria-hidden className="min-w-0 truncate">
+          &nbsp;
+        </span>
+      )}
     </span>
   );
 }

--- a/src/features/calendar/tag-colors.test.ts
+++ b/src/features/calendar/tag-colors.test.ts
@@ -1,0 +1,29 @@
+import { TAG_NAMES } from "@/lib/palette";
+
+import { CALENDAR_TODO_LEGEND_SWATCH, getTodoTitleColor } from "./tag-colors";
+
+describe("getTodoTitleColor — 개인 Todo 제목별 색", () => {
+  it("같은 제목이면 항상 같은 색이다", () => {
+    expect(getTodoTitleColor("주간 보고서 작성")).toEqual(getTodoTitleColor("주간 보고서 작성"));
+  });
+
+  it("제목이 다르면 다른 색이 나올 수 있다", () => {
+    expect(getTodoTitleColor("A")).not.toEqual(getTodoTitleColor("B"));
+  });
+
+  it("팔레트 CSS 변수(var(--tag-*))로만 나온다 — hex를 직접 들고 있지 않다", () => {
+    const { bgColor, textColor, solidColor } = getTodoTitleColor("아무 제목");
+    expect(bgColor).toMatch(/^var\(--tag-[a-z]+-bg\)$/);
+    expect(textColor).toMatch(/^var\(--tag-[a-z]+-fg\)$/);
+    expect(solidColor).toMatch(/^var\(--tag-[a-z]+-solid\)$/);
+  });
+});
+
+describe("CALENDAR_TODO_LEGEND_SWATCH — 범례 색동 원", () => {
+  it("팔레트 색 수만큼 conic-gradient 구간을 그린다", () => {
+    expect(CALENDAR_TODO_LEGEND_SWATCH).toContain("conic-gradient(");
+    TAG_NAMES.forEach((name) => {
+      expect(CALENDAR_TODO_LEGEND_SWATCH).toContain(`var(--tag-${name}-solid)`);
+    });
+  });
+});

--- a/src/features/calendar/tag-colors.ts
+++ b/src/features/calendar/tag-colors.ts
@@ -1,3 +1,5 @@
+import { type PaletteColor, pickPaletteColor, TAG_NAMES } from "@/lib/palette";
+
 import { CALENDAR_ITEM_TAG, type CalendarItemTag } from "./types";
 
 /**
@@ -6,9 +8,10 @@ import { CALENDAR_ITEM_TAG, type CalendarItemTag } from "./types";
  * ⚠️ 예전에는 `--calendar-todo`(#166534)·`--calendar-action`(#6d28d9)이라는 이 화면 전용
  *    값이었다. 팔레트 밖 색이라 프로젝트 태그·상태점 옆에 놓이면 같은 무리인지 알 수 없었고,
  *    진한 원색이라 셀을 칠하면 화면이 무거웠다.
- * ⚠️ **sky ↔ fuchsia**다(연하늘 ↔ 연보라핑크). 앞서 emerald+indigo는 둘 다 채도가 높아
- *    무거웠고, teal+purple은 둘 다 차가운 쪽이라 작은 칩에서 서로 비슷해 보였다 —
- *    지금 쌍은 **차가운 색 하나와 따뜻한 색 하나**라 나란히 놔도 헷갈리지 않는다.
+ * ⚠️ **개인 액션은 fuchsia 고정.** 개인 Todo는 **제목마다 색이 달라진다**(2026-08-14,
+ *    `getTodoTitleColor` 참고) — 항목이 많아질 때 색만으로도 서로 다른 일임을 구분하기
+ *    쉽게 하려는 것이다. `CALENDAR_TAG_BG`/`FG`의 `PERSONAL_TODO` 값은 그 함수를 못 쓰는
+ *    자리(예: 아직 제목이 없는 자리)를 위한 **기본값**으로만 남는다.
  * ⚠️ 빨강 계열은 피한다 — 우리 빨강은 **에러 전용**이라 일정 색으로 쓰면 뜻이 섞인다.
  *    fuchsia는 분홍이되 빨강 쪽으로 넘어가지 않는 자리다.
  * ⚠️ **벌을 섞지 않는다**(§5). 글자가 얹히는 칩은 `bg`+`fg` 한 벌, 글자가 없는 점은 `solid`다.
@@ -35,6 +38,30 @@ export const CALENDAR_TAG_DOT_COLOR: Record<CalendarItemTag, string> = {
   [CALENDAR_ITEM_TAG.PERSONAL_TODO]: "var(--tag-sky-solid)",
   [CALENDAR_ITEM_TAG.PERSONAL_ACTION]: "var(--tag-fuchsia-solid)",
 };
+
+/**
+ * 개인 Todo 제목에서 색을 뽑는다 — **아바타·프로젝트 태그와 같은 팔레트**(`lib/palette`)다.
+ *
+ * ⚠️ 왜 제목으로 거는가. Todo는 회의처럼 담당자·프로젝트가 따로 없어 색을 걸 다른 축이
+ *    없다 — 그나마 화면에 늘 보이는 값이 제목이라, 같은 제목은 같은 색이 나오게 해서
+ *    "그 파란 항목"처럼 색으로도 기억할 수 있게 한다.
+ * ⚠️ 무작위가 아니다(`pickPaletteColor`가 해시로 고른다) — 새로고침해도 색이 안 바뀐다.
+ */
+export function getTodoTitleColor(title: string): PaletteColor {
+  return pickPaletteColor(title);
+}
+
+/**
+ * 범례의 Todo 콩 — 제목마다 색이 달라지니 콩 하나로는 "이 색"을 못 보여준다. 실제로 나올 수
+ * 있는 색 풀(`TAG_NAMES`, 팔레트 순서 그대로)을 색동 원(conic-gradient)으로 둘러 보여준다.
+ * ⚠️ 팔레트가 늘거나 순서가 바뀌면 이 원도 자동으로 따라간다 — 색을 여기 따로 옮겨 적지 않는다.
+ */
+export const CALENDAR_TODO_LEGEND_SWATCH = `conic-gradient(${TAG_NAMES.map(
+  (name, index) =>
+    `var(--tag-${name}-solid) ${(index / TAG_NAMES.length) * 360}deg ${
+      ((index + 1) / TAG_NAMES.length) * 360
+    }deg`,
+).join(", ")})`;
 
 /**
  * **진행 상태**의 색 — 태그 색과 **완전히 다른 벌**이다.


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [x] test — 테스트 코드
- [x] design — UI/UX 변경
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

- `month-grid.tsx`: 날짜별 이벤트 필터를 구간 겹침(`eventOccursOnDay`)으로 바꿔 여러 날 Todo를 이어진 막대로 렌더링 (`spanEdge`로 모서리·배경 여백 처리)
- `computeWeekEventRows`/`compareEventsForStacking` 추가 — 주 단위 고정 줄 배정으로 항목이 날마다 다른 줄로 밀려 보이던 문제(밤티현상) 수정, 빈 줄은 자리만 채워 세로 정렬 유지
- 완료된 항목의 취소선(`after:` 인셋)을 배경 여백 규칙과 맞춰 칸 경계에서 끊기지 않게 수정
- `tag-colors.ts`: `getTodoTitleColor` 추가 — `lib/palette`의 해시 팔레트로 제목마다 다른 색을 뽑음. `month-grid.tsx`/`calendar-event-list-item.tsx`/범례에 적용, 개인 액션은 fuchsia 고정 유지
- `calendar-legend.tsx`: "Todo" 범례를 단색 콩 → 팔레트 전체를 보여주는 색동 원(conic-gradient)으로 교체
- 테스트: `tag-colors.test.ts`(신규), `month-grid.test.tsx`에 줄 배정·취소선·제목별 색상 검증 추가

---

## ✅ 작업 체크리스트

**기본**

- [ ] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [ ] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 해당 없음 (표시 로직만, 권한 변경 없음)
- [ ] 🧬 **zod** — 해당 없음 (렌더링/색상 로직, 폼·검증 아님)
- [x] 🕵️ **정직성** — 해당 없음 (목·미구현 표시 대상 아님)
- [x] 🎨 디자인 토큰 사용 — 기존 `--tag-*` 팔레트(`lib/palette`)만 재사용, 새 하드코딩 없음

**품질**

- [x] ⚡ 최적화 — 해당 없음 (순수 CSS 클래스·해시 계산, 무거운 리소스 없음)
- [x] ♿ a11y — 범례 색동 원은 `aria-hidden`(장식용), 각 칸 `aria-label`은 그대로 정확한 건수를 말함
- [x] ♻️ 재사용 확인 — 아바타·프로젝트 태그가 쓰는 `lib/palette`를 그대로 재사용, 새 팔레트 안 만듦
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 해당 없음 (조회 화면 상태는 상위 컴포넌트가 이미 처리)
- [ ] 브라우저 전용 API — 해당 없음

---

## 🔗 연관 이슈

Closes #306 

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
| (Todo가 고정 sky색, 줄 밀림·취소선 끊김 있음) | (제목별 색상, 연속 막대 정렬·취소선 이어짐) |

⚠️ 이번 PR도 브라우저 미리보기 패널 표시 오류로 스크린샷을 못 찍었습니다 — 리뷰 시 로컬에서 확인 부탁드립니다.

---

## 💬 리뷰 포인트

- 색상은 결정적(deterministic)입니다 — 같은 제목이면 새로고침해도 항상 같은 색이 나옵니다(무작위 아님).
- `--tag-*` 팔레트가 11색뿐이라 제목이 많아지면 겹칠 수 있습니다 — 프로젝트 태그·아바타와 같은 전제입니다(식별은 색이 아니라 제목·태그가 함).

---

## 📝 추가 메모

`npx tsc --noEmit` 통과, `npx jest src/features/calendar`(8 스위트 48건) 통과.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 여러 날에 걸친 일정과 Todo가 월간 달력의 해당 날짜 전체에 표시됩니다.
  * 여러 날 일정의 행 위치가 일관되게 유지되어 달력 가독성이 향상되었습니다.
  * 일정 시작일에만 제목과 상태가 표시됩니다.
* **개선**
  * Todo 제목에 따라 색상이 자동 지정되어 쉽게 구분할 수 있습니다.
  * 캘린더 범례에서 Todo 색상 팔레트를 그레이디언트로 확인할 수 있습니다.
  * 완료된 연속 Todo의 취소선 표시가 기간 전체에 자연스럽게 연결됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->