### PR TITLE
[FEAT] 검색 최근 본 항목 기록 API 연동  #339

### DIFF
--- a/src/features/search/actions.ts
+++ b/src/features/search/actions.ts
@@ -2,6 +2,9 @@
 
 import { revalidatePath } from "next/cache";
 
+import { requireAccessToken } from "@/features/auth/session";
+import { serverApi } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
 import { isMock } from "@/mocks/config";
 
 import { addMockRecentSearch } from "./mock/recent-searches";
@@ -11,6 +14,8 @@ import { addMockRecentSearch } from "./mock/recent-searches";
  * ⚠️ 화면에 결과를 돌려주지 않는다. 이 액션은 **기록만** 하고, 결과는 페이지가
  *    `?q=`로 다시 조회해서 보여준다 — 액션이 결과까지 들고 있으면 새로고침·직접 링크로
  *    들어왔을 때와 화면이 갈린다.
+ * ⚠️ **호출부가 `void`로 던지고 결과를 안 본다**(`search-input.tsx`). 검색 기록 실패가
+ *    검색 자체를 막을 이유는 없어 — 실패해도 조용히 넘어간다(최근 검색어 한 줄이 안 남을 뿐).
  */
 export async function recordSearchAction(keyword: string): Promise<void> {
   const trimmed = keyword.trim();
@@ -23,6 +28,16 @@ export async function recordSearchAction(keyword: string): Promise<void> {
     return;
   }
 
-  // ⚠️ 미구현 — API 스펙 확정 후 검색 기록 경로로 POST한다.
-  throw new Error("검색 기록 API가 아직 연결되지 않았습니다.");
+  /* [스펙 전달, BE 실코드 미대조] `POST /api/v1/search/recent-queries` — 몸통은 `{ query }` */
+  try {
+    const accessToken = await requireAccessToken();
+    await serverApi<unknown>(ep.searchRecentQueries(), {
+      method: "POST",
+      accessToken,
+      json: { query: trimmed },
+    });
+    revalidatePath("/app/search");
+  } catch {
+    // 위 주석대로 — 기록 실패를 검색 흐름에 되돌리지 않는다.
+  }
 }

--- a/src/features/search/actions.ts
+++ b/src/features/search/actions.ts
@@ -8,6 +8,7 @@ import { ep } from "@/lib/endpoints";
 import { isMock } from "@/mocks/config";
 
 import { addMockRecentSearch } from "./mock/recent-searches";
+import type { SearchKind } from "./types";
 
 /**
  * 검색 기록 — 검색창에서 값을 확정(입력을 멈춘 뒤)했을 때 클라이언트가 부른다.
@@ -39,5 +40,30 @@ export async function recordSearchAction(keyword: string): Promise<void> {
     revalidatePath("/app/search");
   } catch {
     // 위 주석대로 — 기록 실패를 검색 흐름에 되돌리지 않는다.
+  }
+}
+
+/**
+ * 최근 본 항목 기록 — 검색/랜딩에서 결과 하나를 열 때(지금은 프로젝트만 실제 이동이라
+ * 프로젝트 클릭에서만 불린다, `record-view-link.tsx`) 클라이언트가 부른다.
+ * ⚠️ **이동을 막지 않는다.** 링크를 누른 김에 fire-and-forget으로 보내는 부가 기록이라,
+ *    실패해도 페이지 이동은 그대로 진행된다(`recordSearchAction`과 같은 이유).
+ * ⚠️ 목엔 대응하는 저장소가 없다 — `SearchHome.recentlyViewed`가 정적 목이라 클릭해도
+ *    안 바뀐다(§정직한 목업: 없는 걸 있는 척 안 한다).
+ */
+export async function recordRecentViewAction(kind: SearchKind, id: number): Promise<void> {
+  if (isMock) return;
+
+  /* [스펙 전달, BE 실코드 미대조] `POST /api/v1/search/recent-views` — 몸통은 `{ type, id }` */
+  try {
+    const accessToken = await requireAccessToken();
+    await serverApi<unknown>(ep.searchRecentViews(), {
+      method: "POST",
+      accessToken,
+      json: { type: kind, id },
+    });
+    revalidatePath("/app/search");
+  } catch {
+    // 위 주석대로 — 기록 실패를 이동 흐름에 되돌리지 않는다.
   }
 }

--- a/src/features/search/components/browse-lists.tsx
+++ b/src/features/search/components/browse-lists.tsx
@@ -1,11 +1,10 @@
-import Link from "next/link";
-
 import { ProfileAvatar } from "@/components/common/profile-avatar";
 import { ProjectTag } from "@/components/common/project-tag";
 import { AUTHORITY_BADGE_CLASS, AUTHORITY_LABEL } from "@/constants/authority";
 import { pickPaletteColor } from "@/lib/palette";
 
 import type { PersonBrowseItem, ProjectBrowseItem } from "../types";
+import { RecordViewLink } from "./record-view-link";
 import { SearchSection } from "./search-section";
 
 interface BrowseProjectsProps {
@@ -27,7 +26,9 @@ export function BrowseProjects({ projects }: BrowseProjectsProps) {
       <ul className="flex flex-col gap-2">
         {projects.map((project) => (
           <li key={project.id}>
-            <Link
+            <RecordViewLink
+              kind="PROJECT"
+              itemId={project.id}
               href={`/app/projects/${project.id}`}
               className="border-border bg-card hover:border-foreground/25 focus-visible:ring-ring flex items-stretch gap-2.5 rounded-xl border py-3 pr-4 pl-3 text-[13px] transition-colors focus-visible:ring-2 focus-visible:outline-hidden [&>*:not(:first-child)]:self-center"
             >
@@ -47,7 +48,7 @@ export function BrowseProjects({ projects }: BrowseProjectsProps) {
               <span className="text-muted-foreground shrink-0 text-[12px] leading-4 tabular-nums">
                 회의 {project.meetingCount}건
               </span>
-            </Link>
+            </RecordViewLink>
           </li>
         ))}
       </ul>

--- a/src/features/search/components/recently-viewed-grid.tsx
+++ b/src/features/search/components/recently-viewed-grid.tsx
@@ -1,9 +1,8 @@
-import Link from "next/link";
-
 import { pickPaletteColor } from "@/lib/palette";
 
 import type { SearchRecentViewItem } from "../types";
 import { KindBadge } from "./kind-badge";
+import { RecordViewLink } from "./record-view-link";
 import { SearchSection } from "./search-section";
 
 interface RecentlyViewedGridProps {
@@ -93,13 +92,15 @@ function RecentlyViewedCard({ item }: RecentlyViewedCardProps) {
 
   if (item.kind === "PROJECT") {
     return (
-      <Link
+      <RecordViewLink
+        kind="PROJECT"
+        itemId={item.id}
         href={`/app/projects/${item.id}`}
         /* ⚠️ 누를 수 있는 것만 면이 짙어진다 — 넷 중 프로젝트 하나만 링크다 */
         className={`${shape} hover:border-foreground/25 transition-colors`}
       >
         {inner}
-      </Link>
+      </RecordViewLink>
     );
   }
 

--- a/src/features/search/components/record-view-link.tsx
+++ b/src/features/search/components/record-view-link.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import Link from "next/link";
+import type { ComponentProps } from "react";
+
+import { recordRecentViewAction } from "../actions";
+import type { SearchKind } from "../types";
+
+interface RecordViewLinkProps extends ComponentProps<typeof Link> {
+  kind: SearchKind;
+  itemId: number;
+}
+
+/**
+ * 검색/랜딩에서 결과를 열 때 "최근 본 항목"에 남긴다(`POST /search/recent-views`).
+ * **상호작용 잎사귀만** 클라이언트다(§핵심 4원칙 1) — 이동 자체는 `next/link`가 그대로 하고,
+ * 여기서는 클릭 시점에 기록 액션 하나만 얹는다.
+ *
+ * ⚠️ **이동을 절대 안 막는다.** 기록은 `void`로 던지고 기다리지 않는다 — 기록 API가 느리거나
+ *    실패해도 화면 전환은 그대로다(`recordRecentViewAction`이 실패를 알아서 삼킨다).
+ */
+export function RecordViewLink({ kind, itemId, onClick, ...linkProps }: RecordViewLinkProps) {
+  return (
+    <Link
+      {...linkProps}
+      onClick={(event) => {
+        onClick?.(event);
+        void recordRecentViewAction(kind, itemId);
+      }}
+    />
+  );
+}

--- a/src/features/search/components/record-view-link.tsx
+++ b/src/features/search/components/record-view-link.tsx
@@ -25,6 +25,7 @@ export function RecordViewLink({ kind, itemId, onClick, ...linkProps }: RecordVi
       {...linkProps}
       onClick={(event) => {
         onClick?.(event);
+        if (event.defaultPrevented) return;
         void recordRecentViewAction(kind, itemId);
       }}
     />

--- a/src/features/search/components/search-result-row.tsx
+++ b/src/features/search/components/search-result-row.tsx
@@ -1,5 +1,3 @@
-import Link from "next/link";
-
 import { AUTHORITY_BADGE_CLASS, AUTHORITY_LABEL } from "@/constants/authority";
 import { formatDate } from "@/lib/date";
 import { pickPaletteColor } from "@/lib/palette";
@@ -8,6 +6,7 @@ import { cn } from "@/lib/utils";
 import type { SearchResultItem } from "../types";
 import { KindBadge } from "./kind-badge";
 import { MatchText } from "./match-text";
+import { RecordViewLink } from "./record-view-link";
 
 /*
   ⚠️ **줄마다 낱장 카드다**(랜딩 목록과 같은 결). 구분선으로 이은 한 덩이는 값을 **비교하는**
@@ -114,12 +113,14 @@ export function SearchResultRow({ item, keyword }: SearchResultRowProps) {
   if (item.kind === "PROJECT") {
     return (
       <li>
-        <Link
+        <RecordViewLink
+          kind="PROJECT"
+          itemId={item.id}
           href={`/app/projects/${item.id}`}
           className={cn(ROW_SHAPE, "hover:border-foreground/25 transition-colors")}
         >
           {content}
-        </Link>
+        </RecordViewLink>
       </li>
     );
   }


### PR DESCRIPTION
## 📋 PR 타입

> 해당하는 타입을 선택해 주세요 (복수 선택 가능)

- [x] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- 최근 본 항목 기록 API(`POST /api/v1/search/recent-views`) 연동
- 이동(`next/link`)은 그대로 두고 클릭 시점에 기록만 얹는 얇은 클라이언트 컴포넌트(`RecordViewLink`) 신설 — `recordSearchAction`과 같이 fire-and-forget + 실패 무시 방식
- 지금 실제로 이동 가능한 프로젝트 링크 3곳에만 적용(회의·액션·사람은 상세 경로가 아직 없어 대상 아님)

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [ ] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 해당 없음(로그인 사용자 공통 기능, 토큰 기준 본인 기록만)
- [x] 🕵️ **정직성** — 스펙 미검증(BE 실코드 미대조) 명시, mock에 대응 저장소가 없어 no-op이라는 점을 주석으로 남김
- [x] 🎨 디자인 토큰 사용 — 해당 없음(기존 UI 그대로, 이동 방식만 래핑)

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [x] ♿ a11y — `next/link` 그대로 감싸서 시맨틱·포커스·키보드 동작 변화 없음
- [x] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 확인, 새 잎사귀는 도메인 전용이라 `search/components`에 배치)
- [ ] 🧪 `loading` / `error` / `empty` 3상태 — 해당 없음(눈에 보이는 결과가 없는 기록용 액션)
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음 — 해당 없음

---

## 🔗 연관 이슈

Closes #339

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

- 이 세션 환경 제약으로 실제 클릭→이동→기록 흐름을 브라우저에서 시각적으로 재현 확인은 못 했음(콘솔 에러는 없었음) — 리뷰 시 실제 클릭 동작 한 번 확인 부탁
- 회의·액션·사람 링크가 생기는 시점에 `RecordViewLink` 적용 범위를 넓히는 후속 작업 필요 여부

---

## 📝 추가 메모

회의·액션·사람 상세 경로가 없어 이번엔 프로젝트 클릭만 기록됨 — 4개 API 전부(#329 스코프) 완료.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 검색어 기록이 실제 검색 기록에 저장됩니다.
  * 프로젝트를 열면 최근 본 항목으로 자동 기록됩니다.
  * 검색 결과, 프로젝트 목록, 최근 본 항목에서 조회 기록이 일관되게 반영됩니다.

* **버그 수정**
  * 기록 저장에 실패해도 페이지 이동이나 검색 기능이 중단되지 않습니다.
  * 인증 또는 API 오류가 사용자 화면에 불필요하게 노출되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->