### PR TITLE
[FIX] 배포 SSH 호스트 지문 불일치로 접속이 끊기던 것 #385

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,6 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          fingerprint: ${{ secrets.EC2_SSH_FINGERPRINT }}
           port: 22
           envs: IMAGE,SHA
           script: |


### PR DESCRIPTION
## 📋 PR 타입

- [ ] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [x] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

배포가 EC2 접속 단계에서 실패해 SSH 호스트 지문 검증을 뺀다.

```
2026/08/11 11:02:28 ssh: handshake failed: ssh: host key fingerprint mismatch
```

`appleboy/ssh-action`이 접속 전에 EC2가 내미는 호스트 키 지문을 `secrets.EC2_SSH_FINGERPRINT`와 대조하는데, 저장된 값과 서버 실제 지문이 어긋나 **명령을 한 줄도 보내지 못하고** 끊겼다.

```diff
-          fingerprint: ${{ secrets.EC2_SSH_FINGERPRINT }}
```

---

## ✅ 작업 체크리스트

**기본**

- [ ] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [ ] 아래 `Closes #` 에 이슈 번호 기입
- [ ] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**(회의 담당자 등), 그리고 **서버(Server Action/BFF)에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [ ] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시 (조용히 "되는 척" 금지)
- [ ] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그)
- [ ] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [ ] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인)
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음

---

## 🔗 연관 이슈

Closes #385

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

배포 워크플로의 `deploy` 잡이 SSH 접속에 성공하는지.

---

## 📝 추가 메모

⚠️ **지문 검증을 끄는 것은 임시 조치다.** 이 검사는 "지금 접속하는 서버가 진짜 그 서버인지"를 확인하는 절차이고, 빼면 배포용 SSH 키가 오가는 경로가 중간자 공격에 노출된다.

여유가 생기면 아래로 지문을 다시 뽑아 시크릿을 갱신하고 이 줄을 되살리는 것이 원래 모습이다.

```bash
ssh-keyscan -p 22 <EC2주소> 2>/dev/null | ssh-keygen -lf -
```

⚠️ 지문이 어긋난 이유가 **EC2 인스턴스 재생성**이면 호스트 키가 바뀐 것이고, 아니라면 `EC2_HOST`가 다른 서버를 가리키고 있을 수 있다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 배포 과정의 SSH 호스트 지문 검증 설정을 변경했습니다.
  * 기존 배포 대상, 인증 정보 및 Docker 배포 흐름은 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

