### PR TITLE
[CHORE] 배포에 BACKEND_API_URL을 EC2 .env로 주입한다 #386

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SHA: ${{ github.sha }}
+      BACKEND_API_URL: ${{ secrets.BACKEND_API_URL }}
 
     steps:
       - name: Deploy via SSH (pull → restart container)
@@ -55,11 +56,13 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           port: 22
-          envs: IMAGE,SHA
+          envs: IMAGE,SHA,BACKEND_API_URL
           script: |
             set -e
 
             docker pull $IMAGE:$SHA
+
+            echo "BACKEND_API_URL=$BACKEND_API_URL" > /home/ubuntu/zebra/.env
 
             docker stop zebra-fe || true
             docker rm zebra-fe || true


### PR DESCRIPTION
## 📋 PR 타입

- [ ] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [x] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

배포된 컨테이너가 BE 주소를 몰라서, 배포 시 `BACKEND_API_URL`을 EC2의 `.env`로 내려 준다.

```diff
     env:
       SHA: ${{ github.sha }}
+      BACKEND_API_URL: ${{ secrets.BACKEND_API_URL }}
...
-          envs: IMAGE,SHA
+          envs: IMAGE,SHA,BACKEND_API_URL
...
+            echo "BACKEND_API_URL=$BACKEND_API_URL" > /home/ubuntu/zebra/.env
```

`BACKEND_API_URL`은 **서버에서만 읽는 런타임 값**이라 도커 이미지에 굽지 않는다(`NEXT_PUBLIC_`이 아니다). `docker run --env-file`이 읽는 `.env`를 배포 때마다 새로 쓰는 방식이다.

---

## ✅ 작업 체크리스트

**기본**

- [ ] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [ ] 아래 `Closes #` 에 이슈 번호 기입
- [ ] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**(회의 담당자 등), 그리고 **서버(Server Action/BFF)에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [ ] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시 (조용히 "되는 척" 금지)
- [ ] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그)
- [ ] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [ ] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인)
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음

---

## 🔗 연관 이슈

Closes #386

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

배포 후 컨테이너가 BE를 실제로 부르는지(로그인·기업코드 조회가 되는지).

---

## 📝 추가 메모

⚠️ `>` 로 덮어쓰기 때문에 `.env`에 **다른 값이 들어 있었다면 지워진다.** 앞으로 런타임 환경변수가 늘면 이 줄도 같이 늘려야 한다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **배포**
  * 배포 시 백엔드 API 주소 설정이 자동으로 전달되고 서버 환경에 반영됩니다.
  * 환경 설정 반영 후 기존 컨테이너 재시작 절차가 수행됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

