### PR TITLE
[FEAT] 회의실 목록 조회 API 연동 (ROOM-01) #358

### DIFF
--- a/src/features/rooms/mapper.ts
+++ b/src/features/rooms/mapper.ts
@@ -1,0 +1,27 @@
+/**
+ * BE shape → UI 계약 (§Mock 격리막). 컴포넌트는 이 파일을 모른다 — `server.ts`/`actions.ts`만 쓴다.
+ * [확인] 회의실 도메인 문서(ROOM-01~05, 2026-08-12) 기준 — BE 실코드는 아직 대조 전이다
+ *   (§연동 검증: Swagger·구두 추측 금지, 문서와 코드가 다르면 코드가 맞다 — 구현 시 컨트롤러로 재확인).
+ */
+
+import type { MeetingRoom } from "./types";
+
+/** `GET /api/meeting-rooms` 배열 원소, `POST`·`PATCH` 성공 응답의 회의실 부분과 같은 모양. */
+export interface BeMeetingRoom {
+  meetingRoomId: number;
+  name: string;
+  /** nullable — 위치 미등록 회의실은 `null`. */
+  location: string | null;
+  availableFrom: string;
+  availableTo: string;
+}
+
+export function toMeetingRoom(be: BeMeetingRoom): MeetingRoom {
+  return {
+    id: String(be.meetingRoomId),
+    name: be.name,
+    location: be.location ?? "",
+    openTime: be.availableFrom,
+    closeTime: be.availableTo,
+  };
+}

--- a/src/features/rooms/server.ts
+++ b/src/features/rooms/server.ts
@@ -2,11 +2,15 @@ import "server-only";
 
 import { endOfWeek, startOfWeek } from "date-fns";
 
+import { requireAccessToken } from "@/features/auth/session";
 import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
 import { PROJECT_TEAM_ACTIONS_MOCK } from "@/features/project/mock/team-actions";
+import { serverApi } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
 import { type Actor, requiresParentTeamAction } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
+import { type BeMeetingRoom, toMeetingRoom } from "./mapper";
 import { listMockMembers } from "./mock/members";
 import { listMockReservations } from "./mock/reservations";
 import { listMockRooms } from "./mock/rooms";
@@ -36,9 +40,18 @@ export async function getWeekReservations(weekOf: Date): Promise<RoomReservation
   throw new Error("회의실 예약 조회 API가 아직 연결되지 않았습니다.");
 }
 
+/**
+ * 회의실 목록(`GET /api/meeting-rooms`, ROOM-01) — 비활성화되지 않은 회의실을 이름 오름차순으로.
+ * 예약 폼의 회의실 select와 `/manage/rooms` 관리 목록이 이 응답을 함께 쓴다.
+ */
 export async function getMeetingRooms(): Promise<MeetingRoom[]> {
   if (isMock) return listMockRooms();
-  throw new Error("회의실 목록 조회 API가 아직 연결되지 않았습니다.");
+
+  const accessToken = await requireAccessToken();
+  const { meetingRooms } = await serverApi<{ meetingRooms: BeMeetingRoom[] }>(ep.meetingRooms(), {
+    accessToken,
+  });
+  return meetingRooms.map(toMeetingRoom);
 }
 
 export async function getReservableMembers(): Promise<RoomMember[]> {

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -171,7 +171,12 @@ export const ep = {
   jobPositions: () => "/api/job-positions",
   jobPosition: (id: number) => `/api/job-positions/${id}`,
   departments: () => "/api/departments",
-  rooms: () => "/api/rooms",
+
+  /**
+   * 회의실 — 도메인 문서(ROOM-01~05, 2026-08-12) 기준, **BE 실코드 미대조**(§연동 검증: 구현
+   *   붙일 때 컨트롤러로 재확인한다).
+   */
+  meetingRooms: () => "/api/meeting-rooms",
 
   /* 기타 */
   notifications: () => "/api/notifications",


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

- `GET /api/meeting-rooms` 실 연동 — `getMeetingRooms()`의 목서버 스텁을 `requireAccessToken` + `serverApi` 호출로 대체
- 응답 봉투를 벗기는 `mapper.ts`를 신설해 BE shape(`meetingRoomId` 등)을 UI 계약(`MeetingRoom`)으로 흡수 — 컴포넌트는 0줄 변경
- `endpoints.ts`에 실사용 경로 `ep.meetingRooms()`를 등록하고, 아무 데서도 안 쓰이던 placeholder `ep.rooms`는 제거

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 서버(`server.ts`)에서 액세스 토큰 존재 여부(`requireAccessToken`)를 재확인, 역할별 화면 진입 가드는 기존 `canAccessManageScope`/`canManageRooms` 그대로 유지
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [ ] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시 (조용히 "되는 척" 금지)
- [x] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그)
- [ ] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [x] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인) — 매퍼 패턴은 `features/action/mapper.ts`와 동일 컨벤션
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 기존 화면의 `error.tsx`/스켈레톤 그대로 활용, `ApiError` 발생 시 그대로 전파
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음

---

## 🔗 연관 이슈

Closes #358

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- `ep.rooms` placeholder를 제거하고 `ep.meetingRooms`로 교체한 것이 다른 곳에서 참조되고 있지 않은지 (grep 확인 결과 미사용)
- 응답 봉투 `{ meetingRooms: [...] }` 형태 가정이 맞는지 — 아직 BE 실코드 미대조 상태([확인] 표시 없음, 문서 기준)

---

## 📝 추가 메모

인증 미연동 상태라 브라우저 확인 불가(요청 사항) — lint·typecheck만 통과 확인.
