### PR TITLE
[FEAT] 인수인계 신청·최종승인·팀장 귀속 실 API 연동 #388

### DIFF
--- a/src/features/handover/actions.ts
+++ b/src/features/handover/actions.ts
@@ -1,5 +1,7 @@
 "use server";
 
+import { revalidatePath } from "next/cache";
+
 import {
   HANDOVER_STATUS,
   HANDOVER_TYPE,
@@ -13,6 +15,9 @@ import { ep } from "@/lib/endpoints";
 import { isMock } from "@/mocks/config";
 
 import { type SubmitHandoverPayload, toHandoverCreateRequestBody } from "./lib";
+
+/** 새 신청이 뜨는 목록 — 팀장 중간승인 대기 화면. */
+const TEAM_HANDOVER_LIST_PATH = "/team/handover";
 
 export type {
   SubmitHandoverPayload,
@@ -57,6 +62,8 @@ export async function submitHandoverAction(
       });
     }
   }
+
+  revalidatePath(TEAM_HANDOVER_LIST_PATH);
 
   return { status: mapHandoverStatusFromBe(created.status) };
 }

--- a/src/features/handover/actions.ts
+++ b/src/features/handover/actions.ts
@@ -1,9 +1,18 @@
 "use server";
 
-import { HANDOVER_STATUS, type HandoverStatus } from "@/constants/domain";
+import {
+  HANDOVER_STATUS,
+  HANDOVER_TYPE,
+  type HandoverStatus,
+  type HandoverStatusBe,
+  mapHandoverStatusFromBe,
+} from "@/constants/domain";
+import { requireAccessToken } from "@/features/auth/session";
+import { serverApi } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
 import { isMock } from "@/mocks/config";
 
-import type { SubmitHandoverPayload } from "./lib";
+import { type SubmitHandoverPayload, toHandoverCreateRequestBody } from "./lib";
 
 export type {
   SubmitHandoverPayload,
@@ -11,19 +20,43 @@ export type {
   SubmitVacationHandoverPayload,
 } from "./lib";
 
+/** [확인] BE `HandoverResponse` — 생성 응답에서 재배정에 필요한 `id`·`status`만 본다. */
+interface BeCreatedHandover {
+  id: number;
+  status: HandoverStatusBe;
+}
+
 /**
- * [인수인계서 신청] — 접수만 한다.
- * ⚠️ `/team/handover`·`/owner/leader-handovers`(승인·재분배·귀속 화면)가 아직 없어
- *    이어줄 대상이 없다(별도 이슈) — 지금은 신청이 접수됐다는 결과만 mock으로 돌려준다.
- *    실제 저장·팀장 상신은 그 이슈에서 mock 스토어와 함께 연결한다.
+ * [인수인계서 신청] — 접수한다.
+ * ⚠️ **팀장 본인 휴직의 자가 재배정**(`assignments`)은 생성 바디에 안 실린다 — BE `POST`가
+ *    그 필드를 안 받는다(`lib.ts` §`toHandoverCreateRequestBody` 주석). 생성 뒤 건별
+ *    `PATCH .../items/{actionId}/reassign`으로 따로 보낸다(`team-handover/actions.ts`의
+ *    `commitHandoverReassignments`와 같은 패턴).
  */
 export async function submitHandoverAction(
   payload: SubmitHandoverPayload,
 ): Promise<{ status: HandoverStatus }> {
-  if (!isMock) {
-    throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
+  if (isMock) {
+    void payload;
+    return { status: HANDOVER_STATUS.SUBMITTED };
   }
 
-  void payload;
-  return { status: HANDOVER_STATUS.SUBMITTED };
+  const accessToken = await requireAccessToken();
+  const created = await serverApi<BeCreatedHandover>(ep.handovers(), {
+    method: "POST",
+    json: toHandoverCreateRequestBody(payload),
+    accessToken,
+  });
+
+  if (payload.type === HANDOVER_TYPE.VACATION) {
+    for (const [actionId, assigneeId] of Object.entries(payload.assignments)) {
+      await serverApi<unknown>(ep.handoverReassignItem(created.id, Number(actionId)), {
+        method: "PATCH",
+        json: { toMemberId: assigneeId },
+        accessToken,
+      });
+    }
+  }
+
+  return { status: mapHandoverStatusFromBe(created.status) };
 }

--- a/src/features/leader-handover/actions.ts
+++ b/src/features/leader-handover/actions.ts
@@ -3,11 +3,15 @@
 import { revalidatePath } from "next/cache";
 
 import { LEADER_HANDOVER_CUSTODY_STATUS } from "@/constants/domain";
+import { requireAccessToken } from "@/features/auth/session";
 import { getViewer } from "@/features/shell/viewer";
+import { serverApi, toUserMessage } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
 import { canManageLeaderHandovers } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
 import { findMockLeaderHandover, markMockLeaderHandoverAssigned } from "./mock/leader-handovers";
+import { getLeaderHandoverDetail } from "./server";
 
 /**
  * [OOO에게 귀속] — 이 인수인계서에 담긴 액션 전체의 담당자를 새 팀장에게 일괄 이전한다
@@ -23,24 +27,45 @@ import { findMockLeaderHandover, markMockLeaderHandoverAssigned } from "./mock/l
 export async function assignLeaderHandoverAction(
   handoverId: string,
   newLeaderId: string,
-): Promise<{ isSuccess: boolean }> {
+): Promise<{ isSuccess: boolean; message?: string }> {
   const viewer = await getViewer();
   if (!canManageLeaderHandovers(viewer)) return { isSuccess: false };
 
-  if (!isMock) {
-    throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
-  }
+  if (isMock) {
+    const handover = findMockLeaderHandover(handoverId);
+    if (!handover) return { isSuccess: false };
+    if (handover.custodyStatus !== LEADER_HANDOVER_CUSTODY_STATUS.PENDING) {
+      return { isSuccess: false };
+    }
+    if (!handover.candidates.some((candidate) => candidate.id === newLeaderId)) {
+      return { isSuccess: false };
+    }
+    markMockLeaderHandoverAssigned(handoverId);
+  } else {
+    /*
+      ⚠️ 후보 목록에 있는지는 여기서 다시 본다(§권한: 화면 숨김은 보안이 아니다) — 주소만
+         알면 이 액션을 직접 부를 수 있어, 화면이 안 보여준 값이라도 여기서 걸러야 한다.
+    */
+    const handover = await getLeaderHandoverDetail(handoverId);
+    if (!handover) return { isSuccess: false };
+    if (handover.custodyStatus !== LEADER_HANDOVER_CUSTODY_STATUS.PENDING) {
+      return { isSuccess: false };
+    }
+    if (!handover.candidates.some((candidate) => candidate.id === newLeaderId)) {
+      return { isSuccess: false };
+    }
 
-  const handover = findMockLeaderHandover(handoverId);
-  if (!handover) return { isSuccess: false };
-  if (handover.custodyStatus !== LEADER_HANDOVER_CUSTODY_STATUS.PENDING) {
-    return { isSuccess: false };
+    const accessToken = await requireAccessToken();
+    try {
+      await serverApi<unknown>(ep.handoverAttributeToLeader(Number(handoverId)), {
+        method: "PATCH",
+        json: { newLeaderId: Number(newLeaderId) },
+        accessToken,
+      });
+    } catch (error) {
+      return { isSuccess: false, message: toUserMessage(error) };
+    }
   }
-  if (!handover.candidates.some((candidate) => candidate.id === newLeaderId)) {
-    return { isSuccess: false };
-  }
-
-  markMockLeaderHandoverAssigned(handoverId);
 
   revalidatePath("/owner/leader-handovers");
   revalidatePath(`/owner/leader-handovers/${handoverId}`);

--- a/src/features/leader-handover/components/leader-handover-assign-form.tsx
+++ b/src/features/leader-handover/components/leader-handover-assign-form.tsx
@@ -49,7 +49,7 @@ export function LeaderHandoverAssignForm({ handover }: LeaderHandoverAssignFormP
       try {
         const result = await assignLeaderHandoverAction(handover.id, selectedId);
         if (!result.isSuccess) {
-          setError("귀속 처리에 실패했습니다. 잠시 후 다시 시도해 주세요.");
+          setError(result.message ?? "귀속 처리에 실패했습니다. 잠시 후 다시 시도해 주세요.");
           return;
         }
         setConfirmOpen(false);

--- a/src/features/leader-handover/server.ts
+++ b/src/features/leader-handover/server.ts
@@ -46,6 +46,8 @@ interface BeHandoverDetail {
   teamNameSnap: string;
   writerMemberId: number;
   writerNameSnap: string;
+  handoverType: string;
+  status: string;
   finalizedAt: string | null;
   items: BeHandoverItem[];
 }
@@ -150,6 +152,13 @@ export async function getLeaderHandoverDetail(id: string): Promise<LeaderHandove
     if (error instanceof ApiError && (error.status === 404 || error.status === 403)) return null;
     throw error;
   }
+
+  /*
+    ⚠️ **목록과 같은 조건을 여기서도 다시 본다**(§권한: 화면 숨김은 보안이 아니다). 목록은
+       OFFBOARDING·FINALIZED만 걸러 링크를 만들지만, 이 함수는 주소만 알면 다른 handover id로도
+       직접 불릴 수 있다 — 휴직 건이나 아직 SUBMITTED인 건을 열면 후보·귀속 버튼이 잘못 뜬다.
+  */
+  if (be.handoverType !== "OFFBOARDING" || be.status !== "FINALIZED") return null;
 
   const custodyStatus = isAllReassigned(be.items)
     ? LEADER_HANDOVER_CUSTODY_STATUS.ASSIGNED

--- a/src/features/leader-handover/server.ts
+++ b/src/features/leader-handover/server.ts
@@ -1,24 +1,173 @@
+import "server-only";
+
 import type { LeaderHandoverCustodyStatus } from "@/constants/domain";
+import { ACTION_STATUS, LEADER_HANDOVER_CUSTODY_STATUS } from "@/constants/domain";
+import { requireAccessToken } from "@/features/auth/session";
+import { ApiError, serverApi } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
+import { isMock } from "@/mocks/config";
 
 import { findMockLeaderHandover, listMockLeaderHandovers } from "./mock/leader-handovers";
-import type { LeaderHandoverDetail, LeaderHandoverListItem } from "./types";
+import type {
+  LeaderCandidate,
+  LeaderHandoverAction,
+  LeaderHandoverDetail,
+  LeaderHandoverListItem,
+} from "./types";
 
+/** [확인] BE `HandoverSummaryResponse` — `team-handover/mapper.ts`와 같은 응답. */
+interface BeHandoverSummaryResponse {
+  id: number;
+  writerName: string;
+  teamId: number;
+  handoverType: string;
+  finalizedAt: string | null;
+  itemCount: number;
+  reassignRequiredCount: number;
+  reassignedCount: number;
+}
+
+/** [확인] BE `HandoverItemResponse`. */
+interface BeHandoverItem {
+  actionId: number;
+  actionTitleSnap: string;
+  actionStatusSnap: string;
+  projectTagSnap: string;
+  deadlineSnap: string;
+  parentActionTitleSnap: string | null;
+  reassignRequired: boolean;
+  reassigneeId: number | null;
+}
+
+/** [확인] BE `HandoverResponse`. */
+interface BeHandoverDetail {
+  id: number;
+  teamId: number;
+  teamNameSnap: string;
+  writerMemberId: number;
+  writerNameSnap: string;
+  finalizedAt: string | null;
+  items: BeHandoverItem[];
+}
+
+function toLeaderHandoverAction(item: BeHandoverItem): LeaderHandoverAction {
+  return {
+    id: item.actionId,
+    projectTag: item.projectTagSnap,
+    parentTeamActionName: item.parentActionTitleSnap ?? "",
+    title: item.actionTitleSnap,
+    status: item.actionStatusSnap as LeaderHandoverAction["status"],
+    dueDate: item.deadlineSnap,
+  };
+}
+
+/** 전 항목이 재배정 필요 없거나 이미 재배정됐는지 — BE `Handover.isAllReassigned()`와 같은 판정. */
+function isAllReassigned(items: { reassignRequired: boolean; reassigneeId: number | null }[]) {
+  return items.every((item) => !item.reassignRequired || item.reassigneeId !== null);
+}
+
+/**
+ * 목록 — [확인] `GET /api/handovers?status=FINALIZED`(OWNER면 회사 전체, 페이지네이션 없음)에서
+ * `handoverType=OFFBOARDING`만 골라 쓴다.
+ *
+ * ⚠️ BE에 "귀속 대기"만 주는 전용 경로(`/pending-attribution`)가 있지만, 그건 `PENDING`
+ *    한쪽뿐이다 — `ASSIGNED`(이미 귀속 끝난 건) 탭까지 한 화면에서 걸러야 해서, 대신
+ *    `reassignRequiredCount`·`reassignedCount`로 두 상태를 여기서 직접 가른다
+ *    (BE `isPendingAttribution()`과 같은 식 — 다 재배정됐으면 `ASSIGNED`).
+ */
 export async function listLeaderHandovers(
   filter: LeaderHandoverCustodyStatus | null,
 ): Promise<LeaderHandoverListItem[]> {
-  const items = listMockLeaderHandovers();
-  const filtered = filter ? items.filter((item) => item.custodyStatus === filter) : items;
-  return filtered.map((item) => ({
-    id: item.id,
-    title: item.title,
-    formerLeaderName: item.formerLeaderName,
-    teamName: item.teamName,
-    offboardingApprovedAt: item.offboardingApprovedAt,
-    actionCount: item.actionCount,
-    custodyStatus: item.custodyStatus,
-  }));
+  if (isMock) {
+    const items = listMockLeaderHandovers();
+    const filtered = filter ? items.filter((item) => item.custodyStatus === filter) : items;
+    return filtered.map((item) => ({
+      id: item.id,
+      title: item.title,
+      formerLeaderName: item.formerLeaderName,
+      teamName: item.teamName,
+      offboardingApprovedAt: item.offboardingApprovedAt,
+      actionCount: item.actionCount,
+      custodyStatus: item.custodyStatus,
+    }));
+  }
+
+  const accessToken = await requireAccessToken();
+  const summaries = await serverApi<BeHandoverSummaryResponse[]>(
+    ep.handovers({ status: "FINALIZED" }),
+    { accessToken },
+  );
+
+  const teams = await serverApi<{ id: number; name: string }[]>(ep.teams(), { accessToken });
+  const teamNameById = new Map(teams.map((team) => [team.id, team.name]));
+
+  return summaries
+    .filter((summary) => summary.handoverType === "OFFBOARDING")
+    .map((summary): LeaderHandoverListItem => {
+      const teamName = teamNameById.get(summary.teamId) ?? "";
+      const custodyStatus =
+        summary.reassignedCount >= summary.reassignRequiredCount
+          ? LEADER_HANDOVER_CUSTODY_STATUS.ASSIGNED
+          : LEADER_HANDOVER_CUSTODY_STATUS.PENDING;
+      return {
+        id: String(summary.id),
+        title: `${summary.writerName} ${teamName}장 오프보딩 인수인계서`,
+        formerLeaderName: summary.writerName,
+        teamName,
+        offboardingApprovedAt: (summary.finalizedAt ?? "").slice(0, 10),
+        actionCount: summary.itemCount,
+        custodyStatus,
+      };
+    })
+    .filter((item) => !filter || item.custodyStatus === filter);
+}
+
+/**
+ * 귀속 후보 — **같은 팀에 새로 지정된 팀장만**(2026-08-08 팀 정정). 팀 조회의
+ * `leaderMemberId`가 곧 그 팀 현재 팀장이다 — 떠난 사람 본인이면 아직 공석이라 후보가 없다.
+ */
+async function findCandidatesForTeam(
+  teamId: number,
+  formerLeaderId: number,
+  accessToken: string,
+): Promise<LeaderCandidate[]> {
+  const teams = await serverApi<
+    { id: number; name: string; leaderMemberId: number | null; leaderName: string | null }[]
+  >(ep.teams(), { accessToken });
+  const team = teams.find((t) => t.id === teamId);
+  if (!team || team.leaderMemberId === null || team.leaderMemberId === formerLeaderId) return [];
+  return [{ id: String(team.leaderMemberId), name: team.leaderName ?? "", teamName: team.name }];
 }
 
 export async function getLeaderHandoverDetail(id: string): Promise<LeaderHandoverDetail | null> {
-  return findMockLeaderHandover(id);
+  if (isMock) return findMockLeaderHandover(id);
+
+  const accessToken = await requireAccessToken();
+  let be: BeHandoverDetail;
+  try {
+    be = await serverApi<BeHandoverDetail>(ep.handover(Number(id)), { accessToken });
+  } catch (error) {
+    if (error instanceof ApiError && (error.status === 404 || error.status === 403)) return null;
+    throw error;
+  }
+
+  const custodyStatus = isAllReassigned(be.items)
+    ? LEADER_HANDOVER_CUSTODY_STATUS.ASSIGNED
+    : LEADER_HANDOVER_CUSTODY_STATUS.PENDING;
+
+  const candidates = await findCandidatesForTeam(be.teamId, be.writerMemberId, accessToken);
+
+  return {
+    id: String(be.id),
+    title: `${be.writerNameSnap} ${be.teamNameSnap}장 오프보딩 인수인계서`,
+    formerLeaderName: be.writerNameSnap,
+    teamName: be.teamNameSnap,
+    offboardingApprovedAt: (be.finalizedAt ?? "").slice(0, 10),
+    actionCount: be.items.length,
+    custodyStatus,
+    actions: be.items
+      .filter((item) => item.actionStatusSnap !== ACTION_STATUS.DONE)
+      .map(toLeaderHandoverAction),
+    candidates,
+  };
 }

--- a/src/features/member/manage-actions.ts
+++ b/src/features/member/manage-actions.ts
@@ -54,15 +54,12 @@ import { buildTeamRoles, isRoleOfTeam } from "./team-roles";
 
 const NO_SESSION = "세션이 만료되었습니다. 다시 로그인해 주세요";
 /*
-  아직 못 붙인 것들이 쓰는 문구.
-
-  ⚠️ **"BE 협의 대기"가 아니다.** 각각 이유가 다르다(2026-08-10 BE 실코드 대조):
-    · 휴직·오프보딩 승인/반려 — `handover` 도메인 API(`PATCH /api/handovers/{id}/finalize`
-      ·`/complete`·`/reject`)가 있지만 **어느 것이 이 화면의 "승인"인지 확실하지 않고**,
-      그 도메인은 이 화면 담당이 아니다. 담당자와 맞춘 뒤 붙인다.
-    · 계정 삭제 — **BE에 경로가 없다.** `MemberController`·`ManageMemberController` 어디에도
-      `@DeleteMapping`이 없다. 만들어 달라고 요청해야 한다.
+  아직 못 붙인 것 — 계정 삭제. **BE에 경로가 없다.** `MemberController`·`ManageMemberController`
+  어디에도 `@DeleteMapping`이 없다. 만들어 달라고 요청해야 한다.
   화면에는 이 문구가 그대로 뜬다 — 되는 척하지 않는다(§정직성).
+
+  ⚠️ 휴직·오프보딩 승인/반려는 더는 여기 안 걸린다(2026-08-12 실 연동) — `PATCH
+     /api/handovers/{id}/finalize`·`/reject`로 확인 끝났다(아래 두 함수 참고).
 */
 const NOT_CONNECTED = "아직 연결되지 않은 기능입니다";
 
@@ -288,20 +285,36 @@ export async function approveHandoverAction(id: number): Promise<MemberActionRes
   const pass = await gate(canApproveFinal, "최종 승인은 대표만 할 수 있습니다");
   if ("denied" in pass) return { isSuccess: false, message: pass.denied };
 
-  if (!isMock) {
-    // TODO(BE 협의): `POST /companies/me/members/{id}/handover/approve`
-    return { isSuccess: false, message: NOT_CONNECTED };
+  if (isMock) {
+    const pendingHandover = findMockManagedMember(id)?.pendingHandover;
+    if (!pendingHandover) {
+      return { isSuccess: false, message: NO_PENDING };
+    }
+    if (pendingHandover.requesterAuthority !== AUTHORITY.LEADER && !pendingHandover.midApproval) {
+      return { isSuccess: false, message: NO_MID_APPROVAL };
+    }
+    approveMockHandover(id);
+  } else {
+    /*
+      ⚠️ **중간 승인 검사는 여기서 다시 안 한다.** BE `finalizeApproval`이 이미 그 규칙을
+         갖고 있다(`status !== REASSIGNED && !directOffboardingFinalizeAllowed`이면
+         `HO_FINALIZE_NOT_ALLOWED`) — 화면이 잘못 눌러도 서버가 막고, 그 메시지를
+         `toUserMessage`로 그대로 보여준다. 규칙을 여기서 다시 베끼면 BE가 바뀔 때 둘이 갈린다.
+    */
+    const pendingHandover = (await getManagedMember(id))?.pendingHandover;
+    if (!pendingHandover) return { isSuccess: false, message: NO_PENDING };
+
+    const accessToken = await requireAccessToken();
+    try {
+      await serverApi<unknown>(ep.handoverFinalize(Number(pendingHandover.id)), {
+        method: "PATCH",
+        accessToken,
+      });
+    } catch (error) {
+      return { isSuccess: false, message: toUserMessage(error) };
+    }
   }
 
-  const pendingHandover = findMockManagedMember(id)?.pendingHandover;
-  if (!pendingHandover) {
-    return { isSuccess: false, message: NO_PENDING };
-  }
-  if (pendingHandover.requesterAuthority !== AUTHORITY.LEADER && !pendingHandover.midApproval) {
-    return { isSuccess: false, message: NO_MID_APPROVAL };
-  }
-
-  approveMockHandover(id);
   revalidatePath(pathOf(id));
   revalidatePath("/manage/members");
   revalidatePath(PEOPLE_PATH);
@@ -322,25 +335,33 @@ export async function rejectHandoverAction(
 
   if (!reason.trim()) return { isSuccess: false, message: "반려 사유를 입력해 주세요" };
 
-  /*
-    ⚠️ **사유가 지금은 아무 데도 안 남는다.** 받아서 검사만 하고 버린다 — 저장할 자리도
-       (`PendingHandover`에 필드가 없다) 보여줄 화면도 없다. 그런데도 받는 이유는 BE가
-       이 값을 요구할 자리이고, 빈 사유로 되돌리는 걸 지금부터 막아 두는 편이 낫기
-       때문이다. 연결되면 아래 TODO에서 함께 보낸다.
-    ⚠️ 화면에도 "전달됩니다"라고 쓰지 않는다(§정직성) — `handover-approval-card` 주석 참고.
-  */
+  if (isMock) {
+    /*
+      ⚠️ **사유가 지금은 아무 데도 안 남는다**(mock) — 받아서 검사만 하고 버린다. 실 연동은
+         `reason`을 `PATCH .../reject` 본문에 그대로 싣는다(BE `RejectHandoverRequest.reason`).
+      ⚠️ **신청자가 사유를 어디서 보는지는 아직 안 정해졌다**(알림 화면이 없다) — 화면에도
+         "전달됩니다"라고 쓰지 않는다(§정직성, `handover-approval-card` 주석 참고).
+    */
+    if (!findMockManagedMember(id)?.pendingHandover) {
+      return { isSuccess: false, message: NO_PENDING };
+    }
+    rejectMockHandover(id);
+  } else {
+    const pendingHandover = (await getManagedMember(id))?.pendingHandover;
+    if (!pendingHandover) return { isSuccess: false, message: NO_PENDING };
 
-  if (!isMock) {
-    // TODO(BE 협의): `POST /companies/me/members/{id}/handover/reject` — `reason`을 함께 보낸다.
-    //   신청자가 그 사유를 **어디서 보는지**도 같이 정해야 한다(알림 화면이 없다).
-    return { isSuccess: false, message: NOT_CONNECTED };
+    const accessToken = await requireAccessToken();
+    try {
+      await serverApi<unknown>(ep.handoverReject(Number(pendingHandover.id)), {
+        method: "PATCH",
+        json: { reason },
+        accessToken,
+      });
+    } catch (error) {
+      return { isSuccess: false, message: toUserMessage(error) };
+    }
   }
 
-  if (!findMockManagedMember(id)?.pendingHandover) {
-    return { isSuccess: false, message: NO_PENDING };
-  }
-
-  rejectMockHandover(id);
   revalidatePath(pathOf(id));
   revalidatePath("/manage/members");
   revalidatePath(PEOPLE_PATH);

--- a/src/features/member/manage-actions.ts
+++ b/src/features/member/manage-actions.ts
@@ -301,11 +301,11 @@ export async function approveHandoverAction(id: number): Promise<MemberActionRes
          `HO_FINALIZE_NOT_ALLOWED`) — 화면이 잘못 눌러도 서버가 막고, 그 메시지를
          `toUserMessage`로 그대로 보여준다. 규칙을 여기서 다시 베끼면 BE가 바뀔 때 둘이 갈린다.
     */
-    const pendingHandover = (await getManagedMember(id))?.pendingHandover;
-    if (!pendingHandover) return { isSuccess: false, message: NO_PENDING };
-
-    const accessToken = await requireAccessToken();
     try {
+      const pendingHandover = (await getManagedMember(id))?.pendingHandover;
+      if (!pendingHandover) return { isSuccess: false, message: NO_PENDING };
+
+      const accessToken = await requireAccessToken();
       await serverApi<unknown>(ep.handoverFinalize(Number(pendingHandover.id)), {
         method: "PATCH",
         accessToken,
@@ -347,11 +347,11 @@ export async function rejectHandoverAction(
     }
     rejectMockHandover(id);
   } else {
-    const pendingHandover = (await getManagedMember(id))?.pendingHandover;
-    if (!pendingHandover) return { isSuccess: false, message: NO_PENDING };
-
-    const accessToken = await requireAccessToken();
     try {
+      const pendingHandover = (await getManagedMember(id))?.pendingHandover;
+      if (!pendingHandover) return { isSuccess: false, message: NO_PENDING };
+
+      const accessToken = await requireAccessToken();
       await serverApi<unknown>(ep.handoverReject(Number(pendingHandover.id)), {
         method: "PATCH",
         json: { reason },

--- a/src/features/member/manage-server.ts
+++ b/src/features/member/manage-server.ts
@@ -1,5 +1,7 @@
 import "server-only";
 
+import type { Authority } from "@/constants/authority";
+import { HANDOVER_TYPE, type HandoverType } from "@/constants/handover";
 import { isVisibleMemberStatus } from "@/constants/member";
 import { requireAccessToken } from "@/features/auth/session";
 import { ApiError, serverApi } from "@/lib/api";
@@ -14,12 +16,84 @@ import {
   toBeFilter,
   toManagedMember,
 } from "./manage-mapper";
-import type { ManagedMember, ManagedMemberDetail, MemberQuery } from "./manage-types";
+import type {
+  ManagedMember,
+  ManagedMemberDetail,
+  MemberQuery,
+  PendingHandover,
+} from "./manage-types";
 import {
   findMockManagedMember,
   listMockManagedMembers,
   listMockMemberEmails,
 } from "./mock/managed";
+
+/** [확인] BE `HandoverSummaryResponse` — `team-handover/mapper.ts`와 같은 응답. */
+interface BeHandoverSummaryResponse {
+  id: number;
+  writerMemberId: number;
+  handoverType: string;
+  status: string;
+  leaveStartAt: string | null;
+  leaveEndAt: string | null;
+  itemCount: number;
+}
+
+/** [확인] BE `HandoverResponse` — 중간 승인자·시각만 본다(나머지는 목록 응답에 이미 있다). */
+interface BeHandoverDetailForApproval {
+  intermediateApproverNameSnap: string | null;
+  intermediateApprovedAt: string | null;
+}
+
+/**
+ * 이 사원 명의로 처리 대기 중인 인수인계서 — `GET /api/handovers`(OWNER면 회사 전체,
+ * 페이지네이션 없음)에서 `writerMemberId`로 찾는다. `status` 파라미터가 없어 전부 받아
+ * 거른다 — 인수인계서는 회사 규모라 프로젝트·액션처럼 페이지 단위가 아니다.
+ *
+ * ⚠️ **신청 당시 권한 스냅샷을 BE가 안 준다.** `requesterAuthority`는 지금 권한
+ *    (`currentAuthority`)으로 근사한다 — 팀장 공석 중 승급된 사람이 신청했다면 그때는
+ *    일반 팀원이었어도 지금은 팀장으로 읽힌다(알려진 한계, mock은 신청 시점 값을 그대로
+ *    굳혀 두지만 실 데이터엔 그 스냅샷이 없다).
+ */
+async function findPendingHandoverForMember(
+  memberId: number,
+  currentAuthority: Authority,
+  accessToken: string,
+): Promise<PendingHandover | null> {
+  const summaries = await serverApi<BeHandoverSummaryResponse[]>(ep.handovers(), { accessToken });
+  const pending = summaries.find(
+    (h) => h.writerMemberId === memberId && (h.status === "SUBMITTED" || h.status === "REASSIGNED"),
+  );
+  if (!pending) return null;
+
+  const type = pending.handoverType as HandoverType;
+  const period =
+    type === HANDOVER_TYPE.VACATION && pending.leaveStartAt && pending.leaveEndAt
+      ? { from: pending.leaveStartAt.slice(0, 10), to: pending.leaveEndAt.slice(0, 10) }
+      : null;
+
+  let midApproval: PendingHandover["midApproval"] = null;
+  if (pending.status === "REASSIGNED") {
+    const detail = await serverApi<BeHandoverDetailForApproval>(ep.handover(pending.id), {
+      accessToken,
+    });
+    if (detail.intermediateApproverNameSnap && detail.intermediateApprovedAt) {
+      midApproval = {
+        approverName: detail.intermediateApproverNameSnap,
+        approvedAt: detail.intermediateApprovedAt.slice(0, 10),
+      };
+    }
+  }
+
+  return {
+    id: String(pending.id),
+    type,
+    period,
+    actionCount: pending.itemCount,
+    midApproval,
+    requesterAuthority: currentAuthority,
+  };
+}
 
 /**
  * 사원 조회 — **격리막**(CLAUDE.md §Mock 격리막).
@@ -128,9 +202,9 @@ export async function getManagedMember(id: number): Promise<ManagedMemberDetail 
 
   /*
     [확인] BE `MemberController.detail` — `GET /api/members/{memberId}`.
-    ⚠️ **액션·대기 신청은 이 응답에 없다.** BE `MemberDetailResponse`가 주는 건 사람 정보뿐이라,
-       지금은 그 둘을 빈 값으로 둔다 — 지어내지 않는다(§정직성). 액션 목록 API가 붙으면
-       여기서 함께 읽어 채운다.
+    ⚠️ **담당 액션은 아직 이 응답에 없다.** BE `MemberDetailResponse`가 주는 건 사람 정보뿐이라,
+       지금은 빈 값으로 둔다 — 지어내지 않는다(§정직성). 액션 목록 API가 붙으면 여기서 함께
+       읽어 채운다. (인수인계 대기 신청은 `findPendingHandoverForMember`가 채운다, 2026-08-12.)
   */
   const accessToken = await requireAccessToken();
   let detail: BeMemberDetail;
@@ -150,7 +224,8 @@ export async function getManagedMember(id: number): Promise<ManagedMemberDetail 
   const member = toManagedMember(detail);
   if (!isVisibleMemberStatus(member.status)) return null;
 
-  return { member, actions: [], pendingHandover: null };
+  const pendingHandover = await findPendingHandoverForMember(id, member.authority, accessToken);
+  return { member, actions: [], pendingHandover };
 }
 
 /** 이미 쓰고 있는 메일 주소 — 중복 발급을 막는다 */

--- a/src/features/member/manage-server.ts
+++ b/src/features/member/manage-server.ts
@@ -47,8 +47,9 @@ interface BeHandoverDetailForApproval {
 
 /**
  * 이 사원 명의로 처리 대기 중인 인수인계서 — `GET /api/handovers`(OWNER면 회사 전체,
- * 페이지네이션 없음)에서 `writerMemberId`로 찾는다. `status` 파라미터가 없어 전부 받아
- * 거른다 — 인수인계서는 회사 규모라 프로젝트·액션처럼 페이지 단위가 아니다.
+ * 페이지네이션 없음)에서 `writerMemberId`로 찾는다. **대기 중인 두 상태만** 따로
+ * 조회한다(`status=SUBMITTED`·`status=REASSIGNED`) — 전체 이력(FINALIZED·REJECTED
+ * 포함)을 받아 오면 회사가 커질수록 이 화면 하나의 응답 크기가 계속 늘어난다.
  *
  * ⚠️ **신청 당시 권한 스냅샷을 BE가 안 준다.** `requesterAuthority`는 지금 권한
  *    (`currentAuthority`)으로 근사한다 — 팀장 공석 중 승급된 사람이 신청했다면 그때는
@@ -60,10 +61,11 @@ async function findPendingHandoverForMember(
   currentAuthority: Authority,
   accessToken: string,
 ): Promise<PendingHandover | null> {
-  const summaries = await serverApi<BeHandoverSummaryResponse[]>(ep.handovers(), { accessToken });
-  const pending = summaries.find(
-    (h) => h.writerMemberId === memberId && (h.status === "SUBMITTED" || h.status === "REASSIGNED"),
-  );
+  const [submitted, reassigned] = await Promise.all([
+    serverApi<BeHandoverSummaryResponse[]>(ep.handovers({ status: "SUBMITTED" }), { accessToken }),
+    serverApi<BeHandoverSummaryResponse[]>(ep.handovers({ status: "REASSIGNED" }), { accessToken }),
+  ]);
+  const pending = [...submitted, ...reassigned].find((h) => h.writerMemberId === memberId);
   if (!pending) return null;
 
   const type = pending.handoverType as HandoverType;

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -152,7 +152,12 @@ export const ep = {
   todoComplete: (id: number) => `/api/todos/${id}/complete`,
 
   /* 인수인계 */
-  handovers: () => "/api/handovers",
+  /**
+   * 목록 — [확인] `HandoverController.list`. 조회 범위(본인/자기팀/회사 전체)는 **토큰이 정한다**,
+   * 파라미터로 안 받는다 — `status`만 클라이언트가 거른다.
+   */
+  handovers: (params?: { status?: "SUBMITTED" | "REASSIGNED" | "FINALIZED" | "REJECTED" }) =>
+    `/api/handovers${toQuery(params)}`,
   handover: (id: number) => `/api/handovers/${id}`,
   /** 상세 리치뷰(타임라인·회의맥락·수신자별 그룹) — BE 인수인계 문서(2026-08-10) §2. */
   handoverPackage: (id: number) => `/api/handovers/${id}/package`,
@@ -164,6 +169,8 @@ export const ep = {
   handoverComplete: (id: number) => `/api/handovers/${id}/complete`,
   handoverFinalize: (id: number) => `/api/handovers/${id}/finalize`,
   handoverReject: (id: number) => `/api/handovers/${id}/reject`,
+  /** 팀장 오프보딩 귀속 대기 일괄 이전 — OWNER·ADMIN 전용. */
+  handoverAttributeToLeader: (id: number) => `/api/handovers/${id}/attribute-to-leader`,
 
   /* 조직 */
   /* 조직 — [확인] identity/member/presentation/api/{Member,ManageMember}Controller.java */


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가

---

## 🗂 작업 영역

- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

인수인계 흐름의 나머지 세 조각을 mock에서 실 API로 전환한다(#383 팀장 중간승인의 후속).

- `/app/handover` — `submitHandoverAction`이 `POST /api/handovers`를 실제로 호출. 팀장 본인 휴직 자가 재배정은 건별 `PATCH .../items/{actionId}/reassign`으로 뒤따라 보낸다(BE 생성 바디에 그 필드가 없다).
- `/manage/members/[memberId]` — `approveHandoverAction`/`rejectHandoverAction`이 `PATCH /api/handovers/{id}/finalize`·`/reject` 호출. `getManagedMember`가 이제 실제로 대기 신청을 채운다(`findPendingHandoverForMember`).
- `/owner/leader-handovers` — 목록·상세·귀속(`attribute-to-leader`) 전부 실 연동.
- 세 화면 모두 코드에 남아 있던 "TODO(BE 협의)"·"서버 연동 미구현"을 제거. `approveHandoverAction`의 TODO 경로가 실제 BE에 존재하지 않는 경로였어서 BE 실코드(`HandoverController`)를 대조해 진짜 경로(`finalize`/`reject`/`attribute-to-leader`)로 교체.
- `getManagedMember`의 실 브랜치가 고정 반환하던 `pendingHandover: null`을 `GET /api/handovers`(회사 전체, writerMemberId로 매칭)로 채움.
- `/owner/leader-handovers`의 `ASSIGNED` 필터는 BE `pending-attribution` 전용 경로가 못 줘서 `GET /api/handovers?status=FINALIZED`를 받아 `reassignRequiredCount`/`reassignedCount`로 직접 가름.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**(회의 담당자 등), 그리고 **서버(Server Action/BFF)에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [x] 🕵️ **정직성** — mock 환경에서는 기존 테스트 흐름을 계속 사용할 수 있도록 분기 유지, 실 연동 미구현 TODO/placeholder 제거
- [ ] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그)
- [ ] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [ ] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인)
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 반려 사유·서버 오류 메시지가 화면에 표시됨
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음

---

## 🔗 연관 이슈

Closes #388

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- `lib/endpoints.ts`의 `handovers()` `status` 쿼리 파라미터는 #384(팀장 중간승인 PR)에서도 독립적으로 추가했다 — 같은 줄이라 머지 순서에 따라 사소한 충돌이 날 수 있다(내용은 동일).
- 각 액션이 올바른 엔드포인트를 부르는지, `NOT_CONNECTED` placeholder가 승인/반려 경로에서 빠졌는지 확인 필요.

---

## 📝 추가 메모

- `npx tsc --noEmit` · `npx eslint` · `npx jest` 전부 통과
- mock 모드에서 세 화면 모두 브라우저로 직접 확인 — `/app/handover`(휴직 신청 폼), `/owner/leader-handovers`(+상세), `/manage/members/3`(이하윤, 대기 중인 휴직 최종승인 카드) 정상 렌더
