### PR TITLE
[FIX] 리뷰 이탈방지 가드 Strict Mode 이중 실행 버그 수정 #308

### DIFF
--- a/src/features/meeting/review/components/review-leave-guard.tsx
+++ b/src/features/meeting/review/components/review-leave-guard.tsx
@@ -37,6 +37,14 @@ export function ReviewLeaveGuard({ isBlocked }: ReviewLeaveGuardProps) {
   const [pendingHref, setPendingHref] = useState<string | null>(null);
   const [pendingBack, setPendingBack] = useState(false);
   const bypassBackRef = useRef(false);
+  /**
+   * ⚠️ **Strict Mode 이중 실행 대비**(2026-08-10 버그#308). 개발 모드에서 React가 아래
+   * popstate effect를 mount→cleanup→mount로 두 번 도는데, 1차 클린업의 `history.back()`이
+   * 만드는 `popstate`는 비동기라 2차 mount가 새로 단 리스너가 이걸 "진짜 사용자가 뒤로
+   * 갔다"로 착각해 진입 즉시 모달을 띄운다. `useRef`는 이 이중 실행 동안 값이 유지되므로,
+   * 클린업이 `back()`을 부르기 직전에 표시해 두고 다음 리스너가 자기 신호를 구분해 무시한다.
+   */
+  const suppressNextPopRef = useRef(false);
 
   const isOpen = pendingHref !== null || pendingBack;
 
@@ -74,6 +82,11 @@ export function ReviewLeaveGuard({ isBlocked }: ReviewLeaveGuardProps) {
     window.history.pushState(null, "", hrefAtMount);
 
     function handlePopState() {
+      if (suppressNextPopRef.current) {
+        // 우리 자신의 클린업이 만든 back() — 사용자가 뒤로 간 게 아니니 조용히 넘긴다.
+        suppressNextPopRef.current = false;
+        return;
+      }
       if (bypassBackRef.current) {
         bypassBackRef.current = false;
         return;
@@ -89,6 +102,7 @@ export function ReviewLeaveGuard({ isBlocked }: ReviewLeaveGuardProps) {
       //    안 지우면 나중에 뒤로 가기를 두 번 눌러야 실제로 벗어난다. 링크·뒤로가기로 이미
       //    나간 경우는 주소가 바뀌어 있어 이 조건에 걸리지 않는다(중복 소비 방지).
       if (window.location.href === hrefAtMount) {
+        suppressNextPopRef.current = true;
         window.history.back();
       }
     };


### PR DESCRIPTION
## 📋 PR 타입

- [ ] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

- AI 액션 분배 리뷰 화면(`/app/meeting/:id/review`) 진입 직후 사용자 조작 없이 '이 화면을 나갈까요?' 모달이 즉시 뜨던 버그를 고쳤다.
- 원인: `ReviewLeaveGuard`의 뒤로가기 감시 effect가 클린업에서 `history.back()`을 호출하는데, 개발 모드의 React 18 Strict Mode가 이 effect를 mount→cleanup→mount로 두 번 실행한다. 1차 클린업의 `history.back()`이 만드는 `popstate`는 비동기라, 그 사이 붙은 2차 mount의 리스너가 이를 "진짜 사용자가 뒤로 갔다"로 착각해 모달을 띄웠다.
- `useRef`(Strict Mode 이중 실행 동안에도 값 유지)로 "이 popstate는 클린업이 만든 신호"임을 표시해, 다음 mount의 리스너가 구분해 무시하도록 수정.

---

## ✅ 작업 체크리스트

**기본**

- [ ] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [ ] 불필요한 `console` · 주석 처리된 코드 제거
- [ ] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**(회의 담당자 등), 그리고 **서버(Server Action/BFF)에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [ ] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시 (조용히 "되는 척" 금지)
- [ ] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그)
- [ ] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [ ] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인)
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음

---

## 🔗 연관 이슈

Closes #308

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

1. 마이페이지 "미확정 액션" 카드에서 회의 항목 클릭 → 리뷰 화면 진입
2. 진입 직후 모달이 뜨지 않는지 확인
3. 화면 안에서 실제로 사이드바 링크 클릭·뒤로가기를 시도했을 때는 기존처럼 확인 모달이 정상적으로 뜨는지 확인
4. [나가기]/[취소] 둘 다 기존 동작(실제 이탈 / 화면 유지) 그대로인지 확인

---

## 📝 추가 메모
