### PR TITLE
[FEAT] 검색 결과 API 연동  #333

### DIFF
--- a/src/app/(shell)/app/search/page.tsx
+++ b/src/app/(shell)/app/search/page.tsx
@@ -7,7 +7,6 @@ import { SearchLanding } from "@/features/search/components/search-landing";
 import { SearchResultsPanel } from "@/features/search/components/search-results-panel";
 import { parseSearchQuery } from "@/features/search/lib";
 import { getSearchHome, getSearchProjects, getSearchResults } from "@/features/search/server";
-import type { RecentSearchEntry } from "@/features/search/types";
 import { PageHeader } from "@/features/shell/components/page-header";
 
 export const metadata: Metadata = {
@@ -38,7 +37,7 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
 
   let content: ReactNode;
   /* 최근 검색어는 입력 바로 아래에 서므로 페이지가 들고 있는다 — 검색 중일 때는 안 띄운다 */
-  let recentSearches: RecentSearchEntry[] = [];
+  let recentSearches: string[] = [];
   if (keyword) {
     const [results, projects] = await Promise.all([getSearchResults(query), getSearchProjects()]);
     content = (

--- a/src/features/search/components/recently-viewed-grid.tsx
+++ b/src/features/search/components/recently-viewed-grid.tsx
@@ -1,23 +1,21 @@
 import Link from "next/link";
 
-import { ProjectTag } from "@/components/common/project-tag";
-import { formatDate } from "@/lib/date";
 import { pickPaletteColor } from "@/lib/palette";
 
-import type { SearchResultItem } from "../types";
+import type { SearchRecentViewItem } from "../types";
 import { KindBadge } from "./kind-badge";
 import { SearchSection } from "./search-section";
 
 interface RecentlyViewedGridProps {
-  items: SearchResultItem[];
+  items: SearchRecentViewItem[];
 }
 
 /**
  * 최근 본 항목 — 2열 카드. 순수 표시(+ 프로젝트만 이동)라 서버에서 그린다.
  *
- * ⚠️ **프로젝트만 링크다.** 회의·액션·사람 상세는 이 검색 목이 별도로 부여한 값이라
- *    실제 회의·액션 상세 화면의 id 체계와 안 이어져 있다 — 안 되는 이동을 만드느니
- *    지금은 정보만 보여준다(§명세에 없는 기능은 안 만든다). 연동되면 실제 id로 이어 붙인다.
+ * ⚠️ **프로젝트만 링크다.** 회의·액션·사람 상세 화면 경로가 아직 이 목의 id 체계로
+ *    안 정해져 있다 — 안 되는 이동을 만드느니 지금은 정보만 보여준다
+ *    (§명세에 없는 기능은 안 만든다). 정해지면 실제 경로로 이어 붙인다.
  */
 export function RecentlyViewedGrid({ items }: RecentlyViewedGridProps) {
   if (items.length === 0) return null;
@@ -42,95 +40,43 @@ export function RecentlyViewedGrid({ items }: RecentlyViewedGridProps) {
   );
 }
 
-/**
- * 보조값을 **둘로 가른다** — 왼쪽은 사람·프로젝트 같은 '누구/무엇', 오른쪽은 날짜·개수 같은 '언제/얼마'.
- *
- * ⚠️ 전에는 `A · B` 한 문장이라 통째로 오른쪽 끝에 붙었고, 제목이 짧은 줄은 **가운데가
- *    400px 넘게 비었다** — 눈이 그 사이를 건너뛰어야 했다.
- * ⚠️ 갈라서 각자 열에 세우면 줄 전체로 퍼지면서도 **열마다 축이 선다**(DESIGN §3).
- */
-function metaParts(item: SearchResultItem): { lead: string; trail: string } {
-  switch (item.kind) {
-    case "MEETING":
-      return { lead: item.projectName, trail: formatDate(item.meetingDate) };
-    case "ACTION":
-      return { lead: item.assigneeName, trail: `마감 ${formatDate(item.dueDate)}` };
-    case "PROJECT":
-      return { lead: `회의 ${item.meetingCount}건`, trail: `액션 ${item.actionCount}건` };
-    case "PERSON":
-      return { lead: item.team ?? "소속 없음", trail: "" };
-  }
-}
-
-function title(item: SearchResultItem): string {
-  switch (item.kind) {
-    case "MEETING":
-    case "ACTION":
-      return item.title;
-    case "PROJECT":
-    case "PERSON":
-      return item.name;
-  }
-}
-
 interface RecentlyViewedCardProps {
-  item: SearchResultItem;
+  item: SearchRecentViewItem;
 }
 
 function RecentlyViewedCard({ item }: RecentlyViewedCardProps) {
   /*
-    ⚠️ **프로젝트도 자기 태그와 색이 있다.** 전에는 "제목이 곧 프로젝트"라며 뺐는데, 그러면
-       그 줄만 막대·칩 자리가 비어 **혼자 텅 빈 것처럼** 보였다 — 태그(`GOODS`)는 짧은
-       코드고 제목은 긴 이름이라 서로 대신하지 못한다.
+    ⚠️ **이 API는 프로젝트 태그를 안 준다**(`GET /search/overview`의 `recentItems`는
+       `{ type, id, title, meta }`뿐). 태그별 색 대신 `search-result-row.tsx`의 사람 항목과
+       같은 규칙 — **자기 id로 고른 색**을 막대에 쓴다(`use-profile-avatar`와 같은 키 규칙).
   */
-  const tag =
-    item.kind === "MEETING" || item.kind === "ACTION"
-      ? item.projectTag
-      : item.kind === "PROJECT"
-        ? item.tag
-        : null;
-  const parts = metaParts(item);
-
   const inner = (
     <>
-      {/*
-        ⚠️ **왼쪽에 프로젝트 색 막대를 세운다.** 한 줄짜리 행이 넷 쌓이니 전부 같은 무게로
-           읽혀 눈에 안 걸렸다 — 색 한 줄이 행마다 다른 표식이 되어 훑을 때 걸린다
-           (대시보드 회의 줄이 쓰는 것과 같은 방식).
-        ⚠️ **프로젝트 항목에도 선다.** 태그가 곧 제목이라 칩은 안 붙지만(아래 자리는 비운다)
-           막대는 그 프로젝트 색이다 — 여기만 비우면 넷 중 하나에 표식이 없어 오히려 튄다.
-      */}
       <span
         /* ⚠️ `h-full`은 부모 높이가 auto라 0이 된다 — 늘어나야 하므로 `self-stretch`다 */
         className="w-1 shrink-0 self-stretch rounded-full"
-        style={{ backgroundColor: tag ? pickPaletteColor(tag).solidColor : "transparent" }}
+        style={{ backgroundColor: pickPaletteColor(String(item.id)).solidColor }}
         aria-hidden
       />
       <KindBadge kind={item.kind} />
-      {/*
-        ⚠️ **태그 자리를 고정한다.** 프로젝트 항목엔 태그가 없어서, 자리를 안 잡아 두면
-           그 줄만 제목이 앞으로 당겨져 오와 열이 어긋난다.
-      */}
-      <span className="flex w-[76px] shrink-0 items-center">{tag && <ProjectTag tag={tag} />}</span>
       {/*
         ⚠️ **줄어들 수 있어야 말줄임이 듣는다**(2026-08-10 리뷰). `shrink-0 truncate`는 서로
            어긋나는 조합이라 — 못 줄이는 상자에는 넘칠 일이 없으니 `truncate`가 아무 일도
            안 한다 — 긴 제목이 그대로 카드를 밀고 나갔다. 줄어드는 쪽은 제목이다.
       */}
       <span className="text-foreground min-w-0 truncate text-[13px] leading-5 font-semibold">
-        {title(item)}
+        {item.title}
       </span>
       {/*
         ⚠️ **제목 뒤에 이어 붙인다.** 오른쪽 끝에 고정 열로 세워 봤더니 제목과 너무 멀어
            한 줄인데 두 덩이로 읽혔다 — 눈이 가운데 빈 자리를 건너뛰어야 했다.
-           검색 결과는 "무엇 · 어디 · 언제"가 한 문장처럼 이어져야 읽힌다.
-        ⚠️ 그래서 제목도 `flex-1`이 아니다. 늘어나면 다시 벌어진다.
+        ⚠️ `meta`는 BE가 이미 조합해 내려준 한 줄이다 — 여기서 더 쪼개지 않는다.
       */}
-      <span className="text-muted-foreground min-w-0 truncate text-[12px] leading-4">
-        {parts.lead}
-        {parts.trail && <span className="px-1.5 opacity-50">·</span>}
-        {parts.trail}
-      </span>
+      {item.meta && (
+        <span className="text-muted-foreground min-w-0 truncate text-[12px] leading-4">
+          {item.meta}
+        </span>
+      )}
     </>
   );
 

--- a/src/features/search/components/search-input.tsx
+++ b/src/features/search/components/search-input.tsx
@@ -8,15 +8,14 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Input } from "@/components/ui/input";
 
 import { recordSearchAction } from "../actions";
-import type { RecentSearchEntry } from "../types";
 
 /** 적기를 멈춘 뒤 이만큼 지나면 보낸다 — 짧으면 요청이 줄줄이 나가고 길면 굼떠 보인다 */
 const SEARCH_DEBOUNCE_MS = 300;
 
 interface SearchInputProps {
   keyword: string;
-  /** 입력을 눌렀을 때 아래로 펼칠 최근 검색어 */
-  recentSearches?: RecentSearchEntry[];
+  /** 입력을 눌렀을 때 아래로 펼칠 최근 검색어 — 최신순 */
+  recentSearches?: string[];
 }
 
 /**
@@ -148,17 +147,17 @@ export function SearchInput({ keyword, recentSearches = [] }: SearchInputProps) 
           <li className="text-muted-foreground/70 px-4 pt-1 pb-1.5 text-[11px] leading-4">
             최근 검색어
           </li>
-          {recentSearches.map((entry) => (
-            <li key={entry.keyword}>
+          {recentSearches.map((keyword) => (
+            <li key={keyword}>
               <Link
-                href={`/app/search?q=${encodeURIComponent(entry.keyword)}`}
+                href={`/app/search?q=${encodeURIComponent(keyword)}`}
                 /* ⚠️ 마우스 다운이 포커스를 빼앗아 목록이 먼저 닫히는 것을 막는다 */
                 onMouseDown={(event) => event.preventDefault()}
                 onClick={() => setIsOpen(false)}
                 className="hover:bg-foreground/5 focus-visible:bg-foreground/5 flex items-center gap-2.5 px-4 py-2 text-[13px] leading-5 outline-hidden"
               >
                 <Clock className="text-muted-foreground/70 size-3.5 shrink-0" aria-hidden />
-                <span className="truncate">{entry.keyword}</span>
+                <span className="truncate">{keyword}</span>
               </Link>
             </li>
           ))}

--- a/src/features/search/components/search-result-row.tsx
+++ b/src/features/search/components/search-result-row.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 
-import { ProjectTag } from "@/components/common/project-tag";
 import { AUTHORITY_BADGE_CLASS, AUTHORITY_LABEL } from "@/constants/authority";
 import { formatDate } from "@/lib/date";
 import { pickPaletteColor } from "@/lib/palette";
@@ -29,15 +28,16 @@ interface SearchResultRowProps {
 }
 
 /**
- * 결과 한 줄 — 종류마다 제목·발췌·보조 정보가 달라 안에서 갈라 그린다. 순수 표시(+ 프로젝트만
- * 이동)라 서버에서 그린다.
+ * 결과 한 줄 — 종류를 가리지 않는 평평한 필드(`제목·발췌·project·date·role`)만으로 그린다.
+ * 순수 표시(+ 프로젝트만 이동)라 서버에서 그린다.
  *
- * ⚠️ **프로젝트만 링크다.** 회의·액션 상세는 이 검색 목이 별도로 부여한 값이라 실제 상세
- *    화면의 id 체계와 안 이어져 있다(`recently-viewed-grid.tsx`와 같은 이유) — 프로젝트는
- *    실제 프로젝트 id를 그대로 쓰므로 `/app/projects/:id`가 유효하다.
+ * ⚠️ **프로젝트만 링크다.** 회의·액션 상세 화면 경로가 아직 이 목의 id 체계로 안 정해져
+ *    있다 — 안 되는 이동을 만드느니 지금은 정보만 보여준다(§명세에 없는 기능은 안 만든다).
+ * ⚠️ **태그 코드가 없다.** `GET /search`의 `project`는 표시용 문구뿐이라(BE 실코드 미대조,
+ *    §연동 검증) 프로젝트 칩(`ProjectTag`)을 못 그린다 — 색 막대만 `project` 문구 기준으로 낸다.
  */
 export function SearchResultRow({ item, keyword }: SearchResultRowProps) {
-  const tag = tagOf(item);
+  const meta = rowMeta(item);
 
   const content = (
     <>
@@ -47,44 +47,36 @@ export function SearchResultRow({ item, keyword }: SearchResultRowProps) {
       */}
       <span
         className="w-1 shrink-0 self-stretch rounded-full"
-        /*
-          ⚠️ 사람은 프로젝트 태그가 없다 — 그렇다고 비워 두면 그 줄만 왼쪽이 뚫려 보인다.
-             **자기 아바타와 같은 색**을 쓴다(같은 팔레트라 사람마다 늘 같은 색이다).
-        */
-        style={{
-          /* ⚠️ 아바타와 **같은 키**(`String(id)`)여야 색이 맞는다 — `use-profile-avatar`와 한 쌍이다 */
-          backgroundColor: pickPaletteColor(tag ?? String(item.id)).solidColor,
-        }}
+        style={{ backgroundColor: pickPaletteColor(item.project ?? String(item.id)).solidColor }}
         aria-hidden
       />
       {/*
         ⚠️ **얼굴을 여기 끼우지 않는다.** 사람 줄에만 아바타를 넣었더니 그 줄만 제목이
            오른쪽으로 밀려 **줄마다 제목이 다른 자리에서 시작했다** — 목록은 한 세로선을
            따라 읽는다. 종류는 이미 왼쪽 배지가 말한다.
-        ⚠️ 랜딩의 `사람으로 찾기`는 **모든 줄이 사람**이라 아바타를 넣어도 열이 안 흔들린다.
       */}
       <KindBadge kind={item.kind} />
 
       <div className="min-w-0 flex-1">
         {/*
-          ⚠️ **제목 줄에 다 세운다.** 제목만 한 줄, 태그·보조값은 아랫줄로 내렸더니 한 항목이
+          ⚠️ **제목 줄에 다 세운다.** 제목만 한 줄, 보조값은 아랫줄로 내렸더니 한 항목이
              세 줄을 먹으면서 오른쪽은 통째로 비었다 — 위아래로는 길고 좌우로는 텅 빈 모양이다.
              한 줄에 이어 붙이면 그 줄이 문장으로 읽히고 카드도 낮아진다.
         */}
         <p className="flex min-w-0 items-center gap-2">
           <span className="text-foreground truncate text-[13px] leading-5 font-semibold">
-            <MatchText text={rowTitle(item)} keyword={keyword} />
+            <MatchText text={item.title} keyword={keyword} />
           </span>
-          <ProjectTagOf item={item} />
         </p>
-        {rowSnippet(item) && (
+        {item.snippet && (
           /*
             ⚠️ **본문 크기(13px)로 올린다.** 12px 흐린 글씨로 두니 정작 찾던 말이 들어 있는
                줄이 제일 안 읽혔다 — 검색어가 걸린 문장이 이 화면에서 제일 중요한 값이다.
             ⚠️ 색은 본문보다 한 단계만 낮춘다. 제목과 같으면 둘 중 뭘 먼저 볼지 알 수 없다.
+            ⚠️ **회의 요약이 아직 없으면 이 줄이 통째로 빠진다** — 발췌를 지어내지 않는다.
           */
           <p className="text-foreground/75 mt-1 truncate text-[13px] leading-5">
-            <MatchText text={rowSnippet(item) ?? ""} keyword={keyword} />
+            <MatchText text={item.snippet} keyword={keyword} />
           </p>
         )}
       </div>
@@ -95,22 +87,25 @@ export function SearchResultRow({ item, keyword }: SearchResultRowProps) {
         ⚠️ 제목 줄이 아니라 **항목 전체의 세로 중앙**에 선다(배지와 같은 높이) — 두 줄짜리
            항목에서 첫 줄에만 매달리면 다시 기울어 보인다.
       */}
-      {/*
-        ⚠️ **여기도 줄어들 수 있어야 한다**(2026-08-10 리뷰). `shrink-0 truncate`는 서로 어긋난다 —
-           못 줄이는 상자에는 넘칠 일이 없어 말줄임이 안 걸리고, 긴 값이 줄을 밀고 나간다.
-      */}
-      <span className="text-muted-foreground min-w-0 truncate text-[12px] leading-4">
-        <MatchText text={rowMeta(item)} keyword={keyword} />
-      </span>
+      {meta && (
+        /*
+          ⚠️ **여기도 줄어들 수 있어야 한다**(2026-08-10 리뷰). `shrink-0 truncate`는 서로 어긋난다 —
+             못 줄이는 상자에는 넘칠 일이 없어 말줄임이 안 걸리고, 긴 값이 줄을 밀고 나간다.
+        */
+        <span className="text-muted-foreground min-w-0 truncate text-[12px] leading-4">
+          <MatchText text={meta} keyword={keyword} />
+        </span>
+      )}
 
-      {item.kind === "PERSON" && (
+      {/* ⚠️ `role`이 `null`이면(안 오면) 빈 값으로 다룬다 — 배지를 안 그린다 */}
+      {item.role && (
         <span
           className={cn(
-            AUTHORITY_BADGE_CLASS[item.authority],
+            AUTHORITY_BADGE_CLASS[item.role],
             "shrink-0 rounded px-1.5 py-0.5 text-[11px] leading-4",
           )}
         >
-          {AUTHORITY_LABEL[item.authority]}
+          {AUTHORITY_LABEL[item.role]}
         </span>
       )}
     </>
@@ -136,52 +131,10 @@ export function SearchResultRow({ item, keyword }: SearchResultRowProps) {
   );
 }
 
-/** 이 결과가 딸린 프로젝트 태그 — 없으면 `null`(사람) */
-function tagOf(item: SearchResultItem): string | null {
-  if (item.kind === "MEETING" || item.kind === "ACTION") return item.projectTag;
-  if (item.kind === "PROJECT") return item.tag;
-  return null;
-}
-
-function ProjectTagOf({ item }: { item: SearchResultItem }) {
-  const tag =
-    item.kind === "MEETING" || item.kind === "ACTION"
-      ? item.projectTag
-      : item.kind === "PROJECT"
-        ? item.tag
-        : null;
-  if (!tag) return null;
-
-  return <ProjectTag tag={tag} />;
-}
-
-function rowTitle(item: SearchResultItem): string {
-  switch (item.kind) {
-    case "MEETING":
-    case "ACTION":
-      return item.title;
-    case "PROJECT":
-      return item.name;
-    case "PERSON":
-      return item.name;
-  }
-}
-
-function rowSnippet(item: SearchResultItem): string | null {
-  if (item.kind === "MEETING") return item.snippet;
-  if (item.kind === "PERSON") return item.description;
-  return null;
-}
-
+/** 소속 프로젝트·일시를 한 줄로 — 둘 다 없으면 빈 문자열(그 줄을 안 그린다) */
 function rowMeta(item: SearchResultItem): string {
-  switch (item.kind) {
-    case "MEETING":
-      return `${item.projectName} · ${formatDate(item.meetingDate)}`;
-    case "ACTION":
-      return `${item.assigneeName} · 마감 ${formatDate(item.dueDate)}`;
-    case "PROJECT":
-      return `회의 ${item.meetingCount}건 · 액션 ${item.actionCount}건`;
-    case "PERSON":
-      return item.team ?? "소속 없음";
-  }
+  const parts = [item.project, item.date ? formatDate(item.date) : null].filter(
+    (part): part is string => Boolean(part),
+  );
+  return parts.join(" · ");
 }

--- a/src/features/search/lib.ts
+++ b/src/features/search/lib.ts
@@ -1,10 +1,4 @@
-import type {
-  SearchCategory,
-  SearchKind,
-  SearchPeriod,
-  SearchQuery,
-  SearchResultItem,
-} from "./types";
+import type { SearchCategory, SearchKind, SearchPeriod, SearchQuery } from "./types";
 import { SEARCH_CATEGORY, SEARCH_PERIOD } from "./types";
 
 /** 글자 한 토막 — 검색어에 걸린 자리인지 함께 들고 있다 */
@@ -54,8 +48,12 @@ const KIND_TO_CATEGORY: Record<SearchKind, Exclude<SearchCategory, "all">> = {
   PERSON: "person",
 };
 
-/** 결과 한 건의 종류를 탭 카테고리 값으로 바꾼다 */
-export function categoryOf(item: SearchResultItem): Exclude<SearchCategory, "all"> {
+/**
+ * 결과 한 건의 종류를 탭 카테고리 값으로 바꾼다.
+ * ⚠️ `kind`만 보므로 실서버의 평평한 `SearchResultItem`·목의 종류별 `MockSearchRecord`
+ *    양쪽 다 그대로 넘길 수 있다.
+ */
+export function categoryOf(item: { kind: SearchKind }): Exclude<SearchCategory, "all"> {
   return KIND_TO_CATEGORY[item.kind];
 }
 

--- a/src/features/search/mapper.ts
+++ b/src/features/search/mapper.ts
@@ -1,6 +1,12 @@
 import { AUTHORITY, type Authority } from "@/constants/domain";
 
-import type { PersonBrowseItem, ProjectBrowseItem, SearchRecentViewItem } from "./types";
+import type {
+  PersonBrowseItem,
+  ProjectBrowseItem,
+  SearchRecentViewItem,
+  SearchResultItem,
+  SearchResults,
+} from "./types";
 import { SEARCH_KIND, type SearchKind } from "./types";
 
 /**
@@ -55,4 +61,65 @@ function toAuthority(role: string | null): Authority {
 
 export function toPersonBrowseItem(person: BeSearchOverview["people"][number]): PersonBrowseItem {
   return { id: person.id, name: person.name, authority: toAuthority(person.role) };
+}
+
+/**
+ * `GET /api/v1/search` 응답 — `results[]`는 종류를 가리지 않는 평평한 모양이다.
+ * ⚠️ `project`는 표시용 문구로 **가정**한다 — shape 미확정(BE 실코드 미대조, §연동 검증).
+ */
+export interface BeSearchResponse {
+  query: string;
+  counts: { all: number; meeting: number; action: number; project: number; person: number };
+  results: {
+    type: string;
+    id: number;
+    title: string;
+    snippet: string | null;
+    project: string | null;
+    date: string | null;
+    role: string | null;
+    score: number;
+  }[];
+}
+
+/**
+ * 모르는 권한 문자열은 **빈 값으로** 둔다 — `toAuthority`(overview의 사람 목록)와 다른 규칙이다.
+ * 거긴 "이 사람의 권한은 늘 있다"는 전제라 최저 권한으로 떨어뜨리지만, 검색 결과의 `role`은
+ * 요구사항대로 "안 오면 빈 값" — 모르는 문자열도 잘못된 권한 배지를 다는 것보다 안 다는 게 낫다.
+ */
+function toAuthorityOrNull(role: string | null): Authority | null {
+  if (role === null) return null;
+  const values = Object.values(AUTHORITY) as string[];
+  return values.includes(role) ? (role as Authority) : null;
+}
+
+/** BE 정렬 순서를 그대로 지킨다 — 여기서 다시 정렬하지 않는다 */
+export function toSearchResults(be: BeSearchResponse): SearchResults {
+  const items = be.results.flatMap((hit): SearchResultItem[] => {
+    const kind = toSearchKind(hit.type);
+    if (!kind) return [];
+    return [
+      {
+        kind,
+        id: hit.id,
+        title: hit.title,
+        snippet: hit.snippet,
+        project: hit.project,
+        date: hit.date,
+        role: toAuthorityOrNull(hit.role),
+      },
+    ];
+  });
+
+  return {
+    keyword: be.query,
+    counts: {
+      total: be.counts.all,
+      meeting: be.counts.meeting,
+      action: be.counts.action,
+      project: be.counts.project,
+      person: be.counts.person,
+    },
+    items,
+  };
 }

--- a/src/features/search/mapper.ts
+++ b/src/features/search/mapper.ts
@@ -1,0 +1,58 @@
+import { AUTHORITY, type Authority } from "@/constants/domain";
+
+import type { PersonBrowseItem, ProjectBrowseItem, SearchRecentViewItem } from "./types";
+import { SEARCH_KIND, type SearchKind } from "./types";
+
+/**
+ * BE shape → UI 계약 (§Mock 격리막 — **shape을 흡수하는 곳은 여기 하나다**).
+ *
+ * ⚠️ 컴포넌트는 이 파일을 모른다. BE가 모양을 바꾸면 여기만 고친다.
+ * ⚠️ API 스펙 전달받음(2026-08-11) — **BE 실코드 미대조**(§연동 검증).
+ */
+
+export interface BeSearchOverview {
+  recentQueries: string[];
+  recentItems: { type: string; id: number; title: string; meta: string | null }[];
+  projects: { id: number; tag: string; name: string; meetingCount: number }[];
+  people: { id: number; name: string; role: string | null }[];
+}
+
+const VALID_SEARCH_KINDS = Object.values(SEARCH_KIND) as string[];
+
+/**
+ * 모르는 종류는 `null` — 화면이 못 그리는 값을 그대로 흘리지 않는다
+ * (§도메인 상수: BE enum과 이름이 어긋나면 매퍼에서 조용히 틀린다).
+ */
+function toSearchKind(type: string): SearchKind | null {
+  return VALID_SEARCH_KINDS.includes(type) ? (type as SearchKind) : null;
+}
+
+/** 종류를 못 알아본 항목은 뺀다 */
+export function toRecentViewItems(items: BeSearchOverview["recentItems"]): SearchRecentViewItem[] {
+  return items.flatMap((item) => {
+    const kind = toSearchKind(item.type);
+    if (!kind) return [];
+    return [{ kind, id: item.id, title: item.title, meta: item.meta }];
+  });
+}
+
+export function toProjectBrowseItem(
+  project: BeSearchOverview["projects"][number],
+): ProjectBrowseItem {
+  return {
+    id: project.id,
+    name: project.name,
+    tag: project.tag,
+    meetingCount: project.meetingCount,
+  };
+}
+
+/** 모르는 권한 문자열은 가장 낮은 권한으로 떨어뜨린다(manage-mapper.ts와 같은 규칙, §권한) */
+function toAuthority(role: string | null): Authority {
+  const values = Object.values(AUTHORITY) as string[];
+  return role !== null && values.includes(role) ? (role as Authority) : AUTHORITY.MEMBER;
+}
+
+export function toPersonBrowseItem(person: BeSearchOverview["people"][number]): PersonBrowseItem {
+  return { id: person.id, name: person.name, authority: toAuthority(person.role) };
+}

--- a/src/features/search/mock/data.ts
+++ b/src/features/search/mock/data.ts
@@ -5,6 +5,7 @@ import type {
   SearchMeetingResult,
   SearchPersonResult,
   SearchProjectResult,
+  SearchRecentViewItem,
 } from "../types";
 
 /**
@@ -153,10 +154,35 @@ export const SEARCH_MOCK_PEOPLE: SearchPersonResult[] = [
   },
 ];
 
-/** 최근 본 항목 — 회의 둘·액션 하나·프로젝트 하나(2×2로 그린다) */
-export const SEARCH_MOCK_RECENTLY_VIEWED = [
-  ROADMAP_MEETING,
-  PAYMENT_API_ACTION,
-  BRAND_KICKOFF_MEETING,
-  GOODS_PROJECT,
+/**
+ * 최근 본 항목 — 회의 둘·액션 하나·프로젝트 하나.
+ * ⚠️ `GET /search/overview`의 `recentItems`는 `{ type, id, title, meta }`뿐이다 —
+ *    종류별 상세 필드(발췌·담당자·마감일 등)를 안 주므로, `meta`는 BE가 이미 조합해
+ *    내려줄 보조 문구를 그대로 흉내 낸다.
+ */
+export const SEARCH_MOCK_RECENTLY_VIEWED: SearchRecentViewItem[] = [
+  {
+    kind: "MEETING",
+    id: ROADMAP_MEETING.id,
+    title: ROADMAP_MEETING.title,
+    meta: `${ROADMAP_MEETING.projectName} · ${ROADMAP_MEETING.meetingDate}`,
+  },
+  {
+    kind: "ACTION",
+    id: PAYMENT_API_ACTION.id,
+    title: PAYMENT_API_ACTION.title,
+    meta: `${PAYMENT_API_ACTION.assigneeName} · 마감 ${PAYMENT_API_ACTION.dueDate}`,
+  },
+  {
+    kind: "MEETING",
+    id: BRAND_KICKOFF_MEETING.id,
+    title: BRAND_KICKOFF_MEETING.title,
+    meta: `${BRAND_KICKOFF_MEETING.projectName} · ${BRAND_KICKOFF_MEETING.meetingDate}`,
+  },
+  {
+    kind: "PROJECT",
+    id: GOODS_PROJECT.id,
+    title: GOODS_PROJECT.name,
+    meta: `회의 ${GOODS_PROJECT.meetingCount}건 · 액션 ${GOODS_PROJECT.actionCount}건`,
+  },
 ];

--- a/src/features/search/mock/recent-searches.ts
+++ b/src/features/search/mock/recent-searches.ts
@@ -1,4 +1,9 @@
-import type { RecentSearchEntry } from "../types";
+/** 목에서만 쓰는 내부 형태 — 정렬용 시각을 들고 있다. 공개 계약(`SearchHome.recentSearches`)은 `string[]`이다 */
+interface MockRecentSearchEntry {
+  keyword: string;
+  /** ISO datetime */
+  searchedAt: string;
+}
 
 /**
  * ⚠️ 목 데이터 — BE 연동 전. **서버 프로세스 메모리에만 있다**(재시작하면 초기값으로 되돌아간다).
@@ -6,7 +11,7 @@ import type { RecentSearchEntry } from "../types";
  * ⚠️ 로그인(세션)이 없어 "이 사용자의 최근 검색"이 아니라 **전역**으로 흉내 낸다(§정직성).
  * ⚠️ `globalThis`에 매단다 — dev의 HMR로 `let`이 초기화되면 방금 한 검색이 사라진다.
  */
-const INITIAL: RecentSearchEntry[] = [
+const INITIAL: MockRecentSearchEntry[] = [
   { keyword: "로드맵", searchedAt: "2026-08-06T09:00:00+09:00" },
   { keyword: "API 명세", searchedAt: "2026-08-07T11:30:00+09:00" },
   { keyword: "브랜드 캠페인", searchedAt: "2026-08-07T15:10:00+09:00" },
@@ -15,12 +20,17 @@ const INITIAL: RecentSearchEntry[] = [
 /** 한 번에 들고 있는 최근 검색어 수 — 넘치면 오래된 것부터 밀어낸다 */
 const MAX_ENTRIES = 5;
 
-const globalStore = globalThis as typeof globalThis & { __recentSearchStore?: RecentSearchEntry[] };
+const globalStore = globalThis as typeof globalThis & {
+  __recentSearchStore?: MockRecentSearchEntry[];
+};
 const store = (globalStore.__recentSearchStore ??= INITIAL);
 
-/** 최근 것이 앞에 오도록 정렬해 돌려준다 */
-export function listMockRecentSearches(): RecentSearchEntry[] {
-  return [...store].sort((a, b) => b.searchedAt.localeCompare(a.searchedAt)).slice(0, MAX_ENTRIES);
+/** 최근 것이 앞에 오도록 정렬해 검색어만 돌려준다(`GET /search/overview`의 `recentQueries`와 같은 모양) */
+export function listMockRecentSearches(): string[] {
+  return [...store]
+    .sort((a, b) => b.searchedAt.localeCompare(a.searchedAt))
+    .slice(0, MAX_ENTRIES)
+    .map((entry) => entry.keyword);
 }
 
 /**

--- a/src/features/search/server.ts
+++ b/src/features/search/server.ts
@@ -92,10 +92,19 @@ export async function getSearchProjects(): Promise<ProjectBrowseItem[]> {
  * ⚠️ **미래 날짜는 포함하지 않는다.** "최근 N일"은 지난 일을 묻는 말이라, 아직 안 지난
  *    마감일까지 걸리면 "최근"이라는 말과 어긋난다.
  */
-function withinPeriod(iso: string, days: number | null, todayMs: number): boolean {
+function isoToUtcMs(iso: string): number | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso);
+  if (!match) return null;
+  const [, y, m, d] = match;
+  return Date.UTC(Number(y), Number(m) - 1, Number(d));
+}
+
+function withinPeriod(iso: string, days: number | null, todayIsoValue: string): boolean {
   if (days === null) return true;
-  const target = new Date(`${iso}T00:00:00`).getTime();
-  const diffDays = (todayMs - target) / 86_400_000;
+  const target = isoToUtcMs(iso);
+  const today = isoToUtcMs(todayIsoValue);
+  if (target === null || today === null) return false;
+  const diffDays = (today - target) / 86_400_000;
   return diffDays >= 0 && diffDays <= days;
 }
 
@@ -142,11 +151,11 @@ function matchesProject(item: MockSearchRecord, projectTag: string | null): bool
 function matchesPeriod(
   item: MockSearchRecord,
   period: SearchQuery["period"],
-  todayMs: number,
+  todayIsoValue: string,
 ): boolean {
   const days = PERIOD_DAYS[period];
-  if (item.kind === "MEETING") return withinPeriod(item.meetingDate, days, todayMs);
-  if (item.kind === "ACTION") return withinPeriod(item.dueDate, days, todayMs);
+  if (item.kind === "MEETING") return withinPeriod(item.meetingDate, days, todayIsoValue);
+  if (item.kind === "ACTION") return withinPeriod(item.dueDate, days, todayIsoValue);
   return true;
 }
 
@@ -247,12 +256,12 @@ export async function getSearchResults(query: SearchQuery): Promise<SearchResult
   }
 
   if (isMock) {
-    const todayMs = Date.now();
+    const today = todayIso();
     const matched = allMockRecords().filter(
       (item) =>
         matchesKeyword(item, keyword) &&
         matchesProject(item, query.projectTag) &&
-        matchesPeriod(item, query.period, todayMs),
+        matchesPeriod(item, query.period, today),
     );
 
     const counts = matched.reduce(

--- a/src/features/search/server.ts
+++ b/src/features/search/server.ts
@@ -2,12 +2,18 @@ import "server-only";
 
 import { requireAccessToken } from "@/features/auth/session";
 import { serverApi } from "@/lib/api";
+import { todayIso } from "@/lib/date";
 import { ep } from "@/lib/endpoints";
 import { isMock } from "@/mocks/config";
 
 import { categoryOf, textIncludes } from "./lib";
-import type { BeSearchOverview } from "./mapper";
-import { toPersonBrowseItem, toProjectBrowseItem, toRecentViewItems } from "./mapper";
+import type { BeSearchOverview, BeSearchResponse } from "./mapper";
+import {
+  toPersonBrowseItem,
+  toProjectBrowseItem,
+  toRecentViewItems,
+  toSearchResults,
+} from "./mapper";
 import {
   SEARCH_MOCK_ACTIONS,
   SEARCH_MOCK_MEETINGS,
@@ -17,7 +23,9 @@ import {
 } from "./mock/data";
 import { listMockRecentSearches } from "./mock/recent-searches";
 import type {
+  MockSearchRecord,
   ProjectBrowseItem,
+  SearchCategory,
   SearchHome,
   SearchQuery,
   SearchResultItem,
@@ -98,7 +106,7 @@ const PERIOD_DAYS: Record<SearchQuery["period"], number | null> = {
   "90d": 90,
 };
 
-function matchesKeyword(item: SearchResultItem, keyword: string): boolean {
+function matchesKeyword(item: MockSearchRecord, keyword: string): boolean {
   switch (item.kind) {
     case "MEETING":
       return textIncludes(item.title, keyword) || textIncludes(item.snippet, keyword);
@@ -117,7 +125,7 @@ function matchesKeyword(item: SearchResultItem, keyword: string): boolean {
   }
 }
 
-function matchesProject(item: SearchResultItem, projectTag: string | null): boolean {
+function matchesProject(item: MockSearchRecord, projectTag: string | null): boolean {
   if (!projectTag) return true;
   switch (item.kind) {
     case "MEETING":
@@ -132,7 +140,7 @@ function matchesProject(item: SearchResultItem, projectTag: string | null): bool
 }
 
 function matchesPeriod(
-  item: SearchResultItem,
+  item: MockSearchRecord,
   period: SearchQuery["period"],
   todayMs: number,
 ): boolean {
@@ -142,7 +150,7 @@ function matchesPeriod(
   return true;
 }
 
-function allItems(): SearchResultItem[] {
+function allMockRecords(): MockSearchRecord[] {
   return [
     ...SEARCH_MOCK_MEETINGS,
     ...SEARCH_MOCK_ACTIONS,
@@ -151,14 +159,84 @@ function allItems(): SearchResultItem[] {
   ];
 }
 
+/**
+ * 목의 종류별 상세 레코드 → 실서버와 같은 평평한 결과 모양.
+ * ⚠️ 실서버(`GET /search`)가 종류별 상세 필드(담당자·회의/액션 건수 등)를 안 주므로,
+ *    목도 **같은 만큼만** 보여준다 — 목이 실서버보다 더 자세하면 연동 전후 화면이 달라진다.
+ */
+function toSearchResultItem(record: MockSearchRecord): SearchResultItem {
+  switch (record.kind) {
+    case "MEETING":
+      return {
+        kind: "MEETING",
+        id: record.id,
+        title: record.title,
+        snippet: record.snippet,
+        project: record.projectName,
+        date: record.meetingDate,
+        role: null,
+      };
+    case "ACTION":
+      return {
+        kind: "ACTION",
+        id: record.id,
+        title: record.title,
+        snippet: null,
+        project: null,
+        date: record.dueDate,
+        role: null,
+      };
+    case "PROJECT":
+      return {
+        kind: "PROJECT",
+        id: record.id,
+        title: record.name,
+        snippet: null,
+        project: null,
+        date: null,
+        role: null,
+      };
+    case "PERSON":
+      return {
+        kind: "PERSON",
+        id: record.id,
+        title: record.name,
+        snippet: record.description,
+        project: null,
+        date: null,
+        role: record.authority,
+      };
+  }
+}
+
+const BE_SEARCH_TYPE: Record<SearchCategory, string> = {
+  all: "ALL",
+  meeting: "MEETING",
+  action: "ACTION",
+  project: "PROJECT",
+  person: "PERSON",
+};
+
+/** 오늘 기준 `days`일 전 — `Date.UTC`로만 셈해 시간대에 안 흔들린다(`lib/date.ts`와 같은 방식) */
+function isoDaysBefore(to: string, days: number): string {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(to);
+  if (!match) return to;
+
+  const [, y, m, d] = match;
+  return new Date(Date.UTC(Number(y), Number(m) - 1, Number(d) - days)).toISOString().slice(0, 10);
+}
+
+/** 기간 프리셋 → `from`/`to` — "전체 기간"은 둘 다 안 보낸다 */
+function toDateRange(period: SearchQuery["period"]): { from: string | null; to: string | null } {
+  const days = PERIOD_DAYS[period];
+  if (days === null) return { from: null, to: null };
+  const to = todayIso();
+  return { from: isoDaysBefore(to, days), to };
+}
+
 /** 검색 결과 — 카테고리 탭 숫자는 키워드·프로젝트·기간까지 반영해 센다(탭을 눌러도 숫자가 안 흔들리게). */
 export async function getSearchResults(query: SearchQuery): Promise<SearchResults> {
   const keyword = query.keyword.trim();
-
-  if (!isMock) {
-    // ⚠️ 미구현 — API 스펙 확정 후 검색 경로로 fetch하고 매퍼로 UI 계약에 맞춘다.
-    throw new Error("검색 API가 아직 연결되지 않았습니다.");
-  }
 
   if (!keyword) {
     return {
@@ -168,27 +246,45 @@ export async function getSearchResults(query: SearchQuery): Promise<SearchResult
     };
   }
 
-  const todayMs = Date.now();
-  const matched = allItems().filter(
-    (item) =>
-      matchesKeyword(item, keyword) &&
-      matchesProject(item, query.projectTag) &&
-      matchesPeriod(item, query.period, todayMs),
-  );
+  if (isMock) {
+    const todayMs = Date.now();
+    const matched = allMockRecords().filter(
+      (item) =>
+        matchesKeyword(item, keyword) &&
+        matchesProject(item, query.projectTag) &&
+        matchesPeriod(item, query.period, todayMs),
+    );
 
-  const counts = matched.reduce(
-    (acc, item) => {
-      acc.total += 1;
-      acc[categoryOf(item)] += 1;
-      return acc;
-    },
-    { total: 0, meeting: 0, action: 0, project: 0, person: 0 },
-  );
+    const counts = matched.reduce(
+      (acc, item) => {
+        acc.total += 1;
+        acc[categoryOf(item)] += 1;
+        return acc;
+      },
+      { total: 0, meeting: 0, action: 0, project: 0, person: 0 },
+    );
 
-  const items =
-    query.category === "all"
-      ? matched
-      : matched.filter((item) => categoryOf(item) === query.category);
+    const items = (
+      query.category === "all"
+        ? matched
+        : matched.filter((item) => categoryOf(item) === query.category)
+    ).map(toSearchResultItem);
 
-  return { keyword, counts, items };
+    return { keyword, counts, items };
+  }
+
+  /*
+    [스펙 전달, BE 실코드 미대조] `GET /api/v1/search` — 탭 숫자(`counts`)는 카테고리(`type`)만
+    빼고 지금 건 프로젝트·기간 필터를 반영해 서버가 센다(우리 mock과 같은 규칙). 정렬도
+    서버가 정한 순서를 그대로 쓴다 — 여기서 다시 정렬하지 않는다.
+  */
+  const accessToken = await requireAccessToken();
+  const { from, to } = toDateRange(query.period);
+  const params = new URLSearchParams({ q: keyword, type: BE_SEARCH_TYPE[query.category] });
+  if (query.projectTag) params.append("tags", query.projectTag);
+  if (from) params.set("from", from);
+  if (to) params.set("to", to);
+
+  const response = await serverApi<BeSearchResponse>(`${ep.search()}?${params}`, { accessToken });
+  return toSearchResults(response);
 }

--- a/src/features/search/server.ts
+++ b/src/features/search/server.ts
@@ -1,8 +1,13 @@
 import "server-only";
 
+import { requireAccessToken } from "@/features/auth/session";
+import { serverApi } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
 import { isMock } from "@/mocks/config";
 
 import { categoryOf, textIncludes } from "./lib";
+import type { BeSearchOverview } from "./mapper";
+import { toPersonBrowseItem, toProjectBrowseItem, toRecentViewItems } from "./mapper";
 import {
   SEARCH_MOCK_ACTIONS,
   SEARCH_MOCK_MEETINGS,
@@ -45,8 +50,19 @@ export async function getSearchHome(): Promise<SearchHome> {
     };
   }
 
-  // ⚠️ 미구현 — API 스펙 확정 후 검색 랜딩 경로로 fetch하고 매퍼로 UI 계약에 맞춘다.
-  throw new Error("검색 랜딩 API가 아직 연결되지 않았습니다.");
+  /*
+    [스펙 전달, BE 실코드 미대조] `GET /api/v1/search/overview` — 최근 검색어·최근 본 항목·
+    둘러보기용 프로젝트·사람 목록을 한 번에 준다. 회사·사람은 토큰 기준으로 서버가 정한다.
+  */
+  const accessToken = await requireAccessToken();
+  const overview = await serverApi<BeSearchOverview>(ep.searchOverview(), { accessToken });
+
+  return {
+    recentSearches: overview.recentQueries,
+    recentlyViewed: toRecentViewItems(overview.recentItems),
+    projects: overview.projects.map(toProjectBrowseItem),
+    people: overview.people.map(toPersonBrowseItem),
+  };
 }
 
 /**

--- a/src/features/search/server.ts
+++ b/src/features/search/server.ts
@@ -96,7 +96,19 @@ function isoToUtcMs(iso: string): number | null {
   const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso);
   if (!match) return null;
   const [, y, m, d] = match;
-  return Date.UTC(Number(y), Number(m) - 1, Number(d));
+  const yNum = Number(y);
+  const mNum = Number(m);
+  const dNum = Number(d);
+  const ms = Date.UTC(yNum, mNum - 1, dNum);
+  const date = new Date(ms);
+  if (
+    date.getUTCFullYear() !== yNum ||
+    date.getUTCMonth() !== mNum - 1 ||
+    date.getUTCDate() !== dNum
+  ) {
+    return null;
+  }
+  return ms;
 }
 
 function withinPeriod(iso: string, days: number | null, todayIsoValue: string): boolean {

--- a/src/features/search/types.ts
+++ b/src/features/search/types.ts
@@ -62,8 +62,35 @@ export interface SearchPersonResult {
   description: string;
 }
 
-export type SearchResultItem =
+/**
+ * 목에서만 쓰는 종류별 상세 레코드 — 필터링(`server.ts`의 mock 분기)에 쓴다.
+ * ⚠️ **공개 계약이 아니다.** `GET /search`가 실제로 주는 건 훨씬 적은 필드뿐이라
+ *    (`SearchResultItem` 참고), 목이든 실서버든 화면에는 그 평평한 모양만 나간다.
+ */
+export type MockSearchRecord =
   SearchMeetingResult | SearchActionResult | SearchProjectResult | SearchPersonResult;
+
+/**
+ * 검색 결과 한 건 — `GET /search`의 `results[]`(`{type, id, title, snippet, project, date,
+ * role, score}`)를 그대로 따른다.
+ *
+ * ⚠️ **종류별 상세 필드가 없다**(담당자 이름·마감일 라벨·회의/액션 건수 등). BE가 종류를 가리지
+ *    않는 평평한 모양으로 내려주므로, 화면이 못 받는 값을 지어내지 않는다(§정직성).
+ * ⚠️ `project`는 표시용 문구로 **가정**한다 — 필드 shape 미확정(BE 실코드 미대조, §연동 검증).
+ */
+export interface SearchResultItem {
+  kind: SearchKind;
+  id: number;
+  title: string;
+  /** 검색어가 걸린 발췌 — 없으면 `null`(회의 요약이 아직 없는 경우 등) */
+  snippet: string | null;
+  /** 소속 프로젝트 표시 문구 — 없으면 `null`(사람) */
+  project: string | null;
+  /** 회의 일시·마감일 등 — 없으면 `null` */
+  date: string | null;
+  /** 사람의 권한 — `null`이면 배지를 안 그린다(빈 값으로 다룬다) */
+  role: Authority | null;
+}
 
 export interface SearchCategoryCounts {
   total: number;

--- a/src/features/search/types.ts
+++ b/src/features/search/types.ts
@@ -85,12 +85,6 @@ export interface SearchResults {
   items: SearchResultItem[];
 }
 
-export interface RecentSearchEntry {
-  keyword: string;
-  /** ISO datetime */
-  searchedAt: string;
-}
-
 export interface ProjectBrowseItem {
   id: number;
   name: string;
@@ -104,10 +98,23 @@ export interface PersonBrowseItem {
   authority: Authority;
 }
 
+/**
+ * 최근 본 항목 — `SearchResultItem`과 다른, **훨씬 적은** 필드만 온다(`GET /search/overview`).
+ * 종류별 상세 필드(발췌·담당자·마감일 등)는 이 API가 안 준다 — `meta`는 BE가 이미 조합한
+ * 보조 문구 한 줄이다(예: "프로젝트명 · 날짜").
+ */
+export interface SearchRecentViewItem {
+  kind: SearchKind;
+  id: number;
+  title: string;
+  meta: string | null;
+}
+
 /** 검색어가 없을 때(랜딩) 보여줄 것 */
 export interface SearchHome {
-  recentSearches: RecentSearchEntry[];
-  recentlyViewed: SearchResultItem[];
+  /** 최신순 — 최대 10개 */
+  recentSearches: string[];
+  recentlyViewed: SearchRecentViewItem[];
   projects: ProjectBrowseItem[];
   people: PersonBrowseItem[];
 }

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -124,6 +124,15 @@ export const ep = {
   notices: () => "/api/notices",
   subscription: () => "/api/subscription",
 
+  /**
+   * 검색 — API 스펙 전달받음(2026-08-11), **BE 실코드 미대조**(§연동 검증: 문서와 코드가
+   * 다르면 코드가 맞다 — 구현 붙일 때 컨트롤러로 재확인한다).
+   */
+  searchOverview: () => "/api/v1/search/overview",
+  search: () => "/api/v1/search",
+  searchRecentQueries: () => "/api/v1/search/recent-queries",
+  searchRecentViews: () => "/api/v1/search/recent-views",
+
   /* 시스템 운영자 */
   systemDashboard: () => "/api/system/dashboard",
 } as const;


### PR DESCRIPTION
## 📋 PR 타입

> 해당하는 타입을 선택해 주세요 (복수 선택 가능)

- [x] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- 검색 결과 API(`GET /api/v1/search`) 연동
- `SearchResultItem`을 API가 실제로 주는 평평한 모양(`{kind, id, title, snippet, project, date, role}`)으로 재정의 — 기존 종류별 상세 유니언(담당자·회의/액션 건수 등)은 이 API가 안 주는 필드라 목 전용 타입(`MockSearchRecord`)으로 분리하고, mock 분기도 최종 반환 전에 같은 평평한 모양으로 변환해 연동 전후 화면 차이가 안 생기게 함
- `SearchResultRow`에서 프로젝트 태그 칩 제거 — 이 API가 태그 코드를 안 주고 표시용 문구(`project`)만 줌
- 탭 숫자(`counts`)·정렬은 서버 값을 그대로 쓰고 프론트에서 다시 정렬하지 않음

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [ ] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 해당 없음(로그인 사용자 공통 기능, 데이터는 서버가 토큰 기준으로 제한)
- [x] 🕵️ **정직성** — 스펙 미검증(BE 실코드 미대조) 상태를 엔드포인트·매퍼 주석에 명시, 이 API가 못 주는 필드(담당자 등)는 지어내지 않고 빈 값으로 처리
- [x] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [x] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [x] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인)
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 결과 0건 empty UI 기존 유지, `error.tsx`/`loading.tsx` 재사용
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음 — 해당 없음

---

## 🔗 연관 이슈

Closes #333

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

- `results[].project`를 문자열로 가정한 부분 — BE 실코드 확인 후 객체 shape이면 매퍼만 고치면 되는지 검토 필요
- 액션 결과에서 담당자 정보가 빠진 것(API가 안 줌)이 실제 화면에서 문제가 안 되는지

---

## 📝 추가 메모

`getSearchProjects()`(필터용 프로젝트 목록)는 이번 스펙에 해당 엔드포인트가 없어 그대로 미구현 상태로 남겨둠 — 범위 밖.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 검색 홈과 검색 결과를 실서버 API와 연동합니다.
  * 카테고리, 프로젝트, 기간 필터를 지원합니다.
  * 최근 검색어와 최근 조회 항목을 카드 형태로 제공합니다.
  * 프로젝트·사람 탐색 결과와 권한, 날짜, 메타 정보를 표시합니다.

* **개선**
  * 검색 결과의 제목, 발췌, 프로젝트, 날짜 표시를 일관되게 통합했습니다.
  * 지원되지 않는 결과 유형도 안정적으로 처리합니다.
  * 최근 검색어를 간결한 문자열 목록으로 제공하고, 결과 유형별 표시 방식을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->