### PR TITLE
[FEAT] 프로젝트·보드 도메인 실 API 연동 #320

### DIFF
--- a/src/app/(shell)/app/actions/[actionId]/page.tsx
+++ b/src/app/(shell)/app/actions/[actionId]/page.tsx
@@ -50,7 +50,6 @@ export default async function PersonalActionDetailPage({ params }: PersonalActio
             key: "source-meeting",
             icon: Video,
             label: "출처 회의",
-            // ⚠️ 회의 상세(`/app/meeting/:id`) 라우트가 아직 없어 href 없이 텍스트만(§9 화면은 사실만).
             content: (
               <>
                 <div className="flex items-center gap-1.5">
@@ -67,6 +66,7 @@ export default async function PersonalActionDetailPage({ params }: PersonalActio
                 </p>
               </>
             ),
+            href: `/app/meeting/${action.sourceMeeting.id}`,
           } satisfies ActionDetailInfoItem,
         ]
       : []),

--- a/src/app/(shell)/app/actions/[actionId]/page.tsx
+++ b/src/app/(shell)/app/actions/[actionId]/page.tsx
@@ -39,55 +39,66 @@ export default async function PersonalActionDetailPage({ params }: PersonalActio
       key: "assignee",
       icon: User,
       label: "담당자",
-      content: `${action.assigneeName}(${action.assigneeRoleLabel})`,
+      // ⚠️ 역할 미지정이면 이름만 보여준다 — 없는 역할을 지어내지 않는다(§정직성).
+      content: action.assigneeRoleLabel
+        ? `${action.assigneeName}(${action.assigneeRoleLabel})`
+        : action.assigneeName,
     },
-    {
-      key: "source-meeting",
-      icon: Video,
-      label: "출처 회의",
-      // ⚠️ 회의 상세(`/app/meeting/:id`) 라우트가 아직 없어 href 없이 텍스트만(§9 화면은 사실만).
-      content: (
-        <>
-          <div className="flex items-center gap-1.5">
-            <p className="truncate">{action.sourceMeeting.title}</p>
-            <span
-              className="shrink-0 rounded px-1.5 py-px text-[11px] leading-4 font-medium"
-              style={{ backgroundColor: tagColor.bgColor, color: tagColor.textColor }}
-            >
-              {action.projectTag}
-            </span>
-          </div>
-          <p className="text-muted-foreground text-[11px] leading-4">
-            {formatMeetingDate(action.sourceMeeting.scheduledAt)}
-          </p>
-        </>
-      ),
-    },
-    {
-      key: "parent-team-action",
-      icon: GitBranch,
-      label: "상위 팀 액션",
-      content: (
-        <>
-          <div className="flex items-center gap-1.5">
-            <p className="truncate">{action.parentTeamAction.name}</p>
-            <span
-              className="shrink-0 rounded px-1.5 py-px text-[11px] leading-4 font-medium"
-              style={{ backgroundColor: tagColor.bgColor, color: tagColor.textColor }}
-            >
-              {action.projectTag}
-            </span>
-            <span className="bg-muted text-muted-foreground shrink-0 rounded px-1.5 py-0.5 text-[10px] leading-none font-semibold">
-              {action.parentTeamAction.team}
-            </span>
-          </div>
-          <p className="text-muted-foreground text-[11px] leading-4">
-            {formatMonthDayWeekday(action.parentTeamAction.dueDate) ?? "-"}까지
-          </p>
-        </>
-      ),
-      href: `/app/projects/${action.projectId}/team/${action.parentTeamAction.id}`,
-    },
+    ...(action.sourceMeeting
+      ? [
+          {
+            key: "source-meeting",
+            icon: Video,
+            label: "출처 회의",
+            // ⚠️ 회의 상세(`/app/meeting/:id`) 라우트가 아직 없어 href 없이 텍스트만(§9 화면은 사실만).
+            content: (
+              <>
+                <div className="flex items-center gap-1.5">
+                  <p className="truncate">{action.sourceMeeting.title}</p>
+                  <span
+                    className="shrink-0 rounded px-1.5 py-px text-[11px] leading-4 font-medium"
+                    style={{ backgroundColor: tagColor.bgColor, color: tagColor.textColor }}
+                  >
+                    {action.projectTag}
+                  </span>
+                </div>
+                <p className="text-muted-foreground text-[11px] leading-4">
+                  {formatMeetingDate(action.sourceMeeting.scheduledAt)}
+                </p>
+              </>
+            ),
+          } satisfies ActionDetailInfoItem,
+        ]
+      : []),
+    ...(action.parentTeamAction
+      ? [
+          {
+            key: "parent-team-action",
+            icon: GitBranch,
+            label: "상위 팀 액션",
+            content: (
+              <>
+                <div className="flex items-center gap-1.5">
+                  <p className="truncate">{action.parentTeamAction.name}</p>
+                  <span
+                    className="shrink-0 rounded px-1.5 py-px text-[11px] leading-4 font-medium"
+                    style={{ backgroundColor: tagColor.bgColor, color: tagColor.textColor }}
+                  >
+                    {action.projectTag}
+                  </span>
+                  <span className="bg-muted text-muted-foreground shrink-0 rounded px-1.5 py-0.5 text-[10px] leading-none font-semibold">
+                    {action.parentTeamAction.team}
+                  </span>
+                </div>
+                <p className="text-muted-foreground text-[11px] leading-4">
+                  {formatMonthDayWeekday(action.parentTeamAction.dueDate) ?? "-"}까지
+                </p>
+              </>
+            ),
+            href: `/app/projects/${action.projectId}/team/${action.parentTeamAction.id}`,
+          } satisfies ActionDetailInfoItem,
+        ]
+      : []),
     {
       key: "project",
       icon: Folder,

--- a/src/app/(shell)/app/projects/[projectId]/page.tsx
+++ b/src/app/(shell)/app/projects/[projectId]/page.tsx
@@ -2,12 +2,13 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { AttachmentList } from "@/components/common/attachment-list";
 import { Badge } from "@/components/ui/badge";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { isDelayed } from "@/constants/domain";
 import type { TimelineActionInput } from "@/features/member/action-timeline";
 import { ActionTimeline, ActionTimelineLegend } from "@/features/member/components/action-timeline";
-import { ProjectAttachmentList } from "@/features/project/components/project-attachment-list";
+import { getProjectAttachmentDownloadUrlAction } from "@/features/project/actions";
 import {
   parseProjectDetailTab,
   PROJECT_DETAIL_TABS,
@@ -157,7 +158,10 @@ export default async function ProjectDetailPage({ params, searchParams }: Projec
             <p className="text-muted-foreground border-border border-t pt-5 text-[13px] leading-[22px] whitespace-pre-wrap">
               {project.description}
             </p>
-            <ProjectAttachmentList projectId={project.id} attachments={project.attachments} />
+            <AttachmentList
+              attachments={project.attachments}
+              fetchDownloadUrl={getProjectAttachmentDownloadUrlAction.bind(null, project.id)}
+            />
           </section>
         ) : (
           <section

--- a/src/app/(shell)/app/projects/[projectId]/page.tsx
+++ b/src/app/(shell)/app/projects/[projectId]/page.tsx
@@ -1,4 +1,3 @@
-import { Paperclip } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
@@ -8,6 +7,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { isDelayed } from "@/constants/domain";
 import type { TimelineActionInput } from "@/features/member/action-timeline";
 import { ActionTimeline, ActionTimelineLegend } from "@/features/member/components/action-timeline";
+import { ProjectAttachmentList } from "@/features/project/components/project-attachment-list";
 import {
   parseProjectDetailTab,
   PROJECT_DETAIL_TABS,
@@ -157,14 +157,7 @@ export default async function ProjectDetailPage({ params, searchParams }: Projec
             <p className="text-muted-foreground border-border border-t pt-5 text-[13px] leading-[22px] whitespace-pre-wrap">
               {project.description}
             </p>
-            {project.attachmentName && (
-              // ⚠️ 목 단계라 다운로드 URL이 없다(§9 화면은 사실만 말한다) — 죽은 링크(href="#") 대신
-              //    지금 있는 파일명만 정직하게 보여준다. API 스펙 확정 후 실제 다운로드 링크로 바꾼다.
-              <span className="text-muted-foreground inline-flex w-fit items-center gap-1.5 text-[13px] leading-5">
-                <Paperclip className="size-3.5" />
-                {project.attachmentName}
-              </span>
-            )}
+            <ProjectAttachmentList projectId={project.id} attachments={project.attachments} />
           </section>
         ) : (
           <section

--- a/src/app/(shell)/app/projects/[projectId]/team/[teamActionId]/page.tsx
+++ b/src/app/(shell)/app/projects/[projectId]/team/[teamActionId]/page.tsx
@@ -94,7 +94,6 @@ export default async function TeamActionDetailPage({
             key: "source-meeting",
             icon: Video,
             label: "출처 회의",
-            // ⚠️ 회의 상세(`/app/meeting/:id`) 라우트가 아직 없어 href 없이 텍스트만(§9 화면은 사실만).
             content: (
               <>
                 <div className="flex items-center gap-1.5">
@@ -111,6 +110,7 @@ export default async function TeamActionDetailPage({
                 </p>
               </>
             ),
+            href: `/app/meeting/${teamAction.sourceMeeting.id}`,
           } satisfies ActionDetailInfoItem,
         ]
       : []),

--- a/src/app/(shell)/app/projects/[projectId]/team/[teamActionId]/page.tsx
+++ b/src/app/(shell)/app/projects/[projectId]/team/[teamActionId]/page.tsx
@@ -7,10 +7,12 @@ import {
   type ActionDetailInfoItem,
   ActionDetailInfoRows,
 } from "@/components/common/action-detail-info-card";
+import { AttachmentList } from "@/components/common/attachment-list";
 import { formatMeetingDate } from "@/components/common/dashboard-meeting-item";
 import { isDelayed } from "@/constants/domain";
 import type { TimelineActionInput } from "@/features/member/action-timeline";
 import { ActionTimeline, ActionTimelineLegend } from "@/features/member/components/action-timeline";
+import { getTeamActionAttachmentDownloadUrlAction } from "@/features/project/actions";
 import {
   parseTeamActionDetailTab,
   TEAM_ACTION_DETAIL_TABS,
@@ -73,34 +75,45 @@ export default async function TeamActionDetailPage({
   });
 
   const infoItems: ActionDetailInfoItem[] = [
-    {
-      key: "assignee",
-      icon: User,
-      label: "담당자",
-      content: `${teamAction.assigneeName}(${teamAction.assigneeRoleLabel})`,
-    },
-    {
-      key: "source-meeting",
-      icon: Video,
-      label: "출처 회의",
-      // ⚠️ 회의 상세(`/app/meeting/:id`) 라우트가 아직 없어 href 없이 텍스트만(§9 화면은 사실만).
-      content: (
-        <>
-          <div className="flex items-center gap-1.5">
-            <p className="truncate">{teamAction.sourceMeeting.title}</p>
-            <span
-              className="shrink-0 rounded px-1.5 py-px text-[11px] leading-4 font-medium"
-              style={{ backgroundColor: tagColor.bgColor, color: tagColor.textColor }}
-            >
-              {teamAction.projectTag}
-            </span>
-          </div>
-          <p className="text-muted-foreground text-[11px] leading-4">
-            {formatMeetingDate(teamAction.sourceMeeting.scheduledAt)}
-          </p>
-        </>
-      ),
-    },
+    // ⚠️ 팀장 공석이면 담당자 행 자체를 안 보여준다 — 없는 사람을 지어내지 않는다(§정직성).
+    ...(teamAction.assigneeName
+      ? [
+          {
+            key: "assignee",
+            icon: User,
+            label: "담당자",
+            content: teamAction.assigneeRoleLabel
+              ? `${teamAction.assigneeName}(${teamAction.assigneeRoleLabel})`
+              : teamAction.assigneeName,
+          } satisfies ActionDetailInfoItem,
+        ]
+      : []),
+    ...(teamAction.sourceMeeting
+      ? [
+          {
+            key: "source-meeting",
+            icon: Video,
+            label: "출처 회의",
+            // ⚠️ 회의 상세(`/app/meeting/:id`) 라우트가 아직 없어 href 없이 텍스트만(§9 화면은 사실만).
+            content: (
+              <>
+                <div className="flex items-center gap-1.5">
+                  <p className="truncate">{teamAction.sourceMeeting.title}</p>
+                  <span
+                    className="shrink-0 rounded px-1.5 py-px text-[11px] leading-4 font-medium"
+                    style={{ backgroundColor: tagColor.bgColor, color: tagColor.textColor }}
+                  >
+                    {teamAction.projectTag}
+                  </span>
+                </div>
+                <p className="text-muted-foreground text-[11px] leading-4">
+                  {formatMeetingDate(teamAction.sourceMeeting.scheduledAt)}
+                </p>
+              </>
+            ),
+          } satisfies ActionDetailInfoItem,
+        ]
+      : []),
     // ⚠️ 상위 팀 액션 — 팀 액션 상세엔 없음(개인 액션 상세에서만 씀).
     {
       key: "project",
@@ -195,10 +208,17 @@ export default async function TeamActionDetailPage({
                  선은 카드 끝까지 이어지는데 이 선만 짧아 카드가 깨져 보였다.
                  선·안쪽 여백은 전폭 래퍼가, 720은 **글에만** 건다(§4 읽는 글은 좁게 둔다).
             */}
-            <div className="border-border border-t px-7 py-6">
+            <div className="border-border flex flex-col gap-4 border-t px-7 py-6">
               <p className="text-muted-foreground max-w-[720px] text-[13px] leading-[22px] whitespace-pre-wrap">
                 {teamAction.description}
               </p>
+              <AttachmentList
+                attachments={teamAction.attachments}
+                fetchDownloadUrl={getTeamActionAttachmentDownloadUrlAction.bind(
+                  null,
+                  teamAction.id,
+                )}
+              />
             </div>
             <ActionDetailInfoRows items={infoItems} />
           </section>

--- a/src/components/common/attachment-list.tsx
+++ b/src/components/common/attachment-list.tsx
@@ -3,25 +3,29 @@
 import { Paperclip } from "lucide-react";
 import { toast } from "sonner";
 
-import { getProjectAttachmentDownloadUrlAction } from "../actions";
-import type { ProjectAttachment } from "../types";
+export interface AttachmentListItem {
+  id: number;
+  fileName: string;
+}
 
-interface ProjectAttachmentListProps {
-  projectId: number;
-  attachments: ProjectAttachment[];
+interface AttachmentListProps {
+  attachments: AttachmentListItem[];
+  /** 클릭한 첨부파일 id로 다운로드 URL을 발급받는다 — 부르는 쪽이 어느 리소스(프로젝트·팀 액션)인지 안다. */
+  fetchDownloadUrl: (attachmentId: number) => Promise<string | null>;
 }
 
 /**
- * 프로젝트 상세의 첨부파일 목록 — 클릭하면 그 자리에서 다운로드 URL을 발급받아 새 탭으로 연다.
+ * 첨부파일 목록 — 클릭하면 그 자리에서 다운로드 URL을 발급받아 새 탭으로 연다.
+ * 프로젝트 상세·팀 액션 상세가 같은 모양을 쓴다(도메인마다 발급 엔드포인트만 다르다).
  * ⚠️ **미리 발급받아 두지 않는다**(5분 만료, 2026-08-10 연동 가이드) — 클릭한 시점에만 부른다.
  * ⚠️ mock 단계는 발급할 실제 파일이 없어 액션이 `null`을 돌려준다 — 그러면 조용히 실패하는
  *    대신 "아직 연동되지 않았다"고 알린다(handover-approval-card.tsx의 PDF 스텁과 같은 패턴).
  */
-export function ProjectAttachmentList({ projectId, attachments }: ProjectAttachmentListProps) {
+export function AttachmentList({ attachments, fetchDownloadUrl }: AttachmentListProps) {
   if (attachments.length === 0) return null;
 
   async function handleClick(attachmentId: number) {
-    const url = await getProjectAttachmentDownloadUrlAction(projectId, attachmentId);
+    const url = await fetchDownloadUrl(attachmentId);
     if (!url) {
       toast("다운로드는 아직 연동되지 않았습니다");
       return;

--- a/src/features/action/mapper.ts
+++ b/src/features/action/mapper.ts
@@ -1,14 +1,11 @@
 import type { ActionStatus } from "@/constants/domain";
 
+import type { PersonalActionDetail } from "./types";
+
 /**
  * BE shape → UI 계약 (§Mock 격리막).
  * [확인] 잇다(Z) REST API 연동 가이드 최종본(2026-08-10) + BACKEND 실코드 대조
- *   `action/presentation/api/response/ActionSummaryResponse.java`
- *
- * ⚠️ **상세(`PersonalActionDetail`) 쪽 매퍼는 아직 없다** — `ActionDetailResponse`에
- *    화면이 쓰는 4개 값(projectId·assigneeRoleLabel·sourceMeeting.scheduledAt·
- *    parentTeamAction.team/dueDate)이 없어서 BE에 추가 요청해 둔 상태다(2026-08-10).
- *    그 답이 오기 전까지 이 파일은 목록(보드)에서 쓰는 요약 응답만 다룬다.
+ *   `action/presentation/api/response/{ActionSummaryResponse,ActionDetailResponse}.java`
  */
 export interface BeActionSummary {
   id: number;
@@ -61,5 +58,67 @@ export function toTeamActionPersonalItem(be: BeActionSummary): {
     startDate: fallbackActionStartDate(be.startDate),
     dueDate: be.dueDate,
     status: be.status,
+  };
+}
+
+/**
+ * 개인 액션 상세(`GET /api/actions/{id}`) 응답.
+ * [확인] `ActionDetailResponse.java`(2026-08-11, 이홍근 요청 필드 4개 반영·PR #337 머지 완료)
+ *
+ * ⚠️ `sourceMeetingId`·`parentActionId`가 전부 `null`일 수 있다 — `POST /api/actions`(예외
+ *    경로)로 수동 추가한 액션은 출처 회의도 상위 팀 액션도 없다. 목 시절엔 항상 있다고
+ *    가정했던 값들이라 매퍼에서 그 경우를 반드시 갈라야 한다(§정직성 — 없는 값을 지어내지 않는다).
+ */
+export interface BeActionDetail {
+  id: number;
+  projectId: number;
+  title: string;
+  description: string;
+  status: ActionStatus;
+  startDate: string | null;
+  dueDate: string;
+  needsReview: boolean;
+  assigneeName: string;
+  /** 역할(sub_team) 미지정이면 `null`. */
+  assigneeRoleLabel: string | null;
+  projectTag: string;
+  projectName: string;
+  teamName: string;
+  parentActionId: number | null;
+  parentActionTitle: string | null;
+  parentActionTeamName: string | null;
+  parentActionDueDate: string | null;
+  sourceMeetingId: number | null;
+  sourceMeetingTitle: string | null;
+  /** ISO datetime, `LocalDateTime` 문자열 그대로 온다. */
+  sourceMeetingScheduledAt: string | null;
+}
+
+export function toPersonalActionDetail(be: BeActionDetail): PersonalActionDetail {
+  return {
+    id: be.id,
+    name: be.title,
+    description: be.description,
+    team: be.teamName,
+    projectId: be.projectId,
+    projectTag: be.projectTag,
+    assigneeName: be.assigneeName,
+    assigneeRoleLabel: be.assigneeRoleLabel ?? undefined,
+    sourceMeeting:
+      be.sourceMeetingTitle && be.sourceMeetingScheduledAt
+        ? { title: be.sourceMeetingTitle, scheduledAt: be.sourceMeetingScheduledAt }
+        : undefined,
+    parentTeamAction:
+      be.parentActionId !== null &&
+      be.parentActionTitle !== null &&
+      be.parentActionTeamName !== null &&
+      be.parentActionDueDate !== null
+        ? {
+            id: be.parentActionId,
+            name: be.parentActionTitle,
+            team: be.parentActionTeamName,
+            dueDate: be.parentActionDueDate,
+          }
+        : undefined,
   };
 }

--- a/src/features/action/mapper.ts
+++ b/src/features/action/mapper.ts
@@ -1,4 +1,5 @@
 import type { ActionStatus } from "@/constants/domain";
+import type { MemberAction } from "@/features/member/types";
 import { type BeAttachment, toProjectAttachment } from "@/features/project/mapper";
 import type { TeamActionDetail } from "@/features/project/types";
 
@@ -60,6 +61,22 @@ export function toTeamActionPersonalItem(be: BeActionSummary): {
     startDate: fallbackActionStartDate(be.startDate),
     dueDate: be.dueDate,
     status: be.status,
+  };
+}
+
+/**
+ * 사원 대시보드 "처리할 액션" 타임라인 한 줄(`GET /api/actions`) → UI 계약.
+ * ⚠️ **TEAM 타입은 걸러야 한다** — 이 대시보드는 "내" 개인 액션만 보여준다(호출자는
+ *    `GET /api/actions`로 이미 본인 소유분만 받지만, 그중에서도 PERSONAL만 남긴다).
+ */
+export function toMemberAction(be: BeActionSummary): MemberAction {
+  return {
+    id: String(be.id),
+    title: be.title,
+    projectTag: be.projectTag ?? "",
+    status: be.status,
+    startDate: fallbackActionStartDate(be.startDate),
+    dueDate: be.dueDate,
   };
 }
 

--- a/src/features/action/mapper.ts
+++ b/src/features/action/mapper.ts
@@ -40,3 +40,26 @@ export function fallbackActionStartDate(startDate: string | null): string {
   tomorrow.setDate(tomorrow.getDate() + 1);
   return tomorrow.toISOString().slice(0, 10);
 }
+
+/**
+ * 팀 액션 상세의 타임라인 탭(`GET /api/team/actions/{id}?tab=timeline`) 한 줄 → UI 계약.
+ * ⚠️ `assigneeRoleLabel`은 못 채운다 — `ActionSummaryResponse`에 직급 라벨이 없다(이름만 옴).
+ *    타입이 optional이라 없어도 화면은 이름만 보여주는 쪽으로 정상 동작한다.
+ */
+export function toTeamActionPersonalItem(be: BeActionSummary): {
+  id: number;
+  title: string;
+  assigneeName: string;
+  startDate: string;
+  dueDate: string;
+  status: ActionStatus;
+} {
+  return {
+    id: be.id,
+    title: be.title,
+    assigneeName: be.assigneeName ?? "",
+    startDate: fallbackActionStartDate(be.startDate),
+    dueDate: be.dueDate,
+    status: be.status,
+  };
+}

--- a/src/features/action/mapper.ts
+++ b/src/features/action/mapper.ts
@@ -1,4 +1,6 @@
 import type { ActionStatus } from "@/constants/domain";
+import { type BeAttachment, toProjectAttachment } from "@/features/project/mapper";
+import type { TeamActionDetail } from "@/features/project/types";
 
 import type { PersonalActionDetail } from "./types";
 
@@ -120,5 +122,48 @@ export function toPersonalActionDetail(be: BeActionDetail): PersonalActionDetail
             dueDate: be.parentActionDueDate,
           }
         : undefined,
+  };
+}
+
+/**
+ * 팀 액션 상세(`GET /api/team/actions/{id}`) 응답.
+ * [확인] `TeamActionDetailResponse.java`(2026-08-11, BACKEND PR #339 머지 완료)
+ *
+ * ⚠️ `assigneeName`·`assigneeRoleLabel`은 **저장된 값이 아니라 BE가 그 팀의 현재 팀장을
+ *    그때그때 유도**해서 채운다(`"{팀명}장"` 고정 포맷도 BE가 조립) — 팀장 공석이면 둘 다
+ *    `null`(정상 상태). `sourceMeetingId`도 없을 수 있다(수동 추가된 팀 액션 등).
+ */
+export interface BeTeamActionDetail {
+  id: number;
+  projectId: number;
+  title: string;
+  description: string;
+  status: ActionStatus;
+  dueDate: string;
+  projectTag: string;
+  teamName: string;
+  assigneeName: string | null;
+  assigneeRoleLabel: string | null;
+  sourceMeetingId: number | null;
+  sourceMeetingTitle: string | null;
+  sourceMeetingScheduledAt: string | null;
+  attachments: BeAttachment[];
+}
+
+export function toTeamActionDetail(be: BeTeamActionDetail): TeamActionDetail {
+  return {
+    id: be.id,
+    name: be.title,
+    description: be.description,
+    team: be.teamName,
+    projectId: be.projectId,
+    projectTag: be.projectTag,
+    assigneeName: be.assigneeName ?? undefined,
+    assigneeRoleLabel: be.assigneeRoleLabel ?? undefined,
+    sourceMeeting:
+      be.sourceMeetingTitle && be.sourceMeetingScheduledAt
+        ? { title: be.sourceMeetingTitle, scheduledAt: be.sourceMeetingScheduledAt }
+        : undefined,
+    attachments: be.attachments.map(toProjectAttachment),
   };
 }

--- a/src/features/action/mapper.ts
+++ b/src/features/action/mapper.ts
@@ -124,8 +124,12 @@ export function toPersonalActionDetail(be: BeActionDetail): PersonalActionDetail
     assigneeName: be.assigneeName,
     assigneeRoleLabel: be.assigneeRoleLabel ?? undefined,
     sourceMeeting:
-      be.sourceMeetingTitle && be.sourceMeetingScheduledAt
-        ? { title: be.sourceMeetingTitle, scheduledAt: be.sourceMeetingScheduledAt }
+      be.sourceMeetingId !== null && be.sourceMeetingTitle && be.sourceMeetingScheduledAt
+        ? {
+            id: be.sourceMeetingId,
+            title: be.sourceMeetingTitle,
+            scheduledAt: be.sourceMeetingScheduledAt,
+          }
         : undefined,
     parentTeamAction:
       be.parentActionId !== null &&
@@ -178,8 +182,12 @@ export function toTeamActionDetail(be: BeTeamActionDetail): TeamActionDetail {
     assigneeName: be.assigneeName ?? undefined,
     assigneeRoleLabel: be.assigneeRoleLabel ?? undefined,
     sourceMeeting:
-      be.sourceMeetingTitle && be.sourceMeetingScheduledAt
-        ? { title: be.sourceMeetingTitle, scheduledAt: be.sourceMeetingScheduledAt }
+      be.sourceMeetingId !== null && be.sourceMeetingTitle && be.sourceMeetingScheduledAt
+        ? {
+            id: be.sourceMeetingId,
+            title: be.sourceMeetingTitle,
+            scheduledAt: be.sourceMeetingScheduledAt,
+          }
         : undefined,
     attachments: be.attachments.map(toProjectAttachment),
   };

--- a/src/features/action/mapper.ts
+++ b/src/features/action/mapper.ts
@@ -1,0 +1,42 @@
+import type { ActionStatus } from "@/constants/domain";
+
+/**
+ * BE shape → UI 계약 (§Mock 격리막).
+ * [확인] 잇다(Z) REST API 연동 가이드 최종본(2026-08-10) + BACKEND 실코드 대조
+ *   `action/presentation/api/response/ActionSummaryResponse.java`
+ *
+ * ⚠️ **상세(`PersonalActionDetail`) 쪽 매퍼는 아직 없다** — `ActionDetailResponse`에
+ *    화면이 쓰는 4개 값(projectId·assigneeRoleLabel·sourceMeeting.scheduledAt·
+ *    parentTeamAction.team/dueDate)이 없어서 BE에 추가 요청해 둔 상태다(2026-08-10).
+ *    그 답이 오기 전까지 이 파일은 목록(보드)에서 쓰는 요약 응답만 다룬다.
+ */
+export interface BeActionSummary {
+  id: number;
+  actionType: "PERSONAL" | "TEAM";
+  title: string;
+  status: ActionStatus;
+  /** "아직 시작 안 함" 액션은 `null`이 정상이다(마이그레이션 문제 아님, BE 주석 확인). */
+  startDate: string | null;
+  dueDate: string;
+  needsReview: boolean;
+  isDelayed: boolean;
+  assigneeName: string | null;
+  projectTag: string | null;
+  teamName: string | null;
+  sourceMeetingTitle: string | null;
+  parentActionId: number | null;
+  parentActionTitle: string | null;
+}
+
+/**
+ * 보드 카드가 요구하는 `startDate`는 `null`을 못 받는다(`getBoardColumn`이 문자열로 가정) —
+ * 시작 전 액션은 "아직 시작 안 함"이 곧 **할일 칸**이라는 뜻이므로, 오늘보다 하루 뒤 날짜로
+ * 채워 항상 할일 칸에 떨어지게 한다(프로젝트 쪽 "과거 기록 없음 → 진행중으로 본다"와는
+ * 정반대 방향 — 여기는 "시작 안 한 게 확실"이라 근거가 있다).
+ */
+export function fallbackActionStartDate(startDate: string | null): string {
+  if (startDate) return startDate;
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  return tomorrow.toISOString().slice(0, 10);
+}

--- a/src/features/action/mock/action-detail.ts
+++ b/src/features/action/mock/action-detail.ts
@@ -17,7 +17,7 @@ export const PERSONAL_ACTION_DETAIL_MOCK: Record<number, PersonalActionDetail> =
     projectTag: "GOODS",
     assigneeName: "이하윤",
     assigneeRoleLabel: "프론트엔드",
-    sourceMeeting: { title: "앱 개발 착수 팀 액션 회의", scheduledAt: "2026-07-21T10:00" },
+    sourceMeeting: { id: 1, title: "앱 개발 착수 팀 액션 회의", scheduledAt: "2026-07-21T10:00" },
     parentTeamAction: { id: 1, name: "앱 개발 착수", team: "개발팀", dueDate: "2026-08-29" },
   },
   2: {
@@ -29,7 +29,7 @@ export const PERSONAL_ACTION_DETAIL_MOCK: Record<number, PersonalActionDetail> =
     projectTag: "GOODS",
     assigneeName: "박도현",
     assigneeRoleLabel: "백엔드",
-    sourceMeeting: { title: "앱 개발 착수 팀 액션 회의", scheduledAt: "2026-07-21T10:00" },
+    sourceMeeting: { id: 2, title: "앱 개발 착수 팀 액션 회의", scheduledAt: "2026-07-21T10:00" },
     parentTeamAction: { id: 1, name: "앱 개발 착수", team: "개발팀", dueDate: "2026-08-29" },
   },
   3: {
@@ -41,7 +41,7 @@ export const PERSONAL_ACTION_DETAIL_MOCK: Record<number, PersonalActionDetail> =
     projectTag: "GOODS",
     assigneeName: "김서준",
     assigneeRoleLabel: "팀장",
-    sourceMeeting: { title: "앱 개발 착수 팀 액션 회의", scheduledAt: "2026-07-21T10:00" },
+    sourceMeeting: { id: 3, title: "앱 개발 착수 팀 액션 회의", scheduledAt: "2026-07-21T10:00" },
     parentTeamAction: { id: 1, name: "앱 개발 착수", team: "개발팀", dueDate: "2026-08-29" },
   },
   4: {
@@ -53,7 +53,11 @@ export const PERSONAL_ACTION_DETAIL_MOCK: Record<number, PersonalActionDetail> =
     projectTag: "GOODS",
     assigneeName: "박도현",
     assigneeRoleLabel: "백엔드",
-    sourceMeeting: { title: "결제 시스템 연동 팀 액션 회의", scheduledAt: "2026-08-11T10:00" },
+    sourceMeeting: {
+      id: 4,
+      title: "결제 시스템 연동 팀 액션 회의",
+      scheduledAt: "2026-08-11T10:00",
+    },
     parentTeamAction: { id: 2, name: "결제 시스템 연동", team: "개발팀", dueDate: "2026-09-12" },
   },
   5: {
@@ -66,6 +70,7 @@ export const PERSONAL_ACTION_DETAIL_MOCK: Record<number, PersonalActionDetail> =
     assigneeName: "최유진",
     assigneeRoleLabel: "팀장",
     sourceMeeting: {
+      id: 9,
       title: "TV 광고 계약 및 모델 섭외 팀 액션 회의",
       scheduledAt: "2026-08-11T13:00",
     },
@@ -85,7 +90,11 @@ export const PERSONAL_ACTION_DETAIL_MOCK: Record<number, PersonalActionDetail> =
     projectTag: "GOODS",
     assigneeName: "강서연",
     assigneeRoleLabel: "팀장",
-    sourceMeeting: { title: "굿즈 디자인 시안 제작 팀 액션 회의", scheduledAt: "2026-07-21T15:00" },
+    sourceMeeting: {
+      id: 5,
+      title: "굿즈 디자인 시안 제작 팀 액션 회의",
+      scheduledAt: "2026-07-21T15:00",
+    },
     parentTeamAction: {
       id: 4,
       name: "굿즈 디자인 시안 제작",
@@ -102,7 +111,11 @@ export const PERSONAL_ACTION_DETAIL_MOCK: Record<number, PersonalActionDetail> =
     projectTag: "BRAND",
     assigneeName: "강서연",
     assigneeRoleLabel: "팀장",
-    sourceMeeting: { title: "로고·가이드라인 개편 팀 액션 회의", scheduledAt: "2026-08-01T14:00" },
+    sourceMeeting: {
+      id: 6,
+      title: "로고·가이드라인 개편 팀 액션 회의",
+      scheduledAt: "2026-08-01T14:00",
+    },
     parentTeamAction: {
       id: 5,
       name: "로고·가이드라인 개편",
@@ -119,7 +132,11 @@ export const PERSONAL_ACTION_DETAIL_MOCK: Record<number, PersonalActionDetail> =
     projectTag: "BRAND",
     assigneeName: "최유진",
     assigneeRoleLabel: "팀장",
-    sourceMeeting: { title: "캠페인 자산 제작 팀 액션 회의", scheduledAt: "2026-08-15T14:00" },
+    sourceMeeting: {
+      id: 7,
+      title: "캠페인 자산 제작 팀 액션 회의",
+      scheduledAt: "2026-08-15T14:00",
+    },
     parentTeamAction: { id: 6, name: "캠페인 자산 제작", team: "마케팅팀", dueDate: "2026-09-12" },
   },
   9: {
@@ -131,7 +148,11 @@ export const PERSONAL_ACTION_DETAIL_MOCK: Record<number, PersonalActionDetail> =
     projectTag: "COLLAB",
     assigneeName: "김서준",
     assigneeRoleLabel: "팀장",
-    sourceMeeting: { title: "협업툴 리뉴얼 착수 팀 액션 회의", scheduledAt: "2026-07-25T11:00" },
+    sourceMeeting: {
+      id: 8,
+      title: "협업툴 리뉴얼 착수 팀 액션 회의",
+      scheduledAt: "2026-07-25T11:00",
+    },
     parentTeamAction: { id: 7, name: "협업툴 리뉴얼 착수", team: "개발팀", dueDate: "2026-08-25" },
   },
   10: {
@@ -144,6 +165,7 @@ export const PERSONAL_ACTION_DETAIL_MOCK: Record<number, PersonalActionDetail> =
     assigneeName: "오현우",
     assigneeRoleLabel: "팀장",
     sourceMeeting: {
+      id: 10,
       title: "회의·문서·일정 흐름 통합 설계 팀 액션 회의",
       scheduledAt: "2026-08-10T14:00",
     },

--- a/src/features/action/server.ts
+++ b/src/features/action/server.ts
@@ -1,5 +1,9 @@
+import { requireAccessToken } from "@/features/auth/session";
+import { ApiError, serverApi } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
 import { isMock } from "@/mocks/config";
 
+import { type BeActionDetail, toPersonalActionDetail } from "./mapper";
 import { PERSONAL_ACTION_DETAIL_MOCK } from "./mock/action-detail";
 import type { PersonalActionDetail } from "./types";
 
@@ -13,5 +17,15 @@ export async function getPersonalActionDetail(
     return PERSONAL_ACTION_DETAIL_MOCK[numericId] ?? null;
   }
 
-  throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
+  const numericId = Number(actionId);
+  if (!Number.isInteger(numericId)) return null;
+
+  const accessToken = await requireAccessToken();
+  try {
+    const detail = await serverApi<BeActionDetail>(ep.action(numericId), { accessToken });
+    return toPersonalActionDetail(detail);
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) return null;
+    throw error;
+  }
 }

--- a/src/features/action/types.ts
+++ b/src/features/action/types.ts
@@ -17,9 +17,11 @@ export interface PersonalActionDetail {
   assigneeRoleLabel?: string;
   /**
    * 이 개인 액션이 나온 회의 — **수동으로 추가한 액션(`POST /api/actions` 예외 경로)엔 없다**
-   * (2026-08-11, 실 API 대조 확인). ⚠️ 회의 상세(`/app/meeting/:id`) 라우트가 아직 없어 링크는 없다.
+   * (2026-08-11, 실 API 대조 확인). 클릭 시 `/app/meeting/:id`로 이동(2026-08-11, 회의 상세
+   * 라우트가 생겨 링크 추가).
    */
   sourceMeeting?: {
+    id: number;
     title: string;
     /** ISO datetime */
     scheduledAt: string;

--- a/src/features/action/types.ts
+++ b/src/features/action/types.ts
@@ -13,16 +13,22 @@ export interface PersonalActionDetail {
   projectId: number;
   projectTag: string;
   assigneeName: string;
-  /** 본인 역할 — "프론트엔드"·"백엔드" 등. Leader면 "팀장". */
-  assigneeRoleLabel: string;
-  /** 이 개인 액션이 나온 팀 액션 회의. ⚠️ 회의 상세(`/app/meeting/:id`) 라우트가 아직 없어 링크는 없다. */
-  sourceMeeting: {
+  /** 본인 역할 — "프론트엔드"·"백엔드" 등. Leader면 "팀장". 역할 미지정이면 없음. */
+  assigneeRoleLabel?: string;
+  /**
+   * 이 개인 액션이 나온 회의 — **수동으로 추가한 액션(`POST /api/actions` 예외 경로)엔 없다**
+   * (2026-08-11, 실 API 대조 확인). ⚠️ 회의 상세(`/app/meeting/:id`) 라우트가 아직 없어 링크는 없다.
+   */
+  sourceMeeting?: {
     title: string;
     /** ISO datetime */
     scheduledAt: string;
   };
-  /** 상위 팀 액션 — 클릭 시 `/app/projects/:projectId/team/:teamActionId`로 이동. */
-  parentTeamAction: {
+  /**
+   * 상위 팀 액션 — **수동으로 추가한 액션엔 없다**(같은 이유, 2026-08-11 확인).
+   * 클릭 시 `/app/projects/:projectId/team/:teamActionId`로 이동.
+   */
+  parentTeamAction?: {
     id: number;
     name: string;
     team: string;

--- a/src/features/board/actions.ts
+++ b/src/features/board/actions.ts
@@ -3,12 +3,16 @@
 import { revalidatePath } from "next/cache";
 
 import { ACTION_STATUS } from "@/constants/domain";
+import { requireAccessToken } from "@/features/auth/session";
 import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
 import { TEAM_ACTION_PERSONAL_ITEMS_MOCK } from "@/features/project/mock/team-action-detail";
+import { serverApi } from "@/lib/api";
 import { todayIso } from "@/lib/date";
+import { ep } from "@/lib/endpoints";
 import { isMock } from "@/mocks/config";
 
 import { canMoveCard, getBoardColumn } from "./lib";
+import { getMyActionBoard, getProjectBoard } from "./server";
 import { BOARD_COLUMN, type BoardChange, type BoardColumnId, type BoardType } from "./types";
 
 const BOARD_PATH = "/app/board";
@@ -29,9 +33,7 @@ export async function commitBoardChangesAction(
   boardType: BoardType,
   changes: BoardChange[],
 ): Promise<{ appliedCount: number }> {
-  if (!isMock) {
-    throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
-  }
+  if (!isMock) return commitBoardChangesLive(boardType, changes);
 
   const today = new Date();
   const items = boardType === "project" ? TOP_LEVEL_PROJECTS : findAllPersonalItems();
@@ -54,6 +56,56 @@ export async function commitBoardChangesAction(
 
   revalidatePath(BOARD_PATH);
   return { appliedCount };
+}
+
+/**
+ * 실연동 저장 — mock의 `applyColumnChange`(로컬 배열 직접 수정)를 못 쓴다. 대신 **지금
+ * 카드 상태를 다시 조회**해 각 변경의 현재 칸을 알아내고(§권한: 화면 숨김은 보안이 아니다,
+ * 클라가 보낸 `toColumn`만 믿지 않는다), `canMoveCard`로 한 번 더 거른 뒤 유효한 것만
+ * bulk API로 보낸다. 두 벌크 API(`/api/projects/status/bulk`·`/api/actions/complete/bulk`)
+ * 둘 다 all-or-nothing이라, 유효한 항목만 추려 보내면 실패할 이유가 없다(호출자 소유
+ * 액션만 보드에 뜨므로 "담당자 본인" 검사도 걸릴 게 없다).
+ */
+async function commitBoardChangesLive(
+  boardType: BoardType,
+  changes: BoardChange[],
+): Promise<{ appliedCount: number }> {
+  const today = new Date();
+  const currentCards =
+    boardType === "project" ? await getProjectBoard() : await getMyActionBoard("");
+
+  const validItems = changes
+    .map((change) => {
+      const card = currentCards.find((candidate) => candidate.id === change.id);
+      if (!card) return null;
+      const currentColumn = getBoardColumn(card, today);
+      if (!canMoveCard(currentColumn, change.toColumn)) return null;
+      return { id: change.id, status: change.toColumn };
+    })
+    .filter((item): item is { id: number; status: BoardColumnId } => item !== null);
+
+  if (validItems.length === 0) {
+    revalidatePath(BOARD_PATH);
+    return { appliedCount: 0 };
+  }
+
+  const accessToken = await requireAccessToken();
+  if (boardType === "project") {
+    await serverApi(ep.projectStatusBulk(), {
+      method: "PATCH",
+      accessToken,
+      json: { items: validItems.map((item) => ({ projectId: item.id, status: item.status })) },
+    });
+  } else {
+    await serverApi(ep.actionCompleteBulk(), {
+      method: "PATCH",
+      accessToken,
+      json: { items: validItems.map((item) => ({ actionId: item.id, status: item.status })) },
+    });
+  }
+
+  revalidatePath(BOARD_PATH);
+  return { appliedCount: validItems.length };
 }
 
 function findAllPersonalItems() {

--- a/src/features/board/components/board-view.tsx
+++ b/src/features/board/components/board-view.tsx
@@ -63,6 +63,21 @@ export function BoardView({ boardType, cards, todayIso }: BoardViewProps) {
     return overrides[card.id] ?? getBoardColumn(card, today);
   }
 
+  /**
+   * 서버에 실제로 저장된 칸 — override를 무시한다.
+   * ⚠️ **드래그 유효성은 항상 이 값 기준으로 본다**, 화면에 보이는 `columnOf`(override 포함) 기준이
+   *    아니다(2026-08-11 버그 수정). override 기준으로 검사하면 두 가지 문제가 있었다:
+   *    ① 할일→진행중으로 옮긴 걸 다시 할일로 되돌리려 하면 "진행중→할일은 금지"에 걸려 막혔다 —
+   *       원본과 같은 칸으로 돌아가는 건 사실 아무것도 안 바뀐 것인데 금지 규칙이 잘못 적용됨.
+   *    ② 할일→진행중→완료를 드래그 두 번으로 이으면 로컬에서는 통과됐지만, 저장 시 서버는
+   *       "할일→완료 직행"으로 보고 거부했다(서버는 마지막 상태만 본다) — 잠재 버그였다.
+   *    원본 기준으로 보면 되돌리기는 항상 허용(같은 칸)되고, 두 번째 문제도 드래그 시점에
+   *    바로 막혀서 저장 실패로 이어지지 않는다.
+   */
+  function originalColumnOf(card: BoardCard): BoardColumnId {
+    return getBoardColumn(card, today);
+  }
+
   const groups: Record<BoardColumnId, BoardCard[]> = { TODO: [], IN_PROGRESS: [], DONE: [] };
   for (const card of cards) groups[columnOf(card)].push(card);
 
@@ -82,7 +97,7 @@ export function BoardView({ boardType, cards, todayIso }: BoardViewProps) {
     const card = cards.find((c) => c.id === event.active.id);
     const targetColumn = event.over.id as BoardColumnId;
     if (!card) return;
-    setActiveInvalidTarget(canMoveCard(columnOf(card), targetColumn) ? null : targetColumn);
+    setActiveInvalidTarget(canMoveCard(originalColumnOf(card), targetColumn) ? null : targetColumn);
   }
 
   function handleDragEnd(event: DragEndEvent) {
@@ -92,10 +107,20 @@ export function BoardView({ boardType, cards, todayIso }: BoardViewProps) {
     if (!event.over) return;
     const card = cards.find((c) => c.id === event.active.id);
     if (!card) return;
-    const from = columnOf(card);
     const to = event.over.id as BoardColumnId;
-    if (from === to) return;
-    if (!canMoveCard(from, to)) {
+    if (columnOf(card) === to) return; // 화면에 이미 보이는 칸으로 또 놓은 것 — 아무것도 안 한다.
+
+    const originalColumn = originalColumnOf(card);
+    if (originalColumn === to) {
+      // 원래 있던 칸으로 되돌아왔다 — 실제로는 변경이 없는 것이니 override를 지운다.
+      setOverrides((prev) => {
+        const next = { ...prev };
+        delete next[card.id];
+        return next;
+      });
+      return;
+    }
+    if (!canMoveCard(originalColumn, to)) {
       toast.error("여기로는 옮길 수 없습니다");
       return;
     }

--- a/src/features/board/server.ts
+++ b/src/features/board/server.ts
@@ -1,9 +1,14 @@
 import { ACTION_STATUS, AUTHORITY, type Authority, PROJECT_STATUS } from "@/constants/domain";
+import { type BeActionSummary, fallbackActionStartDate } from "@/features/action/mapper";
+import { requireAccessToken } from "@/features/auth/session";
+import type { BePageResponse, BeProjectSummary } from "@/features/project/mapper";
 import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
 import {
   TEAM_ACTION_DETAIL_MOCK,
   TEAM_ACTION_PERSONAL_ITEMS_MOCK,
 } from "@/features/project/mock/team-action-detail";
+import { serverApi } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
 import { pickPaletteColor } from "@/lib/palette";
 import { isMock } from "@/mocks/config";
 
@@ -27,7 +32,25 @@ export async function getProjectBoard(): Promise<BoardCard[]> {
     });
   }
 
-  throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
+  // ⚠️ 무한스크롤은 이 화면(보드)에 안 맞는다 — 칸반은 처음부터 전체가 보여야 하니
+  //    size를 크게 잡아 사실상 전체를 받는다(project/server.ts의 fetchAllProjects와 같은 방식).
+  const accessToken = await requireAccessToken();
+  const page = await serverApi<BePageResponse<BeProjectSummary>>(ep.projects({ size: 9999 }), {
+    accessToken,
+  });
+  return page.content.map((project) => {
+    const tagColor = pickPaletteColor(project.tag);
+    return {
+      id: project.id,
+      title: project.name,
+      tagLabel: project.tag,
+      tagBgColor: tagColor.bgColor,
+      tagTextColor: tagColor.textColor,
+      startDate: project.startDate ?? new Date().toISOString().slice(0, 10),
+      dueDate: project.dueDate,
+      isDone: project.status === PROJECT_STATUS.DONE,
+    };
+  });
 }
 
 /**
@@ -59,7 +82,27 @@ export async function getMyActionBoard(assigneeName: string): Promise<BoardCard[
     return cards;
   }
 
-  throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
+  // ⚠️ `assigneeName`은 실연동에선 안 쓴다 — `GET /api/actions`가 이미 토큰의 본인 소유분만
+  //    돌려준다(BE 실코드 확인). 파라미터는 mock 분기 전용으로 시그니처만 유지한다.
+  const accessToken = await requireAccessToken();
+  const page = await serverApi<BePageResponse<BeActionSummary>>(ep.actions({ size: 9999 }), {
+    accessToken,
+  });
+  return page.content
+    .filter((action) => action.actionType === "PERSONAL")
+    .map((action) => {
+      const tagColor = pickPaletteColor(action.projectTag ?? "");
+      return {
+        id: action.id,
+        title: action.title,
+        tagLabel: action.projectTag ?? "",
+        tagBgColor: tagColor.bgColor,
+        tagTextColor: tagColor.textColor,
+        startDate: fallbackActionStartDate(action.startDate),
+        dueDate: action.dueDate,
+        isDone: action.status === ACTION_STATUS.DONE,
+      };
+    });
 }
 
 /**

--- a/src/features/member/server.ts
+++ b/src/features/member/server.ts
@@ -1,9 +1,13 @@
+import { type BeActionSummary, toMemberAction } from "@/features/action/mapper";
+import { requireAccessToken } from "@/features/auth/session";
+import type { BePageResponse } from "@/features/project/mapper";
+import { serverApi } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
+import { isMock } from "@/mocks/config";
+
 import { getDaysUntilDue, isDueSoon, MEETING_MAX_ITEMS } from "./lib";
 import { MEMBER_ACTIONS_MOCK, MEMBER_ATTENDED_MEETINGS_MOCK } from "./mock/dashboard";
 import type { MemberDashboardOverview } from "./types";
-
-// ⚠️ ERD·API 스펙 미확정(BE 협의 전) — 지금은 목 고정. 확정되면 이 분기만 손댄다.
-const isMock = true;
 
 export async function getMemberDashboardOverview(): Promise<MemberDashboardOverview> {
   if (isMock) {
@@ -18,5 +22,25 @@ export async function getMemberDashboardOverview(): Promise<MemberDashboardOverv
         .slice(0, MEETING_MAX_ITEMS),
     };
   }
-  throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
+
+  // ⚠️ "처리할 액션"은 우리 도메인(개인 액션)이라 바로 연동한다. GET /api/actions는 이미
+  //    본인 소유분만 스코프돼 있어서(토큰 기준), 여기선 PERSONAL만 남기고 마감 임박 필터·
+  //    정렬만 클라에서 한다(BE 목록에 이 필터 자체가 없다).
+  const accessToken = await requireAccessToken();
+  const page = await serverApi<BePageResponse<BeActionSummary>>(ep.actions({ size: 9999 }), {
+    accessToken,
+  });
+  const dueSoonActions = page.content
+    .filter((action) => action.actionType === "PERSONAL")
+    .map(toMemberAction)
+    .filter(isDueSoon)
+    .sort((a, b) => getDaysUntilDue(a.dueDate) - getDaysUntilDue(b.dueDate));
+
+  /*
+    ⚠️ "참석 회의"는 회의 도메인 몫이다(캘린더·Todo와 같은 성격, 우리 담당 아님) — 회의
+    담당자가 아직 API를 안 붙였다. 옛 mock 회의를 계속 보여주면 연동된 것처럼 보여서
+    거짓말이 된다(§정직성) — 그 담당자가 붙이기 전까지는 빈 배열이 맞다. 화면엔 이미
+    "참석할 회의가 없습니다" 빈 상태가 있어 자연스럽게 처리된다.
+  */
+  return { dueSoonActions, attendedMeetings: [] };
 }

--- a/src/features/project/actions.ts
+++ b/src/features/project/actions.ts
@@ -3,11 +3,16 @@
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
+import { requireAccessToken } from "@/features/auth/session";
 import { getViewer } from "@/features/shell/viewer";
+import { ApiError, serverApi } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
 import { canCreateProject } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
+import { toCreateProjectRequestBody } from "./mapper";
 import { addMockProject } from "./mock/projects";
+import { resolveTeamIds } from "./server";
 import type { ProjectDraft, ProjectFormErrors } from "./types";
 import { validateProjectDraft } from "./validate";
 
@@ -49,8 +54,21 @@ export async function createProjectAction(
   if (Object.keys(errors).length > 0) return { errors };
 
   if (!isMock) {
-    // ⚠️ 미구현 — API 스펙 확정 후 BFF 경로로 생성 요청을 보낸다(첨부파일 업로드 포함).
-    throw new Error("프로젝트 생성 API가 아직 연결되지 않았습니다.");
+    // ⚠️ 첨부파일은 아직 안 보낸다 — 생성 폼에 실제 파일 선택 UI가 없다(`attachmentName`은
+    //    지금도 목 단계 자리표시자다). 업로드 3단계(발급→업로드→확정)는 화면이 생기면 잇는다.
+    const accessToken = await requireAccessToken();
+    const teamIds = await resolveTeamIds(accessToken, draft.teamNames);
+    const body = toCreateProjectRequestBody(draft, teamIds);
+
+    try {
+      await serverApi(ep.projects(), { method: "POST", json: body, accessToken });
+    } catch (error) {
+      if (error instanceof ApiError) return { errors: { name: error.message } };
+      throw error;
+    }
+
+    revalidatePath(LIST_PATH);
+    redirect(LIST_PATH);
   }
 
   addMockProject(draft);
@@ -58,4 +76,22 @@ export async function createProjectAction(
   revalidatePath(LIST_PATH);
   // ⚠️ `redirect`는 내부적으로 예외를 던진다 — try/catch 밖에 둔다(§렌더링·데이터)
   redirect(LIST_PATH);
+}
+
+/**
+ * 첨부파일 다운로드 URL 발급 — 클릭 시점에 부른다(5분 만료라 미리 받아두면 안 된다).
+ * ⚠️ mock 단계는 파일이 실제로 없어 발급할 게 없다 — 호출부가 `null`을 보고 "연동 전" 토스트를 띄운다.
+ */
+export async function getProjectAttachmentDownloadUrlAction(
+  projectId: number,
+  attachmentId: number,
+): Promise<string | null> {
+  if (isMock) return null;
+
+  const accessToken = await requireAccessToken();
+  const { downloadUrl } = await serverApi<{ downloadUrl: string; expiresInSeconds: number }>(
+    ep.projectAttachmentDownloadUrl(projectId, attachmentId),
+    { accessToken },
+  );
+  return downloadUrl;
 }

--- a/src/features/project/actions.ts
+++ b/src/features/project/actions.ts
@@ -95,3 +95,18 @@ export async function getProjectAttachmentDownloadUrlAction(
   );
   return downloadUrl;
 }
+
+/** 팀 액션 상세의 첨부파일 다운로드 URL 발급 — 프로젝트 쪽과 같은 패턴, 경로만 다르다. */
+export async function getTeamActionAttachmentDownloadUrlAction(
+  teamActionId: number,
+  attachmentId: number,
+): Promise<string | null> {
+  if (isMock) return null;
+
+  const accessToken = await requireAccessToken();
+  const { downloadUrl } = await serverApi<{ downloadUrl: string; expiresInSeconds: number }>(
+    ep.teamActionAttachmentDownloadUrl(teamActionId, attachmentId),
+    { accessToken },
+  );
+  return downloadUrl;
+}

--- a/src/features/project/components/project-attachment-list.tsx
+++ b/src/features/project/components/project-attachment-list.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { Paperclip } from "lucide-react";
+import { toast } from "sonner";
+
+import { getProjectAttachmentDownloadUrlAction } from "../actions";
+import type { ProjectAttachment } from "../types";
+
+interface ProjectAttachmentListProps {
+  projectId: number;
+  attachments: ProjectAttachment[];
+}
+
+/**
+ * 프로젝트 상세의 첨부파일 목록 — 클릭하면 그 자리에서 다운로드 URL을 발급받아 새 탭으로 연다.
+ * ⚠️ **미리 발급받아 두지 않는다**(5분 만료, 2026-08-10 연동 가이드) — 클릭한 시점에만 부른다.
+ * ⚠️ mock 단계는 발급할 실제 파일이 없어 액션이 `null`을 돌려준다 — 그러면 조용히 실패하는
+ *    대신 "아직 연동되지 않았다"고 알린다(handover-approval-card.tsx의 PDF 스텁과 같은 패턴).
+ */
+export function ProjectAttachmentList({ projectId, attachments }: ProjectAttachmentListProps) {
+  if (attachments.length === 0) return null;
+
+  async function handleClick(attachmentId: number) {
+    const url = await getProjectAttachmentDownloadUrlAction(projectId, attachmentId);
+    if (!url) {
+      toast("다운로드는 아직 연동되지 않았습니다");
+      return;
+    }
+    window.open(url, "_blank", "noopener,noreferrer");
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      {attachments.map((attachment) => (
+        <button
+          key={attachment.id}
+          type="button"
+          onClick={() => handleClick(attachment.id)}
+          className="text-muted-foreground hover:text-foreground inline-flex w-fit items-center gap-1.5 text-[13px] leading-5 underline-offset-2 hover:underline"
+        >
+          <Paperclip className="size-3.5" aria-hidden />
+          {attachment.fileName}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/features/project/mapper.ts
+++ b/src/features/project/mapper.ts
@@ -1,0 +1,170 @@
+import type { ProjectStatus } from "@/constants/domain";
+import { hexFromTagName } from "@/lib/palette";
+
+import type {
+  ProjectAttachment,
+  ProjectDetail,
+  ProjectDraft,
+  ProjectListItem,
+  ProjectTeamAction,
+} from "./types";
+
+/**
+ * BE shape → UI 계약 (§Mock 격리막 — 흡수하는 곳은 여기 하나다).
+ * [확인] 잇다(Z) REST API 연동 가이드 최종본(2026-08-10) + BACKEND 실코드 대조
+ *   `project/presentation/api/response/{ProjectSummaryResponse,ProjectDetailResponse}.java`
+ */
+
+/** [확인] `ProjectSummaryResponse` */
+export interface BeProjectSummary {
+  id: number;
+  tag: string;
+  color: string;
+  name: string;
+  status: ProjectStatus;
+  /** 마이그레이션 이전 생성 프로젝트는 `null` — 채울 원천이 없다. */
+  startDate: string | null;
+  dueDate: string;
+  teamCount: number;
+  actionCount: number;
+  completedActionCount: number;
+  meetingCount: number;
+  progressPct: number;
+  /** 생성·수정 응답에서는 항상 빈 배열 — 실제 값은 목록 조회에서만 온다. */
+  teamNames: string[];
+}
+
+/** [확인] `AttachmentResponse` */
+export interface BeAttachment {
+  attachmentId: number;
+  fileName: string;
+  /** 브라우저로 못 여는 S3 오브젝트 키 — 다운로드는 별도 발급 API를 거친다. */
+  fileUrl: string;
+  fileSize: number;
+  createdAt: string;
+}
+
+/** [확인] `ProjectDetailResponse` */
+export interface BeProjectDetail {
+  id: number;
+  tag: string;
+  color: string;
+  name: string;
+  description: string;
+  status: ProjectStatus;
+  startDate: string | null;
+  dueDate: string;
+  teamIds: number[];
+  attachments: BeAttachment[];
+}
+
+/** [확인] `ProjectTimelineItemResponse` */
+export interface BeProjectTimelineItem {
+  actionId: number;
+  title: string;
+  teamId: number;
+  teamName: string;
+  status: ProjectStatus;
+  dueDate: string;
+  isDelayed: boolean;
+}
+
+/** [확인] `PageResponse<T>` — 목록 3종(project·action·team action) 공용 봉투. */
+export interface BePageResponse<T> {
+  content: T[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+  hasNext: boolean;
+}
+
+/**
+ * ⚠️ **`startDate`가 `null`이면 오늘로 대신 채운다.** 보드 칸 구분(`getBoardColumn`)이
+ *    `Pick<..,"startDate">`를 문자열로 가정하고 있어 `null`을 그대로 넘기면 계산이 깨진다.
+ *    마이그레이션 이전에 만들어진 프로젝트라 기록이 없을 뿐이니, "이미 진행 중이었다"로 보고
+ *    오늘 날짜를 넣어 진행중 칸에 들어가게 한다(할일 칸으로 잘못 떨어지는 것보다 안전한 쪽).
+ */
+function fallbackStartDate(startDate: string | null): string {
+  return startDate ?? new Date().toISOString().slice(0, 10);
+}
+
+export function toProjectListItem(be: BeProjectSummary): ProjectListItem {
+  return {
+    id: be.id,
+    name: be.name,
+    // ⚠️ 목록 응답(ProjectSummaryResponse)엔 description이 없다 — 상세에만 있다(BE 실코드 확인,
+    //    2026-08-10). 목록 카드가 첫 줄 스니펫으로 이 값을 쓰고 있어 지금은 빈 문자열로 채운다.
+    description: "",
+    tag: be.tag,
+    departments: be.teamNames,
+    actionTotal: be.actionCount,
+    actionDone: be.completedActionCount,
+    startDate: fallbackStartDate(be.startDate),
+    dueDate: be.dueDate,
+    status: be.status,
+  };
+}
+
+function toProjectAttachment(be: BeAttachment): ProjectAttachment {
+  return { id: be.attachmentId, fileName: be.fileName, fileSize: be.fileSize };
+}
+
+export function toProjectDetail(be: BeProjectDetail, teamNames: string[]): ProjectDetail {
+  return {
+    id: be.id,
+    tag: be.tag,
+    name: be.name,
+    description: be.description,
+    dueDate: be.dueDate,
+    // ⚠️ 상세 응답(ProjectDetailResponse)엔 teamIds만 있고 teamNames가 없다 — 팀 목록을
+    //    따로 조회해 id→이름으로 매핑한 값을 호출부가 넘긴다(server.ts 참고).
+    teamNames,
+    attachments: be.attachments.map(toProjectAttachment),
+  };
+}
+
+export function toProjectTeamAction(be: BeProjectTimelineItem): ProjectTeamAction {
+  return {
+    id: be.actionId,
+    name: be.title,
+    team: be.teamName,
+    // ⚠️ 타임라인 항목엔 startDate가 없다(팀 액션 카드는 진행률만 보여줄 뿐 기간 바가 아니다) —
+    //    ActionTimeline 계약이 요구해서 마감일과 같은 값으로 채운다(막대 폭이 0이 되는 대신
+    //    한 칸짜리로 보인다). 팀 액션에 startDate가 필요해지면 그때 BE에 노출을 요청한다.
+    startDate: be.dueDate,
+    dueDate: be.dueDate,
+    status: be.status,
+  };
+}
+
+/** 프로젝트 생성/수정 요청 바디. */
+export interface CreateProjectRequestBody {
+  name: string;
+  tag: string;
+  description: string;
+  color: string;
+  startDate: string;
+  dueDate: string;
+  teamIds: number[];
+}
+
+/**
+ * 화면 계약(`ProjectDraft`) → BE 요청 바디.
+ * ⚠️ `teamIds`는 호출부가 이름→id로 미리 바꿔 넘긴다(팀 이름 중복이 없다는 전제 — 지금
+ *    회사 팀 목록엔 동명이 없어 괜찮지만, 생기면 이 가정부터 깨진다).
+ */
+export function toCreateProjectRequestBody(
+  draft: ProjectDraft,
+  teamIds: number[],
+): CreateProjectRequestBody {
+  return {
+    name: draft.name,
+    tag: draft.tag,
+    description: draft.description,
+    color: hexFromTagName(draft.tagColor),
+    startDate: draft.startDate,
+    dueDate: draft.dueDate,
+    teamIds,
+  };
+}

--- a/src/features/project/mapper.ts
+++ b/src/features/project/mapper.ts
@@ -106,7 +106,8 @@ export function toProjectListItem(be: BeProjectSummary): ProjectListItem {
   };
 }
 
-function toProjectAttachment(be: BeAttachment): ProjectAttachment {
+/** 팀 액션 상세(action 도메인)도 같은 `Attachment` shape을 복제해서 쓴다 — 그쪽 매퍼가 재사용한다. */
+export function toProjectAttachment(be: BeAttachment): ProjectAttachment {
   return { id: be.attachmentId, fileName: be.fileName, fileSize: be.fileSize };
 }
 

--- a/src/features/project/mock/team-action-detail.ts
+++ b/src/features/project/mock/team-action-detail.ts
@@ -19,7 +19,7 @@ export const TEAM_ACTION_DETAIL_MOCK: Record<number, TeamActionDetail> = {
     projectTag: "GOODS",
     assigneeName: "김서준",
     assigneeRoleLabel: "팀장",
-    sourceMeeting: { title: "프로젝트 기획 회의", scheduledAt: "2026-07-20T14:00" },
+    sourceMeeting: { id: 101, title: "프로젝트 기획 회의", scheduledAt: "2026-07-20T14:00" },
     attachments: [],
   },
   2: {
@@ -31,7 +31,7 @@ export const TEAM_ACTION_DETAIL_MOCK: Record<number, TeamActionDetail> = {
     projectTag: "GOODS",
     assigneeName: "김서준",
     assigneeRoleLabel: "팀장",
-    sourceMeeting: { title: "프로젝트 기획 회의", scheduledAt: "2026-07-20T14:00" },
+    sourceMeeting: { id: 102, title: "프로젝트 기획 회의", scheduledAt: "2026-07-20T14:00" },
     attachments: [],
   },
   3: {
@@ -43,7 +43,7 @@ export const TEAM_ACTION_DETAIL_MOCK: Record<number, TeamActionDetail> = {
     projectTag: "GOODS",
     assigneeName: "최유진",
     assigneeRoleLabel: "팀장",
-    sourceMeeting: { title: "프로젝트 기획 회의", scheduledAt: "2026-07-20T14:00" },
+    sourceMeeting: { id: 103, title: "프로젝트 기획 회의", scheduledAt: "2026-07-20T14:00" },
     attachments: [],
   },
   4: {
@@ -55,7 +55,7 @@ export const TEAM_ACTION_DETAIL_MOCK: Record<number, TeamActionDetail> = {
     projectTag: "GOODS",
     assigneeName: "강서연",
     assigneeRoleLabel: "팀장",
-    sourceMeeting: { title: "프로젝트 기획 회의", scheduledAt: "2026-07-20T14:00" },
+    sourceMeeting: { id: 104, title: "프로젝트 기획 회의", scheduledAt: "2026-07-20T14:00" },
     attachments: [],
   },
   5: {
@@ -67,7 +67,7 @@ export const TEAM_ACTION_DETAIL_MOCK: Record<number, TeamActionDetail> = {
     projectTag: "BRAND",
     assigneeName: "강서연",
     assigneeRoleLabel: "팀장",
-    sourceMeeting: { title: "프로젝트 기획 회의", scheduledAt: "2026-07-31T11:00" },
+    sourceMeeting: { id: 105, title: "프로젝트 기획 회의", scheduledAt: "2026-07-31T11:00" },
     attachments: [],
   },
   6: {
@@ -79,7 +79,7 @@ export const TEAM_ACTION_DETAIL_MOCK: Record<number, TeamActionDetail> = {
     projectTag: "BRAND",
     assigneeName: "최유진",
     assigneeRoleLabel: "팀장",
-    sourceMeeting: { title: "프로젝트 기획 회의", scheduledAt: "2026-07-31T11:00" },
+    sourceMeeting: { id: 106, title: "프로젝트 기획 회의", scheduledAt: "2026-07-31T11:00" },
     attachments: [],
   },
   7: {
@@ -91,7 +91,7 @@ export const TEAM_ACTION_DETAIL_MOCK: Record<number, TeamActionDetail> = {
     projectTag: "COLLAB",
     assigneeName: "김서준",
     assigneeRoleLabel: "팀장",
-    sourceMeeting: { title: "프로젝트 기획 회의", scheduledAt: "2026-07-24T15:00" },
+    sourceMeeting: { id: 107, title: "프로젝트 기획 회의", scheduledAt: "2026-07-24T15:00" },
     attachments: [],
   },
   8: {
@@ -103,7 +103,7 @@ export const TEAM_ACTION_DETAIL_MOCK: Record<number, TeamActionDetail> = {
     projectTag: "COLLAB",
     assigneeName: "오현우",
     assigneeRoleLabel: "팀장",
-    sourceMeeting: { title: "프로젝트 기획 회의", scheduledAt: "2026-07-24T15:00" },
+    sourceMeeting: { id: 108, title: "프로젝트 기획 회의", scheduledAt: "2026-07-24T15:00" },
     attachments: [],
   },
 };

--- a/src/features/project/mock/team-action-detail.ts
+++ b/src/features/project/mock/team-action-detail.ts
@@ -20,6 +20,7 @@ export const TEAM_ACTION_DETAIL_MOCK: Record<number, TeamActionDetail> = {
     assigneeName: "김서준",
     assigneeRoleLabel: "팀장",
     sourceMeeting: { title: "프로젝트 기획 회의", scheduledAt: "2026-07-20T14:00" },
+    attachments: [],
   },
   2: {
     id: 2,
@@ -31,6 +32,7 @@ export const TEAM_ACTION_DETAIL_MOCK: Record<number, TeamActionDetail> = {
     assigneeName: "김서준",
     assigneeRoleLabel: "팀장",
     sourceMeeting: { title: "프로젝트 기획 회의", scheduledAt: "2026-07-20T14:00" },
+    attachments: [],
   },
   3: {
     id: 3,
@@ -42,6 +44,7 @@ export const TEAM_ACTION_DETAIL_MOCK: Record<number, TeamActionDetail> = {
     assigneeName: "최유진",
     assigneeRoleLabel: "팀장",
     sourceMeeting: { title: "프로젝트 기획 회의", scheduledAt: "2026-07-20T14:00" },
+    attachments: [],
   },
   4: {
     id: 4,
@@ -53,6 +56,7 @@ export const TEAM_ACTION_DETAIL_MOCK: Record<number, TeamActionDetail> = {
     assigneeName: "강서연",
     assigneeRoleLabel: "팀장",
     sourceMeeting: { title: "프로젝트 기획 회의", scheduledAt: "2026-07-20T14:00" },
+    attachments: [],
   },
   5: {
     id: 5,
@@ -64,6 +68,7 @@ export const TEAM_ACTION_DETAIL_MOCK: Record<number, TeamActionDetail> = {
     assigneeName: "강서연",
     assigneeRoleLabel: "팀장",
     sourceMeeting: { title: "프로젝트 기획 회의", scheduledAt: "2026-07-31T11:00" },
+    attachments: [],
   },
   6: {
     id: 6,
@@ -75,6 +80,7 @@ export const TEAM_ACTION_DETAIL_MOCK: Record<number, TeamActionDetail> = {
     assigneeName: "최유진",
     assigneeRoleLabel: "팀장",
     sourceMeeting: { title: "프로젝트 기획 회의", scheduledAt: "2026-07-31T11:00" },
+    attachments: [],
   },
   7: {
     id: 7,
@@ -86,6 +92,7 @@ export const TEAM_ACTION_DETAIL_MOCK: Record<number, TeamActionDetail> = {
     assigneeName: "김서준",
     assigneeRoleLabel: "팀장",
     sourceMeeting: { title: "프로젝트 기획 회의", scheduledAt: "2026-07-24T15:00" },
+    attachments: [],
   },
   8: {
     id: 8,
@@ -97,6 +104,7 @@ export const TEAM_ACTION_DETAIL_MOCK: Record<number, TeamActionDetail> = {
     assigneeName: "오현우",
     assigneeRoleLabel: "팀장",
     sourceMeeting: { title: "프로젝트 기획 회의", scheduledAt: "2026-07-24T15:00" },
+    attachments: [],
   },
 };
 

--- a/src/features/project/server.ts
+++ b/src/features/project/server.ts
@@ -1,6 +1,11 @@
 import { DEFAULT_PROJECT_SORT, type ProjectSort, type ProjectStatus } from "@/constants/domain";
 import { COMPANY_TEAM_NAMES } from "@/constants/project";
-import { type BeActionSummary, toTeamActionPersonalItem } from "@/features/action/mapper";
+import {
+  type BeActionSummary,
+  type BeTeamActionDetail,
+  toTeamActionDetail,
+  toTeamActionPersonalItem,
+} from "@/features/action/mapper";
 import { requireAccessToken } from "@/features/auth/session";
 import { ApiError, serverApi } from "@/lib/api";
 import { ep } from "@/lib/endpoints";
@@ -164,7 +169,17 @@ export async function getTeamActionDetail(teamActionId: string): Promise<TeamAct
     return TEAM_ACTION_DETAIL_MOCK[numericId] ?? null;
   }
 
-  throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
+  const numericId = Number(teamActionId);
+  if (!Number.isInteger(numericId)) return null;
+
+  const accessToken = await requireAccessToken();
+  try {
+    const detail = await serverApi<BeTeamActionDetail>(ep.teamAction(numericId), { accessToken });
+    return toTeamActionDetail(detail);
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) return null;
+    throw error;
+  }
 }
 
 /** 팀 액션 상세의 타임라인 탭 — 이 팀 액션에 속한 개인 액션 전체(담당자별 한 행). */

--- a/src/features/project/server.ts
+++ b/src/features/project/server.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_PROJECT_SORT, type ProjectSort, type ProjectStatus } from "@/constants/domain";
 import { COMPANY_TEAM_NAMES } from "@/constants/project";
+import { type BeActionSummary, toTeamActionPersonalItem } from "@/features/action/mapper";
 import { requireAccessToken } from "@/features/auth/session";
 import { ApiError, serverApi } from "@/lib/api";
 import { ep } from "@/lib/endpoints";
@@ -176,7 +177,17 @@ export async function getTeamActionPersonalItems(
     return TEAM_ACTION_PERSONAL_ITEMS_MOCK[numericId] ?? [];
   }
 
-  throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
+  const numericId = Number(teamActionId);
+  if (!Number.isInteger(numericId)) return [];
+
+  // ⚠️ 이 함수는 실연동 준비만 끝난 상태다 — 유일한 호출부(팀 액션 상세 페이지)가
+  //    `getTeamActionDetail`(아래, 필드 부족으로 여전히 미구현) 뒤에 있어서 지금은 화면에서
+  //    닿지 않는다. 상세 필드가 채워지면 그 페이지를 여는 순간 바로 같이 동작한다.
+  const accessToken = await requireAccessToken();
+  const items = await serverApi<BeActionSummary[]>(ep.teamActionTimeline(numericId), {
+    accessToken,
+  });
+  return items.map(toTeamActionPersonalItem);
 }
 
 /** 프로젝트 생성 폼의 "참여 팀" 선택지 — 회사 전체 팀 목록. */

--- a/src/features/project/server.ts
+++ b/src/features/project/server.ts
@@ -1,8 +1,18 @@
 import { DEFAULT_PROJECT_SORT, type ProjectSort, type ProjectStatus } from "@/constants/domain";
 import { COMPANY_TEAM_NAMES } from "@/constants/project";
+import { requireAccessToken } from "@/features/auth/session";
+import { ApiError, serverApi } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
 import { isMock } from "@/mocks/config";
 
 import { sortProjects } from "./lib";
+import type {
+  BePageResponse,
+  BeProjectDetail,
+  BeProjectSummary,
+  BeProjectTimelineItem,
+} from "./mapper";
+import { toProjectDetail, toProjectListItem, toProjectTeamAction } from "./mapper";
 import { TOP_LEVEL_PROJECTS } from "./mock/projects";
 import {
   TEAM_ACTION_DETAIL_MOCK,
@@ -16,6 +26,32 @@ import type {
   TeamActionDetail,
   TeamActionPersonalItem,
 } from "./types";
+
+/** [확인] `TeamController` 응답 — `teamId`·`name`만 쓴다(company/mapper.ts의 `BeTeam`과 같은 shape). */
+interface BeTeamOption {
+  teamId: number;
+  name: string;
+}
+
+/**
+ * 회사 팀 목록 — 이름↔id 변환에 쓴다. 상세 응답(`teamIds`)을 이름으로 보여줄 때,
+ * 생성 폼이 고른 이름을 id로 되돌릴 때 둘 다 여기서 가져온 값을 쓴다.
+ * ⚠️ **이름 중복이 없다는 전제.** 같은 이름의 팀이 둘 생기면 이 매핑이 먼저 잡힌 쪽으로 뭉갠다 —
+ *    지금 팀 이름 정책상 중복을 안 만들지만, 생기면 여기부터 깨진다.
+ */
+async function getTeamOptions(accessToken: string): Promise<BeTeamOption[]> {
+  return serverApi<BeTeamOption[]>(ep.teams(), { accessToken });
+}
+
+/** 목록 API가 페이지네이션이 생겼지만, 이 화면은 아직 전체를 한 번에 받아 클라에서 거른다
+ *  (§목록·페이지네이션 무한스크롤은 별도 작업 — 지금은 기존 화면 동작과 동등하게만 맞춘다).
+ *  `size`를 크게 잡으면 사실상 전체가 온다(문서 안내 그대로). */
+async function fetchAllProjects(accessToken: string): Promise<BeProjectSummary[]> {
+  const page = await serverApi<BePageResponse<BeProjectSummary>>(ep.projects({ size: 9999 }), {
+    accessToken,
+  });
+  return page.content;
+}
 
 /** 이름에 검색어가 들어가는지(대소문자·공백 무시). 검색어가 없으면 항상 통과. */
 function matchesKeyword(project: ProjectListItem, keyword?: string): boolean {
@@ -53,7 +89,12 @@ export async function getProjectList({
     return sortProjects(filtered, sort);
   }
 
-  throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
+  const accessToken = await requireAccessToken();
+  const all = (await fetchAllProjects(accessToken)).map(toProjectListItem);
+  const filtered = all.filter(
+    (project) => project.status === status && matchesKeyword(project, keyword),
+  );
+  return sortProjects(filtered, sort);
 }
 
 /**
@@ -65,6 +106,7 @@ export async function getProjectDetail(id: string): Promise<ProjectDetail | null
   if (isMock) {
     const project = findProjectById(id);
     if (!project) return null;
+    const attachmentName = PROJECT_ATTACHMENT_MOCK[project.tag];
     return {
       id: project.id,
       tag: project.tag,
@@ -72,11 +114,28 @@ export async function getProjectDetail(id: string): Promise<ProjectDetail | null
       description: project.description,
       dueDate: project.dueDate,
       teamNames: project.departments,
-      attachmentName: PROJECT_ATTACHMENT_MOCK[project.tag],
+      attachments: attachmentName ? [{ id: 1, fileName: attachmentName, fileSize: 0 }] : [],
     };
   }
 
-  throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
+  const numericId = Number(id);
+  if (!Number.isInteger(numericId)) return null;
+
+  const accessToken = await requireAccessToken();
+  let detail: BeProjectDetail;
+  try {
+    detail = await serverApi<BeProjectDetail>(ep.project(numericId), { accessToken });
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) return null;
+    throw error;
+  }
+
+  // ⚠️ 상세 응답엔 teamIds만 온다 — 이름으로 보여주려고 팀 목록을 한 번 더 불러 매핑한다.
+  const teamOptions = await getTeamOptions(accessToken);
+  const nameById = new Map(teamOptions.map((team) => [team.teamId, team.name]));
+  const teamNames = detail.teamIds.map((teamId) => nameById.get(teamId) ?? `팀 #${teamId}`);
+
+  return toProjectDetail(detail, teamNames);
 }
 
 /** 프로젝트 상세의 타임라인 탭 — 이 프로젝트에 속한 팀 액션 전체(여러 팀이 하나의 축에 함께). */
@@ -86,7 +145,14 @@ export async function getProjectTeamActions(id: string): Promise<ProjectTeamActi
     return project ? (PROJECT_TEAM_ACTIONS_MOCK[project.tag] ?? []) : [];
   }
 
-  throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
+  const numericId = Number(id);
+  if (!Number.isInteger(numericId)) return [];
+
+  const accessToken = await requireAccessToken();
+  const items = await serverApi<BeProjectTimelineItem[]>(ep.projectTimeline(numericId), {
+    accessToken,
+  });
+  return items.map(toProjectTeamAction);
 }
 
 /** 팀 액션 상세(`/app/projects/:projectId/team/:teamActionId`)의 상세 탭. 못 찾으면 `null`(호출부가 404). */
@@ -117,7 +183,9 @@ export async function getTeamActionPersonalItems(
 export async function getCompanyTeamOptions(): Promise<string[]> {
   if (isMock) return [...COMPANY_TEAM_NAMES];
 
-  throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
+  const accessToken = await requireAccessToken();
+  const teams = await getTeamOptions(accessToken);
+  return teams.map((team) => team.name);
 }
 
 /**
@@ -134,5 +202,22 @@ export async function getProjectStatusCounts(
     return counts;
   }
 
-  throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
+  const accessToken = await requireAccessToken();
+  const all = (await fetchAllProjects(accessToken)).map(toProjectListItem);
+  const counts: Record<ProjectStatus, number> = { TODO: 0, IN_PROGRESS: 0, DONE: 0 };
+  for (const project of all) {
+    if (matchesKeyword(project, keyword)) counts[project.status] += 1;
+  }
+  return counts;
+}
+
+/**
+ * 팀 이름 → id 변환 — 생성 폼이 이름으로 고른 값을 BE `teamIds`로 바꿀 때 쓴다.
+ * ⚠️ 화면 밖에서 부르지 않는다(actions.ts 전용) — `getTeamOptions`는 server-only 모듈이라
+ *    Server Action에서 직접 못 부르길래 이 파일이 대신 감싼다.
+ */
+export async function resolveTeamIds(accessToken: string, teamNames: string[]): Promise<number[]> {
+  const teams = await getTeamOptions(accessToken);
+  const idByName = new Map(teams.map((team) => [team.name, team.teamId]));
+  return teamNames.map((name) => idByName.get(name)).filter((id): id is number => id !== undefined);
 }

--- a/src/features/project/types.ts
+++ b/src/features/project/types.ts
@@ -60,6 +60,13 @@ export type ProjectFormErrors = Partial<
   }
 >;
 
+/** 프로젝트 첨부파일 한 건 — 다운로드는 클릭 시점에 별도로 URL을 발급받아 연다(5분 만료). */
+export interface ProjectAttachment {
+  id: number;
+  fileName: string;
+  fileSize: number;
+}
+
 /**
  * 프로젝트 상세(`/app/projects/:projectId`)의 기획 탭. `ProjectListItem`과 필드가 겹치지만
  * 목록에 없는 첨부파일이 있어 별도 타입으로 둔다 — 목록 카드에 첨부파일까지 끌고 오지 않는다.
@@ -74,8 +81,8 @@ export interface ProjectDetail {
   dueDate: string;
   /** 참여 팀 전체 — 목록과 달리 자르지 않는다(상세라 다 보여준다) */
   teamNames: string[];
-  /** ⚠️ 목 단계라 파일명만 — 실제 다운로드는 API 스펙 확정 후 */
-  attachmentName?: string;
+  /** 여러 개 가능(2026-08-10 다운로드 URL 발급 API 반영) — 예전엔 파일명 하나만 목 단계로 들고 있었다. */
+  attachments: ProjectAttachment[];
 }
 
 /**

--- a/src/features/project/types.ts
+++ b/src/features/project/types.ts
@@ -103,8 +103,10 @@ export interface ProjectTeamAction {
 
 /**
  * 팀 액션 상세(`/app/projects/:projectId/team/:teamActionId`)의 상세 탭.
- * ⚠️ 담당자는 이 팀 액션을 받은 팀의 **팀장**이다(`assigneeRoleLabel`은 항상 "팀장") —
- *    개인 액션 상세를 만들 때는 같은 필드에 그 사람 본인 역할이 들어간다.
+ * ⚠️ **담당자는 저장된 값이 아니다** — BE가 그 팀의 현재 팀장을 그때그때 유도해서 채운다
+ *    (2026-08-11, BACKEND PR #339). 팀장 공석이면 `assigneeName`·`assigneeRoleLabel` 둘 다 없다
+ *    — 실제로 "팀장 없음"이 정상 상태라 optional이다(개인 액션 상세를 만들 때는 같은 자리에
+ *    그 사람 본인 역할이 들어간다는 점만 개념이 다르다).
  */
 export interface TeamActionDetail {
   /** BE 자동증가 정수 PK — `ProjectTeamAction.id`와 같은 값. */
@@ -114,14 +116,17 @@ export interface TeamActionDetail {
   team: string;
   projectId: number;
   projectTag: string;
-  assigneeName: string;
-  assigneeRoleLabel: string;
-  /** 이 팀 액션이 나온 프로젝트 회의. ⚠️ 회의 상세(`/app/meeting/:id`) 라우트가 아직 없어 링크는 없다. */
-  sourceMeeting: {
+  /** 팀장 공석이면 없음. */
+  assigneeName?: string;
+  /** `"{팀명}장"` 고정 포맷(BE가 조립) — 팀장 공석이면 없음. */
+  assigneeRoleLabel?: string;
+  /** 이 팀 액션이 나온 프로젝트 회의 — 수동 추가 등으로 출처가 없으면 없음. */
+  sourceMeeting?: {
     title: string;
     /** ISO datetime */
     scheduledAt: string;
   };
+  attachments: ProjectAttachment[];
 }
 
 /** 팀 액션 상세의 타임라인 탭 한 줄 — 이 팀 액션에 속한 개인 액션 한 건(담당자별 행). */

--- a/src/features/project/types.ts
+++ b/src/features/project/types.ts
@@ -120,8 +120,9 @@ export interface TeamActionDetail {
   assigneeName?: string;
   /** `"{팀명}장"` 고정 포맷(BE가 조립) — 팀장 공석이면 없음. */
   assigneeRoleLabel?: string;
-  /** 이 팀 액션이 나온 프로젝트 회의 — 수동 추가 등으로 출처가 없으면 없음. */
+  /** 이 팀 액션이 나온 프로젝트 회의 — 수동 추가 등으로 출처가 없으면 없음. 클릭 시 `/app/meeting/:id`로 이동. */
   sourceMeeting?: {
+    id: number;
     title: string;
     /** ISO datetime */
     scheduledAt: string;

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -7,6 +7,31 @@
  * ⚠️ 아래 **[확인]** 표시가 붙은 경로는 BE 레포 실코드로 대조했다(2026-08-10).
  *   나머지는 아직 **FE 제안 경로**다 — 쓰기 전에 컨트롤러를 먼저 본다(§연동 검증).
  */
+/** 목록 3종(`GET /api/projects`·`/api/actions`·`/api/team/actions`)이 공유하는 쿼리 파라미터. */
+export interface ProjectListParams {
+  status?: "TODO" | "IN_PROGRESS" | "DONE";
+  sort?: "dueDate" | "createdAt";
+  order?: "asc" | "desc";
+  page?: number;
+  size?: number;
+}
+
+/** 개인 액션 목록만 갖는 `overdue` 필터가 추가된다. */
+export interface ActionListParams extends ProjectListParams {
+  overdue?: boolean;
+}
+
+/** `undefined`·`null` 값은 쿼리에서 빠진다 — 서버 기본값을 그대로 쓰게 둔다. */
+function toQuery(params: object | undefined): string {
+  if (!params) return "";
+  const entries = Object.entries(params).filter(
+    ([, value]) => value !== undefined && value !== null,
+  );
+  if (entries.length === 0) return "";
+  const search = new URLSearchParams(entries.map(([key, value]) => [key, String(value)]));
+  return `?${search.toString()}`;
+}
+
 export const ep = {
   /* 인증 — [확인] identity/auth/presentation/api/AuthController.java */
   login: () => "/api/auth/login",
@@ -65,13 +90,44 @@ export const ep = {
   /** AI 처리 상태(CAP-06) — 종료 뒤 폴링 */
   processingStatus: (meetingId: number) => `/api/meetings/${meetingId}/processing-status`,
 
-  /* 액션 */
-  actions: () => "/api/actions",
-  action: (id: number) => `/api/actions/${id}`,
+  /*
+   * 액션 · 프로젝트 · 캘린더 — [확인] BE 실코드 대조(2026-08-10, 잇다 REST API 연동 가이드 최종본)
+   *   `project/presentation/api/{ProjectController,ProjectAttachmentController}.java`
+   *   `action/presentation/api/{ActionController,TeamActionController,MeetingActionController}.java`
+   *   `calendar/presentation/api/{CalendarController,TodoController}.java`(경로 추정 — 컨트롤러
+   *   클래스명은 아직 실코드로 못 봤다, `/api/calendar`·`/api/todos` 자체는 문서로 확인됨)
+   *
+   * 목록 3종(`projects`·`actions`·`teamActions`)은 `GET /api/projects` 등이 `PageResponse` 봉투로
+   * 오므로 `page`/`size`/`status`/`sort`/`order` 쿼리를 여기서 조립한다 — 값이 없으면 그 파라미터
+   * 자체를 안 붙인다(서버 기본값을 그대로 쓰게).
+   */
+  projects: (params?: ProjectListParams) => `/api/projects${toQuery(params)}`,
+  project: (id: number) => `/api/projects/${id}`,
+  projectStatusBulk: () => "/api/projects/status/bulk",
+  projectTimeline: (id: number) => `/api/projects/${id}/timeline`,
+  projectAttachmentUploadUrl: (projectId: number) =>
+    `/api/projects/${projectId}/attachments/upload-url`,
+  projectAttachmentConfirm: (projectId: number) => `/api/projects/${projectId}/attachments/confirm`,
+  projectAttachmentDownloadUrl: (projectId: number, attachmentId: number) =>
+    `/api/projects/${projectId}/attachments/${attachmentId}/download-url`,
+  projectAttachment: (projectId: number, attachmentId: number) =>
+    `/api/projects/${projectId}/attachments/${attachmentId}`,
 
-  /* 프로젝트 */
-  projects: () => "/api/projects",
-  project: (tag: string) => `/api/projects/${tag}`,
+  actions: (params?: ActionListParams) => `/api/actions${toQuery(params)}`,
+  action: (id: number) => `/api/actions/${id}`,
+  actionCompleteBulk: () => "/api/actions/complete/bulk",
+  meetingActions: (meetingId: number) => `/api/meetings/${meetingId}/actions`,
+
+  teamActions: (params?: ProjectListParams) => `/api/team/actions${toQuery(params)}`,
+  teamAction: (id: number) => `/api/team/actions/${id}`,
+  teamActionTimeline: (id: number) => `/api/team/actions/${id}?tab=timeline`,
+  teamActionAttachmentDownloadUrl: (teamActionId: number, attachmentId: number) =>
+    `/api/team/actions/${teamActionId}/attachments/${attachmentId}/download-url`,
+
+  /** `month` 생략 시 이번 달(서버 기본값) */
+  calendar: (month?: string) => `/api/calendar${toQuery(month ? { month } : undefined)}`,
+  todos: () => "/api/todos",
+  todoComplete: (id: number) => `/api/todos/${id}/complete`,
 
   /* 인수인계 */
   handovers: () => "/api/handovers",

--- a/src/lib/palette.ts
+++ b/src/lib/palette.ts
@@ -68,6 +68,38 @@ export interface PaletteColor {
   solidColor: string;
 }
 
+/**
+ * BE가 저장하는 프로젝트 `color`(자유 HEX가 아니라 이 11개로 검증이 좁혀져 있다,
+ * `ProjectColorPalette.REGEXP` — 2026-08-10 이홍근 요청으로 BE에 반영됨)를 팔레트 이름으로
+ * 되돌린다. BE는 팔레트 키가 아니라 이 HEX 문자열 그대로를 저장·반환하므로, 화면이 라이트/다크
+ * 짝을 알려면 이 역매핑을 거쳐야 한다.
+ * ⚠️ 대소문자 무시(BE 검증도 무시) — 항상 대문자로 비교한다.
+ */
+const HEX_TO_TAG_NAME: Record<string, TagColorName> = {
+  "#475569": "slate",
+  "#A16207": "yellow",
+  "#4D7C0F": "lime",
+  "#059669": "emerald",
+  "#0D9488": "teal",
+  "#0891B2": "cyan",
+  "#0284C7": "sky",
+  "#4F46E5": "indigo",
+  "#9333EA": "purple",
+  "#C026D3": "fuchsia",
+  "#DB2777": "pink",
+};
+
+/** BE `color` 값(HEX) → 팔레트 이름. 모르는 값이면 `slate`로 떨어뜨린다(임의로 지어내지 않는다). */
+export function tagNameFromHex(hex: string): TagColorName {
+  return HEX_TO_TAG_NAME[hex.toUpperCase()] ?? "slate";
+}
+
+/** 팔레트 이름 → BE에 보낼 `color` 값(HEX). `HEX_TO_TAG_NAME`의 역방향. */
+export function hexFromTagName(name: TagColorName): string {
+  const entry = Object.entries(HEX_TO_TAG_NAME).find(([, tagName]) => tagName === name);
+  return entry?.[0] ?? "#475569";
+}
+
 function hashString(value: string): number {
   let hash = 0;
   for (let index = 0; index < value.length; index++) {


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가

---

## 🗂 작업 영역

- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [x] OWNER (대표)
- [ ] ADMIN (관리자)
- [x] LEADER (팀장)
- [x] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자)
- [ ] 공통

---

## 📝 작업 내용

- `lib/endpoints.ts`에 프로젝트·액션·팀액션·캘린더·Todo·첨부파일 실제 경로 + 목록 3종 쿼리 빌더(`toQuery`) 추가
- 프로젝트 목록/상세/타임라인/생성 mock → 실 API 전환(`features/project/{mapper,server,actions}.ts` 신설/수정)
- 첨부파일 다운로드 URL 발급 연동(클릭 시점 발급, 5분 만료) — `ProjectDetail.attachmentName`(단일 파일명) → `attachments: ProjectAttachment[]`로 타입 변경
- 보드(오너=프로젝트, 팀장·사원=본인 액션) 조회·저장 실 API 연동, 저장 시 서버에서 `canMoveCard` 재검증 후 bulk API 호출
- `lib/palette.ts`에 BE `color`(11색 HEX) ↔ 팔레트 이름 변환 유틸 추가(생성 요청 조립용)

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수, base `develop`
- [x] 커밋 컨벤션 준수
- [x] 아래 `Closes #` 기입
- [x] 불필요한 `console` · 주석 처리된 코드 없음
- [x] 민감 정보 없음

**Z 필수**

- [x] 🔐 권한 2축 — 생성은 `canCreateProject` 서버 재검사, 보드 저장은 `canMoveCard`를 서버에서 다시 계산해 클라 입력을 안 믿음(액션 보드는 토큰 스코프라 본인 것만 애초에 조회됨)
- [ ] 🧬 zod — **미적용.** 기존에 이미 연동된 `company/mapper.ts`·`auth/me.ts`도 zod 없이 BE 응답을 바로 인터페이스로 캐스팅하는 방식이라 그 패턴을 그대로 따름 — zod 적용이 팀 방침이면 이 PR과 기존 두 파일 모두 후속 작업 필요
- [x] 🕵️ 정직성 — mock 단계 첨부파일 다운로드는 `null` 반환 시 "아직 연동되지 않았다" 토스트로 명시
- [x] 🎨 디자인 토큰 — 새 UI(`project-attachment-list.tsx`)는 기존 토큰 클래스만 사용

**품질**

- [x] ♻️ 재사용 확인 — 기존 `ConfirmDialog`·`toast` 패턴 재사용, 신규 컴포넌트 1개만 추가
- [x] `loading`/`error`/`empty` — 기존 페이지 구조 그대로 유지(로직만 mock→live 전환)

---

## 🔗 연관 이슈

Closes #320

---

## 💬 리뷰 포인트

- `features/project/server.ts`의 `resolveTeamIds`(팀 이름→id 변환)가 **이름 중복 없음을 전제**로 함 — 지금 회사 팀 이름 정책상 안전하지만 문서화된 가정이니 확인 부탁드립니다.
- `GET /api/projects` 목록 응답에 `description`이 없어(상세에만 있음) 목록 카드 설명 줄이 지금은 빈 문자열 — 이슈 #320 "추가 메모" 참고.
- 액션 상세(`/app/actions/:actionId`)는 이번 스코프에서 의도적으로 제외(BE 응답 필드 4개 부족, 요청해둔 상태).

---

## 📝 추가 메모

typecheck·lint·전체 jest(78 suites/890 tests) 통과 확인.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 프로젝트·액션·팀 액션 정보를 실제 서버와 연동해 조회하고 저장합니다.
  * 프로젝트와 팀 액션의 첨부파일 목록을 확인하고 다운로드할 수 있습니다.
  * 보드에서 변경한 프로젝트와 액션을 서버에 저장합니다.
  * 프로젝트 및 액션 목록에서 상태, 정렬, 페이지네이션, 마감 초과 조건을 지원합니다.

* **개선 사항**
  * 담당자 역할, 회의 출처, 상위 액션 정보가 없을 때 화면이 자연스럽게 표시됩니다.
  * 보드 이동 검증과 되돌리기 동작이 더욱 정확해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->