### PR TITLE
[FIX] shadcn select 태그 수정 #318

### DIFF
--- a/src/features/handover/components/vacation-form.tsx
+++ b/src/features/handover/components/vacation-form.tsx
@@ -51,6 +51,19 @@ export function VacationForm({ context }: VacationFormProps) {
     [actions, startDate, endDate],
   );
 
+  /*
+    ⚠️ `useMemo`로 참조를 고정한다. 매 렌더 새 객체를 넘기면 base-ui `Select`의 내부 이펙트가
+       참조 변화 → store 갱신 → 리렌더 → 새 객체를... 반복해 "Maximum update depth exceeded"로
+       이어진다(CI에서 실제로 터졌다 — `search-filter-bar.tsx`와 같은 이유).
+  */
+  const teammateItems = useMemo(
+    () =>
+      Object.fromEntries(
+        teammates.map((teammate) => [teammate.id, `${teammate.name} ${teammate.position}`]),
+      ),
+    [teammates],
+  );
+
   function handleDateChange(next: { startDate?: string; endDate?: string }) {
     setStartDate(next.startDate ?? startDate);
     setEndDate(next.endDate ?? endDate);
@@ -185,12 +198,7 @@ export function VacationForm({ context }: VacationFormProps) {
                     <Select
                       // ⚠️ `items`를 넘긴다 — 안 넘기면 트리거가 닫혀 있는 동안은 라벨을 못 찾아
                       //    원문 값(`teammate.id`)이 그대로 보인다(`search-filter-bar.tsx`와 같은 이유).
-                      items={Object.fromEntries(
-                        teammates.map((teammate) => [
-                          teammate.id,
-                          `${teammate.name} ${teammate.position}`,
-                        ]),
-                      )}
+                      items={teammateItems}
                       value={
                         assignments[action.id] !== undefined ? String(assignments[action.id]) : ""
                       }

--- a/src/features/handover/components/vacation-form.tsx
+++ b/src/features/handover/components/vacation-form.tsx
@@ -183,6 +183,14 @@ export function VacationForm({ context }: VacationFormProps) {
                       {action.title}
                     </span>
                     <Select
+                      // ⚠️ `items`를 넘긴다 — 안 넘기면 트리거가 닫혀 있는 동안은 라벨을 못 찾아
+                      //    원문 값(`teammate.id`)이 그대로 보인다(`search-filter-bar.tsx`와 같은 이유).
+                      items={Object.fromEntries(
+                        teammates.map((teammate) => [
+                          teammate.id,
+                          `${teammate.name} ${teammate.position}`,
+                        ]),
+                      )}
                       value={
                         assignments[action.id] !== undefined ? String(assignments[action.id]) : ""
                       }

--- a/src/features/rooms/components/room-reservation-fields.tsx
+++ b/src/features/rooms/components/room-reservation-fields.tsx
@@ -85,6 +85,10 @@ export function RoomReservationFields({
       <div className="flex flex-col gap-1.5">
         <Label htmlFor="reservation-project">프로젝트</Label>
         <Select
+          // ⚠️ `items`(값→라벨 맵)를 넘긴다 — 안 넘기면 트리거가 닫혀 있는 동안 `SelectContent`가
+          //    아직 안 그려져 라벨을 못 찾고 원문 값(`project.id`)이 그대로 보인다
+          //    (`search-filter-bar.tsx`와 같은 이유).
+          items={Object.fromEntries(projects.map((project) => [project.id, project.name]))}
           value={form.projectId}
           onValueChange={(value) =>
             // 프로젝트를 바꾸면 그 프로젝트 소속이 아닌 상위 팀 액션 선택은 의미가 없어진다.
@@ -113,6 +117,9 @@ export function RoomReservationFields({
         <div className="flex flex-col gap-1.5">
           <Label htmlFor="reservation-parent-team-action">상위 팀 액션</Label>
           <Select
+            items={Object.fromEntries(
+              availableTeamActions.map((teamAction) => [String(teamAction.id), teamAction.name]),
+            )}
             value={form.parentTeamActionId}
             onValueChange={(value) =>
               setForm((prev) => ({ ...prev, parentTeamActionId: value ?? "" }))

--- a/src/features/rooms/components/room-reservation-fields.tsx
+++ b/src/features/rooms/components/room-reservation-fields.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { Dispatch, SetStateAction } from "react";
+import { useMemo } from "react";
 
 import { FieldError } from "@/components/common/field-error";
 import { Input } from "@/components/ui/input";
@@ -52,8 +53,27 @@ export function RoomReservationFields({
   teamActions,
 }: RoomReservationFieldsProps) {
   const selectedProjectTag = projects.find((project) => project.id === form.projectId)?.tag;
-  const availableTeamActions = teamActions.filter(
-    (teamAction) => teamAction.projectTag === selectedProjectTag,
+
+  /*
+    ⚠️ `useMemo`로 참조를 고정한다 — `.filter()`는 매 렌더 새 배열을 만들고, 거기서 파생한
+       `items` 객체도 매번 새 참조가 된다. base-ui `Select`의 내부 이펙트가 참조 변화 → store
+       갱신 → 리렌더 → 새 객체를... 반복해 "Maximum update depth exceeded"로 이어진다
+       (`search-filter-bar.tsx`가 같은 이유로 `useMemo`를 쓰던 걸 놓쳤다가 실제로 터졌다).
+  */
+  const availableTeamActions = useMemo(
+    () => teamActions.filter((teamAction) => teamAction.projectTag === selectedProjectTag),
+    [teamActions, selectedProjectTag],
+  );
+  const projectItems = useMemo(
+    () => Object.fromEntries(projects.map((project) => [project.id, project.name])),
+    [projects],
+  );
+  const teamActionItems = useMemo(
+    () =>
+      Object.fromEntries(
+        availableTeamActions.map((teamAction) => [String(teamAction.id), teamAction.name]),
+      ),
+    [availableTeamActions],
   );
 
   return (
@@ -88,7 +108,7 @@ export function RoomReservationFields({
           // ⚠️ `items`(값→라벨 맵)를 넘긴다 — 안 넘기면 트리거가 닫혀 있는 동안 `SelectContent`가
           //    아직 안 그려져 라벨을 못 찾고 원문 값(`project.id`)이 그대로 보인다
           //    (`search-filter-bar.tsx`와 같은 이유).
-          items={Object.fromEntries(projects.map((project) => [project.id, project.name]))}
+          items={projectItems}
           value={form.projectId}
           onValueChange={(value) =>
             // 프로젝트를 바꾸면 그 프로젝트 소속이 아닌 상위 팀 액션 선택은 의미가 없어진다.
@@ -117,9 +137,7 @@ export function RoomReservationFields({
         <div className="flex flex-col gap-1.5">
           <Label htmlFor="reservation-parent-team-action">상위 팀 액션</Label>
           <Select
-            items={Object.fromEntries(
-              availableTeamActions.map((teamAction) => [String(teamAction.id), teamAction.name]),
-            )}
+            items={teamActionItems}
             value={form.parentTeamActionId}
             onValueChange={(value) =>
               setForm((prev) => ({ ...prev, parentTeamActionId: value ?? "" }))

--- a/src/features/rooms/components/rooms-calendar-toolbar.tsx
+++ b/src/features/rooms/components/rooms-calendar-toolbar.tsx
@@ -78,6 +78,12 @@ export function RoomsCalendarToolbar({
         </Button>
 
         <Select
+          // ⚠️ `items`를 넘긴다 — 안 넘기면 트리거가 닫혀 있는 동안은 라벨을 못 찾아
+          //    원문 값(`room.id`)이 그대로 보인다(`search-filter-bar.tsx`와 같은 이유).
+          items={{
+            [ALL_ROOMS_VALUE]: ROOMS_CALENDAR_TOOLBAR_LABEL.allRooms,
+            ...Object.fromEntries(rooms.map((room) => [room.id, room.name])),
+          }}
           value={selectedRoomId}
           onValueChange={(value) => onSelectedRoomChange(value ?? ALL_ROOMS_VALUE)}
         >

--- a/src/features/rooms/components/rooms-calendar-toolbar.tsx
+++ b/src/features/rooms/components/rooms-calendar-toolbar.tsx
@@ -1,6 +1,7 @@
 import { addDays, format, startOfWeek } from "date-fns";
 import { ko } from "date-fns/locale";
 import { ChevronLeft, ChevronRight, Plus } from "lucide-react";
+import { useMemo } from "react";
 import type { ToolbarProps } from "react-big-calendar";
 
 import { Button } from "@/components/ui/button";
@@ -45,6 +46,19 @@ export function RoomsCalendarToolbar({
   onSelectedRoomChange,
   onAddClick,
 }: RoomsCalendarToolbarProps) {
+  /*
+    ⚠️ `useMemo`로 참조를 고정한다. 매 렌더 새 객체를 넘기면 base-ui `Select`의 내부 이펙트가
+       참조 변화 → store 갱신 → 리렌더 → 새 객체를... 반복해 "Maximum update depth exceeded"로
+       이어진다(CI에서 실제로 터졌다 — `search-filter-bar.tsx`와 같은 이유).
+  */
+  const roomItems = useMemo(
+    () => ({
+      [ALL_ROOMS_VALUE]: ROOMS_CALENDAR_TOOLBAR_LABEL.allRooms,
+      ...Object.fromEntries(rooms.map((room) => [room.id, room.name])),
+    }),
+    [rooms],
+  );
+
   const weekStart = startOfWeek(date, { weekStartsOn: 1 });
   const weekEnd = addDays(weekStart, 4);
   const rangeLabel =
@@ -80,10 +94,7 @@ export function RoomsCalendarToolbar({
         <Select
           // ⚠️ `items`를 넘긴다 — 안 넘기면 트리거가 닫혀 있는 동안은 라벨을 못 찾아
           //    원문 값(`room.id`)이 그대로 보인다(`search-filter-bar.tsx`와 같은 이유).
-          items={{
-            [ALL_ROOMS_VALUE]: ROOMS_CALENDAR_TOOLBAR_LABEL.allRooms,
-            ...Object.fromEntries(rooms.map((room) => [room.id, room.name])),
-          }}
+          items={roomItems}
           value={selectedRoomId}
           onValueChange={(value) => onSelectedRoomChange(value ?? ALL_ROOMS_VALUE)}
         >

--- a/src/features/system/components/company-filter-bar.tsx
+++ b/src/features/system/components/company-filter-bar.tsx
@@ -96,6 +96,7 @@ export function CompanyFilterBar() {
       </Select>
 
       <Select
+        items={{ [ALL]: "전체 상태", ...COMPANY_STATUS_LABEL }}
         value={searchParams.get("status") ?? ALL}
         onValueChange={(value) => pushWith({ q: keyword, status: value ?? ALL })}
       >

--- a/src/features/system/components/company-filter-bar.tsx
+++ b/src/features/system/components/company-filter-bar.tsx
@@ -28,6 +28,14 @@ const DEFAULT_SORT = COMPANY_SORT.JOINED_DESC;
 /** 필터 셀렉트의 "전체" 값 — 빈 문자열은 URLSearchParams가 지워버려 구분이 안 된다 */
 const ALL = "ALL";
 
+/*
+  ⚠️ 컴포넌트 밖(모듈 스코프)에 둔다 — 렌더마다 새 객체를 `Select`의 `items`로 넘기면
+     base-ui 내부 이펙트가 참조 변화 → store 갱신 → 리렌더 → 새 객체를... 반복해
+     "Maximum update depth exceeded"로 이어진다(CI에서 실제로 터졌다). 값이 상수라
+     `useMemo`도 필요 없이 여기서 한 번만 만들면 참조가 계속 같다.
+*/
+const STATUS_ITEMS = { [ALL]: "전체 상태", ...COMPANY_STATUS_LABEL };
+
 /**
  * 기업명·코드 검색 + 규모·상태 필터.
  *
@@ -96,7 +104,7 @@ export function CompanyFilterBar() {
       </Select>
 
       <Select
-        items={{ [ALL]: "전체 상태", ...COMPANY_STATUS_LABEL }}
+        items={STATUS_ITEMS}
         value={searchParams.get("status") ?? ALL}
         onValueChange={(value) => pushWith({ q: keyword, status: value ?? ALL })}
       >


### PR DESCRIPTION
## 📋 PR 타입

> 해당하는 타입을 선택해 주세요 (복수 선택 가능)

- [ ] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [x] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- `Select`(base-ui)에 `items`(값→라벨 맵)를 넘기지 않으면, 트리거가 닫혀 있는 동안 `SelectContent`가 렌더되지 않아 라벨을 못 찾고 원문 값이 그대로 보이는 문제를 수정
- [room-reservation-fields.tsx](src/features/rooms/components/room-reservation-fields.tsx) — "프로젝트" select(`project.id`→`project.name`), "상위 팀 액션" select(`teamAction.id`→`teamAction.name`)에 `items` 추가
- [vacation-form.tsx](src/features/handover/components/vacation-form.tsx) — 담당자 배정 select에 `items`(`teammate.id`→"이름 직급") 추가, 값 타입도 문자열로 맞춤
- [company-filter-bar.tsx](src/features/system/components/company-filter-bar.tsx) — 상태 필터 select에 `items`(`COMPANY_STATUS_LABEL`) 추가. 같은 파일의 정렬 select는 이미 처리돼 있었는데 상태 필터만 누락돼 있었음

---

## ✅ 작업 체크리스트

**기본**

- [ ] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [ ] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 권한 2축 검사 — 해당 없음 (표시 로직만 수정, 권한·소유권 무관)
- [x] 🧬 zod — 해당 없음 (스키마 변경 없음)
- [x] 🕵️ 정직성 — 해당 없음 (목/미구현/폴백 변경 없음)
- [x] 🎨 디자인 토큰 사용 — 해당 없음 (마크업·스타일 변경 없음)

**품질**

- [x] ⚡ 최적화 — 해당 없음
- [x] ♿ a11y — 기존 라벨·역할 속성 그대로 유지
- [x] ♻️ 재사용 확인 — 기존 컴포넌트(`components/ui/select.tsx`)는 그대로, 각 사용처에서 이미 다른 화면에 적용된 `items` 패턴만 동일하게 적용
- [ ] 🧪 `loading` / `error` / `empty` 3상태 — 해당 없음
- [x] 브라우저 전용 API 관련 — 해당 없음

---

## 🔗 연관 이슈

Closes #318

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

- 세 곳 외에 값↔라벨이 다른 `Select` 사용처가 더 있는지 (전수 확인했으나 재확인 환영)
- `vacation-form.tsx`는 원격 변경(값 `String()` 변환)과 병합된 상태라 `assignments` 타입(`Record<number, number>`)과 Select `value`(string) 간 변환이 맞는지

---

## 📝 추가 메모

같은 파일 안에서도 어떤 select는 이미 고쳐져 있고 어떤 select는 빠져 있는 경우가 있었음 — 새 Select 추가 시 값과 라벨이 다르면 `items` 또는 render-prop을 반드시 쓰는 걸 컨벤션으로 굳히면 재발을 막을 수 있음.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 담당자, 프로젝트, 팀 액션 및 회의실 선택 필드에서 선택된 항목의 이름과 직급이 표시됩니다.
  * 회의실 선택 메뉴에서 전체 회의실과 개별 회의실 이름을 확인할 수 있습니다.
  * 상태 필터에 전체 상태와 각 상태를 설명하는 라벨이 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->