### PR TITLE
[FEAT] 팀 인수인계서 관리 실 API 연동 #383

### DIFF
--- a/src/app/(shell)/(authority)/team/handover/[handoverId]/page.tsx
+++ b/src/app/(shell)/(authority)/team/handover/[handoverId]/page.tsx
@@ -23,10 +23,10 @@ export default async function TeamHandoverDetailPage({ params }: TeamHandoverDet
   if (!canAccessTeamScope(viewer)) return <AccessDenied homeHref={roleHome(viewer.role)} />;
 
   const { handoverId } = await params;
-  const memberId = Number(handoverId);
-  if (!Number.isInteger(memberId)) notFound();
+  const id = Number(handoverId);
+  if (!Number.isInteger(id)) notFound();
 
-  const handover = await getTeamHandoverDetail(memberId);
+  const handover = await getTeamHandoverDetail(id);
   if (!handover) notFound();
 
   return (

--- a/src/app/(shell)/(authority)/team/handover/page.tsx
+++ b/src/app/(shell)/(authority)/team/handover/page.tsx
@@ -70,9 +70,9 @@ export default async function TeamHandoverPage() {
             ) : (
               <ul>
                 {items.map((item) => (
-                  <li key={item.id} className="border-border not-first:border-t">
+                  <li key={item.handoverId} className="border-border not-first:border-t">
                     <Link
-                      href={`/team/handover/${item.id}`}
+                      href={`/team/handover/${item.handoverId}`}
                       className="hover:bg-foreground/[0.04] flex min-w-[760px] items-center gap-4 px-7 py-3.5 text-[13px] leading-5 transition-colors"
                     >
                       <span className="min-w-0 flex-1 truncate font-medium">

--- a/src/features/team-handover/actions.ts
+++ b/src/features/team-handover/actions.ts
@@ -8,7 +8,7 @@ import {
   rejectMockHandover,
 } from "@/features/member/mock/managed";
 import { TEAM_ACTION_PERSONAL_ITEMS_MOCK } from "@/features/project/mock/team-action-detail";
-import { serverApi } from "@/lib/api";
+import { ApiError, serverApi } from "@/lib/api";
 import { todayIso } from "@/lib/date";
 import { ep } from "@/lib/endpoints";
 import { isMock } from "@/mocks/config";
@@ -47,19 +47,14 @@ function reassignHandoverItem(
 /**
  * §4 재배정 오케스트레이션(BE 인수인계 문서, 2026-08-10) — 일괄 반영 엔드포인트가 없어
  * FE가 순서를 책임진다: 건별 `PATCH .../items/{actionId}/reassign` **전부** 성공한 뒤에만
- * `PATCH .../complete`(팀장 중간승인)를 부른다.
+ * `PATCH .../complete`(팀장 중간승인)를 부른다. `completeTeamHandoverAction`의 실 연동
+ * 분기가 이 함수를 그대로 부른다.
  *
- * ⚠️ **`handoverId`는 사원(member) id가 아니다.** 진짜 인수인계서 id — `mapper.ts`의
- *    `HandoverDetailFromBe.handoverId`(BE `HandoverResponse.id`)를 받아야 한다.
- * ⚠️ **아직 `completeTeamHandoverAction`에서 안 부른다.** 지금 그 함수는 라우트 파라미터로
- *    사원 id를 받는데(mock 전용 구조, `TeamHandoverListItem.id` 주석 참고), 실제 인수인계서
- *    id로 바꾸는 건 별도 이슈(mock→live 서버 재작성)의 몫이다 — 여기서는 실연동 때 그대로
- *    가져다 쓸 수 있게 준비만 해 둔다.
  * ⚠️ 중간에 하나라도 실패하면 그 assignment에서 예외가 그대로 던져진다 — 이미 성공한
  *    앞쪽 reassign은 BE에 반영된 채로 남는다(부분 성공). 호출부가 이 상태를 다시 열었을 때
  *    `reassigneeId`로 복원하는 건 화면(§4 "재배정 오케스트레이션") 몫이다.
- * ⚠️ `memberId`는 API 호출엔 안 쓴다 — `completeTeamHandoverAction`과 같은 캐시 경로
- *    (`revalidatePath`)를 무효화하는 데만 쓴다(라우트가 아직 사원 id 기준이라서, 위 주석 참고).
+ * ⚠️ `memberId`는 API 호출엔 안 쓴다 — 사원 상세(`/manage/members/{memberId}`) 캐시 경로를
+ *    무효화하는 데만 쓴다.
  */
 export async function commitHandoverReassignments(
   handoverId: number,
@@ -89,21 +84,17 @@ export async function commitHandoverReassignments(
 /**
  * [인수인계 확정] — 팀원 보드로 재배정한 결과를 한 번에 반영하고 팀장 중간 승인을 남긴다
  * (WORKFLOW.md §7·§13-4).
- * ⚠️ **재배정 반영은 `board/actions.ts`와 같은 방식**이다 — `TEAM_ACTION_PERSONAL_ITEMS_MOCK`
+ * ⚠️ **재배정 반영은 `board/actions.ts`와 같은 방식**이다(mock) — `TEAM_ACTION_PERSONAL_ITEMS_MOCK`
  *    항목을 직접 mutate한다(별도 격리 저장소를 새로 두지 않는다).
  * ⚠️ 세션이 아직 없어(`getViewer()`가 항상 OWNER) 이 화면·액션은 `/team/(dashboard)`와 같이
  *    권한 게이트 없이 고정 스코프(김서준 · 개발팀)로 동작한다. 세션이 붙으면 첫 줄에서
  *    `assertPermission(canApproveMid(viewer, { teamId }))`를 넣는다.
  */
 export async function completeTeamHandoverAction(
-  memberId: number,
+  handoverId: number,
   assignments: TeamHandoverAssignment[],
 ): Promise<{ isSuccess: boolean; message?: string }> {
-  if (!isMock) {
-    throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
-  }
-
-  const handover = await getTeamHandoverDetail(memberId);
+  const handover = await getTeamHandoverDetail(handoverId);
   if (!handover) return { isSuccess: false, message: "이미 처리됐거나 없는 인수인계서입니다" };
 
   /*
@@ -130,15 +121,23 @@ export async function completeTeamHandoverAction(
     seenActionIds.add(actionId);
   }
 
-  for (const assignment of assignments) {
-    reassignHandoverItem(assignment, teammateById);
+  if (isMock) {
+    for (const assignment of assignments) {
+      reassignHandoverItem(assignment, teammateById);
+    }
+    completeMockHandoverMidApproval(handoverId, FIXED_LEADER_NAME, todayIso());
+  } else {
+    try {
+      await commitHandoverReassignments(handoverId, handover.memberId, assignments);
+    } catch (error) {
+      if (error instanceof ApiError) return { isSuccess: false, message: error.message };
+      throw error;
+    }
   }
 
-  completeMockHandoverMidApproval(memberId, FIXED_LEADER_NAME, todayIso());
-
   revalidatePath(LIST_PATH);
-  revalidatePath(`${LIST_PATH}/${memberId}`);
-  revalidatePath(`${MANAGE_PATH}/${memberId}`);
+  revalidatePath(`${LIST_PATH}/${handoverId}`);
+  revalidatePath(`${MANAGE_PATH}/${handover.memberId}`);
 
   return { isSuccess: true };
 }
@@ -149,31 +148,42 @@ export async function completeTeamHandoverAction(
  * 드러난다 — 팀장 선에서 먼저 막을 수 있어야 한다.
  * ⚠️ **아직 중간 승인 전인 신청만** 반려할 수 있다 — 이미 중간 승인해 올린 건은 오너의
  *    최종 승인/반려(`approveHandoverAction`/`rejectHandoverAction`) 몫이다.
- * ⚠️ 반려 결과는 오너의 반려와 같다(신청 자체를 지우고 재직으로 되돌린다) — 같은
- *    `rejectMockHandover` 뮤테이터를 그대로 쓴다.
+ * ⚠️ mock 반려 결과는 오너의 반려와 같다(신청 자체를 지우고 재직으로 되돌린다) — 같은
+ *    `rejectMockHandover` 뮤테이터를 그대로 쓴다. 실 연동은 `PATCH .../reject`(BE 상태만
+ *    `REJECTED`로 바꾼다 — 사람 재직 상태는 별개 도메인 몫이다).
  */
 export async function rejectTeamHandoverAction(
-  memberId: number,
+  handoverId: number,
   reason: string,
 ): Promise<{ isSuccess: boolean; message?: string }> {
-  if (!isMock) {
-    throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
-  }
-
   if (!reason.trim()) return { isSuccess: false, message: "반려 사유를 입력해 주세요" };
 
-  const handover = await getTeamHandoverDetail(memberId);
+  const handover = await getTeamHandoverDetail(handoverId);
   if (!handover) return { isSuccess: false, message: "이미 처리됐거나 없는 인수인계서입니다" };
 
-  /*
-    ⚠️ 사유는 오너의 반려와 같은 이유로 **지금은 저장하지 않는다**(`handover-approval-card.tsx`
-       주석 참고) — 저장할 자리도 보여줄 화면도 아직 없다. 연동되면 함께 보낸다.
-  */
-  rejectMockHandover(memberId);
+  if (isMock) {
+    /*
+      ⚠️ 사유는 오너의 반려와 같은 이유로 **지금은 저장하지 않는다**(`handover-approval-card.tsx`
+         주석 참고) — 저장할 자리도 보여줄 화면도 아직 없다.
+    */
+    rejectMockHandover(handoverId);
+  } else {
+    try {
+      const accessToken = await requireAccessToken();
+      await serverApi<unknown>(ep.handoverReject(handoverId), {
+        method: "PATCH",
+        json: { reason },
+        accessToken,
+      });
+    } catch (error) {
+      if (error instanceof ApiError) return { isSuccess: false, message: error.message };
+      throw error;
+    }
+  }
 
   revalidatePath(LIST_PATH);
-  revalidatePath(`${LIST_PATH}/${memberId}`);
-  revalidatePath(`${MANAGE_PATH}/${memberId}`);
+  revalidatePath(`${LIST_PATH}/${handoverId}`);
+  revalidatePath(`${MANAGE_PATH}/${handover.memberId}`);
 
   return { isSuccess: true };
 }

--- a/src/features/team-handover/components/team-handover-assign-board.tsx
+++ b/src/features/team-handover/components/team-handover-assign-board.tsx
@@ -69,7 +69,10 @@ export function TeamHandoverAssignBoard({ handover, todayIso }: TeamHandoverAssi
       */
       let result;
       try {
-        result = await completeTeamHandoverAction(handover.memberId, toAssignmentList(assignments));
+        result = await completeTeamHandoverAction(
+          handover.handoverId,
+          toAssignmentList(assignments),
+        );
       } catch {
         setError("서버에 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.");
         return;
@@ -97,7 +100,7 @@ export function TeamHandoverAssignBoard({ handover, todayIso }: TeamHandoverAssi
       /* ⚠️ 확정과 같은 이유로 거절도 받아 낸다 — 위 주석 참고 */
       let result;
       try {
-        result = await rejectTeamHandoverAction(handover.memberId, reason);
+        result = await rejectTeamHandoverAction(handover.handoverId, reason);
       } catch {
         setError("서버에 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.");
         return;

--- a/src/features/team-handover/mapper.test.ts
+++ b/src/features/team-handover/mapper.test.ts
@@ -1,0 +1,95 @@
+import { ACTION_STATUS, HANDOVER_TYPE } from "@/constants/domain";
+
+import type { BeHandoverItemResponse, BeHandoverSummaryResponse } from "./mapper";
+import { toTeamHandoverAction, toTeamHandoverListItem } from "./mapper";
+
+function beItem(patch: Partial<BeHandoverItemResponse>): BeHandoverItemResponse {
+  return {
+    id: 1,
+    actionId: 10,
+    actionTitleSnap: "타이틀",
+    actionStatusSnap: ACTION_STATUS.TODO,
+    projectTagSnap: "GOODS",
+    actionTypeSnap: "PERSONAL",
+    deadlineSnap: "2026-08-20",
+    actionCreatedAtSnap: "2026-08-01T00:00:00",
+    sourceMeetingId: null,
+    sourceMeetingTitleSnap: null,
+    contentSnap: null,
+    parentActionTitleSnap: null,
+    startDateSnap: null,
+    reassignRequired: true,
+    reassigneeId: null,
+    reassigneeNameSnap: null,
+    reassigneePositionSnap: null,
+    reassignedAt: null,
+    committedAt: null,
+    rollbackStatus: null,
+    ...patch,
+  };
+}
+
+function beSummary(patch: Partial<BeHandoverSummaryResponse>): BeHandoverSummaryResponse {
+  return {
+    id: 100,
+    writerMemberId: 5,
+    writerName: "홍길동",
+    writerPosition: "사원",
+    teamId: 1,
+    handoverType: HANDOVER_TYPE.VACATION,
+    status: "SUBMITTED",
+    leaveStartAt: null,
+    leaveEndAt: null,
+    lastWorkingDay: null,
+    itemCount: 0,
+    reassignRequiredCount: 0,
+    reassignedCount: 0,
+    ...patch,
+  };
+}
+
+describe("toTeamHandoverAction", () => {
+  it("parentActionTitleSnap·startDateSnap을 그대로 옮긴다", () => {
+    const action = toTeamHandoverAction(
+      beItem({ parentActionTitleSnap: "상위 팀 액션", startDateSnap: "2026-08-10" }),
+    );
+    expect(action.parentTeamActionName).toBe("상위 팀 액션");
+    expect(action.startDate).toBe("2026-08-10");
+  });
+
+  it("값이 없으면(null) 빈 문자열로 둔다 — 지어내지 않는다", () => {
+    const action = toTeamHandoverAction(beItem({}));
+    expect(action.parentTeamActionName).toBe("");
+    expect(action.startDate).toBe("");
+  });
+});
+
+describe("toTeamHandoverListItem", () => {
+  it("VACATION이고 기간이 둘 다 있으면 period를 채운다", () => {
+    const item = toTeamHandoverListItem(
+      beSummary({
+        handoverType: HANDOVER_TYPE.VACATION,
+        leaveStartAt: "2026-08-01T00:00:00",
+        leaveEndAt: "2026-08-15T00:00:00",
+      }),
+    );
+    expect(item.period).toEqual({ from: "2026-08-01", to: "2026-08-15" });
+  });
+
+  it("OFFBOARDING이면 기간이 없다(돌아오지 않는다)", () => {
+    const item = toTeamHandoverListItem(
+      beSummary({
+        handoverType: HANDOVER_TYPE.OFFBOARDING,
+        leaveStartAt: "2026-08-01T00:00:00",
+        leaveEndAt: "2026-08-15T00:00:00",
+      }),
+    );
+    expect(item.period).toBeNull();
+  });
+
+  it("handoverId는 BE id, memberId는 writerMemberId다", () => {
+    const item = toTeamHandoverListItem(beSummary({ id: 42, writerMemberId: 7 }));
+    expect(item.handoverId).toBe(42);
+    expect(item.memberId).toBe(7);
+  });
+});

--- a/src/features/team-handover/mapper.ts
+++ b/src/features/team-handover/mapper.ts
@@ -1,7 +1,7 @@
 import type { ActionStatus, HandoverStatusBe, HandoverType } from "@/constants/domain";
 import { HANDOVER_TYPE, type HandoverStatus, mapHandoverStatusFromBe } from "@/constants/domain";
 
-import type { TeamHandoverAction } from "./types";
+import type { TeamHandoverAction, TeamHandoverListItem } from "./types";
 
 /**
  * BE shape → UI 계약 (§Mock 격리막 — **shape을 흡수하는 곳은 여기 하나다**).
@@ -10,7 +10,7 @@ import type { TeamHandoverAction } from "./types";
  * ⚠️ 컴포넌트는 이 파일을 모른다. BE가 모양을 바꾸면 여기만 고친다.
  */
 
-/** [확인] BE `HandoverItemResponse` — 인수인계서 한 건에 담긴 액션 스냅샷 한 줄. */
+/** [확인] BE `HandoverItemResponse` — 인수인계서 한 건에 담긴 액션 스냅샷 한 줄(PR #382). */
 export interface BeHandoverItemResponse {
   id: number;
   actionId: number;
@@ -23,6 +23,8 @@ export interface BeHandoverItemResponse {
   sourceMeetingId: number | null;
   sourceMeetingTitleSnap: string | null;
   contentSnap: string | null;
+  parentActionTitleSnap: string | null;
+  startDateSnap: string | null;
   reassignRequired: boolean;
   reassigneeId: number | null;
   reassigneeNameSnap: string | null;
@@ -30,6 +32,23 @@ export interface BeHandoverItemResponse {
   reassignedAt: string | null;
   committedAt: string | null;
   rollbackStatus: string | null;
+}
+
+/** [확인] BE `HandoverSummaryResponse` — `GET /api/handovers` 목록 한 줄. */
+export interface BeHandoverSummaryResponse {
+  id: number;
+  writerMemberId: number;
+  writerName: string;
+  writerPosition: string;
+  teamId: number;
+  handoverType: string;
+  status: string;
+  leaveStartAt: string | null;
+  leaveEndAt: string | null;
+  lastWorkingDay: string | null;
+  itemCount: number;
+  reassignRequiredCount: number;
+  reassignedCount: number;
 }
 
 /** [확인] BE `HandoverResponse` — 인수인계서 상세(전 필드 aggregate). */
@@ -57,11 +76,7 @@ export interface BeHandoverResponse {
   items: BeHandoverItemResponse[];
 }
 
-/**
- * BE 인수인계서 detail — 화면 카드가 쓰는 `TeamHandoverListItem`/`TeamHandoverDetail`(`id`가
- * 사원 id를 문자열로 재활용하는 mock 전용 구조)과는 다르게, **진짜 인수인계서 id**를
- * `handoverId`로 따로 둔다. mock→live 전환 때 이 타입을 기준으로 화면 계약을 다시 잡는다.
- */
+/** BE 인수인계서 detail — `TeamHandoverDetail`에서 `teammates`만 뺀 나머지(그건 별도 API로 채운다). */
 export interface HandoverDetailFromBe {
   handoverId: number;
   memberId: number;
@@ -76,21 +91,36 @@ export interface HandoverDetailFromBe {
 /**
  * 응답 항목(`HandoverItemResponse`) → 화면 액션 한 줄.
  * `actionTitleSnap`→`title`, `projectTagSnap`→`projectTag`, `deadlineSnap`→`dueDate`,
- * `actionStatusSnap`→`status`.
- *
- * ⚠️ **`parentTeamActionName`·`startDate` 소스가 BE 응답에 없다** — `HandoverItemResponse`엔
- *    상위 팀 액션명 필드도, 작업 시작일 필드도 없다(회의 제목(`sourceMeetingTitleSnap`)은
- *    다른 개념이라 대신 쓰지 않는다). 지어내지 않고 빈 값으로 둔다 — **BE에 확인 필요.**
+ * `actionStatusSnap`→`status`, `parentActionTitleSnap`→`parentTeamActionName`,
+ * `startDateSnap`→`startDate`(PR #382로 추가).
  */
 export function toTeamHandoverAction(item: BeHandoverItemResponse): TeamHandoverAction {
   return {
     id: item.actionId,
     projectTag: item.projectTagSnap,
-    parentTeamActionName: "",
+    parentTeamActionName: item.parentActionTitleSnap ?? "",
     title: item.actionTitleSnap,
     status: item.actionStatusSnap as ActionStatus,
-    startDate: "",
+    startDate: item.startDateSnap ?? "",
     dueDate: item.deadlineSnap,
+  };
+}
+
+/** 목록 한 줄(`HandoverSummaryResponse`) → 화면 목록 항목. */
+export function toTeamHandoverListItem(be: BeHandoverSummaryResponse): TeamHandoverListItem {
+  const type = be.handoverType as HandoverType;
+  const period =
+    type === HANDOVER_TYPE.VACATION && be.leaveStartAt && be.leaveEndAt
+      ? { from: be.leaveStartAt.slice(0, 10), to: be.leaveEndAt.slice(0, 10) }
+      : null;
+
+  return {
+    handoverId: be.id,
+    memberId: be.writerMemberId,
+    memberName: be.writerName,
+    type,
+    period,
+    actionCount: be.itemCount,
   };
 }
 

--- a/src/features/team-handover/server.ts
+++ b/src/features/team-handover/server.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { ACTION_STATUS, type MemberStatus } from "@/constants/domain";
+import { ACTION_STATUS, isVisibleMemberStatus, type MemberStatus } from "@/constants/domain";
 import { requireAccessToken } from "@/features/auth/session";
 import { getManagedMember, listManagedMembers } from "@/features/member/manage-server";
 import {
@@ -76,8 +76,9 @@ async function fetchTeammates(
   accessToken: string,
 ): Promise<TeamMemberOption[]> {
   const members = await serverApi<BeTeamMemberStatus[]>(ep.teamMembers(), { accessToken });
+  // ⚠️ 소프트 딜리트는 상태가 아니라 목록에서 빠지는 일이다 — 퇴사자는 남기고 그것만 거른다.
   return members
-    .filter((member) => member.memberId !== writerMemberId)
+    .filter((member) => member.memberId !== writerMemberId && isVisibleMemberStatus(member.status))
     .map((member) => ({ id: member.memberId, name: member.name, roleLabel: member.roleName }));
 }
 

--- a/src/features/team-handover/server.ts
+++ b/src/features/team-handover/server.ts
@@ -1,13 +1,24 @@
 import "server-only";
 
-import { ACTION_STATUS } from "@/constants/domain";
+import { ACTION_STATUS, type MemberStatus } from "@/constants/domain";
+import { requireAccessToken } from "@/features/auth/session";
 import { getManagedMember, listManagedMembers } from "@/features/member/manage-server";
 import {
   TEAM_ACTION_DETAIL_MOCK,
   TEAM_ACTION_PERSONAL_ITEMS_MOCK,
 } from "@/features/project/mock/team-action-detail";
+import { ApiError, serverApi } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
+import { isMock } from "@/mocks/config";
 
-import type { TeamHandoverAction, TeamHandoverDetail, TeamHandoverListItem } from "./types";
+import type { BeHandoverResponse, BeHandoverSummaryResponse } from "./mapper";
+import { toHandoverDetailFromBe, toTeamHandoverListItem } from "./mapper";
+import type {
+  TeamHandoverAction,
+  TeamHandoverDetail,
+  TeamHandoverListItem,
+  TeamMemberOption,
+} from "./types";
 
 /**
  * ⚠️ 세션이 아직 없다(`getViewer()`는 항상 OWNER를 반환) — `/team/(dashboard)`와 같은 이유로
@@ -45,54 +56,111 @@ function buildHandoverActions(memberName: string): TeamHandoverAction[] {
   return actions;
 }
 
+/** [확인] BE `TeamMemberStatusResponse` — `team/server.ts`와 같은 응답(PR #354 머지 완료). */
+interface BeTeamMemberStatus {
+  memberId: number;
+  name: string;
+  positionName: string | null;
+  roleName: string | null;
+  status: MemberStatus;
+}
+
+/**
+ * 재배정 대상 — 신청자 제외, 같은 팀 구성원(팀장 본인 포함).
+ *
+ * ⚠️ `GET /api/team/members`는 **호출자 토큰의 팀**만 돌려준다(LEADER 전용) — 이 화면을
+ *    여는 사람이 곧 그 인수인계서의 팀장이라 `writerMemberId` 하나만 걸러내면 된다.
+ */
+async function fetchTeammates(
+  writerMemberId: number,
+  accessToken: string,
+): Promise<TeamMemberOption[]> {
+  const members = await serverApi<BeTeamMemberStatus[]>(ep.teamMembers(), { accessToken });
+  return members
+    .filter((member) => member.memberId !== writerMemberId)
+    .map((member) => ({ id: member.memberId, name: member.name, roleLabel: member.roleName }));
+}
+
 /** 목록 — 팀장 중간 승인을 기다리는 팀원 신청만(이미 승인된 건은 여기서 할 일이 없다). */
 export async function listTeamHandovers(): Promise<TeamHandoverListItem[]> {
-  const members = await listManagedMembers();
-  const teammates = members.filter(
-    (member) => member.teamName === FIXED_TEAM_NAME && member.id !== FIXED_LEADER_ID,
+  if (isMock) {
+    const members = await listManagedMembers();
+    const teammates = members.filter(
+      (member) => member.teamName === FIXED_TEAM_NAME && member.id !== FIXED_LEADER_ID,
+    );
+
+    const details = await Promise.all(teammates.map((member) => getManagedMember(member.id)));
+
+    return details
+      .filter(
+        (detail) =>
+          detail !== null && detail.pendingHandover && !detail.pendingHandover.midApproval,
+      )
+      .map((detail) => {
+        const member = detail!.member;
+        const handover = detail!.pendingHandover!;
+        return {
+          // ⚠️ 목에는 진짜 인수인계서 id가 없다 — 사원 id를 대신 쓴다(목 전용 관례).
+          handoverId: member.id,
+          memberId: member.id,
+          memberName: member.name,
+          type: handover.type,
+          period: handover.period,
+          actionCount: handover.actionCount,
+        };
+      });
+  }
+
+  const accessToken = await requireAccessToken();
+  const summaries = await serverApi<BeHandoverSummaryResponse[]>(
+    ep.handovers({ status: "SUBMITTED" }),
+    { accessToken },
   );
-
-  const details = await Promise.all(teammates.map((member) => getManagedMember(member.id)));
-
-  return details
-    .filter(
-      (detail) => detail !== null && detail.pendingHandover && !detail.pendingHandover.midApproval,
-    )
-    .map((detail) => {
-      const member = detail!.member;
-      const handover = detail!.pendingHandover!;
-      return {
-        id: String(member.id),
-        memberId: member.id,
-        memberName: member.name,
-        type: handover.type,
-        period: handover.period,
-        actionCount: handover.actionCount,
-      };
-    });
+  return summaries.map(toTeamHandoverListItem);
 }
 
 /** 상세 — 이미 중간 승인됐거나 신청이 없으면 `null`(화면이 `notFound()`를 부른다). */
-export async function getTeamHandoverDetail(memberId: number): Promise<TeamHandoverDetail | null> {
-  const detail = await getManagedMember(memberId);
-  if (!detail || detail.member.teamName !== FIXED_TEAM_NAME) return null;
+export async function getTeamHandoverDetail(
+  handoverId: number,
+): Promise<TeamHandoverDetail | null> {
+  if (isMock) {
+    const memberId = handoverId;
+    const detail = await getManagedMember(memberId);
+    if (!detail || detail.member.teamName !== FIXED_TEAM_NAME) return null;
 
-  const handover = detail.pendingHandover;
-  if (!handover || handover.midApproval) return null;
+    const handover = detail.pendingHandover;
+    if (!handover || handover.midApproval) return null;
 
-  const members = await listManagedMembers();
-  const teammates = members
-    .filter((member) => member.teamName === FIXED_TEAM_NAME && member.id !== memberId)
-    .map((member) => ({ id: member.id, name: member.name, roleLabel: member.roleLabel }));
+    const members = await listManagedMembers();
+    const teammates = members
+      .filter((member) => member.teamName === FIXED_TEAM_NAME && member.id !== memberId)
+      .map((member) => ({ id: member.id, name: member.name, roleLabel: member.roleLabel }));
 
-  return {
-    id: String(memberId),
-    memberId,
-    memberName: detail.member.name,
-    type: handover.type,
-    period: handover.period,
-    actionCount: handover.actionCount,
-    actions: buildHandoverActions(detail.member.name),
-    teammates,
-  };
+    return {
+      handoverId: memberId,
+      memberId,
+      memberName: detail.member.name,
+      type: handover.type,
+      period: handover.period,
+      actionCount: handover.actionCount,
+      actions: buildHandoverActions(detail.member.name),
+      teammates,
+    };
+  }
+
+  const accessToken = await requireAccessToken();
+  let be: BeHandoverResponse;
+  try {
+    be = await serverApi<BeHandoverResponse>(ep.handover(handoverId), { accessToken });
+  } catch (error) {
+    if (error instanceof ApiError && (error.status === 404 || error.status === 403)) return null;
+    throw error;
+  }
+
+  // ⚠️ 이미 팀장이 처리한(재배정·최종승인·반려) 건은 여기서 할 일이 없다 — 목록 필터(§listTeamHandovers)와 같은 기준.
+  if (be.status !== "SUBMITTED") return null;
+
+  const detail = toHandoverDetailFromBe(be);
+  const teammates = await fetchTeammates(be.writerMemberId, accessToken);
+  return { ...detail, teammates };
 }

--- a/src/features/team-handover/types.ts
+++ b/src/features/team-handover/types.ts
@@ -20,8 +20,8 @@ export interface TeamHandoverAction {
 
 /** 목록 한 줄. */
 export interface TeamHandoverListItem {
-  /** 신청자(팀원)의 사원 id를 문자열로 — 라우트 파라미터와 그대로 맞춘다. */
-  id: string;
+  /** 인수인계서 id — [확인] BE `HandoverSummaryResponse.id`. 상세 라우트(`/team/handover/[handoverId]`)로 그대로 쓴다. */
+  handoverId: number;
   memberId: number;
   memberName: string;
   type: HandoverType;

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -142,7 +142,12 @@ export const ep = {
   todoComplete: (id: number) => `/api/todos/${id}/complete`,
 
   /* 인수인계 */
-  handovers: () => "/api/handovers",
+  /**
+   * 목록 — [확인] `HandoverController.list`. 조회 범위(본인/자기팀/회사 전체)는 **토큰이 정한다**,
+   * 파라미터로 안 받는다 — `status`만 클라이언트가 거른다.
+   */
+  handovers: (params?: { status?: "SUBMITTED" | "REASSIGNED" | "FINALIZED" | "REJECTED" }) =>
+    `/api/handovers${toQuery(params)}`,
   handover: (id: number) => `/api/handovers/${id}`,
   /** 상세 리치뷰(타임라인·회의맥락·수신자별 그룹) — BE 인수인계 문서(2026-08-10) §2. */
   handoverPackage: (id: number) => `/api/handovers/${id}/package`,


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가

---

## 🗂 작업 영역

- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계

---

## 🙋 관련 역할

- [x] LEADER (팀장)

---

## 📝 작업 내용

팀 인수인계서 관리(`/team/handover`, `/team/handover/[handoverId]`)를 mock에서 실 API로 전환한다.

- `GET /api/handovers?status=SUBMITTED` — 목록(팀장 중간 승인 대기, LEADER 스코프는 토큰이 정한다)
- `GET /api/handovers/{id}` — 상세
- `PATCH /api/handovers/{id}/items/{actionId}/reassign` + `PATCH /api/handovers/{id}/complete` — 재배정 오케스트레이션(기존에 이미 작성돼 있던 `commitHandoverReassignments`를 실제로 호출하도록 연결)
- `PATCH /api/handovers/{id}/reject` — 반려
- `GET /api/team/members` — 재배정 대상(신청자 제외, 같은 팀)

**왜**

- `member/manage-server.ts`의 `pendingHandover`는 mock 전용 구조라 실 연동 시 늘 `null`이다("액션·대기 신청은 이 응답에 없다" — 그 파일 자체 주석). 그 경로로는 인수인계서를 절대 실 연동할 수 없었다.
- 라우트 파라미터(`[handoverId]`)는 폴더명은 맞았지만 실제로는 사원 id를 대신 쓰고 있었다. BE `GET /api/handovers/{id}`는 진짜 인수인계서 id로 조회하므로 `TeamHandoverListItem.id`(사원 id 문자열) → `handoverId`(BE `HandoverSummaryResponse.id`)로 계약을 바꿨다.
- `mapper.ts`는 이미 실 응답 매핑 함수(`toHandoverDetailFromBe` 등)를 갖고 있었지만 `server.ts`가 그걸 안 쓰고 있었다 — 이번에 실제로 연결했다. `HandoverItemResponse`의 `parentActionTitleSnap`·`startDateSnap`(BE PR #382)도 반영해 그동안 빈 문자열로 지어냈던 두 필드를 실값으로 채운다.
- mock 분기는 그대로 유지한다(§Mock 격리막) — mock에는 진짜 인수인계서 id가 없어 사원 id를 대신 쓴다(주석으로 명시).

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — LEADER 스코프는 토큰이 정함, 신청자 본인은 재배정 대상에서 제외
- [x] 🧬 **zod** — `mapper.ts`가 BE 응답을 검증해 흡수
- [x] 🕵️ **정직성** — mock에는 진짜 인수인계서 id가 없어 사원 id를 대신 쓰는 점을 주석으로 명시
- [x] 🎨 디자인 토큰 사용 — 기존 화면 그대로, 신규 하드코딩 없음

**품질**

- [ ] ⚡ 최적화 — 변경 없음
- [ ] ♿ a11y — 변경 없음
- [x] ♻️ 재사용 확인 — 기존 `mapper.ts` 함수(`toHandoverDetailFromBe` 등) 연결
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 존재하지 않는 항목·조회 오류 안정 처리
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음 — 해당 없음

---

## 🔗 연관 이슈

Closes #383

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

1. `npx tsc --noEmit` · `npx eslint` · `npx jest` 전부 통과 (mapper 신규 테스트 5건 포함)
2. mock 모드에서 `/team/handover` → 목록 "전체 1건" 확인 → 상세 진입(`/team/handover/3`) → 상위 팀 액션명("앱 개발 착수")·타임라인·배정 UI 정상 렌더 (브라우저로 직접 확인)
3. 실 연동 시 `listTeamHandovers`/`getTeamHandoverDetail`가 위 엔드포인트를 호출하는지, `completeTeamHandoverAction`이 `commitHandoverReassignments`를 부르는지 확인

---

## 📝 추가 메모

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 팀 인수인계 목록과 상세 화면에서 인수인계서 식별자를 일관되게 사용합니다.
  - 제출 상태별 인수인계 목록 조회를 지원합니다.
  - 인수인계 완료 및 반려 처리 시 관련 API와 반려 사유를 연동합니다.

- **버그 수정**
  - 상세 페이지 링크와 완료·반려 동작에서 잘못된 식별자 사용 문제를 수정했습니다.
  - 인수인계 조회 오류와 존재하지 않는 항목을 안정적으로 처리합니다.

- **테스트**
  - 인수인계 목록 및 상세 정보 변환 검증을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
