### PR TITLE
[FEAT] 회의실 주간 예약 현황 조회 API 연동 (ROOM-02) #360

### DIFF
--- a/src/app/(shell)/app/rooms/page.tsx
+++ b/src/app/(shell)/app/rooms/page.tsx
@@ -2,12 +2,13 @@ import { format } from "date-fns";
 import type { Metadata } from "next";
 
 import { RoomsBoard } from "@/features/rooms/components/rooms-board";
+import { toRoomCalendarEvents } from "@/features/rooms/mapper";
 import {
   getMeetingRooms,
   getReservableMembers,
   getReservableProjects,
   getReservableTeamActions,
-  getWeekReservations,
+  getRoomWeekAvailability,
 } from "@/features/rooms/server";
 import { getViewer } from "@/features/shell/viewer";
 import { requiresParentTeamAction } from "@/lib/permission";
@@ -27,31 +28,47 @@ function parseWeekParam(raw: string | undefined): Date {
 }
 
 interface RoomsPageProps {
-  searchParams: Promise<{ week?: string }>;
+  searchParams: Promise<{ week?: string; roomId?: string }>;
 }
 
+/**
+ * `/app/rooms` — ROOM-02 전환(2026-08-10) 이후 축이 "회의실 1개 × 5일"이라, 그리드를 그리기
+ * 전에 **어느 회의실을 볼지**부터 정해야 한다. `roomId` 검색 파라미터가 유효한 활성 회의실을
+ * 가리키지 않으면(없음·삭제됨) 첫 회의실로 조용히 되돌아간다 — 회의실이 하나도 없으면 그리드
+ * 없이 안내만 보여준다(`RoomsBoard`).
+ */
 export default async function RoomsPage({ searchParams }: RoomsPageProps) {
-  const { week: weekParam } = await searchParams;
+  const { week: weekParam, roomId: roomIdParam } = await searchParams;
   const week = parseWeekParam(weekParam);
 
   // ⚠️ 팀 액션 목록은 지금 보고 있는 사람이 누구인지(권한·소속 팀)에 따라 달라져서 먼저 받는다.
   const viewer = await getViewer();
 
-  const [reservations, rooms, members, projects, teamActions] = await Promise.all([
-    getWeekReservations(week),
+  const [rooms, members, projects, teamActions] = await Promise.all([
     getMeetingRooms(),
     getReservableMembers(),
     getReservableProjects(),
     getReservableTeamActions(viewer),
   ]);
 
+  const selectedRoomId =
+    roomIdParam && rooms.some((room) => room.id === roomIdParam)
+      ? roomIdParam
+      : (rooms[0]?.id ?? null);
+
+  const weekAvailability = selectedRoomId
+    ? await getRoomWeekAvailability(selectedRoomId, week)
+    : null;
+  const events = weekAvailability ? toRoomCalendarEvents(weekAvailability) : [];
+
   return (
     <main className="flex min-h-0 flex-1 flex-col overflow-y-auto px-8 py-7 lg:overflow-hidden">
       <div className="mx-auto flex min-h-0 w-full max-w-[1440px] flex-1 flex-col gap-7">
         <RoomsBoard
-          key={format(week, "yyyy-MM-dd")}
-          initialReservations={reservations}
+          key={`${format(week, "yyyy-MM-dd")}-${selectedRoomId ?? "none"}`}
+          initialEvents={events}
           rooms={rooms}
+          selectedRoomId={selectedRoomId}
           members={members}
           projects={projects}
           showParentTeamAction={requiresParentTeamAction(viewer)}

--- a/src/features/rooms/components/room-reservation-event.tsx
+++ b/src/features/rooms/components/room-reservation-event.tsx
@@ -3,11 +3,18 @@ import { format } from "date-fns";
 import type { PaletteColor } from "@/lib/palette";
 
 import { NEUTRAL_ACCENT_COLOR } from "../accent-color";
-import type { RoomMember, RoomReservation } from "../types";
+import type { RoomMember } from "../types";
 import { AttendeeAvatarStack } from "./attendee-avatar-stack";
 
 interface RoomReservationEventProps {
-  event: RoomReservation;
+  title: string;
+  start: Date;
+  end: Date;
+  /**
+   * 참석자 id — 방금 만든 예약만 채워진다(주간 그리드 API는 참석자 id를 안 내려준다,
+   * ROOM-02 규칙). 없으면 아바타 자리를 그리지 않는다.
+   */
+  attendeeIds?: number[];
   members: RoomMember[];
   /**
    * 막대 색 — 이 컴포넌트는 계산하지 않고 그대로 받아 그린다(호출부 `weekly-room-calendar.tsx`가
@@ -26,7 +33,10 @@ interface RoomReservationEventProps {
  *    관측돼 화면 전체가 죽는 것보다 중립색으로라도 그리는 쪽을 택한다.
  */
 export function RoomReservationEvent({
-  event,
+  title,
+  start,
+  end,
+  attendeeIds,
   members,
   accentColor = NEUTRAL_ACCENT_COLOR,
 }: RoomReservationEventProps) {
@@ -39,12 +49,12 @@ export function RoomReservationEvent({
       }}
       className="flex h-full flex-col justify-center gap-0.5 overflow-hidden rounded-[5px] border-l-2 px-1.5 py-0.5 text-left leading-tight"
     >
-      <span className="truncate text-[11px] font-medium">{event.title}</span>
+      <span className="truncate text-[11px] font-medium">{title}</span>
       <span className="flex items-center justify-between gap-1">
         <span className="text-muted-foreground truncate text-[11px] tabular-nums">
-          {format(event.start, "HH:mm")}–{format(event.end, "HH:mm")}
+          {format(start, "HH:mm")}–{format(end, "HH:mm")}
         </span>
-        <AttendeeAvatarStack memberIds={event.attendeeIds} members={members} />
+        {attendeeIds && <AttendeeAvatarStack memberIds={attendeeIds} members={members} />}
       </span>
     </div>
   );

--- a/src/features/rooms/components/rooms-board.test.tsx
+++ b/src/features/rooms/components/rooms-board.test.tsx
@@ -43,8 +43,9 @@ describe("RoomsBoard", () => {
     const user = userEvent.setup();
     render(
       <RoomsBoard
-        initialReservations={[]}
+        initialEvents={[]}
         rooms={ROOMS}
+        selectedRoomId="room-large"
         members={MEMBERS}
         projects={PROJECTS}
         showParentTeamAction={false}

--- a/src/features/rooms/components/rooms-board.tsx
+++ b/src/features/rooms/components/rooms-board.tsx
@@ -2,12 +2,13 @@
 
 import { useState } from "react";
 
+import { toCalendarEventFromReservation } from "../mapper";
 import { getNextAvailableSlot } from "../next-available-slot";
 import type {
   MeetingRoom,
+  RoomCalendarEvent,
   RoomMember,
   RoomProjectOption,
-  RoomReservation,
   RoomTeamActionOption,
 } from "../types";
 import { RoomListPanel } from "./room-list-panel";
@@ -15,8 +16,10 @@ import { RoomReservationDialog } from "./room-reservation-dialog";
 import { WeeklyRoomCalendarLoader } from "./weekly-room-calendar-loader";
 
 interface RoomsBoardProps {
-  initialReservations: RoomReservation[];
+  initialEvents: RoomCalendarEvent[];
   rooms: MeetingRoom[];
+  /** 지금 그리드에 보이는 회의실 — 회의실이 하나도 없으면 `null`(그리드 대신 안내). */
+  selectedRoomId: string | null;
   members: RoomMember[];
   projects: RoomProjectOption[];
   /** "상위 팀 액션" 필드를 보여줄지 — 서버 컴포넌트(`page.tsx`)가 `requiresParentTeamAction`으로
@@ -26,24 +29,26 @@ interface RoomsBoardProps {
   teamActions: RoomTeamActionOption[];
   /** 참석자 "내 부서만" 필터 기준 — `RoomReservationDialog`로 그대로 흘려보낸다. */
   viewerTeamName: string | null;
-  /** "YYYY-MM-DD" — 이 주의 월요일. 서버 컴포넌트가 이 주 기준으로 `initialReservations`를 내려준다. */
+  /** "YYYY-MM-DD" — 이 주의 월요일. 서버 컴포넌트가 이 주 기준으로 `initialEvents`를 내려준다. */
   week: string;
 }
 
 /**
- * 회의실 화면 본체(client). 서버가 내려준 예약을 로컬 state로 들고 있다가, 예약 생성 성공 시
- * 재조회 없이 바로 얹는다(`calendar-board.tsx`와 같은 패턴, §최적화: action 리턴값으로 화면 반영).
+ * 회의실 화면 본체(client). 서버가 내려준 주간 그리드(현재 `selectedRoomId` 하나 기준)를 로컬
+ * state로 들고 있다가, 예약 생성 성공 시 재조회 없이 바로 얹는다(`calendar-board.tsx`와 같은
+ * 패턴, §최적화: action 리턴값으로 화면 반영).
+ * ⚠️ **회의실 전환은 `WeeklyRoomCalendarLoader`가 URL(`?roomId=`)로 한다** — 서버 컴포넌트가
+ *    그 회의실의 새 그리드를 내려주고, 이 컴포넌트는 `key`로 다시 마운트된다(주 이동과 같은 이유).
  * 주의: 30분 칸을 클릭하면 그 시작 시각을 `slotStart`에 담아 예약 모달을 연다 — 모달이 열려 있는지는
  *    `slotStart !== null`로만 판단한다(별도 `isOpen` state를 안 둔다).
- * 주의: 주를 옮기면(`?week=`) 서버가 새 `initialReservations`를 내려주는데, 이 컴포넌트는 그때마다
- *    호출부에서 `key={week}`로 다시 마운트된다(개인 캘린더와 같은 이유).
  * 주의: "회의 추가" 진입점은 `RoomListPanel` 상단(2026-08-11, 캘린더 툴바 안에서 이동)에
  *    있다 — 여는 시각은 `getNextAvailableSlot`이 "지금"을 30분 단위로 올려 계산하는
  *    로직은 그대로다.
  */
 export function RoomsBoard({
-  initialReservations,
+  initialEvents,
   rooms,
+  selectedRoomId,
   members,
   projects,
   showParentTeamAction,
@@ -51,16 +56,17 @@ export function RoomsBoard({
   viewerTeamName,
   week,
 }: RoomsBoardProps) {
-  const [reservations, setReservations] = useState(initialReservations);
+  const [events, setEvents] = useState(initialEvents);
   const [slotStart, setSlotStart] = useState<Date | null>(null);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-6 lg:flex-row lg:items-stretch">
       <div className="flex min-h-0 min-w-0 flex-1 flex-col">
         <WeeklyRoomCalendarLoader
-          reservations={reservations}
+          events={events}
           members={members}
           rooms={rooms}
+          selectedRoomId={selectedRoomId}
           week={week}
           onSelectSlot={setSlotStart}
         />
@@ -80,7 +86,12 @@ export function RoomsBoard({
         showParentTeamAction={showParentTeamAction}
         teamActions={teamActions}
         viewerTeamName={viewerTeamName}
-        onCreated={(created) => setReservations((prev) => [...prev, created])}
+        onCreated={(created) => {
+          // ⚠️ 지금 보고 있는 회의실과 다른 회의실에 예약했으면 이 그리드엔 안 얹는다 — 다른
+          //    회의실의 예약을 이 화면에 섞으면 그 그리드가 거짓말을 하게 된다(§정직성).
+          if (created.roomId !== selectedRoomId) return;
+          setEvents((prev) => [...prev, toCalendarEventFromReservation(created)]);
+        }}
       />
     </div>
   );

--- a/src/features/rooms/components/rooms-calendar-toolbar.tsx
+++ b/src/features/rooms/components/rooms-calendar-toolbar.tsx
@@ -13,14 +13,13 @@ import {
 } from "@/components/ui/select";
 
 import { ROOMS_CALENDAR_TOOLBAR_LABEL } from "../constants";
-import type { MeetingRoom, RoomReservation } from "../types";
+import type { MeetingRoom, RoomCalendarEvent } from "../types";
 
-export const ALL_ROOMS_VALUE = "all";
-
-interface RoomsCalendarToolbarProps extends ToolbarProps<RoomReservation> {
+interface RoomsCalendarToolbarProps extends ToolbarProps<RoomCalendarEvent> {
   rooms: MeetingRoom[];
-  /** `ALL_ROOMS_VALUE` = 전체 회의실. */
+  /** 지금 그리드가 보여주는 회의실 — ROOM-02가 회의실 하나를 필수로 요구해서 "전체"는 없다. */
   selectedRoomId: string;
+  /** 회의실을 바꾸면 `WeeklyRoomCalendar`가 URL(`?roomId=`)을 바꿔 서버가 새 그리드를 내려준다. */
   onSelectedRoomChange: (roomId: string) => void;
 }
 
@@ -34,8 +33,9 @@ interface RoomsCalendarToolbarProps extends ToolbarProps<RoomReservation> {
  *    (`calendar-toolbar.tsx`와 같은 이유, CLAUDE.md §카피: 날짜는 한글로).
  * 주의: 구간 라벨은 좁은 화면에서 줄어들 수 있다 — 자릿수가 달라져도 `tabular-nums`로 숫자
  *    폭만 맞춘다(고정 폭 대신 `max-w`로 최소 여백만 보장).
- * 주의: 회의실 거르개는 **화면 표시만 거른다** — `weekly-room-calendar.tsx`가 `reservations`를
- *    `selectedRoomId`로 걸러 `Calendar`에 넘긴다(서버 재조회 없음, 이미 그 주 예약을 다 갖고 있다).
+ * 주의: 회의실 select는 이제 **서버 재조회 파라미터다**(ROOM-02 전환) — 고르면
+ *    `weekly-room-calendar.tsx`가 URL(`?roomId=`)을 바꿔 그 회의실의 새 그리드를 받아온다.
+ *    "전체 회의실"은 없다 — API가 회의실 하나를 필수로 요구한다.
  * 주의: 좁은 화면에서는 두 그룹(구간 라벨 / 거르개+주간 이동)을 세로로 쌓는다.
  */
 export function RoomsCalendarToolbar({
@@ -51,10 +51,7 @@ export function RoomsCalendarToolbar({
        이어진다(CI에서 실제로 터졌다 — `search-filter-bar.tsx`와 같은 이유).
   */
   const roomItems = useMemo(
-    () => ({
-      [ALL_ROOMS_VALUE]: ROOMS_CALENDAR_TOOLBAR_LABEL.allRooms,
-      ...Object.fromEntries(rooms.map((room) => [room.id, room.name])),
-    }),
+    () => Object.fromEntries(rooms.map((room) => [room.id, room.name])),
     [rooms],
   );
 
@@ -88,13 +85,12 @@ export function RoomsCalendarToolbar({
           //    원문 값(`room.id`)이 그대로 보인다(`search-filter-bar.tsx`와 같은 이유).
           items={roomItems}
           value={selectedRoomId}
-          onValueChange={(value) => onSelectedRoomChange(value ?? ALL_ROOMS_VALUE)}
+          onValueChange={(value) => value && onSelectedRoomChange(value)}
         >
           <SelectTrigger size="sm" aria-label={ROOMS_CALENDAR_TOOLBAR_LABEL.roomFilter}>
-            <SelectValue placeholder={ROOMS_CALENDAR_TOOLBAR_LABEL.allRooms} />
+            <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value={ALL_ROOMS_VALUE}>{ROOMS_CALENDAR_TOOLBAR_LABEL.allRooms}</SelectItem>
             {rooms.map((room) => (
               <SelectItem key={room.id} value={room.id}>
                 {room.name}

--- a/src/features/rooms/components/weekly-room-calendar-loader.tsx
+++ b/src/features/rooms/components/weekly-room-calendar-loader.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import { DoorClosed } from "lucide-react";
 import dynamic from "next/dynamic";
 
+import { EmptyState } from "@/components/common/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
 
 import { WEEKLY_CALENDAR_HEIGHT_PX } from "../calendar-height";
-import type { MeetingRoom, RoomMember, RoomReservation } from "../types";
+import type { MeetingRoom, RoomCalendarEvent, RoomMember } from "../types";
 
 /** `react-big-calendar`는 무겁다 — 첫 로드 번들에서 뺀다(CLAUDE.md §최적화). */
 const WeeklyRoomCalendar = dynamic(
@@ -23,13 +25,22 @@ const WeeklyRoomCalendar = dynamic(
 );
 
 interface WeeklyRoomCalendarLoaderProps {
-  reservations: RoomReservation[];
+  events: RoomCalendarEvent[];
   members: RoomMember[];
   rooms: MeetingRoom[];
+  selectedRoomId: string | null;
   week: string;
   onSelectSlot: (start: Date) => void;
 }
 
 export function WeeklyRoomCalendarLoader(props: WeeklyRoomCalendarLoaderProps) {
-  return <WeeklyRoomCalendar {...props} />;
+  if (!props.selectedRoomId) {
+    return (
+      <div className="border-border bg-card flex w-full items-center justify-center rounded-lg border">
+        <EmptyState icon={DoorClosed} title="등록된 회의실이 없습니다" />
+      </div>
+    );
+  }
+
+  return <WeeklyRoomCalendar {...props} selectedRoomId={props.selectedRoomId} />;
 }

--- a/src/features/rooms/components/weekly-room-calendar.test.tsx
+++ b/src/features/rooms/components/weekly-room-calendar.test.tsx
@@ -1,5 +1,6 @@
+const pushMock = jest.fn();
 jest.mock("next/navigation", () => ({
-  useRouter: () => ({ push: jest.fn() }),
+  useRouter: () => ({ push: pushMock }),
 }));
 
 // react-big-calendar 자체는 무겁고 DOM 레이아웃(getBoundingClientRect 등)에 기대는 부분이 많다 —
@@ -33,10 +34,9 @@ jest.mock("react-big-calendar", () => {
   };
 });
 
-// 실제 툴바(회의실 select)는 base-ui 팝업 조작이 얽혀 있어 테스트 대상(필터링 로직)과
+// 실제 툴바(회의실 select)는 base-ui 팝업 조작이 얽혀 있어 테스트 대상(URL 전환 로직)과
 // 무관하다 — `onSelectedRoomChange`를 그대로 노출하는 버튼 스텁으로 바꿔 그 로직만 검증한다.
 jest.mock("./rooms-calendar-toolbar", () => ({
-  ALL_ROOMS_VALUE: "all",
   RoomsCalendarToolbar: ({
     rooms,
     onSelectedRoomChange,
@@ -45,9 +45,6 @@ jest.mock("./rooms-calendar-toolbar", () => ({
     onSelectedRoomChange: (roomId: string) => void;
   }) => (
     <div>
-      <button type="button" onClick={() => onSelectedRoomChange("all")}>
-        전체 회의실
-      </button>
       {rooms.map((room) => (
         <button key={room.id} type="button" onClick={() => onSelectedRoomChange(room.id)}>
           {room.name}
@@ -62,7 +59,7 @@ import userEvent from "@testing-library/user-event";
 
 import { AUTHORITY } from "@/constants/authority";
 
-import type { MeetingRoom, RoomMember, RoomReservation } from "../types";
+import type { MeetingRoom, RoomCalendarEvent, RoomMember } from "../types";
 import { WeeklyRoomCalendar } from "./weekly-room-calendar";
 
 const ROOMS: MeetingRoom[] = [
@@ -73,76 +70,47 @@ const MEMBERS: RoomMember[] = [
   { id: 1, name: "박대표", teamName: null, authority: AUTHORITY.OWNER },
 ];
 
-const RESERVATIONS: RoomReservation[] = [
+const EVENTS: RoomCalendarEvent[] = [
   {
     id: "res-a",
     title: "A 회의",
     start: new Date("2026-08-10T10:00:00"),
     end: new Date("2026-08-10T10:30:00"),
-    roomId: "room-a",
-    roomName: "대회의실",
-    projectId: "1",
-    projectTag: "GOODS",
-    topics: [{ main: "안건", sub: "" }],
     attendeeIds: [1],
-    ownerId: 1,
-  },
-  {
-    id: "res-b",
-    title: "B 회의",
-    start: new Date("2026-08-10T11:00:00"),
-    end: new Date("2026-08-10T11:30:00"),
-    roomId: "room-b",
-    roomName: "소회의실",
-    projectId: "1",
-    projectTag: "GOODS",
-    topics: [{ main: "안건", sub: "" }],
-    attendeeIds: [1],
-    ownerId: 1,
   },
 ];
 
 function renderCalendar() {
   return render(
     <WeeklyRoomCalendar
-      reservations={RESERVATIONS}
+      events={EVENTS}
       members={MEMBERS}
       rooms={ROOMS}
+      selectedRoomId="room-a"
       week="2026-08-10"
       onSelectSlot={jest.fn()}
     />,
   );
 }
 
-describe("WeeklyRoomCalendar visibleReservations", () => {
-  it("ALL_ROOMS_VALUE면 전체 예약을 Calendar에 넘긴다", () => {
+describe("WeeklyRoomCalendar", () => {
+  beforeEach(() => {
+    pushMock.mockClear();
+  });
+
+  it("서버가 내려준 events를 그대로 Calendar에 넘긴다", () => {
     renderCalendar();
 
     const list = screen.getByTestId("visible-events");
     expect(within(list).getByText("res-a")).toBeInTheDocument();
-    expect(within(list).getByText("res-b")).toBeInTheDocument();
   });
 
-  it("특정 회의실을 고르면 그 회의실 예약만 Calendar에 넘긴다", async () => {
-    const user = userEvent.setup();
-    renderCalendar();
-
-    await user.click(screen.getByRole("button", { name: "대회의실" }));
-
-    const list = screen.getByTestId("visible-events");
-    expect(within(list).getByText("res-a")).toBeInTheDocument();
-    expect(within(list).queryByText("res-b")).not.toBeInTheDocument();
-  });
-
-  it("전체 회의실로 되돌리면 다시 전체 예약을 보여준다", async () => {
+  it("다른 회의실을 고르면 그 회의실 id로 URL을 바꾼다(서버 재조회)", async () => {
     const user = userEvent.setup();
     renderCalendar();
 
     await user.click(screen.getByRole("button", { name: "소회의실" }));
-    await user.click(screen.getByRole("button", { name: "전체 회의실" }));
 
-    const list = screen.getByTestId("visible-events");
-    expect(within(list).getByText("res-a")).toBeInTheDocument();
-    expect(within(list).getByText("res-b")).toBeInTheDocument();
+    expect(pushMock).toHaveBeenCalledWith("/app/rooms?week=2026-08-10&roomId=room-b");
   });
 });

--- a/src/features/rooms/components/weekly-room-calendar.tsx
+++ b/src/features/rooms/components/weekly-room-calendar.tsx
@@ -6,14 +6,14 @@ import "./weekly-room-calendar.css";
 import { format, getDay, parse, startOfWeek } from "date-fns";
 import { ko } from "date-fns/locale";
 import { useRouter } from "next/navigation";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { Calendar, dateFnsLocalizer, type SlotInfo, type ToolbarProps } from "react-big-calendar";
 
 import { getReservationAccentColor } from "../accent-color";
 import { WEEKLY_CALENDAR_HEIGHT_PX } from "../calendar-height";
-import type { MeetingRoom, RoomMember, RoomReservation } from "../types";
+import type { MeetingRoom, RoomCalendarEvent, RoomMember } from "../types";
 import { RoomReservationEvent } from "./room-reservation-event";
-import { ALL_ROOMS_VALUE, RoomsCalendarToolbar } from "./rooms-calendar-toolbar";
+import { RoomsCalendarToolbar } from "./rooms-calendar-toolbar";
 
 const localizer = dateFnsLocalizer({
   format,
@@ -28,10 +28,13 @@ function toWeekParam(date: Date): string {
 }
 
 interface WeeklyRoomCalendarProps {
-  reservations: RoomReservation[];
+  events: RoomCalendarEvent[];
   members: RoomMember[];
   rooms: MeetingRoom[];
-  /** "YYYY-MM-DD" — 이 주의 월요일. 서버 컴포넌트가 이 값 기준으로 예약을 걸러 내려준다. */
+  /** 지금 그리드가 보여주는 회의실 — ROOM-02 전환(2026-08-10)으로 축이 "회의실 1개 × 5일"이라
+   *  화면 표시가 아니라 **서버 재조회 파라미터**다(예전 "전체 회의실" 거르개와 다르다). */
+  selectedRoomId: string;
+  /** "YYYY-MM-DD" — 이 주의 월요일. 서버 컴포넌트가 이 값·`selectedRoomId` 기준으로 그리드를 내려준다. */
   week: string;
   /** 빈 슬롯을 선택하면(30분 칸 클릭) 그 시작 시각을 올려보낸다 — 예약 모달이 이 값으로 연다. */
   onSelectSlot: (start: Date) => void;
@@ -47,34 +50,33 @@ interface WeeklyRoomCalendarProps {
  *    `lg` 미만은 `calendar-height.ts`의 고정값(페이지 스크롤), `lg` 이상은 `lg:h-full!`로
  *    부모 flex 컨테이너의 실제 높이를 그대로 채운다 — RBC가 반칸 높이를 화면 크기에 맞게
  *    다시 나눠 담는다(의도된 동작).
- * 주의: 회의실 거르개(`selectedRoomId`)는 화면 표시만 거른다 — 서버 재조회 없음, 이미 그 주
- *    예약 전체(`reservations`)를 갖고 있다.
+ * 주의: 회의실 거르개(`RoomsCalendarToolbar`)는 이제 **URL(`?roomId=`)을 바꾼다** — ROOM-02가
+ *    회의실 하나 기준으로만 그리드를 내려주므로, 화면 안에서 거를 목록 자체가 없다(서버 재조회).
  */
 export function WeeklyRoomCalendar({
-  reservations,
+  events,
   members,
   rooms,
+  selectedRoomId,
   week,
   onSelectSlot,
 }: WeeklyRoomCalendarProps) {
   const router = useRouter();
-  const [selectedRoomId, setSelectedRoomId] = useState<string>(ALL_ROOMS_VALUE);
 
   const currentDate = useMemo(() => parse(week, "yyyy-MM-dd", new Date()), [week]);
 
-  const visibleReservations = useMemo(
-    () =>
-      selectedRoomId === ALL_ROOMS_VALUE
-        ? reservations
-        : reservations.filter((reservation) => reservation.roomId === selectedRoomId),
-    [reservations, selectedRoomId],
-  );
-
   const handleNavigate = useCallback(
     (nextDate: Date) => {
-      router.push(`/app/rooms?week=${toWeekParam(nextDate)}`);
+      router.push(`/app/rooms?week=${toWeekParam(nextDate)}&roomId=${selectedRoomId}`);
     },
-    [router],
+    [router, selectedRoomId],
+  );
+
+  const handleSelectedRoomChange = useCallback(
+    (roomId: string) => {
+      router.push(`/app/rooms?week=${week}&roomId=${roomId}`);
+    },
+    [router, week],
   );
 
   const handleSelectSlot = useCallback(
@@ -83,32 +85,35 @@ export function WeeklyRoomCalendar({
   );
 
   const EventComponent = useCallback(
-    ({ event }: { event: RoomReservation }) => (
+    ({ event }: { event: RoomCalendarEvent }) => (
       <RoomReservationEvent
-        event={event}
+        title={event.title}
+        start={event.start}
+        end={event.end}
+        attendeeIds={event.attendeeIds}
         members={members}
-        accentColor={getReservationAccentColor(event.projectTag)}
+        accentColor={getReservationAccentColor(event.projectTag ?? event.id)}
       />
     ),
     [members],
   );
 
   const ToolbarComponent = useCallback(
-    (toolbarProps: ToolbarProps<RoomReservation>) => (
+    (toolbarProps: ToolbarProps<RoomCalendarEvent>) => (
       <RoomsCalendarToolbar
         {...toolbarProps}
         rooms={rooms}
         selectedRoomId={selectedRoomId}
-        onSelectedRoomChange={setSelectedRoomId}
+        onSelectedRoomChange={handleSelectedRoomChange}
       />
     ),
-    [rooms, selectedRoomId],
+    [rooms, selectedRoomId, handleSelectedRoomChange],
   );
 
   return (
     <Calendar
       localizer={localizer}
-      events={visibleReservations}
+      events={events}
       views={["work_week"]}
       defaultView="work_week"
       date={currentDate}

--- a/src/features/rooms/constants.ts
+++ b/src/features/rooms/constants.ts
@@ -35,8 +35,7 @@ export const ROOM_ATTENDEE_FILTER_LABEL: Record<RoomAttendeeFilter, string> = {
 /** 회의실 캘린더 툴바(`rooms-calendar-toolbar.tsx`)·회의실 목록(`room-list-panel.tsx`) 카피
  * — 라벨 하드코딩 금지 원칙에 맞춰 뺐다. */
 export const ROOMS_CALENDAR_TOOLBAR_LABEL = {
-  roomFilter: "회의실 필터",
-  allRooms: "전체 회의실",
+  roomFilter: "회의실 선택",
   addMeeting: "회의 추가",
 } as const;
 

--- a/src/features/rooms/mapper.ts
+++ b/src/features/rooms/mapper.ts
@@ -4,7 +4,14 @@
  *   (§연동 검증: Swagger·구두 추측 금지, 문서와 코드가 다르면 코드가 맞다 — 구현 시 컨트롤러로 재확인).
  */
 
-import type { MeetingRoom } from "./types";
+import type {
+  MeetingRoom,
+  RoomCalendarEvent,
+  RoomDayAvailability,
+  RoomReservation,
+  RoomSlotStatus,
+  RoomWeekAvailability,
+} from "./types";
 
 /** `GET /api/meeting-rooms` 배열 원소, `POST`·`PATCH` 성공 응답의 회의실 부분과 같은 모양. */
 export interface BeMeetingRoom {
@@ -23,5 +30,120 @@ export function toMeetingRoom(be: BeMeetingRoom): MeetingRoom {
     location: be.location ?? "",
     openTime: be.availableFrom,
     closeTime: be.availableTo,
+  };
+}
+
+/**
+ * 주간 예약 현황(`GET /api/meeting-rooms/availability`, ROOM-02) 안의 회의실 사본 — `location`이
+ * 없다(BE가 이 엔드포인트에서는 안 내려준다).
+ */
+export interface BeRoomAvailabilityMeetingRoom {
+  meetingRoomId: number;
+  name: string;
+  availableFrom: string;
+  availableTo: string;
+}
+
+export interface BeRoomAvailabilitySlot {
+  startTime: string;
+  status: RoomSlotStatus;
+  meetingId: number | null;
+  title: string | null;
+}
+
+export interface BeRoomDayAvailability {
+  date: string;
+  dayOfWeek: string;
+  slots: BeRoomAvailabilitySlot[];
+}
+
+export interface BeRoomWeekAvailability {
+  weekStart: string;
+  weekEnd: string;
+  slotMinutes: number;
+  meetingRoom: BeRoomAvailabilityMeetingRoom;
+  days: BeRoomDayAvailability[];
+}
+
+export function toRoomWeekAvailability(be: BeRoomWeekAvailability): RoomWeekAvailability {
+  return {
+    weekStart: be.weekStart,
+    slotMinutes: be.slotMinutes,
+    meetingRoom: {
+      id: String(be.meetingRoom.meetingRoomId),
+      name: be.meetingRoom.name,
+      location: "",
+      openTime: be.meetingRoom.availableFrom,
+      closeTime: be.meetingRoom.availableTo,
+    },
+    days: be.days.map((day) => ({
+      date: day.date,
+      slots: day.slots.map((slot) => ({
+        startTime: slot.startTime,
+        status: slot.status,
+        meetingId: slot.meetingId !== null ? String(slot.meetingId) : null,
+        title: slot.title,
+      })),
+    })),
+  };
+}
+
+/**
+ * 하루치 RESERVED 슬롯을 연속 구간으로 병합해 캘린더 막대로 만든다. 같은 `meetingId`가 슬롯
+ * 간격 없이 이어질 때만 한 막대로 합친다 — 예약은 보통 30분 고정이지만, 이 API는 다른 경로로
+ * 생성된 더 긴 회의도 그대로 반영해야 해서 병합이 필요하다.
+ */
+function toDayCalendarEvents(day: RoomDayAvailability, slotMinutes: number): RoomCalendarEvent[] {
+  const events: RoomCalendarEvent[] = [];
+  let current: { meetingId: string; title: string; start: Date; end: Date } | null = null;
+
+  const flush = () => {
+    if (!current) return;
+    events.push({
+      id: current.meetingId,
+      title: current.title,
+      start: current.start,
+      end: current.end,
+    });
+    current = null;
+  };
+
+  for (const slot of day.slots) {
+    const start = new Date(`${day.date}T${slot.startTime}:00`);
+    const end = new Date(start.getTime() + slotMinutes * 60_000);
+
+    if (slot.status === "RESERVED" && slot.meetingId !== null) {
+      if (
+        current &&
+        current.meetingId === slot.meetingId &&
+        current.end.getTime() === start.getTime()
+      ) {
+        current.end = end;
+      } else {
+        flush();
+        current = { meetingId: slot.meetingId, title: slot.title ?? "", start, end };
+      }
+    } else {
+      flush();
+    }
+  }
+  flush();
+
+  return events;
+}
+
+export function toRoomCalendarEvents(week: RoomWeekAvailability): RoomCalendarEvent[] {
+  return week.days.flatMap((day) => toDayCalendarEvents(day, week.slotMinutes));
+}
+
+/** 방금 만든 예약(`createRoomReservationAction`의 반환값)을 캘린더 막대 모양으로 맞춘다. */
+export function toCalendarEventFromReservation(reservation: RoomReservation): RoomCalendarEvent {
+  return {
+    id: reservation.id,
+    title: reservation.title,
+    start: reservation.start,
+    end: reservation.end,
+    attendeeIds: reservation.attendeeIds,
+    projectTag: reservation.projectTag,
   };
 }

--- a/src/features/rooms/mapper.ts
+++ b/src/features/rooms/mapper.ts
@@ -1,0 +1,27 @@
+/**
+ * BE shape → UI 계약 (§Mock 격리막). 컴포넌트는 이 파일을 모른다 — `server.ts`/`actions.ts`만 쓴다.
+ * [확인] 회의실 도메인 문서(ROOM-01~05, 2026-08-12) 기준 — BE 실코드는 아직 대조 전이다
+ *   (§연동 검증: Swagger·구두 추측 금지, 문서와 코드가 다르면 코드가 맞다 — 구현 시 컨트롤러로 재확인).
+ */
+
+import type { MeetingRoom } from "./types";
+
+/** `GET /api/meeting-rooms` 배열 원소, `POST`·`PATCH` 성공 응답의 회의실 부분과 같은 모양. */
+export interface BeMeetingRoom {
+  meetingRoomId: number;
+  name: string;
+  /** nullable — 위치 미등록 회의실은 `null`. */
+  location: string | null;
+  availableFrom: string;
+  availableTo: string;
+}
+
+export function toMeetingRoom(be: BeMeetingRoom): MeetingRoom {
+  return {
+    id: String(be.meetingRoomId),
+    name: be.name,
+    location: be.location ?? "",
+    openTime: be.availableFrom,
+    closeTime: be.availableTo,
+  };
+}

--- a/src/features/rooms/server.ts
+++ b/src/features/rooms/server.ts
@@ -1,43 +1,116 @@
 import "server-only";
 
-import { endOfWeek, startOfWeek } from "date-fns";
+import { addDays, format, startOfWeek } from "date-fns";
 
 import { requireAccessToken } from "@/features/auth/session";
 import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
 import { PROJECT_TEAM_ACTIONS_MOCK } from "@/features/project/mock/team-actions";
-import { serverApi } from "@/lib/api";
+import { ApiError, serverApi } from "@/lib/api";
 import { ep } from "@/lib/endpoints";
 import { type Actor, requiresParentTeamAction } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
-import { type BeMeetingRoom, toMeetingRoom } from "./mapper";
+import {
+  type BeMeetingRoom,
+  type BeRoomWeekAvailability,
+  toMeetingRoom,
+  toRoomWeekAvailability,
+} from "./mapper";
 import { listMockMembers } from "./mock/members";
-import { listMockReservations } from "./mock/reservations";
-import { listMockRooms } from "./mock/rooms";
+import { listMockReservationsByRoom } from "./mock/reservations";
+import { findMockRoom, listMockRooms } from "./mock/rooms";
 import type {
   MeetingRoom,
+  RoomAvailabilitySlot,
+  RoomDayAvailability,
   RoomMember,
   RoomProjectOption,
-  RoomReservation,
   RoomTeamActionOption,
+  RoomWeekAvailability,
 } from "./types";
 
-/**
- * 그 주(월요일 시작)와 겹치는 예약만 걸러 내려준다. 격리막(CLAUDE.md §Mock 격리막).
- * ⚠️ 예약 시작일 기준이 아니라 **그 주와 겹치는지**(start~end 구간)로 본다 — 지금은 예약이
- *    전부 하루 안에서 끝나 차이가 없지만, 개인 캘린더 월 필터와 같은 이유로 구간 비교로 둔다.
- */
-export async function getWeekReservations(weekOf: Date): Promise<RoomReservation[]> {
-  if (isMock) {
-    const weekStart = startOfWeek(weekOf, { weekStartsOn: 1 });
-    const weekEnd = endOfWeek(weekOf, { weekStartsOn: 1 });
-    return listMockReservations().filter(
-      (reservation) => reservation.start <= weekEnd && reservation.end >= weekStart,
+const WEEKDAYS_PER_WEEK = 5;
+const SLOT_MINUTES = 30;
+
+function toMinutesOfDay(hhmm: string): number {
+  const [hours, minutes] = hhmm.split(":").map(Number);
+  return hours! * 60 + minutes!;
+}
+
+function toHHMM(minutesOfDay: number): string {
+  const hours = Math.floor(minutesOfDay / 60);
+  const minutes = minutesOfDay % 60;
+  return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
+}
+
+/** 목 데이터로 하루치 슬롯을 만든다 — 회의실 운영 시간을 30분 단위로 나누고 겹치는 예약이 있으면 RESERVED로 채운다. */
+function buildMockDaySlots(date: Date, room: MeetingRoom): RoomDayAvailability {
+  const reservations = listMockReservationsByRoom(room.id);
+  const slots: RoomAvailabilitySlot[] = [];
+
+  for (
+    let minutesOfDay = toMinutesOfDay(room.openTime);
+    minutesOfDay < toMinutesOfDay(room.closeTime);
+    minutesOfDay += SLOT_MINUTES
+  ) {
+    const startTime = toHHMM(minutesOfDay);
+    const slotStart = new Date(`${format(date, "yyyy-MM-dd")}T${startTime}:00`);
+    const slotEnd = new Date(slotStart.getTime() + SLOT_MINUTES * 60_000);
+    const overlapping = reservations.find(
+      (reservation) => reservation.start < slotEnd && reservation.end > slotStart,
     );
+
+    slots.push({
+      startTime,
+      status: overlapping ? "RESERVED" : "AVAILABLE",
+      meetingId: overlapping?.id ?? null,
+      title: overlapping?.title ?? null,
+    });
   }
 
-  // ⚠️ 미구현 — API 스펙 확정 후 회의실 예약 조회 경로를 매퍼로 UI 계약에 맞춘다.
-  throw new Error("회의실 예약 조회 API가 아직 연결되지 않았습니다.");
+  return { date: format(date, "yyyy-MM-dd"), slots };
+}
+
+/**
+ * 회의실 하나의 주간(월~금) 슬롯 현황(`GET /api/meeting-rooms/availability`, ROOM-02).
+ * 회의실이 없으면 `null`(호출부가 "존재하지 않는 회의실" 처리).
+ * ⚠️ **축이 "회의실 1개 × 5일"이다**(기존 "하루 × 전체 회의실" 그리드는 폐기, 2026-08-10 전환).
+ */
+export async function getRoomWeekAvailability(
+  roomId: string,
+  weekOf: Date,
+): Promise<RoomWeekAvailability | null> {
+  if (isMock) {
+    const room = findMockRoom(roomId);
+    if (!room) return null;
+
+    const weekStart = startOfWeek(weekOf, { weekStartsOn: 1 });
+    const days = Array.from({ length: WEEKDAYS_PER_WEEK }, (_, index) =>
+      buildMockDaySlots(addDays(weekStart, index), room),
+    );
+
+    return {
+      weekStart: format(weekStart, "yyyy-MM-dd"),
+      slotMinutes: SLOT_MINUTES,
+      meetingRoom: room,
+      days,
+    };
+  }
+
+  const accessToken = await requireAccessToken();
+  try {
+    const be = await serverApi<BeRoomWeekAvailability>(
+      ep.meetingRoomAvailability({
+        meetingRoomId: Number(roomId),
+        date: format(weekOf, "yyyy-MM-dd"),
+      }),
+      { accessToken },
+    );
+    return toRoomWeekAvailability(be);
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) return null;
+    throw error;
+  }
 }
 
 /**

--- a/src/features/rooms/server.ts
+++ b/src/features/rooms/server.ts
@@ -2,11 +2,15 @@ import "server-only";
 
 import { endOfWeek, startOfWeek } from "date-fns";
 
+import { requireAccessToken } from "@/features/auth/session";
 import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
 import { PROJECT_TEAM_ACTIONS_MOCK } from "@/features/project/mock/team-actions";
+import { serverApi } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
 import { type Actor, requiresParentTeamAction } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
+import { type BeMeetingRoom, toMeetingRoom } from "./mapper";
 import { listMockMembers } from "./mock/members";
 import { listMockReservations } from "./mock/reservations";
 import { listMockRooms } from "./mock/rooms";
@@ -36,9 +40,18 @@ export async function getWeekReservations(weekOf: Date): Promise<RoomReservation
   throw new Error("회의실 예약 조회 API가 아직 연결되지 않았습니다.");
 }
 
+/**
+ * 회의실 목록(`GET /api/meeting-rooms`, ROOM-01) — 비활성화되지 않은 회의실을 이름 오름차순으로.
+ * 예약 폼의 회의실 select와 `/manage/rooms` 관리 목록이 이 응답을 함께 쓴다.
+ */
 export async function getMeetingRooms(): Promise<MeetingRoom[]> {
   if (isMock) return listMockRooms();
-  throw new Error("회의실 목록 조회 API가 아직 연결되지 않았습니다.");
+
+  const accessToken = await requireAccessToken();
+  const { meetingRooms } = await serverApi<{ meetingRooms: BeMeetingRoom[] }>(ep.meetingRooms(), {
+    accessToken,
+  });
+  return meetingRooms.map(toMeetingRoom);
 }
 
 export async function getReservableMembers(): Promise<RoomMember[]> {

--- a/src/features/rooms/types.ts
+++ b/src/features/rooms/types.ts
@@ -117,3 +117,57 @@ export interface RoomReservationDraft {
 }
 
 export type RoomReservationFormErrors = Partial<Record<keyof RoomReservationDraft, string>>;
+
+/** 회의실 주간 슬롯 그리드 한 칸의 상태(`GET /api/meeting-rooms/availability`, ROOM-02). */
+export type RoomSlotStatus = "AVAILABLE" | "RESERVED";
+
+/**
+ * 30분 슬롯 한 칸.
+ * ⚠️ `meetingId`·`title`은 BE가 숫자로 내려주지만, UI 계약은 다른 회의실 도메인 id와 같은
+ *    규칙으로 문자열로 든다(`MeetingRoom.id`·`RoomReservation.id`와 같은 관례).
+ * ⚠️ 요청자가 참석자가 아닌 회의는 `title`이 `null`로 마스킹돼 온다 — 지어내지 않는다(§정직성).
+ */
+export interface RoomAvailabilitySlot {
+  /** "HH:mm" */
+  startTime: string;
+  status: RoomSlotStatus;
+  meetingId: string | null;
+  title: string | null;
+}
+
+/** 하루치 슬롯 — 월~금 중 하루. */
+export interface RoomDayAvailability {
+  /** "YYYY-MM-DD" */
+  date: string;
+  slots: RoomAvailabilitySlot[];
+}
+
+/**
+ * 회의실 하나의 주간(월~금) 슬롯 그리드 — 축이 "회의실 하나 × 요일"이다(2026-08-10 전환,
+ * 기존 "하루 × 전체 회의실"은 폐기). `meetingRoom`은 이 응답 전용 경량 사본이라 `location`이
+ * 없다(BE가 이 엔드포인트에서 안 내려준다) — 회의실 관리 화면의 `MeetingRoom`과 헷갈리지 않도록
+ * `location`은 빈 문자열로 채운다.
+ */
+export interface RoomWeekAvailability {
+  /** "YYYY-MM-DD" — 이 주의 월요일 */
+  weekStart: string;
+  slotMinutes: number;
+  meetingRoom: MeetingRoom;
+  days: RoomDayAvailability[];
+}
+
+/**
+ * 캘린더에 그려지는 예약 막대 한 칸 — 주간 그리드(연속 RESERVED 슬롯 병합)와 방금 만든 예약이
+ * 함께 이 모양으로 합쳐져 `WeeklyRoomCalendar`에 올라간다.
+ * ⚠️ `attendeeIds`는 방금 만든 예약에만 채워진다 — 주간 그리드 API는 참석자 id를 안 내려준다
+ *    (열람 권한이 따로 있어서다, ROOM-02 규칙). 없으면 아바타를 안 그린다.
+ */
+export interface RoomCalendarEvent {
+  id: string;
+  title: string;
+  start: Date;
+  end: Date;
+  attendeeIds?: number[];
+  /** 방금 만든 예약에만 채워진다 — 주간 그리드 API는 프로젝트 태그를 안 내려준다(막대 색 계산용). */
+  projectTag?: string;
+}

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -177,6 +177,13 @@ export const ep = {
    *   붙일 때 컨트롤러로 재확인한다).
    */
   meetingRooms: () => "/api/meeting-rooms",
+  /**
+   * 회의실 주간(월~금) 슬롯 현황(ROOM-02). `meetingRoomId`는 필수, `date`는 생략하면 서버가
+   * KST 오늘 기준 주를 채운다(§연동 검증 — 요청 축이 "회의실 1개 × 5일"로, 하루 단위 전체
+   * 회의실 조회는 폐기됐다).
+   */
+  meetingRoomAvailability: (params: { meetingRoomId: number; date?: string }) =>
+    `/api/meeting-rooms/availability${toQuery(params)}`,
 
   /* 기타 */
   notifications: () => "/api/notifications",

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -171,7 +171,12 @@ export const ep = {
   jobPositions: () => "/api/job-positions",
   jobPosition: (id: number) => `/api/job-positions/${id}`,
   departments: () => "/api/departments",
-  rooms: () => "/api/rooms",
+
+  /**
+   * 회의실 — 도메인 문서(ROOM-01~05, 2026-08-12) 기준, **BE 실코드 미대조**(§연동 검증: 구현
+   *   붙일 때 컨트롤러로 재확인한다).
+   */
+  meetingRooms: () => "/api/meeting-rooms",
 
   /* 기타 */
   notifications: () => "/api/notifications",


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

- `GET /api/meeting-rooms/availability` 실 연동 — 축이 "하루 × 전체 회의실"에서 "회의실 1개 × 5일"로 바뀐 API 변경에 맞춰 `getWeekReservations`(폐기)를 `getRoomWeekAvailability(roomId, week)`로 교체
- `mapper.ts`에 연속 RESERVED 슬롯 병합 로직 추가 — 슬롯 API가 30분 단위로 쪼개 내려주는 같은 회의를 캘린더 막대 하나로 합침
- 기존 회의실 select 드롭다운은 그대로 두고, 선택이 로컬 필터에서 `?roomId=` URL 파라미터(서버 재조회)로 바뀌도록 배선만 교체 — 디자인 변경 최소화
- 회의실이 없거나 `roomId`가 유효하지 않으면 첫 회의실로 조용히 대체, 회의실 자체가 없으면 안내 화면

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 서버(`server.ts`)에서 액세스 토큰 확인, 참석자 아닌 회의 제목 마스킹은 BE 응답을 그대로 신뢰(지어내지 않음)
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [ ] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시 (조용히 "되는 척" 금지)
- [x] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨 — 기존 스타일 그대로 재사용

**품질**

- [ ] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그)
- [ ] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [x] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인) — 기존 셀 렌더(`RoomReservationEvent`), 툴바, 로더 구조 그대로 유지하고 데이터 흐름만 교체
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 회의실 없음(`EmptyState`), 로딩 스켈레톤 그대로, `ApiError` 404는 `null` 처리
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음

---

## 🔗 연관 이슈

Closes #360

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- 연속 슬롯 병합 로직(`toDayCalendarEvents`)이 "슬롯 간격 없이 이어짐 + 같은 meetingId"만 병합 조건으로 삼는 게 맞는지
- `roomId` 파라미터가 유효하지 않을 때 URL을 캐노니컬화(redirect)하지 않고 조용히 첫 회의실로 대체하도록 한 결정 — 필요하면 redirect로 바꿀 수 있음
- `RoomCalendarEvent`의 `projectTag`/`attendeeIds`가 optional인 이유(주간 그리드 API는 안 주고, 방금 만든 예약에만 채워짐)

---

## 📝 추가 메모

인증 미연동 상태라 브라우저 확인 불가(요청 사항) — lint·typecheck·jest 전체 통과(895개) 확인. 관련 컴포넌트 테스트(`rooms-board.test.tsx`, `weekly-room-calendar.test.tsx`)도 새 계약에 맞춰 갱신.
