### PR TITLE
[FEAT] 마이페이지 테마 설정 UI 디자인 개선 #314

### DIFF
--- a/src/features/appearance/components/theme-card.tsx
+++ b/src/features/appearance/components/theme-card.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Monitor, Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 import { type KeyboardEvent, useSyncExternalStore } from "react";
 
@@ -22,10 +21,10 @@ function useMounted(): boolean {
 
 type ThemeOption = "light" | "dark" | "system";
 
-const THEME_OPTIONS: { value: ThemeOption; label: string; icon: typeof Sun }[] = [
-  { value: "light", label: "라이트", icon: Sun },
-  { value: "dark", label: "다크", icon: Moon },
-  { value: "system", label: "시스템", icon: Monitor },
+const THEME_OPTIONS: { value: ThemeOption; label: string }[] = [
+  { value: "light", label: "라이트" },
+  { value: "dark", label: "다크" },
+  { value: "system", label: "시스템" },
 ];
 
 function nextThemeByKey(key: string): 1 | -1 | null {
@@ -85,7 +84,6 @@ export function ThemeCard() {
       >
         {THEME_OPTIONS.map((option) => {
           const isSelected = mounted && theme === option.value;
-          const Icon = option.icon;
 
           return (
             <button
@@ -97,14 +95,20 @@ export function ThemeCard() {
               data-theme-option={option.value}
               onClick={() => setTheme(option.value)}
               className={cn(
-                "focus-visible:ring-ring flex h-9 min-w-[92px] items-center justify-center gap-1.5 rounded-lg border px-3 text-[13px] leading-none transition-colors focus-visible:ring-2 focus-visible:outline-hidden",
-                isSelected
-                  ? "border-foreground bg-foreground text-background"
-                  : "border-border hover:bg-secondary",
+                "focus-visible:ring-ring flex min-w-[132px] flex-1 flex-col items-center gap-2 rounded-xl border p-2 transition-colors focus-visible:ring-2 focus-visible:outline-hidden",
+                isSelected ? "border-foreground" : "border-border hover:bg-secondary",
               )}
             >
-              <Icon className="size-3.5" aria-hidden />
-              {option.label}
+              <span
+                aria-hidden
+                className={cn(
+                  "h-11 w-full rounded-lg border",
+                  option.value === "light" && "border-border bg-white",
+                  option.value === "dark" && "border-border bg-black",
+                  option.value === "system" && "border-border bg-linear-to-br from-white to-black",
+                )}
+              />
+              <span className="text-[13px] leading-none">{option.label}</span>
             </button>
           );
         })}


### PR DESCRIPTION
## 📋 PR 타입

> 해당하는 타입을 선택해 주세요 (복수 선택 가능)

- [ ] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [x] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [x] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [x] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- 마이페이지 "테마" 카드(`ThemeCard`)의 옵션 버튼을 아이콘+텍스트 버튼에서 라이트/다크/시스템 프리뷰 스와치 카드 방식으로 교체
- 선택 상태 표시를 채움색 대신 카드 테두리 강조로 변경
- 미사용 처리된 `lucide-react` 아이콘(Sun/Moon/Monitor) import 및 옵션 타입의 `icon` 필드 제거

---

## ✅ 작업 체크리스트

**기본**

- [ ] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [ ] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 권한 2축 검사 — 해당 없음 (디자인 전용, 데이터·권한 변경 없음)
- [x] 🧬 zod — 해당 없음 (스키마·API 변경 없음)
- [x] 🕵️ 정직성 — 해당 없음 (목/미구현/폴백 변경 없음)
- [x] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [x] ⚡ 최적화 — 해당 없음 (마크업 구조 변경만)
- [x] ♿ a11y (label · role · alt · 키보드) · 기존 라디오그룹 키보드 내비게이션 그대로 유지
- [x] ♻️ 재사용 확인 — 기존 컴포넌트 내부 수정, 신규 컴포넌트 없음
- [ ] 🧪 `loading` / `error` / `empty` 3상태 — 해당 없음 (정적 UI)
- [x] 브라우저 전용 API(STT · 녹음) 사용 시 미지원 · 권한거부 안내 있음 — 해당 없음

---

## 🔗 연관 이슈

Closes #314

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

- 스와치 색상(라이트=흰색, 다크=검정, 시스템=그라디언트)이 시안과 일치하는지
- 선택 표시(테두리 강조)가 다크모드에서도 충분히 구분되는지

---

## 📝 추가 메모

디자인 전용 변경으로 별도 테스트/린트 검증은 생략함 (요청에 따름).