### PR TITLE
[FEAT] 회의실 관리 모달 시간 선택을 shadcn 팝오버 방식으로 교체#312

### DIFF
--- a/src/components/common/time-picker-field.tsx
+++ b/src/components/common/time-picker-field.tsx
@@ -20,6 +20,10 @@ function parseValue(value: string): Date | undefined {
 }
 
 function buildOptions(step: number): string[] {
+  if (!Number.isInteger(step) || step <= 0) {
+    throw new Error(`TimePickerField: step은 양의 정수여야 합니다 (받은 값: ${step})`);
+  }
+
   const options: string[] = [];
   for (let minutes = 0; minutes < MINUTES_IN_DAY; minutes += step) {
     const hour = Math.floor(minutes / 60)
@@ -79,7 +83,7 @@ export function TimePickerField({
   return (
     <Popover open={open} onOpenChange={setOpen}>
       {/* ⚠️ 네이티브 제출용 — 화면엔 안 보이지만 `FormData`엔 `name`으로 잡힌다. */}
-      {name && <input type="hidden" name={name} value={value} />}
+      {name && <input type="hidden" name={name} value={value} disabled={disabled} />}
       <PopoverTrigger
         render={
           <Button

--- a/src/components/common/time-picker-field.tsx
+++ b/src/components/common/time-picker-field.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { format, parse } from "date-fns";
+import { ko } from "date-fns/locale";
+import { ClockIcon } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+const VALUE_FORMAT = "HH:mm";
+const DISPLAY_FORMAT = "a h:mm";
+const MINUTES_IN_DAY = 24 * 60;
+
+function parseValue(value: string): Date | undefined {
+  if (!value) return undefined;
+  const parsed = parse(value, VALUE_FORMAT, new Date());
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+function buildOptions(step: number): string[] {
+  const options: string[] = [];
+  for (let minutes = 0; minutes < MINUTES_IN_DAY; minutes += step) {
+    const hour = Math.floor(minutes / 60)
+      .toString()
+      .padStart(2, "0");
+    const minute = (minutes % 60).toString().padStart(2, "0");
+    options.push(`${hour}:${minute}`);
+  }
+  return options;
+}
+
+interface TimePickerFieldProps {
+  id?: string;
+  /** `<form action={formAction}>` 네이티브 제출용 — 넘기면 숨은 `<input>`으로 같이 낸다. */
+  name?: string;
+  /** `HH:mm`(24시간). 아직 안 골랐으면 빈 문자열. */
+  value: string;
+  onChange: (value: string) => void;
+  /** 목록 간격(분) — 기본 30분. */
+  step?: number;
+  placeholder?: string;
+  "aria-label"?: string;
+  "aria-invalid"?: boolean;
+  disabled?: boolean;
+  /** 트리거 버튼에 붙는 클래스 — 표에 나란히 넣을 때 폭을 좁히는 용도. */
+  className?: string;
+}
+
+/**
+ * 시간 하나를 고르는 팝오버 목록 — 네이티브 `<input type="time">` 대체
+ * (`date-picker-field.tsx`와 같은 팝오버+먹색 선택 톤을 시간에도 맞춘다).
+ * 브라우저마다 다르게 생기는 기본 시간 UI 대신 이 서비스 톤으로 고정된 모습을 쓴다.
+ */
+export function TimePickerField({
+  id,
+  name,
+  value,
+  onChange,
+  step = 30,
+  placeholder = "시간 선택",
+  "aria-label": ariaLabel,
+  "aria-invalid": ariaInvalid,
+  disabled,
+  className,
+}: TimePickerFieldProps) {
+  const [open, setOpen] = useState(false);
+  const selectedRef = useRef<HTMLButtonElement>(null);
+  const selected = parseValue(value);
+  const options = buildOptions(step);
+
+  useEffect(() => {
+    if (open) {
+      selectedRef.current?.scrollIntoView({ block: "center" });
+    }
+  }, [open]);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      {/* ⚠️ 네이티브 제출용 — 화면엔 안 보이지만 `FormData`엔 `name`으로 잡힌다. */}
+      {name && <input type="hidden" name={name} value={value} />}
+      <PopoverTrigger
+        render={
+          <Button
+            id={id}
+            type="button"
+            variant="outline"
+            disabled={disabled}
+            aria-label={ariaLabel}
+            aria-invalid={ariaInvalid}
+            className={cn("h-10 justify-start gap-2 font-normal", className)}
+          />
+        }
+      >
+        <ClockIcon aria-hidden className="size-4 shrink-0 text-current" />
+        <span className={cn("truncate", !selected && "text-muted-foreground")}>
+          {selected ? format(selected, DISPLAY_FORMAT, { locale: ko }) : placeholder}
+        </span>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-40 p-1">
+        <div
+          role="listbox"
+          aria-label={ariaLabel ?? placeholder}
+          className="max-h-60 overflow-y-auto"
+        >
+          {options.map((option) => {
+            const isSelected = option === value;
+            return (
+              <button
+                key={option}
+                ref={isSelected ? selectedRef : undefined}
+                type="button"
+                role="option"
+                aria-selected={isSelected}
+                onClick={() => {
+                  onChange(option);
+                  setOpen(false);
+                }}
+                className={cn(
+                  "hover:bg-muted flex w-full items-center rounded-md px-2 py-1.5 text-left text-sm tabular-nums",
+                  isSelected && "bg-foreground text-background hover:bg-foreground",
+                )}
+              >
+                {format(parseValue(option) ?? new Date(), DISPLAY_FORMAT, { locale: ko })}
+              </button>
+            );
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/features/rooms/components/room-form.tsx
+++ b/src/features/rooms/components/room-form.tsx
@@ -3,6 +3,7 @@
 import { useActionState, useEffect, useRef, useState } from "react";
 
 import { FieldError } from "@/components/common/field-error";
+import { TimePickerField } from "@/components/common/time-picker-field";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
@@ -27,8 +28,9 @@ interface RoomFormProps {
 }
 
 /**
- * 회의실 추가·수정 폼 — `notice-form.tsx`와 같은 골격(실제 `<form action={formAction}>`,
- * 필드가 전부 plain input이라 shadcn `Select` 우회 없이 그대로 쓴다).
+ * 회의실 추가·수정 폼 — `notice-form.tsx`와 같은 골격(실제 `<form action={formAction}>`).
+ * 이용 시작·종료는 `TimePickerField`(shadcn Popover 기반)로 고른다 — 네이티브
+ * `<input type="time">` 대신 서비스 톤에 맞춘 팝오버 목록을 쓴다(2026-08-10 변경).
  */
 export function RoomForm({ action, room, onSuccess, onPendingChange, formRef }: RoomFormProps) {
   const [state, formAction, isPending] = useActionState(action, { errors: {} });
@@ -82,26 +84,26 @@ export function RoomForm({ action, room, onSuccess, onPendingChange, formRef }: 
       <div className="grid grid-cols-2 gap-3">
         <div className="flex flex-col gap-1.5">
           <Label htmlFor="room-open-time">이용 시작</Label>
-          <Input
+          <TimePickerField
             id="room-open-time"
             name="openTime"
-            type="time"
             value={openTime}
-            onChange={(event) => setOpenTime(event.target.value)}
+            onChange={setOpenTime}
             aria-invalid={Boolean(state.errors.openTime)}
+            className="w-full"
           />
           <FieldError reserveSpace message={state.errors.openTime} />
         </div>
 
         <div className="flex flex-col gap-1.5">
           <Label htmlFor="room-close-time">이용 종료</Label>
-          <Input
+          <TimePickerField
             id="room-close-time"
             name="closeTime"
-            type="time"
             value={closeTime}
-            onChange={(event) => setCloseTime(event.target.value)}
+            onChange={setCloseTime}
             aria-invalid={Boolean(state.errors.closeTime)}
+            className="w-full"
           />
           <FieldError reserveSpace message={state.errors.closeTime} />
         </div>


### PR DESCRIPTION
## 📋 PR 타입

> 해당하는 타입을 선택해 주세요 (복수 선택 가능)

- [ ] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [x] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [x] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- 회의실 관리(`/manage/rooms`) 추가·수정 모달의 이용 시작·종료 시간 입력을 네이티브 `<input type="time">`에서 shadcn Popover 기반 `TimePickerField`로 교체
- `components/common/date-picker-field.tsx`와 같은 골격(Popover + 트리거 버튼 + 숨은 `<input>` 네이티브 제출)으로 `components/common/time-picker-field.tsx` 신설, 30분 간격 목록에서 시간을 고르는 방식
- 값 포맷(`HH:mm`)·검증 로직(`validate.ts`)은 변경 없음 — UI 컴포넌트만 교체

---

## ✅ 작업 체크리스트

**기본**

- [ ] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [ ] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 해당 없음(UI 컴포넌트 교체만, 기존 `canManageRooms` 가드·서버 재검사 변경 없음)
- [x] 🧬 **zod** — 해당 없음(스키마·타입 변경 없음, 기존 `MeetingRoomFormState`·`validate.ts` 그대로)
- [x] 🕵️ **정직성** — 목·미구현·폴백 아님(순수 UI 컴포넌트 교체)
- [x] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨 — `DatePickerField`와 동일하게 `bg-foreground`/`text-background` 등 토큰만 사용

**품질**

- [x] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그) — 해당 없음(경량 컴포넌트)
- [x] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로 — `role="listbox"`/`role="option"`·`aria-selected`·`aria-label` 전달
- [x] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인) — `components/ui`에 시간 전용 피커 없음 확인 후 `common`에 `DatePickerField`와 짝을 이루는 컴포넌트로 신설
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 해당 없음(폼 필드 UI, 상위 폼의 기존 3상태 그대로)
- [x] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음 — 해당 없음

---

## 🔗 연관 이슈

Closes #312

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

- `TimePickerField`의 목록 간격을 30분(`step` 기본값)으로 뒀는데, 회의실 운영 시간 등록에 이 간격이 맞는지(기존 `validate.ts` 테스트는 `09:15` 같은 15분 단위도 유효한 값으로 허용) 확인 부탁드립니다.
- 회의실 **예약** 모달(`room-reservation-dialog.tsx`)은 이번 변경 대상이 아닙니다 — 시간이 캘린더 셀 클릭으로 정해지는 구조라 시간 입력 UI 자체가 없습니다.

---

## 📝 추가 메모


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 시간을 30분 단위 등 설정된 간격으로 선택할 수 있는 팝오버형 시간 선택기를 추가했습니다.
  - 선택한 시간은 한국어 오전·오후 형식으로 표시되며, 키보드 접근성과 네이티브 폼 제출을 지원합니다.

- **개선 사항**
  - 회의실 이용 시작·종료 시간 입력을 새로운 시간 선택기로 변경했습니다.
  - 기존 값 관리와 오류 표시 기능은 그대로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->