### PR TITLE
[FEAT] 검색 기록 API 연동  #335

### DIFF
--- a/src/features/search/actions.ts
+++ b/src/features/search/actions.ts
@@ -2,6 +2,9 @@
 
 import { revalidatePath } from "next/cache";
 
+import { requireAccessToken } from "@/features/auth/session";
+import { serverApi } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
 import { isMock } from "@/mocks/config";
 
 import { addMockRecentSearch } from "./mock/recent-searches";
@@ -11,6 +14,8 @@ import { addMockRecentSearch } from "./mock/recent-searches";
  * ⚠️ 화면에 결과를 돌려주지 않는다. 이 액션은 **기록만** 하고, 결과는 페이지가
  *    `?q=`로 다시 조회해서 보여준다 — 액션이 결과까지 들고 있으면 새로고침·직접 링크로
  *    들어왔을 때와 화면이 갈린다.
+ * ⚠️ **호출부가 `void`로 던지고 결과를 안 본다**(`search-input.tsx`). 검색 기록 실패가
+ *    검색 자체를 막을 이유는 없어 — 실패해도 조용히 넘어간다(최근 검색어 한 줄이 안 남을 뿐).
  */
 export async function recordSearchAction(keyword: string): Promise<void> {
   const trimmed = keyword.trim();
@@ -23,6 +28,16 @@ export async function recordSearchAction(keyword: string): Promise<void> {
     return;
   }
 
-  // ⚠️ 미구현 — API 스펙 확정 후 검색 기록 경로로 POST한다.
-  throw new Error("검색 기록 API가 아직 연결되지 않았습니다.");
+  /* [스펙 전달, BE 실코드 미대조] `POST /api/v1/search/recent-queries` — 몸통은 `{ query }` */
+  try {
+    const accessToken = await requireAccessToken();
+    await serverApi<unknown>(ep.searchRecentQueries(), {
+      method: "POST",
+      accessToken,
+      json: { query: trimmed },
+    });
+    revalidatePath("/app/search");
+  } catch {
+    // 위 주석대로 — 기록 실패를 검색 흐름에 되돌리지 않는다.
+  }
 }


### PR DESCRIPTION
## 📋 PR 타입

> 해당하는 타입을 선택해 주세요 (복수 선택 가능)

- [x] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- 검색 기록 API(`POST /api/v1/search/recent-queries`) 연동
- 호출부(`search-input.tsx`)가 결과를 안 보고 `void`로 fire-and-forget 하므로, 기록 실패가 검색 흐름을 막지 않도록 서버 액션 내부에서 예외를 삼킴 — 실패 시 최근 검색어 한 줄만 안 남을 뿐 검색 자체는 정상 동작

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [ ] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 해당 없음(로그인 사용자 공통 기능, 토큰 기준 본인 기록만)
- [x] 🕵️ **정직성** — 스펙 미검증(BE 실코드 미대조) 상태를 주석에 명시, 기록 실패를 조용히 삼키는 이유를 주석으로 남김
- [x] 🎨 디자인 토큰 사용 — 해당 없음(UI 변경 없음)

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [ ] ♿ a11y — 해당 없음(UI 변경 없음)
- [x] ♻️ 재사용 확인 (`company/actions.ts`의 `serverApi<unknown>(..., { method: "POST", json })` 패턴 그대로 따름)
- [ ] 🧪 `loading` / `error` / `empty` 3상태 — 해당 없음(눈에 보이는 결과가 없는 기록용 액션)
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음 — 해당 없음

---

## 🔗 연관 이슈

Closes #335

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

- 기록 실패를 조용히 삼키는 게 맞는 선택인지(사용자에게 실패를 알릴 필요가 없는 기능이라 판단)

---

## 📝 추가 메모

없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 검색 기록이 서버에 저장되어 최근 검색어에서 확인할 수 있습니다.
  * 검색 기록 저장 후 최신 검색 결과가 자동으로 갱신됩니다.

* **버그 수정**
  * 인증 또는 저장 과정에서 문제가 발생해도 검색 흐름이 중단되지 않도록 개선했습니다.
  * 테스트 및 모의 환경에서 기존 동작을 유지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->