### PR TITLE
[FIX] http 배포에서 로그인 쿠키가 버려지던 것 #354

### DIFF
--- a/src/features/auth/actions.ts
+++ b/src/features/auth/actions.ts
@@ -224,21 +224,40 @@ export interface LoginState {
   error?: string;
   /** 검증은 통과했지만 더 갈 수 없을 때 보여 줄 말 */
   notice?: string;
+  /**
+   * 방금 적은 이메일 — **실패했을 때 되살린다.**
+   *
+   * ⚠️ React 19의 `<form action={서버액션}>`은 액션이 끝나면 **폼을 리셋한다.** 그래서
+   *    비밀번호를 한 번 틀리면 이메일까지 통째로 날아가 처음부터 다시 적어야 했다.
+   * ⚠️ **비밀번호는 안 돌려준다.** 서버가 받은 비밀번호를 화면 상태로 되돌리면 그게 그대로
+   *    RSC 응답에 실려 나간다 — 틀린 값을 지우고 다시 치는 게 맞다.
+   */
+  email?: string;
+  /** 몇 번째 시도인가 — 화면이 입력칸의 `key`를 바꿔 되살리는 데 쓴다 */
+  attempt: number;
 }
 
-export async function loginAction(_prevState: LoginState, formData: FormData): Promise<LoginState> {
+export async function loginAction(prevState: LoginState, formData: FormData): Promise<LoginState> {
   const email = String(formData.get("email") ?? "");
   const password = String(formData.get("password") ?? "");
+
+  /** 실패하면 적어 둔 이메일을 함께 돌려준다 — 되살리는 건 화면이 한다 */
+  const keep = (state: Omit<LoginState, "email" | "attempt">): LoginState => ({
+    ...state,
+    email,
+    attempt: prevState.attempt + 1,
+  });
+
   const errors = validateCredentials({ email, password });
-  if (Object.keys(errors).length > 0) return { errors };
+  if (Object.keys(errors).length > 0) return keep({ errors });
 
   const companyCode = String(formData.get("companyCode") ?? "").trim();
   if (!companyCode) {
     // 1단계에서 확인한 코드가 숨은 칸으로 실려 온다 — 없으면 회사부터 다시 고르게 한다
-    return {
+    return keep({
       errors: {},
       error: "기업 코드를 다시 확인해 주세요. [변경]을 눌러 다시 연결해 주세요.",
-    };
+    });
   }
 
   if (!isMock) {
@@ -251,7 +270,7 @@ export async function loginAction(_prevState: LoginState, formData: FormData): P
         keepSignedIn: formData.get("keepSignedIn") === "on",
       });
     } catch (error) {
-      return { errors: {}, error: toUserMessage(error) };
+      return keep({ errors: {}, error: toUserMessage(error) });
     }
 
     /*
@@ -266,10 +285,10 @@ export async function loginAction(_prevState: LoginState, formData: FormData): P
     목으로 돌 때는 로그인시킬 서버가 없다. 조용히 아무것도 안 하면 사용자는 비밀번호가
     틀린 줄 안다 — 안 되는 건 안 된다고 말한다(§정직성).
   */
-  return {
+  return keep({
     errors: {},
     notice: "목 모드입니다. 실제 로그인은 `NEXT_PUBLIC_USE_MOCK=false`로 켜집니다.",
-  };
+  });
 }
 
 /**

--- a/src/features/auth/components/login-form.tsx
+++ b/src/features/auth/components/login-form.tsx
@@ -22,7 +22,7 @@ import { SubmitButton } from "./submit-button";
  *    사용자는 비밀번호가 틀린 줄 안다 — 액션이 안내를 돌려주고 여기서 보여 준다(§정직성).
  * ⚠️ 비밀번호 재발급 화면은 만들지 않는다(팀 결정) — 링크가 아니라 안내 문구로 둔다.
  */
-const INITIAL: LoginState = { errors: {} };
+const INITIAL: LoginState = { errors: {}, attempt: 0 };
 export function LoginForm() {
   // 기억해 둔 회사가 있으면 1단계를 건너뛴다
   const company = useSavedCompany();
@@ -78,8 +78,10 @@ export function LoginForm() {
           </Label>
           <Input
             id="email"
+            key={`email-${state.attempt}`}
             name="email"
             type="email"
+            defaultValue={state.email}
             placeholder="name@company.com"
             autoComplete="email"
             aria-invalid={loginErrors.email !== undefined}

--- a/src/features/auth/cookie.ts
+++ b/src/features/auth/cookie.ts
@@ -39,13 +39,35 @@ export const ACCESS_TOKEN_MAX_AGE = 60 * 30;
  */
 export const REFRESH_TOKEN_MAX_AGE = 60 * 60 * 24 * 14;
 
-/** 쿠키 공통 속성 — 토큰이 브라우저 JS에 안 보이게 하는 게 핵심이다. */
-export function tokenCookieOptions(maxAge?: number) {
+/**
+ * 이 요청이 **HTTPS로 들어왔는가** — `secure` 플래그를 여기서 정한다.
+ *
+ * ⚠️ **`NODE_ENV`로 판단하면 안 된다.** 전에는 `secure: NODE_ENV === "production"`이었는데,
+ *    도커 이미지가 `NODE_ENV=production`으로 굳어 있어서 **http로 띄운 서버에서도 `secure`가
+ *    켜졌다.** 브라우저는 http에서 `Secure` 쿠키를 **조용히 버린다** — 로그인은 성공하고
+ *    리다이렉트까지 가는데 쿠키가 없어서 `proxy.ts`가 로그인 화면으로 되돌렸다.
+ *    303(로그인 성공) → 307(가드가 되돌림) → 200(로그인 화면)이 그 흔적이다.
+ * ⚠️ 배포 방식이 아니라 **지금 이 요청의 프로토콜**을 본다. 그래야 http로 띄운 데모에서도
+ *    로그인이 되고, 나중에 앞단에 HTTPS를 붙이는 순간 **설정을 안 고쳐도** 다시 켜진다.
+ * ⚠️ `x-forwarded-proto`는 앞단(ALB·nginx)이 붙여 준다. 없으면 앞단이 없다는 뜻이라 http로 본다.
+ *    값이 여럿이면(`https,http`) 맨 앞이 사용자와 맺은 프로토콜이다.
+ */
+export function isSecureRequest(forwardedProto: string | null | undefined): boolean {
+  if (!forwardedProto) return false;
+  return forwardedProto.split(",")[0]?.trim().toLowerCase() === "https";
+}
+
+/**
+ * 쿠키 공통 속성 — 토큰이 브라우저 JS에 안 보이게 하는 게 핵심이다.
+ *
+ * ⚠️ `isSecure`는 부르는 쪽이 정한다. Server Action은 `headers()`로, `proxy.ts`는
+ *    `request.headers`로 읽는다 — 이 파일은 요청을 모른다(Edge에서도 읽히므로 `server-only`를 못 쓴다).
+ */
+export function tokenCookieOptions(maxAge: number | undefined, isSecure: boolean) {
   return {
     httpOnly: true,
     sameSite: "lax" as const,
-    // 개발은 http라 `secure`를 켜면 쿠키가 아예 안 굽힌다
-    secure: process.env.NODE_ENV === "production",
+    secure: isSecure,
     path: "/",
     ...(maxAge === undefined ? {} : { maxAge }),
   };

--- a/src/features/auth/session.ts
+++ b/src/features/auth/session.ts
@@ -1,10 +1,11 @@
 import "server-only";
 
-import { cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
 
 import {
   ACCESS_TOKEN_COOKIE,
   ACCESS_TOKEN_MAX_AGE,
+  isSecureRequest,
   KEEP_SIGNED_IN_COOKIE,
   REFRESH_TOKEN_COOKIE,
   REFRESH_TOKEN_MAX_AGE,
@@ -31,8 +32,17 @@ export interface SessionTokens {
 
 export async function setSession(tokens: SessionTokens, keepSignedIn: boolean): Promise<void> {
   const jar = await cookies();
+  /*
+    ⚠️ **이 요청이 https로 들어왔는지를 보고** `secure`를 정한다. `NODE_ENV`로 정하면
+       http로 띄운 서버에서 쿠키가 통째로 버려져 로그인이 안 된다(`cookie.ts` 참고).
+  */
+  const isSecure = isSecureRequest((await headers()).get("x-forwarded-proto"));
 
-  jar.set(ACCESS_TOKEN_COOKIE, tokens.accessToken, tokenCookieOptions(ACCESS_TOKEN_MAX_AGE));
+  jar.set(
+    ACCESS_TOKEN_COOKIE,
+    tokens.accessToken,
+    tokenCookieOptions(ACCESS_TOKEN_MAX_AGE, isSecure),
+  );
   /*
     ⚠️ "로그인 상태 유지"를 끄면 갱신표는 **세션 쿠키**다(수명 없음) — 브라우저를 닫으면 사라진다.
        공용 PC에서 체크를 끄는 사람이 기대하는 동작이다.
@@ -40,7 +50,7 @@ export async function setSession(tokens: SessionTokens, keepSignedIn: boolean): 
   jar.set(
     REFRESH_TOKEN_COOKIE,
     tokens.refreshToken,
-    tokenCookieOptions(keepSignedIn ? REFRESH_TOKEN_MAX_AGE : undefined),
+    tokenCookieOptions(keepSignedIn ? REFRESH_TOKEN_MAX_AGE : undefined, isSecure),
   );
   /*
     ⚠️ 재발급할 때 이 값을 BE에 같이 보내야 갱신표 수명이 로그인 때와 같게 유지된다.
@@ -49,7 +59,7 @@ export async function setSession(tokens: SessionTokens, keepSignedIn: boolean): 
   jar.set(
     KEEP_SIGNED_IN_COOKIE,
     keepSignedIn ? "1" : "0",
-    tokenCookieOptions(keepSignedIn ? REFRESH_TOKEN_MAX_AGE : undefined),
+    tokenCookieOptions(keepSignedIn ? REFRESH_TOKEN_MAX_AGE : undefined, isSecure),
   );
 }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from "next/server";
 import {
   ACCESS_TOKEN_COOKIE,
   ACCESS_TOKEN_MAX_AGE,
+  isSecureRequest,
   KEEP_SIGNED_IN_COOKIE,
   REFRESH_TOKEN_COOKIE,
   REFRESH_TOKEN_MAX_AGE,
@@ -156,21 +157,24 @@ function withSession(
 
   const response = NextResponse.next({ request });
   const refreshMaxAge = keepSignedIn ? REFRESH_TOKEN_MAX_AGE : undefined;
+  // ⚠️ 재발급한 쿠키도 로그인 때와 **같은 기준**으로 구워야 한다 — 여기만 `secure`가 어긋나면
+  //    갱신 직후에 쿠키가 버려져 30분마다 로그인 화면으로 튕긴다.
+  const isSecure = isSecureRequest(request.headers.get("x-forwarded-proto"));
 
   response.cookies.set(
     ACCESS_TOKEN_COOKIE,
     tokens.accessToken,
-    tokenCookieOptions(ACCESS_TOKEN_MAX_AGE),
+    tokenCookieOptions(ACCESS_TOKEN_MAX_AGE, isSecure),
   );
   response.cookies.set(
     REFRESH_TOKEN_COOKIE,
     tokens.refreshToken,
-    tokenCookieOptions(refreshMaxAge),
+    tokenCookieOptions(refreshMaxAge, isSecure),
   );
   response.cookies.set(
     KEEP_SIGNED_IN_COOKIE,
     keepSignedIn ? "1" : "0",
-    tokenCookieOptions(refreshMaxAge),
+    tokenCookieOptions(refreshMaxAge, isSecure),
   );
 
   return response;


### PR DESCRIPTION
## 📋 PR 타입

- [ ] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [x] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

**배포 서버에서 로그인이 안 됐다 — 정확히는 되는데 못 들어갔다.**

```
login          303   ← 로그인 성공, redirect(landingPath) 발행
1?_rsc=d369s   307   ← /onboarding/1 갔는데 proxy.ts가 되돌림
login          200   ← 로그인 화면 복귀
```

BE 인증을 통과하고 토큰까지 받았는데 **쿠키가 브라우저에 저장되지 않아** 가드가 되돌렸다.

원인은 `secure` 플래그를 배포 방식으로 정한 것이다.

```ts
secure: process.env.NODE_ENV === "production",   // Dockerfile: ENV NODE_ENV=production
```

http로 띄운 서버에서도 `secure`가 켜지고, 브라우저는 http에서 `Secure` 쿠키를 **조용히 버린다** — 콘솔 오류도 안 난다.

**고친 방식 — 배포 방식이 아니라 요청의 프로토콜을 본다**

`x-forwarded-proto`로 판정한다(`isSecureRequest`). 앞단(ALB·nginx)이 붙여 주는 값이라:
- 지금 http 데모 → 헤더 없음 → `secure: false` → **로그인된다**
- 나중에 HTTPS 붙이면 → 헤더 생김 → `secure: true` → **설정을 안 고쳐도 다시 켜진다**

Server Action은 `headers()`로, `proxy.ts`는 `request.headers`로 읽는다. **재발급 경로도 같은 기준으로 맞췄다** — 거기만 어긋나면 30분마다 로그인 화면으로 튕긴다.

**같이 고친 것 — 로그인 폼 입력값 보존**

React 19가 서버 액션 뒤 폼을 리셋해서, 비밀번호를 한 번 틀리면 이메일까지 날아가 처음부터 다시 적어야 했다. 등록 폼은 앞서 고쳤는데 로그인 폼이 빠져 있었다.

⚠️ **비밀번호는 일부러 안 되살린다.** 서버가 받은 비밀번호를 화면 상태로 돌려주면 그게 그대로 RSC 응답에 실려 나간다 — 틀린 값은 지우고 다시 치는 게 맞다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`fix/login-cookie-secure-and-form-reset#354`, base `main`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 세션 쿠키를 다루는 코드다. 판정은 그대로 서버(`proxy.ts`·가드)가 한다
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [x] 🕵️ **정직성** — 왜 `NODE_ENV`가 아닌지 주석에 남겼다
- [ ] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그)
- [ ] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [ ] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인)
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음

---

## 🔗 연관 이슈

Closes #354

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
| 로그인 → 303 → 307 → 로그인 화면 복귀 | 로그인 → 온보딩 진입 |

---

## 💬 리뷰 포인트

- 배포 후 `http://<서버>:3000/login`에서 로그인 → 온보딩으로 넘어가는지
- 개발자도구 Application → Cookies 에 `z_access_token`이 생기는지 (`Secure` 열이 비어 있어야 정상)
- 비밀번호를 일부러 틀려 보고 **이메일이 남아 있는지**
- `tsc --noEmit` 통과 · `eslint src` 통과 · `jest` **896개 전부 통과**

---

## 📝 추가 메모

⚠️ **근본 해결은 HTTPS입니다.** http로 서비스하면 로그인 비밀번호와 토큰이 평문으로 오갑니다. 이 PR은 데모를 굴리기 위한 것이고, 도메인·인증서가 붙는 순간 이 코드가 **자동으로** `secure`를 다시 켭니다.

⚠️ base를 `main`으로 잡았습니다 — 배포 트리거가 main이고, main이 develop보다 3커밋 앞서 있습니다(도커·배포 수정이 main에 직접 들어갔습니다). **머지 후 main → develop 동기화가 필요합니다.**