### PR TITLE
[FEAT] 팀 대시보드·팀원 관리 실 API 연동 + 회의 v1 접두사 정리 #370

### DIFF
--- a/src/app/(shell)/(authority)/team/(dashboard)/page.tsx
+++ b/src/app/(shell)/(authority)/team/(dashboard)/page.tsx
@@ -33,7 +33,7 @@ export default async function TeamDashboardPage() {
     doneActionCount,
     members,
     meetings,
-  } = await getTeamDashboardOverview();
+  } = await getTeamDashboardOverview(viewer);
 
   /* 상단 요약 — 오너 대시보드와 같은 공용 카드다(DESIGN §2). 색 강조는 두지 않는다(§5). */
   const summaryItems = [

--- a/src/app/(shell)/(authority)/team/members/page.tsx
+++ b/src/app/(shell)/(authority)/team/members/page.tsx
@@ -30,7 +30,7 @@ export default async function TeamMembersPage({ searchParams }: TeamMembersPageP
   const params = await searchParams;
   const sort = parseTeamMemberSort(params.sort);
   const filter = parseTeamMemberFilter(params.filter);
-  const members = await getTeamMemberStatuses(sort, filter);
+  const members = await getTeamMemberStatuses(sort, filter, viewer);
 
   return (
     <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">

--- a/src/features/team/members/server.ts
+++ b/src/features/team/members/server.ts
@@ -1,7 +1,13 @@
+import type { ActionStatus, MemberStatus } from "@/constants/domain";
+import { requireAccessToken } from "@/features/auth/session";
+import type { BePageResponse } from "@/features/project/mapper";
 import {
   TEAM_ACTION_DETAIL_MOCK,
   TEAM_ACTION_PERSONAL_ITEMS_MOCK,
 } from "@/features/project/mock/team-action-detail";
+import { serverApi } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
+import { isMock } from "@/mocks/config";
 
 import {
   filterTeamMembers,
@@ -11,6 +17,53 @@ import {
 } from "./lib";
 import { TEAM_MEMBER_ROSTER_MOCK } from "./mock/roster";
 import type { TeamMemberAction, TeamMemberStatusItem } from "./types";
+
+/** [확인] BE `TeamMemberStatusResponse` — PR #354 머지 완료. */
+interface BeTeamMemberStatus {
+  memberId: number;
+  name: string;
+  positionName: string | null;
+  roleName: string | null;
+  status: MemberStatus;
+  actionCount: number;
+}
+
+/** [확인] BE `ActionSummaryResponse` — 이 화면이 쓰는 필드만 적는다. */
+interface BeActionSummaryForMember {
+  id: number;
+  title: string;
+  status: ActionStatus;
+  dueDate: string;
+  projectTag: string;
+  parentActionTitle: string | null;
+}
+
+function toTeamMemberAction(be: BeActionSummaryForMember): TeamMemberAction {
+  return {
+    id: be.id,
+    projectTag: be.projectTag,
+    parentTeamActionName: be.parentActionTitle ?? "",
+    title: be.title,
+    status: be.status,
+    dueDate: be.dueDate,
+  };
+}
+
+/**
+ * 팀원 한 명의 개인 액션 전체 — `GET /api/actions?assigneeMemberId=`(2026-08-11, 이홍근 요청으로
+ * BE에 이미 반영됨, LEADER 전용·같은 팀 소속만). 무한스크롤 화면이 아니라 카드 펼침에 전부
+ * 필요하므로 `size`를 크게 잡아 한 번에 받는다(보드·내 액션 목록과 같은 패턴).
+ */
+async function fetchMemberActions(
+  memberId: number,
+  accessToken: string,
+): Promise<TeamMemberAction[]> {
+  const page = await serverApi<BePageResponse<BeActionSummaryForMember>>(
+    ep.actions({ assigneeMemberId: memberId, size: 9999 }),
+    { accessToken },
+  );
+  return page.content.map(toTeamMemberAction);
+}
 
 /**
  * ⚠️ 목 데이터라도 **새 데이터를 안 만든다** — 팀 액션 상세(`project` 피처)의
@@ -42,11 +95,35 @@ function buildMemberActions(memberName: string): TeamMemberAction[] {
 export async function getTeamMemberStatuses(
   sort: TeamMemberSort,
   filter: TeamMemberFilter,
+  viewer: { teamName?: string },
 ): Promise<TeamMemberStatusItem[]> {
-  const members: TeamMemberStatusItem[] = TEAM_MEMBER_ROSTER_MOCK.map((member) => ({
-    ...member,
-    actions: buildMemberActions(member.name),
-  }));
+  if (isMock) {
+    const members: TeamMemberStatusItem[] = TEAM_MEMBER_ROSTER_MOCK.map((member) => ({
+      ...member,
+      actions: buildMemberActions(member.name),
+    }));
+
+    return sortTeamMembers(filterTeamMembers(members, filter), sort);
+  }
+
+  const accessToken = await requireAccessToken();
+  const roster = await serverApi<BeTeamMemberStatus[]>(ep.teamMembers(), { accessToken });
+
+  /*
+   * ⚠️ 팀원 ~6명 규모 가정(WORKFLOW.md) — 카드 펼침에 전부 필요해 서버 컴포넌트가 한 번에
+   *    가져온다. 인원이 크게 늘면 이 병렬호출을 카드 펼침 시점의 클라이언트 조회로 옮겨야 한다.
+   */
+  const members: TeamMemberStatusItem[] = await Promise.all(
+    roster.map(async (member) => ({
+      id: member.memberId,
+      name: member.name,
+      position: member.positionName ?? "",
+      role: member.roleName ?? "없음",
+      teamName: viewer.teamName ?? "",
+      status: member.status,
+      actions: await fetchMemberActions(member.memberId, accessToken),
+    })),
+  );
 
   return sortTeamMembers(filterTeamMembers(members, filter), sort);
 }

--- a/src/features/team/server.ts
+++ b/src/features/team/server.ts
@@ -1,11 +1,45 @@
+import type { MemberStatus } from "@/constants/domain";
+import { requireAccessToken } from "@/features/auth/session";
+import { serverApi } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
+import { isMock } from "@/mocks/config";
+
 import { MEETING_MAX_ITEMS } from "./lib";
 import { TEAM_DASHBOARD_MOCK } from "./mock/dashboard";
-import type { TeamDashboardOverview } from "./types";
+import type { TeamDashboardMember, TeamDashboardOverview } from "./types";
 
-// ⚠️ ERD·API 스펙 미확정(BE 협의 전) — 지금은 목 고정. 확정되면 이 분기만 손댄다.
-const isMock = true;
+/** [확인] BE `TeamDashboardSummaryResponse` — PR #354 머지 완료. */
+interface BeTeamDashboardSummary {
+  teamActionCount: number;
+  teamMemberActionCount: number;
+  myActionCount: number;
+  completedActionCount: number;
+}
 
-export async function getTeamDashboardOverview(): Promise<TeamDashboardOverview> {
+/** [확인] BE `TeamMemberStatusResponse` — PR #354 머지 완료. */
+interface BeTeamMemberStatus {
+  memberId: number;
+  name: string;
+  positionName: string | null;
+  roleName: string | null;
+  status: MemberStatus;
+  actionCount: number;
+}
+
+function toTeamDashboardMember(be: BeTeamMemberStatus): TeamDashboardMember {
+  return {
+    id: String(be.memberId),
+    name: be.name,
+    position: be.positionName ?? "",
+    role: be.roleName ?? "없음",
+    assignedActionCount: be.actionCount,
+    status: be.status,
+  };
+}
+
+export async function getTeamDashboardOverview(viewer: {
+  teamName?: string;
+}): Promise<TeamDashboardOverview> {
   if (isMock) {
     return {
       ...TEAM_DASHBOARD_MOCK,
@@ -15,5 +49,22 @@ export async function getTeamDashboardOverview(): Promise<TeamDashboardOverview>
         .slice(0, MEETING_MAX_ITEMS),
     };
   }
-  throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
+
+  const accessToken = await requireAccessToken();
+  const [summary, members] = await Promise.all([
+    serverApi<BeTeamDashboardSummary>(ep.teamDashboardSummary(), { accessToken }),
+    serverApi<BeTeamMemberStatus[]>(ep.teamMembers(), { accessToken }),
+  ]);
+
+  return {
+    teamName: viewer.teamName ?? "",
+    teamActionCount: summary.teamActionCount,
+    memberActionCount: summary.teamMemberActionCount,
+    myActionCount: summary.myActionCount,
+    doneActionCount: summary.completedActionCount,
+    members: members.map(toTeamDashboardMember),
+    // ⚠️ 최근 팀 회의 API가 아직 BE에 없다(모성진에게 scope=team 요청함, 2026-08-12) —
+    //    지어내지 않고 빈 배열로 둔다(§정직성). API 도착하면 이 자리만 고친다.
+    meetings: [],
+  };
 }

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -19,6 +19,11 @@ export interface ProjectListParams {
 /** 개인 액션 목록만 갖는 `overdue` 필터가 추가된다. */
 export interface ActionListParams extends ProjectListParams {
   overdue?: boolean;
+  /**
+   * 값을 주면 호출자 본인이 아니라 **그 팀원의** 목록을 대신 조회한다(2026-08-11 추가,
+   * 이홍근 요청 — 팀원 관리 화면). LEADER 전용, 같은 팀 소속만 — [확인] `ActionController.java`.
+   */
+  assigneeMemberId?: number;
 }
 
 /** `undefined`·`null` 값은 쿼리에서 빠진다 — 서버 기본값을 그대로 쓰게 둔다. */
@@ -126,6 +131,10 @@ export const ep = {
   teamActionTimeline: (id: number) => `/api/team/actions/${id}?tab=timeline`,
   teamActionAttachmentDownloadUrl: (teamActionId: number, attachmentId: number) =>
     `/api/team/actions/${teamActionId}/attachments/${attachmentId}/download-url`,
+  /** 팀 대시보드 KPI 4종(팀 액션·팀원 액션·내 액션·완료 액션) — [확인] PR #354 머지 완료(2026-08-11) */
+  teamDashboardSummary: () => "/api/team/actions/dashboard-summary",
+  /** 팀원 현황(이름·직급·역할·재직상태·담당 액션 수) — [확인] PR #354 머지 완료, LEADER 전용 */
+  teamMembers: () => "/api/team/members",
 
   /** `month` 생략 시 이번 달(서버 기본값) */
   calendar: (month?: string) => `/api/calendar${toQuery(month ? { month } : undefined)}`,

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -46,34 +46,30 @@ export const ep = {
   companyOnboarding: () => "/api/companies/me/onboarding",
 
   /*
-   * 회의 — [확인] BE 실코드 대조(2026-08-11)
+   * 회의 — [확인] BE 실코드 대조(2026-08-12, "회의·회의실·공지사항 API 경로 통일" 리팩터 반영)
    *   `meeting/presentation/api/{MeetingController,MeetingListController,MeetingDetailController}.java`
    *
-   * ⚠️ **회의도 `/api/v1/`이다.** 전에 `/api/meetings`로 적어 뒀던 건 FE 제안 경로였고
-   *    실제 컨트롤러는 전부 `@RequestMapping("/api/v1/meetings")`다 — 그대로 부르면 404다.
-   * ⚠️ **캡처 전용 조회는 없다.** 캡처 화면도 상세(MEET-04)를 쓴다 — 있지도 않은
-   *    `/{id}/capture`를 지어내지 않는다(§환각 API 방지).
+   * ⚠️ **`/api/v1/` 접두사는 폐기됐다**(2026-08-12, 커밋 `51b5482f`) — 그 전에 붙였던 v1은
+   *    이제 전부 404다. 캡처 전용 조회는 없다 — 캡처 화면도 상세(MEET-04)를 쓴다(§환각 API 방지).
    */
-  meetings: () => "/api/v1/meetings",
+  meetings: () => "/api/meetings",
   /** 상세(MEET-04) — 캡처 진입도 이걸 쓴다. 없으면 404 `MT-001`, 열람 권한 없으면 403 `MT-011` */
-  meeting: (id: number) => `/api/v1/meetings/${id}`,
+  meeting: (id: number) => `/api/meetings/${id}`,
 
   /*
-   * 캡처 — [확인] BE 실코드 대조(2026-08-10)
+   * 캡처 — [확인] BE 실코드 대조(2026-08-12, "회의·회의실·공지사항 API 경로 통일" 리팩터 반영)
    *   `cap/presentation/api/{CaptureUploadController,CaptionController,CaptureQueryController}.java`
    *   `meeting/presentation/api/{CaptureSessionController,MeetingCompletionController}.java`
    *   `capture/presentation/api/AnalysisController.java`
    *
-   * ⚠️ **접두사가 두 갈래다.** 캡처 세션(CAP-01·02·03·10)과 회의 종료(MEET-08)는 `/api/v1/`,
-   *    자막·조각·분석은 `/api/`다. 보기 싫다고 통일하면 전부 404다 — BE의 컨트롤러
-   *    `@RequestMapping`이 실제로 그렇게 갈려 있다.
+   * ⚠️ **`/api/v1/` 접두사는 폐기됐다**(2026-08-12, 커밋 `51b5482f`). 캡처 세션(CAP-01·02·03)과
+   *    회의 종료(MEET-08)도 이제 자막·조각·분석과 똑같이 `/api/`만 쓴다 — v1을 되살리면 전부 404다.
    */
-  captureSession: (meetingId: number) => `/api/v1/meetings/${meetingId}/capture-session`,
-  captureSessionPause: (meetingId: number) => `/api/v1/meetings/${meetingId}/capture-session/pause`,
-  captureSessionResume: (meetingId: number) =>
-    `/api/v1/meetings/${meetingId}/capture-session/resume`,
+  captureSession: (meetingId: number) => `/api/meetings/${meetingId}/capture-session`,
+  captureSessionPause: (meetingId: number) => `/api/meetings/${meetingId}/capture-session/pause`,
+  captureSessionResume: (meetingId: number) => `/api/meetings/${meetingId}/capture-session/resume`,
   /** 회의 종료 + 분석 접수(MEET-08) — 분석은 **서버가** 큐에 건다, 프론트가 부르지 않는다 */
-  meetingComplete: (meetingId: number) => `/api/v1/meetings/${meetingId}/complete`,
+  meetingComplete: (meetingId: number) => `/api/meetings/${meetingId}/complete`,
 
   /** 자막 청크 **배치** 전송(CAP-11)·전체 조회(CAP-12) */
   captions: (meetingId: number) => `/api/meetings/${meetingId}/captions`,


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [x] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

3개 커밋으로 나눠 담았습니다 — 서로 무관한 변경이지만 PR 순서 충돌을 피하려고 같은 브랜치에 묻었습니다.

- `fix`: 회의·캡처세션·회의종료 API `/api/v1/` 접두사 제거 — BE 커밋 `51b5482f`(경로 통일)로 이미 바뀐 경로를 우리 레지스트리가 못 따라가서 캡처 연동 붙이면 전부 404였을 상태
- `feat`: 팀 대시보드 KPI 4종 + 팀원 현황 실 연동(`GET /api/team/actions/dashboard-summary`, `GET /api/team/members` — PR #354 머지 완료)
- `feat`: 팀원 관리 화면 실 연동(`GET /api/team/members` + `GET /api/actions?assigneeMemberId=`)
- **권한 조건**: 역할 조건은 LEADER 전용(`canAccessTeamScope`), 리소스 소유권 조건은 팀장 본인 팀 스코프만(JWT `teamId`)
- **최근 팀 회의**는 BE API가 아직 없어서(모성진에게 `scope=team` 요청함) 지어내지 않고 빈 배열로 둠(§정직성) — 도착하면 그 자리만 고침

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`type: 제목 #{이슈번호}`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #370`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — LEADER 전용, BE도 JWT teamId로 재검증
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [x] 🕵️ **정직성** — 최근 팀 회의는 API 없어서 빈 배열, 없는 걸 지어내지 않음
- [ ] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그)
- [ ] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [x] ♻️ 재사용 확인 — 기존 mapper 패턴(`BePageResponse` 등) 그대로 사용
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음

---

## 🔗 연관 이슈

Closes #370

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- 팀원 관리는 팀원 수만큼 `GET /api/actions?assigneeMemberId=`를 병렬 호출합니다(`Promise.all`) — WORKFLOW.md가 "팀원 ~6명 규모"를 가정하고 있어 지금은 괜찮은데, 인원이 크게 늘면 카드 펼침 시점의 클라이언트 조회로 옮겨야 합니다(코드 주석에 남겨뒀습니다).

---

## 📝 추가 메모

```
npx tsc --noEmit   # 통과
npx eslint         # 통과
npx jest --silent  # 81 suites / 919 tests 전부 통과
npx next build     # 성공
```
