### PR TITLE
[FEAT] 검색 랜딩 API 연동 #331

### DIFF
--- a/src/app/(shell)/app/search/page.tsx
+++ b/src/app/(shell)/app/search/page.tsx
@@ -7,7 +7,6 @@ import { SearchLanding } from "@/features/search/components/search-landing";
 import { SearchResultsPanel } from "@/features/search/components/search-results-panel";
 import { parseSearchQuery } from "@/features/search/lib";
 import { getSearchHome, getSearchProjects, getSearchResults } from "@/features/search/server";
-import type { RecentSearchEntry } from "@/features/search/types";
 import { PageHeader } from "@/features/shell/components/page-header";
 
 export const metadata: Metadata = {
@@ -38,7 +37,7 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
 
   let content: ReactNode;
   /* 최근 검색어는 입력 바로 아래에 서므로 페이지가 들고 있는다 — 검색 중일 때는 안 띄운다 */
-  let recentSearches: RecentSearchEntry[] = [];
+  let recentSearches: string[] = [];
   if (keyword) {
     const [results, projects] = await Promise.all([getSearchResults(query), getSearchProjects()]);
     content = (

--- a/src/features/search/components/recently-viewed-grid.tsx
+++ b/src/features/search/components/recently-viewed-grid.tsx
@@ -1,23 +1,21 @@
 import Link from "next/link";
 
-import { ProjectTag } from "@/components/common/project-tag";
-import { formatDate } from "@/lib/date";
 import { pickPaletteColor } from "@/lib/palette";
 
-import type { SearchResultItem } from "../types";
+import type { SearchRecentViewItem } from "../types";
 import { KindBadge } from "./kind-badge";
 import { SearchSection } from "./search-section";
 
 interface RecentlyViewedGridProps {
-  items: SearchResultItem[];
+  items: SearchRecentViewItem[];
 }
 
 /**
  * 최근 본 항목 — 2열 카드. 순수 표시(+ 프로젝트만 이동)라 서버에서 그린다.
  *
- * ⚠️ **프로젝트만 링크다.** 회의·액션·사람 상세는 이 검색 목이 별도로 부여한 값이라
- *    실제 회의·액션 상세 화면의 id 체계와 안 이어져 있다 — 안 되는 이동을 만드느니
- *    지금은 정보만 보여준다(§명세에 없는 기능은 안 만든다). 연동되면 실제 id로 이어 붙인다.
+ * ⚠️ **프로젝트만 링크다.** 회의·액션·사람 상세 화면 경로가 아직 이 목의 id 체계로
+ *    안 정해져 있다 — 안 되는 이동을 만드느니 지금은 정보만 보여준다
+ *    (§명세에 없는 기능은 안 만든다). 정해지면 실제 경로로 이어 붙인다.
  */
 export function RecentlyViewedGrid({ items }: RecentlyViewedGridProps) {
   if (items.length === 0) return null;
@@ -42,95 +40,43 @@ export function RecentlyViewedGrid({ items }: RecentlyViewedGridProps) {
   );
 }
 
-/**
- * 보조값을 **둘로 가른다** — 왼쪽은 사람·프로젝트 같은 '누구/무엇', 오른쪽은 날짜·개수 같은 '언제/얼마'.
- *
- * ⚠️ 전에는 `A · B` 한 문장이라 통째로 오른쪽 끝에 붙었고, 제목이 짧은 줄은 **가운데가
- *    400px 넘게 비었다** — 눈이 그 사이를 건너뛰어야 했다.
- * ⚠️ 갈라서 각자 열에 세우면 줄 전체로 퍼지면서도 **열마다 축이 선다**(DESIGN §3).
- */
-function metaParts(item: SearchResultItem): { lead: string; trail: string } {
-  switch (item.kind) {
-    case "MEETING":
-      return { lead: item.projectName, trail: formatDate(item.meetingDate) };
-    case "ACTION":
-      return { lead: item.assigneeName, trail: `마감 ${formatDate(item.dueDate)}` };
-    case "PROJECT":
-      return { lead: `회의 ${item.meetingCount}건`, trail: `액션 ${item.actionCount}건` };
-    case "PERSON":
-      return { lead: item.team ?? "소속 없음", trail: "" };
-  }
-}
-
-function title(item: SearchResultItem): string {
-  switch (item.kind) {
-    case "MEETING":
-    case "ACTION":
-      return item.title;
-    case "PROJECT":
-    case "PERSON":
-      return item.name;
-  }
-}
-
 interface RecentlyViewedCardProps {
-  item: SearchResultItem;
+  item: SearchRecentViewItem;
 }
 
 function RecentlyViewedCard({ item }: RecentlyViewedCardProps) {
   /*
-    ⚠️ **프로젝트도 자기 태그와 색이 있다.** 전에는 "제목이 곧 프로젝트"라며 뺐는데, 그러면
-       그 줄만 막대·칩 자리가 비어 **혼자 텅 빈 것처럼** 보였다 — 태그(`GOODS`)는 짧은
-       코드고 제목은 긴 이름이라 서로 대신하지 못한다.
+    ⚠️ **이 API는 프로젝트 태그를 안 준다**(`GET /search/overview`의 `recentItems`는
+       `{ type, id, title, meta }`뿐). 태그별 색 대신 `search-result-row.tsx`의 사람 항목과
+       같은 규칙 — **자기 id로 고른 색**을 막대에 쓴다(`use-profile-avatar`와 같은 키 규칙).
   */
-  const tag =
-    item.kind === "MEETING" || item.kind === "ACTION"
-      ? item.projectTag
-      : item.kind === "PROJECT"
-        ? item.tag
-        : null;
-  const parts = metaParts(item);
-
   const inner = (
     <>
-      {/*
-        ⚠️ **왼쪽에 프로젝트 색 막대를 세운다.** 한 줄짜리 행이 넷 쌓이니 전부 같은 무게로
-           읽혀 눈에 안 걸렸다 — 색 한 줄이 행마다 다른 표식이 되어 훑을 때 걸린다
-           (대시보드 회의 줄이 쓰는 것과 같은 방식).
-        ⚠️ **프로젝트 항목에도 선다.** 태그가 곧 제목이라 칩은 안 붙지만(아래 자리는 비운다)
-           막대는 그 프로젝트 색이다 — 여기만 비우면 넷 중 하나에 표식이 없어 오히려 튄다.
-      */}
       <span
         /* ⚠️ `h-full`은 부모 높이가 auto라 0이 된다 — 늘어나야 하므로 `self-stretch`다 */
         className="w-1 shrink-0 self-stretch rounded-full"
-        style={{ backgroundColor: tag ? pickPaletteColor(tag).solidColor : "transparent" }}
+        style={{ backgroundColor: pickPaletteColor(String(item.id)).solidColor }}
         aria-hidden
       />
       <KindBadge kind={item.kind} />
-      {/*
-        ⚠️ **태그 자리를 고정한다.** 프로젝트 항목엔 태그가 없어서, 자리를 안 잡아 두면
-           그 줄만 제목이 앞으로 당겨져 오와 열이 어긋난다.
-      */}
-      <span className="flex w-[76px] shrink-0 items-center">{tag && <ProjectTag tag={tag} />}</span>
       {/*
         ⚠️ **줄어들 수 있어야 말줄임이 듣는다**(2026-08-10 리뷰). `shrink-0 truncate`는 서로
            어긋나는 조합이라 — 못 줄이는 상자에는 넘칠 일이 없으니 `truncate`가 아무 일도
            안 한다 — 긴 제목이 그대로 카드를 밀고 나갔다. 줄어드는 쪽은 제목이다.
       */}
       <span className="text-foreground min-w-0 truncate text-[13px] leading-5 font-semibold">
-        {title(item)}
+        {item.title}
       </span>
       {/*
         ⚠️ **제목 뒤에 이어 붙인다.** 오른쪽 끝에 고정 열로 세워 봤더니 제목과 너무 멀어
            한 줄인데 두 덩이로 읽혔다 — 눈이 가운데 빈 자리를 건너뛰어야 했다.
-           검색 결과는 "무엇 · 어디 · 언제"가 한 문장처럼 이어져야 읽힌다.
-        ⚠️ 그래서 제목도 `flex-1`이 아니다. 늘어나면 다시 벌어진다.
+        ⚠️ `meta`는 BE가 이미 조합해 내려준 한 줄이다 — 여기서 더 쪼개지 않는다.
       */}
-      <span className="text-muted-foreground min-w-0 truncate text-[12px] leading-4">
-        {parts.lead}
-        {parts.trail && <span className="px-1.5 opacity-50">·</span>}
-        {parts.trail}
-      </span>
+      {item.meta && (
+        <span className="text-muted-foreground min-w-0 truncate text-[12px] leading-4">
+          {item.meta}
+        </span>
+      )}
     </>
   );
 

--- a/src/features/search/components/search-input.tsx
+++ b/src/features/search/components/search-input.tsx
@@ -8,15 +8,14 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Input } from "@/components/ui/input";
 
 import { recordSearchAction } from "../actions";
-import type { RecentSearchEntry } from "../types";
 
 /** 적기를 멈춘 뒤 이만큼 지나면 보낸다 — 짧으면 요청이 줄줄이 나가고 길면 굼떠 보인다 */
 const SEARCH_DEBOUNCE_MS = 300;
 
 interface SearchInputProps {
   keyword: string;
-  /** 입력을 눌렀을 때 아래로 펼칠 최근 검색어 */
-  recentSearches?: RecentSearchEntry[];
+  /** 입력을 눌렀을 때 아래로 펼칠 최근 검색어 — 최신순 */
+  recentSearches?: string[];
 }
 
 /**
@@ -148,17 +147,17 @@ export function SearchInput({ keyword, recentSearches = [] }: SearchInputProps) 
           <li className="text-muted-foreground/70 px-4 pt-1 pb-1.5 text-[11px] leading-4">
             최근 검색어
           </li>
-          {recentSearches.map((entry) => (
-            <li key={entry.keyword}>
+          {recentSearches.map((keyword) => (
+            <li key={keyword}>
               <Link
-                href={`/app/search?q=${encodeURIComponent(entry.keyword)}`}
+                href={`/app/search?q=${encodeURIComponent(keyword)}`}
                 /* ⚠️ 마우스 다운이 포커스를 빼앗아 목록이 먼저 닫히는 것을 막는다 */
                 onMouseDown={(event) => event.preventDefault()}
                 onClick={() => setIsOpen(false)}
                 className="hover:bg-foreground/5 focus-visible:bg-foreground/5 flex items-center gap-2.5 px-4 py-2 text-[13px] leading-5 outline-hidden"
               >
                 <Clock className="text-muted-foreground/70 size-3.5 shrink-0" aria-hidden />
-                <span className="truncate">{entry.keyword}</span>
+                <span className="truncate">{keyword}</span>
               </Link>
             </li>
           ))}

--- a/src/features/search/mapper.ts
+++ b/src/features/search/mapper.ts
@@ -1,0 +1,58 @@
+import { AUTHORITY, type Authority } from "@/constants/domain";
+
+import type { PersonBrowseItem, ProjectBrowseItem, SearchRecentViewItem } from "./types";
+import { SEARCH_KIND, type SearchKind } from "./types";
+
+/**
+ * BE shape → UI 계약 (§Mock 격리막 — **shape을 흡수하는 곳은 여기 하나다**).
+ *
+ * ⚠️ 컴포넌트는 이 파일을 모른다. BE가 모양을 바꾸면 여기만 고친다.
+ * ⚠️ API 스펙 전달받음(2026-08-11) — **BE 실코드 미대조**(§연동 검증).
+ */
+
+export interface BeSearchOverview {
+  recentQueries: string[];
+  recentItems: { type: string; id: number; title: string; meta: string | null }[];
+  projects: { id: number; tag: string; name: string; meetingCount: number }[];
+  people: { id: number; name: string; role: string | null }[];
+}
+
+const VALID_SEARCH_KINDS = Object.values(SEARCH_KIND) as string[];
+
+/**
+ * 모르는 종류는 `null` — 화면이 못 그리는 값을 그대로 흘리지 않는다
+ * (§도메인 상수: BE enum과 이름이 어긋나면 매퍼에서 조용히 틀린다).
+ */
+function toSearchKind(type: string): SearchKind | null {
+  return VALID_SEARCH_KINDS.includes(type) ? (type as SearchKind) : null;
+}
+
+/** 종류를 못 알아본 항목은 뺀다 */
+export function toRecentViewItems(items: BeSearchOverview["recentItems"]): SearchRecentViewItem[] {
+  return items.flatMap((item) => {
+    const kind = toSearchKind(item.type);
+    if (!kind) return [];
+    return [{ kind, id: item.id, title: item.title, meta: item.meta }];
+  });
+}
+
+export function toProjectBrowseItem(
+  project: BeSearchOverview["projects"][number],
+): ProjectBrowseItem {
+  return {
+    id: project.id,
+    name: project.name,
+    tag: project.tag,
+    meetingCount: project.meetingCount,
+  };
+}
+
+/** 모르는 권한 문자열은 가장 낮은 권한으로 떨어뜨린다(manage-mapper.ts와 같은 규칙, §권한) */
+function toAuthority(role: string | null): Authority {
+  const values = Object.values(AUTHORITY) as string[];
+  return role !== null && values.includes(role) ? (role as Authority) : AUTHORITY.MEMBER;
+}
+
+export function toPersonBrowseItem(person: BeSearchOverview["people"][number]): PersonBrowseItem {
+  return { id: person.id, name: person.name, authority: toAuthority(person.role) };
+}

--- a/src/features/search/mock/data.ts
+++ b/src/features/search/mock/data.ts
@@ -5,6 +5,7 @@ import type {
   SearchMeetingResult,
   SearchPersonResult,
   SearchProjectResult,
+  SearchRecentViewItem,
 } from "../types";
 
 /**
@@ -153,10 +154,35 @@ export const SEARCH_MOCK_PEOPLE: SearchPersonResult[] = [
   },
 ];
 
-/** 최근 본 항목 — 회의 둘·액션 하나·프로젝트 하나(2×2로 그린다) */
-export const SEARCH_MOCK_RECENTLY_VIEWED = [
-  ROADMAP_MEETING,
-  PAYMENT_API_ACTION,
-  BRAND_KICKOFF_MEETING,
-  GOODS_PROJECT,
+/**
+ * 최근 본 항목 — 회의 둘·액션 하나·프로젝트 하나.
+ * ⚠️ `GET /search/overview`의 `recentItems`는 `{ type, id, title, meta }`뿐이다 —
+ *    종류별 상세 필드(발췌·담당자·마감일 등)를 안 주므로, `meta`는 BE가 이미 조합해
+ *    내려줄 보조 문구를 그대로 흉내 낸다.
+ */
+export const SEARCH_MOCK_RECENTLY_VIEWED: SearchRecentViewItem[] = [
+  {
+    kind: "MEETING",
+    id: ROADMAP_MEETING.id,
+    title: ROADMAP_MEETING.title,
+    meta: `${ROADMAP_MEETING.projectName} · ${ROADMAP_MEETING.meetingDate}`,
+  },
+  {
+    kind: "ACTION",
+    id: PAYMENT_API_ACTION.id,
+    title: PAYMENT_API_ACTION.title,
+    meta: `${PAYMENT_API_ACTION.assigneeName} · 마감 ${PAYMENT_API_ACTION.dueDate}`,
+  },
+  {
+    kind: "MEETING",
+    id: BRAND_KICKOFF_MEETING.id,
+    title: BRAND_KICKOFF_MEETING.title,
+    meta: `${BRAND_KICKOFF_MEETING.projectName} · ${BRAND_KICKOFF_MEETING.meetingDate}`,
+  },
+  {
+    kind: "PROJECT",
+    id: GOODS_PROJECT.id,
+    title: GOODS_PROJECT.name,
+    meta: `회의 ${GOODS_PROJECT.meetingCount}건 · 액션 ${GOODS_PROJECT.actionCount}건`,
+  },
 ];

--- a/src/features/search/mock/recent-searches.ts
+++ b/src/features/search/mock/recent-searches.ts
@@ -1,4 +1,9 @@
-import type { RecentSearchEntry } from "../types";
+/** 목에서만 쓰는 내부 형태 — 정렬용 시각을 들고 있다. 공개 계약(`SearchHome.recentSearches`)은 `string[]`이다 */
+interface MockRecentSearchEntry {
+  keyword: string;
+  /** ISO datetime */
+  searchedAt: string;
+}
 
 /**
  * ⚠️ 목 데이터 — BE 연동 전. **서버 프로세스 메모리에만 있다**(재시작하면 초기값으로 되돌아간다).
@@ -6,7 +11,7 @@ import type { RecentSearchEntry } from "../types";
  * ⚠️ 로그인(세션)이 없어 "이 사용자의 최근 검색"이 아니라 **전역**으로 흉내 낸다(§정직성).
  * ⚠️ `globalThis`에 매단다 — dev의 HMR로 `let`이 초기화되면 방금 한 검색이 사라진다.
  */
-const INITIAL: RecentSearchEntry[] = [
+const INITIAL: MockRecentSearchEntry[] = [
   { keyword: "로드맵", searchedAt: "2026-08-06T09:00:00+09:00" },
   { keyword: "API 명세", searchedAt: "2026-08-07T11:30:00+09:00" },
   { keyword: "브랜드 캠페인", searchedAt: "2026-08-07T15:10:00+09:00" },
@@ -15,12 +20,17 @@ const INITIAL: RecentSearchEntry[] = [
 /** 한 번에 들고 있는 최근 검색어 수 — 넘치면 오래된 것부터 밀어낸다 */
 const MAX_ENTRIES = 5;
 
-const globalStore = globalThis as typeof globalThis & { __recentSearchStore?: RecentSearchEntry[] };
+const globalStore = globalThis as typeof globalThis & {
+  __recentSearchStore?: MockRecentSearchEntry[];
+};
 const store = (globalStore.__recentSearchStore ??= INITIAL);
 
-/** 최근 것이 앞에 오도록 정렬해 돌려준다 */
-export function listMockRecentSearches(): RecentSearchEntry[] {
-  return [...store].sort((a, b) => b.searchedAt.localeCompare(a.searchedAt)).slice(0, MAX_ENTRIES);
+/** 최근 것이 앞에 오도록 정렬해 검색어만 돌려준다(`GET /search/overview`의 `recentQueries`와 같은 모양) */
+export function listMockRecentSearches(): string[] {
+  return [...store]
+    .sort((a, b) => b.searchedAt.localeCompare(a.searchedAt))
+    .slice(0, MAX_ENTRIES)
+    .map((entry) => entry.keyword);
 }
 
 /**

--- a/src/features/search/server.ts
+++ b/src/features/search/server.ts
@@ -1,8 +1,13 @@
 import "server-only";
 
+import { requireAccessToken } from "@/features/auth/session";
+import { serverApi } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
 import { isMock } from "@/mocks/config";
 
 import { categoryOf, textIncludes } from "./lib";
+import type { BeSearchOverview } from "./mapper";
+import { toPersonBrowseItem, toProjectBrowseItem, toRecentViewItems } from "./mapper";
 import {
   SEARCH_MOCK_ACTIONS,
   SEARCH_MOCK_MEETINGS,
@@ -45,8 +50,19 @@ export async function getSearchHome(): Promise<SearchHome> {
     };
   }
 
-  // ⚠️ 미구현 — API 스펙 확정 후 검색 랜딩 경로로 fetch하고 매퍼로 UI 계약에 맞춘다.
-  throw new Error("검색 랜딩 API가 아직 연결되지 않았습니다.");
+  /*
+    [스펙 전달, BE 실코드 미대조] `GET /api/v1/search/overview` — 최근 검색어·최근 본 항목·
+    둘러보기용 프로젝트·사람 목록을 한 번에 준다. 회사·사람은 토큰 기준으로 서버가 정한다.
+  */
+  const accessToken = await requireAccessToken();
+  const overview = await serverApi<BeSearchOverview>(ep.searchOverview(), { accessToken });
+
+  return {
+    recentSearches: overview.recentQueries,
+    recentlyViewed: toRecentViewItems(overview.recentItems),
+    projects: overview.projects.map(toProjectBrowseItem),
+    people: overview.people.map(toPersonBrowseItem),
+  };
 }
 
 /**

--- a/src/features/search/types.ts
+++ b/src/features/search/types.ts
@@ -85,12 +85,6 @@ export interface SearchResults {
   items: SearchResultItem[];
 }
 
-export interface RecentSearchEntry {
-  keyword: string;
-  /** ISO datetime */
-  searchedAt: string;
-}
-
 export interface ProjectBrowseItem {
   id: number;
   name: string;
@@ -104,10 +98,23 @@ export interface PersonBrowseItem {
   authority: Authority;
 }
 
+/**
+ * 최근 본 항목 — `SearchResultItem`과 다른, **훨씬 적은** 필드만 온다(`GET /search/overview`).
+ * 종류별 상세 필드(발췌·담당자·마감일 등)는 이 API가 안 준다 — `meta`는 BE가 이미 조합한
+ * 보조 문구 한 줄이다(예: "프로젝트명 · 날짜").
+ */
+export interface SearchRecentViewItem {
+  kind: SearchKind;
+  id: number;
+  title: string;
+  meta: string | null;
+}
+
 /** 검색어가 없을 때(랜딩) 보여줄 것 */
 export interface SearchHome {
-  recentSearches: RecentSearchEntry[];
-  recentlyViewed: SearchResultItem[];
+  /** 최신순 — 최대 10개 */
+  recentSearches: string[];
+  recentlyViewed: SearchRecentViewItem[];
   projects: ProjectBrowseItem[];
   people: PersonBrowseItem[];
 }

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -124,6 +124,15 @@ export const ep = {
   notices: () => "/api/notices",
   subscription: () => "/api/subscription",
 
+  /**
+   * 검색 — API 스펙 전달받음(2026-08-11), **BE 실코드 미대조**(§연동 검증: 문서와 코드가
+   * 다르면 코드가 맞다 — 구현 붙일 때 컨트롤러로 재확인한다).
+   */
+  searchOverview: () => "/api/v1/search/overview",
+  search: () => "/api/v1/search",
+  searchRecentQueries: () => "/api/v1/search/recent-queries",
+  searchRecentViews: () => "/api/v1/search/recent-views",
+
   /* 시스템 운영자 */
   systemDashboard: () => "/api/system/dashboard",
 } as const;


### PR DESCRIPTION
## 📋 PR 타입

> 해당하는 타입을 선택해 주세요 (복수 선택 가능)

- [x] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- 검색 랜딩 API(`GET /api/v1/search/overview`) 연동 — 순서상 결과 API(#2)보다 먼저 진행
- `ep.searchOverview()` 등록(BE 실코드 미대조, 스펙 전달 기준) 및 `search/mapper.ts` 신설로 BE `{recentItems, people, projects, recentQueries}` → UI 계약 매핑
- 이 API가 `recentItems`에 `{type, id, title, meta}`만 주므로(기존 mock의 종류별 상세 필드 없음), `SearchRecentViewItem` 타입을 새로 두고 `RecentlyViewedGrid`를 그 모양에 맞게 단순화(프로젝트 태그 칩 제거, BE가 준 `meta` 문구 그대로 노출)
- `recentSearches`는 BE가 타임스탬프 없이 문자열 배열만 주므로 `SearchHome.recentSearches: string[]`로 단순화

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [ ] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 해당 없음(로그인 사용자 공통 기능, 데이터는 서버가 토큰 기준으로 제한)
- [ ] 🧬 **zod** — 매퍼에 `safeParse` 미적용(타입 단언만 사용) — TODO
- [x] 🕵️ **정직성** — 스펙 미검증(BE 실코드 미대조) 상태를 엔드포인트·매퍼 주석에 명시
- [x] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 — 해당 없음(이미지·폰트·dynamic import 변경 없음)
- [x] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [x] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인)
- [ ] 🧪 `loading` / `error` / `empty` 3상태 — 기존 `error.tsx`/`loading.tsx` 재사용, 신규 empty 처리 없음
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음 — 해당 없음

---

## 🔗 연관 이슈

Closes #331

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

- `SearchRecentViewItem`으로 타입을 줄인 것이 맞는 방향인지 (API가 종류별 상세 필드를 안 줘서 불가피했음)
- `mapper.ts`의 `toSearchKind`/`toAuthority` 폴백(모르는 값 조용히 버림/최저권한)이 이 도메인에 맞는지

---

## 📝 추가 메모

zod `safeParse` 미적용 부분은 다음 PR에서 보완 예정으로 남겨둘지 이번에 같이 넣을지 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 검색 홈이 실제 검색 API와 연동되어 최근 검색어, 최근 본 항목, 프로젝트 및 사람 정보를 표시합니다.
  * 검색 관련 API 경로를 지원합니다.

* **개선 사항**
  * 최근 검색어를 간결한 문자열 목록으로 표시합니다.
  * 최근 본 항목에 API가 제공하는 메타 정보를 표시하고, 불필요한 프로젝트 태그와 날짜 표시를 제거했습니다.
  * 검색 결과 유형과 권한 정보를 안정적으로 변환해 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->