### PR TITLE
[FEAT] 내 액션 리스트·팀 액션 관리 타임라인 재구축 + 실 API 연동 #337

### DIFF
--- a/src/app/(shell)/(authority)/team/action/error.tsx
+++ b/src/app/(shell)/(authority)/team/action/error.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { ScreenError } from "@/components/common/screen-error";
+
+interface TeamActionErrorProps {
+  reset: () => void;
+}
+
+export default function Error({ reset }: TeamActionErrorProps) {
+  // 셸(상단바 h1) 안에서 뜨므로 isInsideShell — h1 중복·높이 잘림을 막는다
+  return <ScreenError title="팀 액션을 불러오지 못했습니다" reset={reset} isInsideShell />;
+}

--- a/src/app/(shell)/(authority)/team/action/layout.tsx
+++ b/src/app/(shell)/(authority)/team/action/layout.tsx
@@ -1,0 +1,14 @@
+import { Columns3 } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { PageHeader } from "@/features/shell/components/page-header";
+
+/** 팀 액션 상단바 — 사이드바에서 바로 닿는 화면이라 backTo는 두지 않는다. */
+export default function TeamActionLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <PageHeader title="팀 액션" icon={Columns3} />
+      {children}
+    </>
+  );
+}

--- a/src/app/(shell)/(authority)/team/action/loading.tsx
+++ b/src/app/(shell)/(authority)/team/action/loading.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
+      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-4">
+        <Skeleton className="h-7 w-40 rounded-lg" />
+        <Skeleton className="h-60 w-full rounded-2xl" />
+        <Skeleton className="h-40 w-full rounded-2xl" />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/(authority)/team/action/page.tsx
+++ b/src/app/(shell)/(authority)/team/action/page.tsx
@@ -1,0 +1,84 @@
+import type { Metadata } from "next";
+
+import { isDelayed } from "@/constants/domain";
+import { getTeamActionsGroupedByProject } from "@/features/action/server";
+import type { TeamActionProjectGroup, TeamActionTimelineItem } from "@/features/action/types";
+import type { TimelineActionInput } from "@/features/member/action-timeline";
+import { ActionTimeline, ActionTimelineLegend } from "@/features/member/components/action-timeline";
+import { pickPaletteColor } from "@/lib/palette";
+
+export const metadata: Metadata = {
+  title: "팀 액션",
+};
+
+/** 이 프로젝트의 팀 액션들을 타임라인 입력으로 — 프로젝트 상세 타임라인 탭과 같은 모양(§디자인). */
+function toTimelineItems(
+  group: TeamActionProjectGroup,
+  teamActions: TeamActionTimelineItem[],
+): TimelineActionInput[] {
+  const tagColor = pickPaletteColor(group.projectTag);
+  return teamActions.map((action) => ({
+    id: String(action.id),
+    title: action.name,
+    tag: group.projectTag,
+    tagBgColor: tagColor.bgColor,
+    tagTextColor: tagColor.textColor,
+    startDate: action.startDate,
+    dueDate: action.dueDate,
+    tone: isDelayed(action) ? "DELAYED" : action.status,
+    href: `/app/projects/${group.projectId}/team/${action.id}`,
+  }));
+}
+
+export default async function TeamActionPage() {
+  const groups = await getTeamActionsGroupedByProject();
+  const totalTeamActions = groups.reduce((sum, group) => sum + group.teamActions.length, 0);
+
+  return (
+    <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
+      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-4">
+        <p className="text-muted-foreground self-end text-xs tabular-nums">
+          {groups.length}개 프로젝트 · 총 {totalTeamActions}개 팀 액션
+        </p>
+
+        {groups.length === 0 ? (
+          <p className="text-muted-foreground flex min-h-[240px] items-center justify-center text-sm">
+            아직 하달된 팀 액션이 없습니다.
+          </p>
+        ) : (
+          groups.map((group) => {
+            const tagColor = pickPaletteColor(group.projectTag);
+            return (
+              <section
+                key={group.projectId}
+                className="border-border bg-card flex flex-col overflow-hidden rounded-2xl border"
+              >
+                <div className="border-border flex shrink-0 items-baseline justify-between gap-3 border-b px-7 pt-6 pb-3">
+                  <h3 className="flex items-center gap-2 text-[17px] leading-7 font-semibold tracking-[-0.3px]">
+                    <span className="bg-foreground size-2 rounded-full" aria-hidden />
+                    {group.projectName}
+                    <span
+                      className="rounded px-1.5 py-0.5 font-mono text-xs leading-none font-semibold"
+                      style={{ backgroundColor: tagColor.bgColor, color: tagColor.textColor }}
+                    >
+                      {group.projectTag}
+                    </span>
+                  </h3>
+                  <p className="text-muted-foreground text-[12px] leading-4 tabular-nums">
+                    {group.teamActions.length}개 팀 액션
+                  </p>
+                </div>
+                <ActionTimeline
+                  items={toTimelineItems(group, group.teamActions)}
+                  today={new Date()}
+                />
+              </section>
+            );
+          })
+        )}
+
+        <ActionTimelineLegend />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/app/my/actions/error.tsx
+++ b/src/app/(shell)/app/my/actions/error.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { ScreenError } from "@/components/common/screen-error";
+
+interface MyActionsErrorProps {
+  reset: () => void;
+}
+
+export default function Error({ reset }: MyActionsErrorProps) {
+  // 셸(상단바 h1) 안에서 뜨므로 isInsideShell — h1 중복·높이 잘림을 막는다
+  return <ScreenError title="내 액션을 불러오지 못했습니다" reset={reset} isInsideShell />;
+}

--- a/src/app/(shell)/app/my/actions/layout.tsx
+++ b/src/app/(shell)/app/my/actions/layout.tsx
@@ -1,0 +1,14 @@
+import { ListChecks } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { PageHeader } from "@/features/shell/components/page-header";
+
+/** 내 액션 상단바 — 사이드바에서 바로 닿는 화면이라 backTo는 두지 않는다. */
+export default function MyActionsLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <PageHeader title="내 액션" icon={ListChecks} />
+      {children}
+    </>
+  );
+}

--- a/src/app/(shell)/app/my/actions/loading.tsx
+++ b/src/app/(shell)/app/my/actions/loading.tsx
@@ -1,0 +1,12 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
+      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-4">
+        <Skeleton className="h-5 w-40 rounded-lg" />
+        <Skeleton className="h-60 w-full rounded-2xl" />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(shell)/app/my/actions/page.tsx
+++ b/src/app/(shell)/app/my/actions/page.tsx
@@ -1,0 +1,96 @@
+import type { Metadata } from "next";
+
+import { MyActionListItemRow } from "@/features/action/components/my-action-list-item";
+import { getMyActionList } from "@/features/action/server";
+import type { MyActionListItem } from "@/features/action/types";
+import { pickPaletteColor } from "@/lib/palette";
+
+export const metadata: Metadata = {
+  title: "내 액션",
+};
+
+// ⚠️ 로그인 전이라 실제 담당자를 알 수 없다 — 팀 대시보드 목과 같은 대표 인물(이하윤)로 대신한다.
+//    세션이 붙으면 실연동 분기(server.ts)는 이 값을 안 쓰고 토큰의 본인 소유분만 받는다.
+const MOCK_ASSIGNEE_NAME = "이하윤";
+
+/** 프로젝트별로 묶는다 — 마감 임박순으로 이미 정렬된 목록이라 그룹 안 순서도 그대로 유지된다. */
+function groupByProject(
+  actions: MyActionListItem[],
+): { projectId: number; projectName: string; projectTag: string; actions: MyActionListItem[] }[] {
+  const groups: Map<
+    number,
+    { projectName: string; projectTag: string; actions: MyActionListItem[] }
+  > = new Map();
+  for (const action of actions) {
+    const group = groups.get(action.projectId);
+    if (group) group.actions.push(action);
+    else {
+      groups.set(action.projectId, {
+        projectName: action.projectName,
+        projectTag: action.projectTag,
+        actions: [action],
+      });
+    }
+  }
+  return [...groups.entries()].map(([projectId, group]) => ({ projectId, ...group }));
+}
+
+export default async function MyActionsPage() {
+  const actions = await getMyActionList(MOCK_ASSIGNEE_NAME);
+  const groups = groupByProject(actions);
+
+  return (
+    <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
+      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-4">
+        <p className="text-muted-foreground text-sm">나에게 할당된 개인 액션 {actions.length}건</p>
+
+        {groups.length === 0 ? (
+          <section className="border-border bg-card overflow-hidden rounded-2xl border">
+            <p className="text-muted-foreground flex min-h-[240px] items-center justify-center text-sm">
+              아직 할당된 개인 액션이 없습니다.
+            </p>
+          </section>
+        ) : (
+          groups.map((group) => {
+            const tagColor = pickPaletteColor(group.projectTag);
+            return (
+              <section
+                key={group.projectId}
+                className="border-border bg-card flex flex-col overflow-hidden rounded-2xl border"
+              >
+                <div className="border-border flex shrink-0 items-baseline justify-between gap-3 border-b px-7 pt-6 pb-3">
+                  <h3 className="flex items-center gap-2 text-[17px] leading-7 font-semibold tracking-[-0.3px]">
+                    <span className="bg-foreground size-2 rounded-full" aria-hidden />
+                    {group.projectName}
+                    <span
+                      className="rounded px-1.5 py-0.5 font-mono text-xs leading-none font-semibold"
+                      style={{ backgroundColor: tagColor.bgColor, color: tagColor.textColor }}
+                    >
+                      {group.projectTag}
+                    </span>
+                  </h3>
+                  <p className="text-muted-foreground text-[12px] leading-4 tabular-nums">
+                    {group.actions.length}건
+                  </p>
+                </div>
+                <ul>
+                  {group.actions.map((action, index) => (
+                    <MyActionListItemRow
+                      key={action.id}
+                      action={action}
+                      showDivider={index > 0}
+                      // ⚠️ 항상 false — 카드 위쪽 모서리는 헤더가 이미 차지해서 목록의 첫 행은
+                      //    거기 안 닿는다(맞물리는 건 마지막 행뿐).
+                      isFirst={false}
+                      isLast={index === group.actions.length - 1}
+                    />
+                  ))}
+                </ul>
+              </section>
+            );
+          })
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/features/action/components/my-action-list-item.tsx
+++ b/src/features/action/components/my-action-list-item.tsx
@@ -1,0 +1,94 @@
+import Link from "next/link";
+
+import { Badge } from "@/components/ui/badge";
+import { ACTION_DELAYED_LABEL, ACTION_STATUS_LABEL, isDelayed } from "@/constants/domain";
+import { formatMonthDayWeekday } from "@/lib/date";
+import { pickPaletteColor } from "@/lib/palette";
+import { cn } from "@/lib/utils";
+
+import type { MyActionListItem } from "../types";
+
+/** 상태 배지 색 — `member/components/action-timeline`의 BAR_CLASS와 같은 결(할일·완료=무채색, 진행중=초록, 지연=빨강). */
+const STATUS_TONE: Record<"TODO" | "IN_PROGRESS" | "DONE" | "DELAYED", string> = {
+  TODO: "bg-muted text-muted-foreground",
+  IN_PROGRESS: "bg-success/12 text-success",
+  DONE: "bg-muted text-muted-foreground",
+  DELAYED: "bg-destructive/10 text-destructive",
+};
+
+interface MyActionListItemRowProps {
+  action: MyActionListItem;
+  /** 목록의 첫 항목이 아니면 위쪽 구분선을 그린다 */
+  showDivider: boolean;
+  /**
+   * 카드 모서리(rounded-2xl)와 맞물리는 위치인지 — 왼쪽 막대가 카드 곡선과 어긋나면
+   * 위아래 끝이 잘린 것처럼 보인다. 막대 자체를 카드와 같은 반지름으로 둥글려서 카드의
+   * `overflow-hidden`이 정확히 그 곡선만 잘라내게 한다.
+   */
+  isFirst: boolean;
+  isLast: boolean;
+}
+
+/** 좌: 태그색 막대 / 제목·프로젝트 태그·팀명 라벨 + 세부 설명 한 줄 / 우: 마감일 + 상태 배지. */
+export function MyActionListItemRow({
+  action,
+  showDivider,
+  isFirst,
+  isLast,
+}: MyActionListItemRowProps) {
+  const tagColor = pickPaletteColor(action.projectTag);
+  const delayed = isDelayed(action);
+  const tone = delayed ? "DELAYED" : action.status;
+  const statusLabel = delayed ? ACTION_DELAYED_LABEL : ACTION_STATUS_LABEL[action.status];
+  const due = formatMonthDayWeekday(action.dueDate);
+
+  return (
+    <li className={cn(showDivider && "border-border border-t")}>
+      <Link
+        href={`/app/actions/${action.id}`}
+        className="hover:bg-muted flex items-stretch transition-colors"
+      >
+        {/* 프로젝트 색 왼쪽 막대 — 카드 모서리와 만나는 첫·마지막 행만 그만큼 둥글린다 */}
+        <span
+          className={cn("w-1 shrink-0", isFirst && "rounded-tl-2xl", isLast && "rounded-bl-2xl")}
+          style={{ backgroundColor: tagColor.solidColor }}
+          aria-hidden
+        />
+
+        <div className="flex min-w-0 flex-1 items-center gap-3 px-4 py-4">
+          {/* 좌: 제목 · 프로젝트 태그 · 팀명 라벨 + 세부 설명 한 줄 */}
+          <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+            <div className="flex min-w-0 items-center gap-2">
+              <span className="truncate text-[15px]">{action.title}</span>
+              <span
+                className="shrink-0 rounded px-1.5 py-0.5 font-mono text-[10px] font-semibold"
+                style={{ backgroundColor: tagColor.bgColor, color: tagColor.textColor }}
+              >
+                {action.projectTag}
+              </span>
+              <Badge variant="secondary" className="shrink-0">
+                {action.team}
+              </Badge>
+            </div>
+            <p className="text-muted-foreground line-clamp-1 text-xs">{action.description}</p>
+          </div>
+
+          {/* 우: 마감일 + 상태 배지(맨 오른쪽 끝) */}
+          <div className="flex shrink-0 items-center gap-3">
+            <span className="text-muted-foreground text-xs tabular-nums">
+              {due ? `${due}까지` : "-"}
+            </span>
+            <span
+              className={cn(
+                "inline-flex h-5 shrink-0 items-center rounded-full px-2 text-xs font-medium",
+                STATUS_TONE[tone],
+              )}
+            >
+              {statusLabel}
+            </span>
+          </div>
+        </div>
+      </Link>
+    </li>
+  );
+}

--- a/src/features/action/mapper.ts
+++ b/src/features/action/mapper.ts
@@ -3,17 +3,22 @@ import type { MemberAction } from "@/features/member/types";
 import { type BeAttachment, toProjectAttachment } from "@/features/project/mapper";
 import type { TeamActionDetail } from "@/features/project/types";
 
-import type { PersonalActionDetail } from "./types";
+import type { MyActionListItem, PersonalActionDetail } from "./types";
 
 /**
  * BE shape → UI 계약 (§Mock 격리막).
  * [확인] 잇다(Z) REST API 연동 가이드 최종본(2026-08-10) + BACKEND 실코드 대조
  *   `action/presentation/api/response/{ActionSummaryResponse,ActionDetailResponse}.java`
+ *
+ * ⚠️ `description`·`projectId`·`projectName`은 2026-08-11 이홍근 요청으로 추가됨(내 액션
+ *    리스트·프로젝트별 그룹핑용). `projectName`은 목록 2경로(개인·팀 액션 목록)에서만 채워지고
+ *    타임라인·회의별 조회에서는 "이미 그 화면 안이라 중복"이라 `null`로 온다.
  */
 export interface BeActionSummary {
   id: number;
   actionType: "PERSONAL" | "TEAM";
   title: string;
+  description: string;
   status: ActionStatus;
   /** "아직 시작 안 함" 액션은 `null`이 정상이다(마이그레이션 문제 아님, BE 주석 확인). */
   startDate: string | null;
@@ -21,7 +26,9 @@ export interface BeActionSummary {
   needsReview: boolean;
   isDelayed: boolean;
   assigneeName: string | null;
+  projectId: number;
   projectTag: string | null;
+  projectName: string | null;
   teamName: string | null;
   sourceMeetingTitle: string | null;
   parentActionId: number | null;
@@ -77,6 +84,26 @@ export function toMemberAction(be: BeActionSummary): MemberAction {
     status: be.status,
     startDate: fallbackActionStartDate(be.startDate),
     dueDate: be.dueDate,
+  };
+}
+
+/**
+ * 내 액션 리스트(`/app/my/actions`) 한 줄(`GET /api/actions`) → UI 계약.
+ * ⚠️ `team`은 `teamName`이 없으면(수동 추가 등) "-"로 채운다 — 배지에 빈 문자열을 그대로
+ *    보여주면 빈 배지처럼 보인다.
+ */
+export function toMyActionListItem(be: BeActionSummary): MyActionListItem {
+  return {
+    id: be.id,
+    title: be.title,
+    description: be.description,
+    team: be.teamName ?? "-",
+    projectId: be.projectId,
+    projectName: be.projectName ?? "",
+    projectTag: be.projectTag ?? "",
+    startDate: fallbackActionStartDate(be.startDate),
+    dueDate: be.dueDate,
+    status: be.status,
   };
 }
 

--- a/src/features/action/mapper.ts
+++ b/src/features/action/mapper.ts
@@ -3,7 +3,7 @@ import type { MemberAction } from "@/features/member/types";
 import { type BeAttachment, toProjectAttachment } from "@/features/project/mapper";
 import type { TeamActionDetail } from "@/features/project/types";
 
-import type { MyActionListItem, PersonalActionDetail } from "./types";
+import type { MyActionListItem, PersonalActionDetail, TeamActionProjectGroup } from "./types";
 
 /**
  * BE shape → UI 계약 (§Mock 격리막).
@@ -105,6 +105,34 @@ export function toMyActionListItem(be: BeActionSummary): MyActionListItem {
     dueDate: be.dueDate,
     status: be.status,
   };
+}
+
+/**
+ * 팀 액션 목록(`GET /api/team/actions`) → 프로젝트별 그룹.
+ * ⚠️ 목록 순서를 유지한 채 `projectId`로 묶는다(첫 등장 순서가 그룹 순서다).
+ */
+export function groupTeamActionsByProject(items: BeActionSummary[]): TeamActionProjectGroup[] {
+  const groups = new Map<number, TeamActionProjectGroup>();
+  for (const be of items) {
+    let group = groups.get(be.projectId);
+    if (!group) {
+      group = {
+        projectId: be.projectId,
+        projectName: be.projectName ?? "",
+        projectTag: be.projectTag ?? "",
+        teamActions: [],
+      };
+      groups.set(be.projectId, group);
+    }
+    group.teamActions.push({
+      id: be.id,
+      name: be.title,
+      startDate: fallbackActionStartDate(be.startDate),
+      dueDate: be.dueDate,
+      status: be.status,
+    });
+  }
+  return [...groups.values()];
 }
 
 /**

--- a/src/features/action/server.ts
+++ b/src/features/action/server.ts
@@ -2,6 +2,7 @@ import { requireAccessToken } from "@/features/auth/session";
 import type { BePageResponse } from "@/features/project/mapper";
 import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
 import { TEAM_ACTION_PERSONAL_ITEMS_MOCK } from "@/features/project/mock/team-action-detail";
+import { PROJECT_TEAM_ACTIONS_MOCK } from "@/features/project/mock/team-actions";
 import { ApiError, serverApi } from "@/lib/api";
 import { ep } from "@/lib/endpoints";
 import { isMock } from "@/mocks/config";
@@ -9,11 +10,15 @@ import { isMock } from "@/mocks/config";
 import {
   type BeActionDetail,
   type BeActionSummary,
+  groupTeamActionsByProject,
   toMyActionListItem,
   toPersonalActionDetail,
 } from "./mapper";
 import { PERSONAL_ACTION_DETAIL_MOCK } from "./mock/action-detail";
-import type { MyActionListItem, PersonalActionDetail } from "./types";
+import type { MyActionListItem, PersonalActionDetail, TeamActionProjectGroup } from "./types";
+
+/** 로그인 팀장의 팀 — 세션 붙기 전까지 mock 분기에서만 쓰는 고정값(board/server.ts와 같은 인물). */
+const MOCK_LEADER_TEAM = "개발팀";
 
 /** 개인 액션 상세(`/app/actions/:actionId`). 못 찾으면 `null`(호출부가 404). */
 export async function getPersonalActionDetail(
@@ -78,4 +83,40 @@ export async function getMyActionList(assigneeName: string): Promise<MyActionLis
     .filter((action) => action.actionType === "PERSONAL")
     .map(toMyActionListItem)
     .sort((a, b) => a.dueDate.localeCompare(b.dueDate));
+}
+
+/**
+ * 팀 액션 관리(`/team/action`) — 로그인 팀장의 팀 액션 전체를 프로젝트별로 묶어 돌려준다.
+ * ⚠️ 실연동은 `GET /api/team/actions`가 JWT teamId로 이미 자동 스코프하므로 팀명을 안 넘긴다.
+ *    mock은 세션이 없어 팀명 필터가 필요하다(board/server.ts와 같은 이유).
+ */
+export async function getTeamActionsGroupedByProject(): Promise<TeamActionProjectGroup[]> {
+  if (isMock) {
+    const groups: TeamActionProjectGroup[] = [];
+    for (const project of TOP_LEVEL_PROJECTS) {
+      const teamActions = (PROJECT_TEAM_ACTIONS_MOCK[project.tag] ?? []).filter(
+        (action) => action.team === MOCK_LEADER_TEAM,
+      );
+      if (teamActions.length === 0) continue;
+      groups.push({
+        projectId: project.id,
+        projectName: project.name,
+        projectTag: project.tag,
+        teamActions: teamActions.map((action) => ({
+          id: action.id,
+          name: action.name,
+          startDate: action.startDate,
+          dueDate: action.dueDate,
+          status: action.status,
+        })),
+      });
+    }
+    return groups;
+  }
+
+  const accessToken = await requireAccessToken();
+  const page = await serverApi<BePageResponse<BeActionSummary>>(ep.teamActions({ size: 9999 }), {
+    accessToken,
+  });
+  return groupTeamActionsByProject(page.content);
 }

--- a/src/features/action/server.ts
+++ b/src/features/action/server.ts
@@ -1,11 +1,19 @@
 import { requireAccessToken } from "@/features/auth/session";
+import type { BePageResponse } from "@/features/project/mapper";
+import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
+import { TEAM_ACTION_PERSONAL_ITEMS_MOCK } from "@/features/project/mock/team-action-detail";
 import { ApiError, serverApi } from "@/lib/api";
 import { ep } from "@/lib/endpoints";
 import { isMock } from "@/mocks/config";
 
-import { type BeActionDetail, toPersonalActionDetail } from "./mapper";
+import {
+  type BeActionDetail,
+  type BeActionSummary,
+  toMyActionListItem,
+  toPersonalActionDetail,
+} from "./mapper";
 import { PERSONAL_ACTION_DETAIL_MOCK } from "./mock/action-detail";
-import type { PersonalActionDetail } from "./types";
+import type { MyActionListItem, PersonalActionDetail } from "./types";
 
 /** 개인 액션 상세(`/app/actions/:actionId`). 못 찾으면 `null`(호출부가 404). */
 export async function getPersonalActionDetail(
@@ -28,4 +36,46 @@ export async function getPersonalActionDetail(
     if (error instanceof ApiError && error.status === 404) return null;
     throw error;
   }
+}
+
+/**
+ * 내 액션 목록(`/app/my/actions`) — 담당자 이름이 일치하는 개인 액션 전체, 마감 임박순.
+ * ⚠️ 실연동에선 `assigneeName`을 안 쓴다 — `GET /api/actions`가 이미 토큰의 본인 소유분만
+ *    돌려준다(board/server.ts와 같은 이유). 파라미터는 mock 분기 전용으로 시그니처만 유지한다.
+ */
+export async function getMyActionList(assigneeName: string): Promise<MyActionListItem[]> {
+  if (isMock) {
+    const list: MyActionListItem[] = [];
+    for (const items of Object.values(TEAM_ACTION_PERSONAL_ITEMS_MOCK)) {
+      for (const item of items) {
+        if (item.assigneeName !== assigneeName) continue;
+        const detail = PERSONAL_ACTION_DETAIL_MOCK[item.id];
+        if (!detail) continue;
+        const project = TOP_LEVEL_PROJECTS.find((p) => p.id === detail.projectId);
+        if (!project) continue;
+        list.push({
+          id: item.id,
+          title: item.title,
+          description: detail.description,
+          team: detail.team,
+          projectId: detail.projectId,
+          projectName: project.name,
+          projectTag: detail.projectTag,
+          startDate: item.startDate,
+          dueDate: item.dueDate,
+          status: item.status,
+        });
+      }
+    }
+    return list.sort((a, b) => a.dueDate.localeCompare(b.dueDate));
+  }
+
+  const accessToken = await requireAccessToken();
+  const page = await serverApi<BePageResponse<BeActionSummary>>(ep.actions({ size: 9999 }), {
+    accessToken,
+  });
+  return page.content
+    .filter((action) => action.actionType === "PERSONAL")
+    .map(toMyActionListItem)
+    .sort((a, b) => a.dueDate.localeCompare(b.dueDate));
 }

--- a/src/features/action/types.ts
+++ b/src/features/action/types.ts
@@ -1,3 +1,5 @@
+import type { ActionStatus } from "@/constants/domain";
+
 /**
  * 개인 액션 상세(`/app/actions/:actionId`)의 UI 계약.
  * ⚠️ 팀 액션 상세(`TeamActionDetail`)와 거의 같은 모양이다 — 다른 점 둘뿐:
@@ -37,4 +39,23 @@ export interface PersonalActionDetail {
     /** 마감일 `YYYY-MM-DD` */
     dueDate: string;
   };
+}
+
+/**
+ * 내 액션(`/app/my/actions`) 목록 한 줄 — 리스트 전용이라 상세 화면의 회의·상위 팀 액션
+ * 정보는 없다. 제목·태그·팀명·상태·마감일·세부 설명 한 줄만 있으면 된다.
+ */
+export interface MyActionListItem {
+  id: number;
+  title: string;
+  description: string;
+  team: string;
+  projectId: number;
+  projectName: string;
+  projectTag: string;
+  /** 작업 시작일 `YYYY-MM-DD` — 지연 판정에는 안 쓰지만(`isDelayed`는 마감일만 본다) 계약은 갖춰 둔다. */
+  startDate: string;
+  /** 마감일 `YYYY-MM-DD` */
+  dueDate: string;
+  status: ActionStatus;
 }

--- a/src/features/action/types.ts
+++ b/src/features/action/types.ts
@@ -59,3 +59,26 @@ export interface MyActionListItem {
   dueDate: string;
   status: ActionStatus;
 }
+
+/** 팀 액션 관리(`/team/action`) 타임라인의 팀 액션 한 줄. */
+export interface TeamActionTimelineItem {
+  id: number;
+  name: string;
+  /** 작업 시작일 `YYYY-MM-DD` — 타임라인 막대 왼쪽 끝 */
+  startDate: string;
+  /** 마감일 `YYYY-MM-DD` */
+  dueDate: string;
+  status: ActionStatus;
+}
+
+/**
+ * 팀 액션 관리 화면 — 프로젝트별로 묶은 팀 액션 그룹.
+ * ⚠️ 하위 개인 액션 진척률(게이지)은 이 목록 API(`GET /api/team/actions`)에 값이 없어 아직 없다
+ *    — BE에 `childDoneCount`·`childTotalCount` 추가 요청해 둠(2026-08-11). 나오면 게이지만 얹는다.
+ */
+export interface TeamActionProjectGroup {
+  projectId: number;
+  projectName: string;
+  projectTag: string;
+  teamActions: TeamActionTimelineItem[];
+}

--- a/src/features/project/mapper.ts
+++ b/src/features/project/mapper.ts
@@ -21,6 +21,8 @@ export interface BeProjectSummary {
   tag: string;
   color: string;
   name: string;
+  /** 목록 카드 첫 줄 요약용 — 2026-08-11 이홍근 요청으로 추가됨. */
+  description: string;
   status: ProjectStatus;
   /** 마이그레이션 이전 생성 프로젝트는 `null` — 채울 원천이 없다. */
   startDate: string | null;
@@ -93,9 +95,8 @@ export function toProjectListItem(be: BeProjectSummary): ProjectListItem {
   return {
     id: be.id,
     name: be.name,
-    // ⚠️ 목록 응답(ProjectSummaryResponse)엔 description이 없다 — 상세에만 있다(BE 실코드 확인,
-    //    2026-08-10). 목록 카드가 첫 줄 스니펫으로 이 값을 쓰고 있어 지금은 빈 문자열로 채운다.
-    description: "",
+    // ⚠️ 2026-08-11 해결 — ProjectSummaryResponse에 description 추가됨(이홍근 요청).
+    description: be.description,
     tag: be.tag,
     departments: be.teamNames,
     actionTotal: be.actionCount,


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [x] LEADER (팀장)
- [x] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

> PR #321 머지 이후 이어서 작업한 내용을 분리해 새 브랜치·이슈로 재작성한 것입니다.

- **내 액션 리스트(`/app/my/actions`)** 재구축 + 실 API 연동 — `GET /api/actions`에서 PERSONAL만 필터·마감 임박순·프로젝트별 그룹핑, 항목 클릭 시 개인 액션 상세로 이동. 머지 누락으로 유실됐던 화면(`feature/my-actions-list#206`)을 현재 코드/API에 맞춰 재작성.
- **팀 액션 관리 타임라인(`/team/action`)** 재구축 + 실 API 연동 — `GET /api/team/actions`(LEADER, JWT teamId 자동 스코프)를 프로젝트별로 묶어 타임라인 표시, 항목 클릭 시 팀 액션 상세로 이동. 유실됐던 화면(`feature/team-action-dashboard#204`) 재작성.
- **프로젝트 목록 `description` 매핑** — BE가 `ProjectSummaryResponse`에 `description` 추가함에 맞춰 매퍼에서 빈 문자열 → 실제 값으로 교체.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/my-actions-team-actions-api#337`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 두 목록 모두 토큰 스코프(내 소유분 / 내 팀)로 **서버가 좁힌다**, FE는 조회만
- [ ] 🧬 **zod** — 미적용(기존 매퍼 패턴 유지, PR #321 리뷰포인트와 동일)
- [x] 🕵️ **정직성** — 팀 액션 진척률 게이지는 API에 값이 없어 뺐고, 필요 필드는 BE에 요청해 둠(주석 명시)
- [x] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨 — 신규 컴포넌트도 기존 토큰만 사용

**품질**

- [ ] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그)
- [ ] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [x] ♻️ 재사용 확인 — `ActionTimeline`·`ScreenError`·`PageHeader` 등 기존 것 재사용, 신규는 목록 행 컴포넌트 1개만
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 각 라우트에 `loading.tsx`·`error.tsx` + 빈 상태 문구
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음

---

## 🔗 연관 이슈

Closes #337

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- 팀 액션 **진척률 게이지**는 이번 범위에서 뺐습니다 — `GET /api/team/actions` 응답에 하위 개인 액션 진척 수가 없어서, BE에 `childDoneCount`·`childTotalCount` 추가 요청해 둔 상태입니다(나오면 게이지만 얹으면 됨).
- 두 화면 모두 mock 분기는 대표 인물(이하윤/개발팀)로 고정, 실연동 분기는 토큰 스코프를 그대로 씁니다.

---

## 📝 추가 메모

typecheck·lint·전체 jest(78 suites/890 tests) 통과. 브라우저에서 두 화면 렌더 확인 완료.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 개인 액션 목록을 프로젝트별로 확인하고, 제목·설명·팀·마감일·상태를 볼 수 있습니다.
  * 팀 액션을 프로젝트별 타임라인으로 확인하고, 지연 상태·액션 수·상세 링크를 제공합니다.
  * 프로젝트 설명이 목록에 표시됩니다.
* **사용성 개선**
  * 액션 화면에 로딩 스켈레톤과 빈 상태 안내를 추가했습니다.
  * 데이터 로드 실패 시 화면에서 다시 시도할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
