### PR TITLE
[FEAT] 회의 상세 하달된 액션 칸 상태 세분화 #325

### DIFF
--- a/src/features/meeting/components/meeting-detail-view.tsx
+++ b/src/features/meeting/components/meeting-detail-view.tsx
@@ -11,7 +11,8 @@ import type { MeetingContentPending, MeetingDetail } from "../view-types";
 import { ProjectAccent } from "./project-accent";
 
 /**
- * 회의 상세 — **완료 회의만** 여기까지 온다(WORKFLOW §3-2).
+ * 회의 상세 — **예정·진행중도 여기까지 온다**(2026-08-10 팀 협의, WORKFLOW §3-2). 메타(시간·
+ * 장소·참석자·안건)는 늘 보여주고, 아직 없는 것(산출물·발화 기록)만 그 두 칸 안에서 안내한다.
  *
  * 라벨 4종(§12): 프로젝트 태그 · (Owner 개설 / 상위 팀 액션) · 회의 안건 · 산출물 목록.
  * ⚠️ 태그·상위 팀 액션은 **실제로 이동하는 링크**다 — 순환 추적의 핵심이라 눌리지 않는
@@ -77,7 +78,64 @@ function SectionNotice({ reason }: { reason: MeetingContentPending }) {
   );
 }
 
+/**
+ * 산출물(하달된 액션) 칸이 **지금 무엇을 보여줄지**.
+ *
+ * ⚠️ **대기·중단을 "없음"으로 뭉치지 않는다.** 요약이 끝났는데 Host가 [액션 분배 확정]을
+ *    아직 안 눌렀거나(`pendingReview`) 요약 자체가 서버 문제로 중단된 것(`stalled`)은 진짜로
+ *    하달된 게 없는 것과 다른 사정이라 각자 다른 문구·다른 Host용 이동 수단이 필요하다.
+ * ⚠️ 순서가 있다. 회의가 안 끝났거나 요약 중이면(`SectionNotice` 3종) 그게 먼저다 — 아직
+ *    검토·중단을 말할 단계조차 아니다.
+ */
+type ActionsSectionState =
+  | { kind: "notice"; reason: MeetingContentPending }
+  | { kind: "list" }
+  | { kind: "pendingReview" }
+  | { kind: "stalled" }
+  | { kind: "empty" };
+
+function actionsSectionStateOf(detail: MeetingDetail): ActionsSectionState {
+  if (
+    detail.pendingReason === "SCHEDULED" ||
+    detail.pendingReason === "IN_PROGRESS" ||
+    detail.pendingReason === "SUMMARIZING"
+  ) {
+    return { kind: "notice", reason: detail.pendingReason };
+  }
+  if (detail.outputs.length > 0) return { kind: "list" };
+  if (detail.pendingActionCount > 0) return { kind: "pendingReview" };
+  if (detail.pendingReason === "FAILED") {
+    return detail.isStalled ? { kind: "stalled" } : { kind: "notice", reason: "FAILED" };
+  }
+  return { kind: "empty" };
+}
+
+/** 확정 대기·중단 안내 — 문구는 공통, Host에게만 갈 곳을 더 보여준다. */
+function ActionsNotice({
+  message,
+  action,
+}: {
+  message: string;
+  action: { href: string; label: string } | null;
+}) {
+  return (
+    <div className="px-7 pt-2 pb-8 text-center">
+      <p className="text-muted-foreground text-[13px] leading-5">{message}</p>
+      {action && (
+        <Link
+          href={action.href}
+          className="text-foreground focus-visible:ring-ring mt-2 inline-block rounded-md text-[13px] leading-5 font-medium underline underline-offset-2 transition-opacity hover:opacity-70 focus-visible:ring-2 focus-visible:outline-hidden"
+        >
+          {action.label}
+        </Link>
+      )}
+    </div>
+  );
+}
+
 export function MeetingDetailView({ detail }: { detail: MeetingDetail }) {
+  const actionsState = actionsSectionStateOf(detail);
+
   return (
     /*
       ⚠️ **한 컬럼이다.** 곁 컬럼(360)에 참석자만 두니 이름 몇 줄 아래로 오른쪽이 통째로 비었다 —
@@ -181,17 +239,33 @@ export function MeetingDetailView({ detail }: { detail: MeetingDetail }) {
             <h2 className="text-[17px] leading-7 font-semibold tracking-[-0.3px]">
               하달된 {detail.outputKindLabel}
             </h2>
-            {/* ⚠️ 아직 안 찬 회의에 `전체 0건`이라 적으면 하나도 안 나온 회의로 읽힌다 */}
-            {!detail.pendingReason && (
+            {/* ⚠️ 아직 안 찬·확정 대기·중단된 회의에 `전체 0건`이라 적으면 하나도 안 나온 회의로 읽힌다 */}
+            {(actionsState.kind === "list" || actionsState.kind === "empty") && (
               <p className="text-muted-foreground text-[12px] leading-4 tabular-nums">
                 전체 {detail.outputs.length}건
               </p>
             )}
           </div>
 
-          {detail.pendingReason ? (
-            <SectionNotice reason={detail.pendingReason} />
-          ) : detail.outputs.length === 0 ? (
+          {actionsState.kind === "notice" ? (
+            <SectionNotice reason={actionsState.reason} />
+          ) : actionsState.kind === "pendingReview" ? (
+            <ActionsNotice
+              message="아직 액션 분배가 확정되지 않았습니다"
+              action={
+                detail.isHost
+                  ? { href: `/app/meeting/${detail.id}/review`, label: "액션 검토" }
+                  : null
+              }
+            />
+          ) : actionsState.kind === "stalled" ? (
+            <ActionsNotice
+              message="AI 요약이 중단되어 액션이 생성되지 않았습니다"
+              action={
+                detail.isHost ? { href: "/app/me", label: "마이페이지에서 다시 분석하기" } : null
+              }
+            />
+          ) : actionsState.kind === "empty" ? (
             <p className="text-muted-foreground px-7 pt-2 pb-8 text-center text-[13px] leading-5">
               이 회의에서 하달된 {detail.outputKindLabel}이 없습니다.
             </p>

--- a/src/features/meeting/mock/seed.ts
+++ b/src/features/meeting/mock/seed.ts
@@ -28,6 +28,11 @@ interface SeedExtras {
    *    산출물 표가 비게 된다. 없는 값을 정의하는 것이지 있는 값을 베끼는 게 아니다.
    */
   outputPersonalActions?: { id: number; status: ActionStatus; dueDate: string }[];
+  /**
+   * 요약 실패(`AI_SUMMARY_STATUS.FAILED`)가 서버 문제로 중단된 것인지 — 실제 분석 실패와
+   * 문구·재분석 안내를 가른다(마이페이지 "요약이 중단된 회의"와 같은 판정, §server).
+   */
+  isStalled?: boolean;
 }
 
 const globalStore = globalThis as typeof globalThis & {
@@ -204,6 +209,55 @@ export function ensureMockMeetingsSeeded(): void {
     ],
     outputTeamActionIds: [5, 6],
   });
+
+  /*
+    m6 — Owner의 완료 회의. 요약은 끝났지만(REVIEWED) Host가 검토 화면에서 [액션 분배 확정]을
+    아직 안 눌렀다 — 산출물 칸이 "확정 대기"를 말하는 경우를 확인하는 자리다.
+  */
+  const pendingReview = addMockMeeting({
+    title: "굿즈 앱 배송 정책 협의",
+    start: new Date("2026-08-04T11:00:00+09:00"),
+    end: new Date("2026-08-04T11:30:00+09:00"),
+    roomId: "room-small",
+    roomName: "소회의실",
+    projectId: 1,
+    projectTag: "GOODS",
+    topics: [{ main: "운영", sub: "배송 정책" }],
+    attendeeIds: [1, 2, 3, 4],
+    hostId: 1,
+    hostAuthority: AUTHORITY.OWNER,
+    roomReservationId: "seed-reservation-6",
+  });
+  endMockMeeting(pendingReview.id, "2026-08-04T11:31:00.000Z");
+  setMockSummaryStatus(pendingReview.id, AI_SUMMARY_STATUS.REVIEWED);
+  extras.set(pendingReview.id, {
+    script: [
+      { at: "11:00", text: "배송 정책 협의를 시작하겠습니다." },
+      { at: "11:12", text: "무료 배송 기준과 반품 정책을 다음 주까지 정리해 주세요." },
+    ],
+  });
+
+  /*
+    m7 — Owner의 완료 회의. AI 요약이 서버 문제로 중단됐다(FAILED + isStalled) — 산출물 칸이
+    "요약 실패"와는 다른 문구·재분석 안내를 말하는 경우를 확인하는 자리다.
+  */
+  const stalled = addMockMeeting({
+    title: "굿즈 앱 결제 오류 대응 회의",
+    start: new Date("2026-08-06T15:00:00+09:00"),
+    end: new Date("2026-08-06T15:30:00+09:00"),
+    roomId: "room-small",
+    roomName: "소회의실",
+    projectId: 1,
+    projectTag: "GOODS",
+    topics: [{ main: "운영", sub: "결제 오류" }],
+    attendeeIds: [1, 2, 5],
+    hostId: 1,
+    hostAuthority: AUTHORITY.OWNER,
+    roomReservationId: "seed-reservation-7",
+  });
+  endMockMeeting(stalled.id, "2026-08-06T15:31:00.000Z");
+  setMockSummaryStatus(stalled.id, AI_SUMMARY_STATUS.FAILED);
+  extras.set(stalled.id, { script: [], isStalled: true });
 }
 
 /** 테스트 전용 — 시드를 되돌린다(스토어는 `meetings.ts`가 들고 있어 함께 비운다) */

--- a/src/features/meeting/server.ts
+++ b/src/features/meeting/server.ts
@@ -4,12 +4,18 @@ import { AI_SUMMARY_STATUS, MEETING_STATUS } from "@/constants/meeting";
 import { PERSONAL_ACTION_DETAIL_MOCK } from "@/features/action/mock/action-detail";
 import { listMockManagedMembers } from "@/features/member/mock/managed";
 import { PROJECT_TEAM_ACTIONS_MOCK } from "@/features/project/mock/team-actions";
-import { type Actor, canCaptureMeeting, canViewMeetingDetail } from "@/lib/permission";
+import {
+  type Actor,
+  canCaptureMeeting,
+  canOperateMeeting,
+  canViewMeetingDetail,
+} from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
 import { formatMeetingSchedule } from "./lib";
 import { findMockMeeting, listMockMeetings } from "./mock/meetings";
 import { ensureMockMeetingsSeeded, findMockMeetingExtras } from "./mock/seed";
+import { findMockMeetingReview } from "./review/mock/review";
 import { meetingStatusOf } from "./status";
 import type { Meeting } from "./types";
 import type {
@@ -194,6 +200,19 @@ export async function getMeetingDetail(id: string, viewer: Actor): Promise<Meeti
   const roster = new Map(listMockManagedMembers().map((member) => [member.id, member.name]));
   const { kindLabel, outputs } = outputsOf(meeting);
 
+  /*
+    ⚠️ 검토 대기·중단은 **산출물 칸만의 사정**이다(회의 안 끝남·요약 중과는 다른 축) — 요약이
+       끝났는데도(REVIEWED) Host가 [액션 분배 확정]을 안 눌렀거나, 요약 자체가 서버 문제로
+       중단됐을 때(FAILED + isStalled) 산출물 칸이 왜 비었는지 갈라 보여준다(§view-types).
+  */
+  const review =
+    meeting.aiSummaryStatus === AI_SUMMARY_STATUS.REVIEWED
+      ? findMockMeetingReview(meeting.id)
+      : null;
+  const pendingActionCount = review && !review.actionsConfirmed ? review.drafts.length : 0;
+  const isStalled =
+    pendingReason === "FAILED" ? (findMockMeetingExtras(meeting.id)?.isStalled ?? false) : false;
+
   return {
     kind: "ok",
     detail: {
@@ -217,6 +236,9 @@ export async function getMeetingDetail(id: string, viewer: Actor): Promise<Meeti
       outputs,
       script: findMockMeetingExtras(meeting.id)?.script ?? [],
       pendingReason,
+      pendingActionCount,
+      isStalled,
+      isHost: canOperateMeeting(viewer, { ownerId: meeting.hostId }),
     },
   };
 }

--- a/src/features/meeting/view-types.ts
+++ b/src/features/meeting/view-types.ts
@@ -116,6 +116,18 @@ export interface MeetingDetail {
   script: ScriptChunk[];
   /** 산출물·발화 기록이 아직 없는 이유 — 다 찼으면 `null` */
   pendingReason: MeetingContentPending | null;
+  /**
+   * 확정 전 AI 액션 초안 건수 — 요약은 끝났지만 Host가 아직 검토 화면에서 [액션 분배 확정]을
+   * 안 누른 만큼이다. 확정됐거나 처음부터 없으면 0(§3-4 `MeetingReviewInfo.actionsConfirmed`).
+   */
+  pendingActionCount: number;
+  /**
+   * 요약 실패가 서버 문제로 중단된 것인지 — `pendingReason === "FAILED"`일 때만 뜻이 있다
+   * (마이페이지 "요약이 중단된 회의"와 같은 판정).
+   */
+  isStalled: boolean;
+  /** 보는 사람이 이 회의 개설자인가 — 재분석·검토 이동은 Host에게만 보여준다(§권한 ②축) */
+  isHost: boolean;
 }
 
 /**


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- 회의 상세 "하달된 액션" 칸을 목록 있음 / 확정 대기 / AI 요약 중단 / 진짜 없음 4가지로
  분기해, "확정 대기"·"AI 요약 중단"을 "하달된 액션이 없습니다"로 잘못 읽히던 문제를 해결
- `MeetingDetail`에 `pendingActionCount`·`isStalled`·`isHost` 필드를 추가하고
  `server.ts`에서 리뷰 목(`review/mock/review.ts`)·시드 extras를 근거로 값을 계산
- 두 상태 모두 Host에게만 다음 동작(액션 검토 이동 / 마이페이지 재분석 안내)을 보여주고,
  참석자에게는 문구만 노출(리소스 소유권 축)
- 목 시드에 확정 대기·요약 중단 시나리오 각 1건 추가(`mock/seed.ts`)해 화면에서 확인 가능

## ✅ 작업 체크리스트

**기본**

- [ ] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [ ] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 검토·재분석 링크는 `canOperateMeeting`(리소스 소유권)으로
      Host만 노출. 서버(`getMeetingDetail`)에서 `isHost`를 계산해 내려주므로 화면이
      직접 역할을 비교하지 않음
- [x] 🧬 **zod** — 해당 없음(기존 `MeetingDetail` UI 계약 확장, 서버 응답 스키마는 BE 협의 전)
- [x] 🕵️ **정직성** — 확정 대기·중단을 "없음"으로 뭉치지 않고 각자 다른 문구로 안내
- [x] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [x] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그)
- [x] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [x] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인) — 기존
      `SectionNotice` 패턴을 확장해 `ActionsNotice` 추가
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 신규 2상태(확정 대기·중단) 포함해 4상태 분기
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음 — 해당 없음

## 🔗 연관 이슈

Closes #325

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

- `actionsSectionStateOf`의 분기 순서(진행중/요약중 → 목록 → 확정 대기 → 중단 → 없음)가
  기존 `pendingReason`(발화 기록 칸과 공유)과 충돌 없이 맞는지
- Host 전용 링크(`/app/meeting/:id/review`, `/app/me`) 노출 조건이 참석자 시점에서
  안 보이는지

## 📝 추가 메모

- `GET /meetings/:id` 응답의 `pendingActionCount`·`isStalled` 상당 필드는 아직 BE와
  스펙 미확정 — 현재는 목(리뷰 목·시드 extras)에서 계산. 연동 시 `server.ts`의 계산 로직만
  매퍼로 교체하면 됨(컴포넌트 0줄 변경).