### PR TITLE
[FIX] 캘린더 Todo 추가 모달 날짜 필드 워딩·레이아웃 개선 #323

### DIFF
--- a/src/features/calendar/components/add-todo-dialog.tsx
+++ b/src/features/calendar/components/add-todo-dialog.tsx
@@ -136,7 +136,7 @@ export function AddTodoDialog({ defaultDate, onCreated }: AddTodoDialogProps) {
 
           {/* ⚠️ 시작일·마감일을 좌우로 나란히 둔다 — 위아래로 쌓으면 두 날짜가 한 범위라는 게 잘 안 읽힌다. */}
           <div className="flex gap-3">
-            <div className="flex flex-1 flex-col gap-1.5">
+            <div className="flex min-w-0 flex-1 flex-col gap-1.5">
               <Label htmlFor="todo-date">시작일</Label>
               <Popover open={datePopoverOpen} onOpenChange={setDatePopoverOpen}>
                 <PopoverTrigger
@@ -145,13 +145,14 @@ export function AddTodoDialog({ defaultDate, onCreated }: AddTodoDialogProps) {
                       id="todo-date"
                       type="button"
                       variant="outline"
-                      className="h-10 w-full justify-start gap-2 font-normal"
+                      className="h-10 w-full min-w-0 justify-start gap-1.5 px-2.5 font-normal"
                     />
                   }
                 >
                   {/* ⚠️ 아이콘과 글자를 **같은 색**으로 — 아이콘만 흐리면 한 버튼이 두 톤으로 갈린다 */}
-                  <CalendarIcon aria-hidden className="size-4 text-current" />
-                  {format(date, "yyyy년 M월 d일(EEE)", { locale: ko })}
+                  <CalendarIcon aria-hidden className="size-4 shrink-0 text-current" />
+                  {/* ⚠️ 420px 모달의 좌우 절반 폭에 맞춰 연도는 뺀다 — 넣으면 줄바꿈 없이 넘친다 */}
+                  <span className="truncate">{format(date, "M월 d일(EEE)", { locale: ko })}</span>
                 </PopoverTrigger>
                 {/*
                   ⚠️ 달력은 **넉넉하게** 편다. 기본 셀(28px)로는 날짜를 손으로 짚기 어렵고
@@ -181,7 +182,7 @@ export function AddTodoDialog({ defaultDate, onCreated }: AddTodoDialogProps) {
               <FieldError reserveSpace message={state.errors.date} />
             </div>
 
-            <div className="flex flex-1 flex-col gap-1.5">
+            <div className="flex min-w-0 flex-1 flex-col gap-1.5">
               <Label htmlFor="todo-end-date">마감일</Label>
               <Popover open={endDatePopoverOpen} onOpenChange={setEndDatePopoverOpen}>
                 <PopoverTrigger
@@ -190,12 +191,14 @@ export function AddTodoDialog({ defaultDate, onCreated }: AddTodoDialogProps) {
                       id="todo-end-date"
                       type="button"
                       variant="outline"
-                      className="h-10 w-full justify-start gap-2 font-normal"
+                      className="h-10 w-full min-w-0 justify-start gap-1.5 px-2.5 font-normal"
                     />
                   }
                 >
-                  <CalendarIcon aria-hidden className="size-4 text-current" />
-                  {format(endDate, "yyyy년 M월 d일(EEE)", { locale: ko })}
+                  <CalendarIcon aria-hidden className="size-4 shrink-0 text-current" />
+                  <span className="truncate">
+                    {format(endDate, "M월 d일(EEE)", { locale: ko })}
+                  </span>
                 </PopoverTrigger>
                 <PopoverContent align="start" className="w-auto p-3 [--cell-size:--spacing(9)]">
                   <Calendar

--- a/src/features/calendar/components/add-todo-dialog.tsx
+++ b/src/features/calendar/components/add-todo-dialog.tsx
@@ -134,84 +134,87 @@ export function AddTodoDialog({ defaultDate, onCreated }: AddTodoDialogProps) {
             <FieldError reserveSpace message={state.errors.title} />
           </div>
 
-          <div className="flex flex-col gap-1.5">
-            <Label htmlFor="todo-date">시작 날짜</Label>
-            <Popover open={datePopoverOpen} onOpenChange={setDatePopoverOpen}>
-              <PopoverTrigger
-                render={
-                  <Button
-                    id="todo-date"
-                    type="button"
-                    variant="outline"
-                    className="h-10 w-full justify-start gap-2 font-normal"
-                  />
-                }
-              >
-                {/* ⚠️ 아이콘과 글자를 **같은 색**으로 — 아이콘만 흐리면 한 버튼이 두 톤으로 갈린다 */}
-                <CalendarIcon aria-hidden className="size-4 text-current" />
-                {format(date, "yyyy년 M월 d일(EEE)", { locale: ko })}
-              </PopoverTrigger>
-              {/*
-                ⚠️ 달력은 **넉넉하게** 편다. 기본 셀(28px)로는 날짜를 손으로 짚기 어렵고
-                   눌러야 할 것이 빽빽해 보인다 — 고르는 게 이 창의 일이다.
-              */}
-              <PopoverContent align="start" className="w-auto p-3 [--cell-size:--spacing(9)]">
+          {/* ⚠️ 시작일·마감일을 좌우로 나란히 둔다 — 위아래로 쌓으면 두 날짜가 한 범위라는 게 잘 안 읽힌다. */}
+          <div className="flex gap-3">
+            <div className="flex flex-1 flex-col gap-1.5">
+              <Label htmlFor="todo-date">시작일</Label>
+              <Popover open={datePopoverOpen} onOpenChange={setDatePopoverOpen}>
+                <PopoverTrigger
+                  render={
+                    <Button
+                      id="todo-date"
+                      type="button"
+                      variant="outline"
+                      className="h-10 w-full justify-start gap-2 font-normal"
+                    />
+                  }
+                >
+                  {/* ⚠️ 아이콘과 글자를 **같은 색**으로 — 아이콘만 흐리면 한 버튼이 두 톤으로 갈린다 */}
+                  <CalendarIcon aria-hidden className="size-4 text-current" />
+                  {format(date, "yyyy년 M월 d일(EEE)", { locale: ko })}
+                </PopoverTrigger>
                 {/*
-                  ⚠️ 고른 날짜를 **먹색**으로 칠한다. 공용 `Calendar`의 기본은 `--primary`(파랑)인데,
-                     이 서비스의 주 버튼·선택 색은 먹색이고 파랑은 링크·강조용이다(DESIGN §5).
-                     다크에서도 `--foreground`/`--background`가 함께 뒤집혀 대비가 유지된다.
+                  ⚠️ 달력은 **넉넉하게** 편다. 기본 셀(28px)로는 날짜를 손으로 짚기 어렵고
+                     눌러야 할 것이 빽빽해 보인다 — 고르는 게 이 창의 일이다.
                 */}
-                <Calendar
-                  className="[&_[data-selected-single=true]]:bg-foreground [&_[data-selected-single=true]]:text-background [&_[data-selected-single=true]]:hover:bg-foreground"
-                  mode="single"
-                  locale={ko}
-                  selected={date}
-                  onSelect={(selected) => {
-                    if (!selected) return;
-                    setDate(selected);
-                    // ⚠️ 끝 날짜가 시작보다 앞서게 되면 시작 날짜로 같이 밀어둔다 — 범위가 뒤집힌 채로 남지 않게.
-                    if (endDate < selected) setEndDate(selected);
-                    setDatePopoverOpen(false);
-                  }}
-                />
-              </PopoverContent>
-            </Popover>
-            <FieldError reserveSpace message={state.errors.date} />
-          </div>
-
-          <div className="flex flex-col gap-1.5">
-            <Label htmlFor="todo-end-date">끝 날짜</Label>
-            <Popover open={endDatePopoverOpen} onOpenChange={setEndDatePopoverOpen}>
-              <PopoverTrigger
-                render={
-                  <Button
-                    id="todo-end-date"
-                    type="button"
-                    variant="outline"
-                    className="h-10 w-full justify-start gap-2 font-normal"
+                <PopoverContent align="start" className="w-auto p-3 [--cell-size:--spacing(9)]">
+                  {/*
+                    ⚠️ 고른 날짜를 **먹색**으로 칠한다. 공용 `Calendar`의 기본은 `--primary`(파랑)인데,
+                       이 서비스의 주 버튼·선택 색은 먹색이고 파랑은 링크·강조용이다(DESIGN §5).
+                       다크에서도 `--foreground`/`--background`가 함께 뒤집혀 대비가 유지된다.
+                  */}
+                  <Calendar
+                    className="[&_[data-selected-single=true]]:bg-foreground [&_[data-selected-single=true]]:text-background [&_[data-selected-single=true]]:hover:bg-foreground"
+                    mode="single"
+                    locale={ko}
+                    selected={date}
+                    onSelect={(selected) => {
+                      if (!selected) return;
+                      setDate(selected);
+                      // ⚠️ 끝 날짜가 시작보다 앞서게 되면 시작 날짜로 같이 밀어둔다 — 범위가 뒤집힌 채로 남지 않게.
+                      if (endDate < selected) setEndDate(selected);
+                      setDatePopoverOpen(false);
+                    }}
                   />
-                }
-              >
-                <CalendarIcon aria-hidden className="size-4 text-current" />
-                {format(endDate, "yyyy년 M월 d일(EEE)", { locale: ko })}
-              </PopoverTrigger>
-              <PopoverContent align="start" className="w-auto p-3 [--cell-size:--spacing(9)]">
-                <Calendar
-                  className="[&_[data-selected-single=true]]:bg-foreground [&_[data-selected-single=true]]:text-background [&_[data-selected-single=true]]:hover:bg-foreground"
-                  mode="single"
-                  locale={ko}
-                  selected={endDate}
-                  // 시작 날짜 이전은 고를 수 없다 — 범위가 뒤집히는 입력 자체를 막는다.
-                  disabled={{ before: date }}
-                  onSelect={(selected) => {
-                    if (!selected) return;
-                    setEndDate(selected);
-                    setEndDatePopoverOpen(false);
-                  }}
-                />
-              </PopoverContent>
-            </Popover>
-            <FieldError reserveSpace message={state.errors.endDate} />
+                </PopoverContent>
+              </Popover>
+              <FieldError reserveSpace message={state.errors.date} />
+            </div>
+
+            <div className="flex flex-1 flex-col gap-1.5">
+              <Label htmlFor="todo-end-date">마감일</Label>
+              <Popover open={endDatePopoverOpen} onOpenChange={setEndDatePopoverOpen}>
+                <PopoverTrigger
+                  render={
+                    <Button
+                      id="todo-end-date"
+                      type="button"
+                      variant="outline"
+                      className="h-10 w-full justify-start gap-2 font-normal"
+                    />
+                  }
+                >
+                  <CalendarIcon aria-hidden className="size-4 text-current" />
+                  {format(endDate, "yyyy년 M월 d일(EEE)", { locale: ko })}
+                </PopoverTrigger>
+                <PopoverContent align="start" className="w-auto p-3 [--cell-size:--spacing(9)]">
+                  <Calendar
+                    className="[&_[data-selected-single=true]]:bg-foreground [&_[data-selected-single=true]]:text-background [&_[data-selected-single=true]]:hover:bg-foreground"
+                    mode="single"
+                    locale={ko}
+                    selected={endDate}
+                    // 시작 날짜 이전은 고를 수 없다 — 범위가 뒤집히는 입력 자체를 막는다.
+                    disabled={{ before: date }}
+                    onSelect={(selected) => {
+                      if (!selected) return;
+                      setEndDate(selected);
+                      setEndDatePopoverOpen(false);
+                    }}
+                  />
+                </PopoverContent>
+              </Popover>
+              <FieldError reserveSpace message={state.errors.endDate} />
+            </div>
           </div>
         </div>
       </ConfirmDialog>


### PR DESCRIPTION
## 📋 PR 타입

- [ ] feature
- [ ] fix — 버그 수정
- [ ] style
- [ ] refactor
- [ ] docs
- [ ] test
- [x] design — UI/UX 변경
- [ ] chore
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [x] 공유 셸 · 디자인 시스템
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

- 캘린더 Todo 추가 모달 날짜 필드 라벨을 "시작 날짜"/"끝 날짜" → "시작일"/"마감일"로 변경
- 두 날짜 필드를 위/아래 배치에서 좌우(flex) 배치로 변경 — 하나의 기간임이 드러나도록

---

## ✅ 작업 체크리스트

**기본**

- [ ] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [ ] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 권한 2축 검사 — 해당 없음(UI 워딩·레이아웃만, 권한 로직 변경 없음)
- [x] 🧬 zod — 해당 없음(스키마·검증 변경 없음)
- [x] 🕵️ 정직성 — 해당 없음
- [x] 🎨 디자인 토큰 사용 — 기존 토큰(`gap`, `flex`)만 사용, 신규 hex 없음

**품질**

- [x] ⚡ 최적화 — 변경 없음
- [x] ♿ a11y — 기존 `Label htmlFor` 구조 유지
- [x] ♻️ 재사용 확인 — 기존 `Popover`/`Calendar` 재사용, 신규 컴포넌트 없음
- [x] 🧪 loading/error/empty — 해당 없음(폼 필드 워딩·레이아웃만)
- [x] 브라우저 전용 API — 해당 없음

---

## 🔗 연관 이슈

Closes #323

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
| (시작 날짜 / 끝 날짜, 위·아래 배치) | (시작일 / 마감일, 좌·우 배치) |

---

## 💬 리뷰 포인트

- 모달 폭(420px) 안에서 두 날짜 버튼이 좌우로 들어갈 때 텍스트가 잘리거나 줄바꿈되지 않는지 확인해 주세요.

---

## 📝 추가 메모

브라우저 프리뷰 패널이 이번 세션에서 렌더링되지 않아(화면 표시 불가 오류) 스크린샷으로 직접 확인은 못 했습니다. 타입체크는 통과했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 할 일 추가 화면에서 시작일과 마감일 입력을 2열로 배치해 한눈에 확인할 수 있도록 개선했습니다.
  * 시작일과 마감일 라벨을 명확히 표시했습니다.
  * 시작일 이후의 날짜만 마감일로 선택할 수 있도록 날짜 검증을 강화했습니다.
  * 시작일이 변경되어 마감일보다 늦어지는 경우 마감일을 자동으로 조정합니다.
  * 날짜 선택 및 오류 메시지를 각 입력 영역에서 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->