### PR TITLE
[FEAT] 확정 대기 회의 목록 API 연동 (MEET-10) #390

### DIFF
--- a/src/app/(shell)/app/meeting/[meetingId]/page.tsx
+++ b/src/app/(shell)/app/meeting/[meetingId]/page.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 
 import { MeetingDetailView } from "@/features/meeting/components/meeting-detail-view";
 import { getMeetingDetail } from "@/features/meeting/server";
+import { canEditMeetingAttendees } from "@/features/meeting/status";
 import { getReservableMembers } from "@/features/rooms/server";
 import { getViewer } from "@/features/shell/viewer";
 
@@ -85,9 +86,7 @@ export default async function MeetingDetailPage({
     ⚠️ 참석자 후보 목록은 **host이고 아직 안 끝난 회의일 때만** 가져온다(MEET-09 편집 조건과
     같다) — 그 외엔 다이얼로그 자체가 안 뜨는데 목록만 미리 불러오면 헛수고다.
   */
-  const canEditAttendees =
-    result.detail.isHost &&
-    (result.detail.pendingReason === "SCHEDULED" || result.detail.pendingReason === "IN_PROGRESS");
+  const canEditAttendees = canEditMeetingAttendees(result.detail);
   const members = canEditAttendees ? await getReservableMembers() : [];
 
   return (

--- a/src/constants/meeting.ts
+++ b/src/constants/meeting.ts
@@ -21,6 +21,11 @@ export const MEETING_STATUS_LABEL: Record<MeetingStatus, string> = {
   CANCELED: "취소",
 };
 
+/** URL 쿼리처럼 바깥에서 들어오는 값을 검증할 때 쓴다(`isVisibleMemberStatus`와 같은 패턴). */
+export function isMeetingStatus(value: string): value is MeetingStatus {
+  return (Object.values(MEETING_STATUS) as string[]).includes(value);
+}
+
 /** 캡처 세션 — 담당자만 조작 가능(권한 2축, lib/permission.ts) */
 export const CAPTURE_STATUS = {
   IDLE: "IDLE",

--- a/src/features/meeting/actions.ts
+++ b/src/features/meeting/actions.ts
@@ -37,7 +37,8 @@ function toAttendeesErrorMessage(error: unknown): string {
  * 재사용하는 다이얼로그(`MeetingAttendeesEditDialog`)가 이 액션을 부른다.
  * ⚠️ 권한은 `canManageMeeting`(host·OWNER·ADMIN) 하나로 본다 — 화면 가드는 UX일 뿐이라
  *    여기서 다시 확인한다(§권한).
- * ⚠️ **host는 자동 포함·제거 불가**다 — 폼에서 빠졌어도 여기서 끼워 넣는다.
+ * ⚠️ **host는 자동 포함·제거 불가**다 — 이 액션이 직접 끼워 넣지는 않는다. mock 분기는
+ *    `updateMockMeetingAttendees`가, 실연동은 서버(BE)가 그 규칙을 보장한다.
  */
 export async function updateMeetingAttendeesAction(
   _prev: UpdateMeetingAttendeesState,

--- a/src/features/meeting/components/meeting-attendees-edit-dialog.tsx
+++ b/src/features/meeting/components/meeting-attendees-edit-dialog.tsx
@@ -39,11 +39,11 @@ export function MeetingAttendeesEditDialog({
     updateMeetingAttendeesAction,
     INITIAL_STATE,
   );
-  const handledAt = useRef<number>(0);
+  const handled = useRef<number[] | null>(null);
 
   useEffect(() => {
-    if (state.attendeeIds && handledAt.current !== state.attendeeIds.length) {
-      handledAt.current = state.attendeeIds.length;
+    if (state.attendeeIds && handled.current !== state.attendeeIds) {
+      handled.current = state.attendeeIds;
       setOpen(false);
       toast.success("참석자 명단을 바꿨습니다");
     }

--- a/src/features/meeting/components/meeting-detail-view.tsx
+++ b/src/features/meeting/components/meeting-detail-view.tsx
@@ -20,6 +20,7 @@ import { ACTION_STATUS_LABEL } from "@/constants/action";
 import type { RoomMember } from "@/features/rooms/types";
 import { formatDate } from "@/lib/date";
 
+import { canCancelMeeting, canEditMeetingAttendees } from "../status";
 import type { MeetingContentPending, MeetingDetail } from "../view-types";
 import { MeetingAttendeesEditDialog } from "./meeting-attendees-edit-dialog";
 import { MeetingCancelDialog } from "./meeting-cancel-dialog";
@@ -203,19 +204,8 @@ interface MeetingDetailViewProps {
 
 export function MeetingDetailView({ detail, members, viewerTeamName }: MeetingDetailViewProps) {
   const actionsState = actionsSectionStateOf(detail);
-  /*
-    ⚠️ 참석자 교체는 **host만, 끝나지 않은 회의에서만**(MEET-09 규칙). `pendingReason`이
-    "SCHEDULED"·"IN_PROGRESS"일 때만 회의가 아직 안 끝났다는 뜻이다(§view-types) — 그 값이
-    `SUMMARIZING`·`FAILED`·`null`이면 이미 DONE이라 교체할 수 없다.
-  */
-  const canEditAttendees =
-    detail.isHost &&
-    (detail.pendingReason === "SCHEDULED" || detail.pendingReason === "IN_PROGRESS");
-  /*
-    ⚠️ 취소는 참석자 교체보다 조건이 좁다 — **시작 전(SCHEDULED)만**(MEET-06 규칙: "시작 전
-    회의만 취소 가능"). 진행중은 종료(MEET-08, 캡처 화면)를 써야 한다.
-  */
-  const canCancel = detail.isHost && detail.pendingReason === "SCHEDULED";
+  const canEditAttendees = canEditMeetingAttendees(detail);
+  const canCancel = canCancelMeeting(detail);
 
   return (
     /*

--- a/src/features/meeting/mapper.ts
+++ b/src/features/meeting/mapper.ts
@@ -4,7 +4,7 @@
  */
 
 import type { DashboardMeeting } from "@/components/common/dashboard-meeting-item";
-import type { MeetingStatus } from "@/constants/meeting";
+import { isMeetingStatus } from "@/constants/meeting";
 
 import { formatMeetingSchedule } from "./lib";
 import type { CaptureAttendee, MeetingCaptureInfo } from "./view-types";
@@ -42,11 +42,15 @@ export interface BeUpcomingMeetingsResponse {
  *    화면의 카드에만 있음) 쓰지 않는다 — 화면에 없는 기능을 새로 만들지 않는다(§명세).
  */
 export function toDashboardMeeting(be: BeUpcomingMeeting): DashboardMeeting {
+  if (!isMeetingStatus(be.status)) {
+    throw new Error(`알 수 없는 회의 상태입니다: ${be.status}`);
+  }
+
   return {
     id: String(be.meetingId),
     title: be.title,
     projectTag: be.project.tag,
-    status: be.status as MeetingStatus,
+    status: be.status,
     room: be.meetingRoom.name,
     scheduledAt: be.startAt,
     attendeeCount: be.attendeeCount,

--- a/src/features/meeting/mock/seed.ts
+++ b/src/features/meeting/mock/seed.ts
@@ -284,7 +284,7 @@ export function ensureMockMeetingsSeeded(): void {
     hostAuthority: AUTHORITY.OWNER,
     roomReservationId: "seed-reservation-8",
   });
-  cancelMockMeeting(canceled.id, "2026-08-13T09:00:00.000Z");
+  cancelMockMeeting(canceled.id, "2026-08-11T09:00:00.000Z");
 }
 
 /** 테스트 전용 — 시드를 되돌린다(스토어는 `meetings.ts`가 들고 있어 함께 비운다) */

--- a/src/features/meeting/review/mapper.test.ts
+++ b/src/features/meeting/review/mapper.test.ts
@@ -1,0 +1,21 @@
+import { type BePendingActionDistributionMeeting, toPendingReviewSummary } from "./mapper";
+
+/** MEET-10 응답 그대로 — 필드 이름을 BE 실코드에 맞춰 둔다 */
+const BASE: BePendingActionDistributionMeeting = {
+  meetingId: 13,
+  title: "주간 백엔드 회의",
+  status: "DONE",
+  startAt: "2026-08-07T14:00:00",
+  pendingActionCount: 3,
+  project: { projectId: 12, tag: "Z-GROUPWARE", name: "잇다 그룹웨어" },
+};
+
+describe("toPendingReviewSummary", () => {
+  it("id를 문자열로 바꾸고 화면이 쓰는 필드만 남긴다", () => {
+    expect(toPendingReviewSummary(BASE)).toEqual({
+      meetingId: "13",
+      meetingTitle: "주간 백엔드 회의",
+      actionCount: 3,
+    });
+  });
+});

--- a/src/features/meeting/review/mapper.ts
+++ b/src/features/meeting/review/mapper.ts
@@ -1,0 +1,38 @@
+/**
+ * BE shape → UI 계약(§Mock 격리막). 컴포넌트는 이 파일을 모른다 — `server.ts`만 쓴다.
+ * [확인] D도메인 REST API 명세(2026-08-12) 대조.
+ */
+
+import type { PendingReviewSummary } from "./types";
+
+/**
+ * `GET /api/meetings/pending-action-distributions`(MEET-10, 구현 완료) 목록 원소.
+ * ⚠️ `status`·`startAt`·`project`도 오지만 마이페이지 위젯(회의 제목·액션 건수만 표시)은
+ *    안 쓴다 — 안 쓰는 필드는 적지 않는다(`BeMeetingDetail`과 같은 원칙).
+ */
+export interface BePendingActionDistributionMeeting {
+  meetingId: number;
+  title: string;
+  status: string;
+  startAt: string;
+  pendingActionCount: number;
+  project: { projectId: number; tag: string; name: string };
+}
+
+export interface BePendingActionDistributionsResponse {
+  meetings: BePendingActionDistributionMeeting[];
+}
+
+/**
+ * 마이페이지 "미확정 액션" 목록이 받는 모양으로 바꾼다.
+ * ⚠️ `meetingId`는 BE가 숫자로 주지만 화면 계약은 문자열이다(다른 회의 id와 동일 규칙).
+ */
+export function toPendingReviewSummary(
+  be: BePendingActionDistributionMeeting,
+): PendingReviewSummary {
+  return {
+    meetingId: String(be.meetingId),
+    meetingTitle: be.title,
+    actionCount: be.pendingActionCount,
+  };
+}

--- a/src/features/meeting/review/server.ts
+++ b/src/features/meeting/review/server.ts
@@ -1,6 +1,11 @@
+import { requireAccessToken } from "@/features/auth/session";
 import { getViewer } from "@/features/shell/viewer";
+import { serverApi } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
 import { canOperateMeeting } from "@/lib/permission";
+import { isMock } from "@/mocks/config";
 
+import { type BePendingActionDistributionsResponse, toPendingReviewSummary } from "./mapper";
 import { findMockMeetingReview, listMockPendingReviewMeetingIds } from "./mock/review";
 import type { MeetingReviewInfo, MeetingReviewResult, PendingReviewSummary } from "./types";
 
@@ -23,10 +28,23 @@ export async function getMeetingReview(meetingId: string): Promise<MeetingReview
 /**
  * 마이페이지 "미확정 액션" 탭 — 이 사람이 Host이고 아직 [액션 분배 확정]을 안 누른
  * 회의만 회의 제목 단위로 모아 보여준다(WORKFLOW.md §3-4 "Host만 접근"과 같은 축).
+ *
+ * ⚠️ `GET /api/meetings/pending-action-distributions`(MEET-10, 구현 완료)는 **서버가 이미
+ *    host 본인 회의로 스코프한다** — 역할이 아니라 `hostMemberId` 일치가 기준이라 OWNER·ADMIN도
+ *    남의 회의는 안 온다. 그래서 실서버 경로엔 `viewerId` 필터가 없다(목 경로만 직접 거른다).
  */
 export async function listPendingReviewsForViewer(
   viewerId: number,
 ): Promise<PendingReviewSummary[]> {
+  if (!isMock) {
+    const accessToken = await requireAccessToken();
+    const { meetings } = await serverApi<BePendingActionDistributionsResponse>(
+      ep.meetingsPendingActionDistributions(),
+      { accessToken },
+    );
+    return meetings.map(toPendingReviewSummary);
+  }
+
   return listMockPendingReviewMeetingIds()
     .map((meetingId) => findMockMeetingReview(meetingId))
     .filter((review): review is MeetingReviewInfo => review !== null)

--- a/src/features/meeting/server.ts
+++ b/src/features/meeting/server.ts
@@ -101,8 +101,8 @@ export async function getMeetingDirectory(viewerId: number): Promise<MeetingDire
 
   items.sort((a, b) => {
     if (rank[a.status] !== rank[b.status]) return rank[a.status] - rank[b.status];
-    // 예정은 가까운 회의부터, 완료·취소는 최근 회의부터
-    return a.status === MEETING_STATUS.SCHEDULED
+    // 예정·진행중은 가까운 회의부터, 완료·취소는 최근 회의부터
+    return a.status === MEETING_STATUS.SCHEDULED || a.status === MEETING_STATUS.IN_PROGRESS
       ? startOf(a) - startOf(b)
       : startOf(b) - startOf(a);
   });

--- a/src/features/meeting/status.ts
+++ b/src/features/meeting/status.ts
@@ -1,6 +1,7 @@
 import { AI_SUMMARY_STATUS, MEETING_STATUS, type MeetingStatus } from "@/constants/meeting";
 
 import type { Meeting } from "./types";
+import type { MeetingDetail } from "./view-types";
 import type { MeetingListItem } from "./view-types";
 
 /**
@@ -61,4 +62,24 @@ export function meetingCardAffordanceOf(
   if (meeting.aiSummaryStatus === AI_SUMMARY_STATUS.REVIEWED && meeting.isHost) return "review";
 
   return "open";
+}
+
+/**
+ * 참석자 명단 교체(MEET-09) 가능 여부 — **host만, 끝나지 않은 회의에서만**. `pendingReason`이
+ * "SCHEDULED"·"IN_PROGRESS"일 때만 회의가 아직 안 끝났다는 뜻이다(§view-types) — 그 값이
+ * `SUMMARIZING`·`FAILED`·`null`이면 이미 DONE이라 교체할 수 없다.
+ * ⚠️ 판정은 여기 한 곳이다 — 회의 상세 화면과 그 서버 컴포넌트가 각자 조합하면 조건이 갈린다.
+ */
+export function canEditMeetingAttendees(
+  detail: Pick<MeetingDetail, "isHost" | "pendingReason">,
+): boolean {
+  return (
+    detail.isHost &&
+    (detail.pendingReason === "SCHEDULED" || detail.pendingReason === "IN_PROGRESS")
+  );
+}
+
+/** 회의 취소(MEET-06) 가능 여부 — **시작 전(SCHEDULED)만**. 진행중은 종료(MEET-08)를 써야 한다. */
+export function canCancelMeeting(detail: Pick<MeetingDetail, "isHost" | "pendingReason">): boolean {
+  return detail.isHost && detail.pendingReason === "SCHEDULED";
 }

--- a/src/features/member/server.ts
+++ b/src/features/member/server.ts
@@ -24,7 +24,11 @@ export async function getMemberDashboardOverview(): Promise<MemberDashboardOverv
         시절 목이다. 지금은 SCHEDULED·IN_PROGRESS만, 가까운 시간부터.
       */
       attendedMeetings: [...MEMBER_ATTENDED_MEETINGS_MOCK]
-        .filter((meeting) => meeting.status !== MEETING_STATUS.DONE)
+        .filter(
+          (meeting) =>
+            meeting.status === MEETING_STATUS.SCHEDULED ||
+            meeting.status === MEETING_STATUS.IN_PROGRESS,
+        )
         .sort((a, b) => new Date(a.scheduledAt).getTime() - new Date(b.scheduledAt).getTime())
         .slice(0, MEETING_MAX_ITEMS),
     };
@@ -34,20 +38,18 @@ export async function getMemberDashboardOverview(): Promise<MemberDashboardOverv
   //    본인 소유분만 스코프돼 있어서(토큰 기준), 여기선 PERSONAL만 남기고 마감 임박 필터·
   //    정렬만 클라에서 한다(BE 목록에 이 필터 자체가 없다).
   const accessToken = await requireAccessToken();
-  const page = await serverApi<BePageResponse<BeActionSummary>>(ep.actions({ size: 9999 }), {
-    accessToken,
-  });
+  const [page, { meetings }] = await Promise.all([
+    serverApi<BePageResponse<BeActionSummary>>(ep.actions({ size: 9999 }), { accessToken }),
+    // "참석 회의" = 내 예정 회의(MEET-03) — 정렬·필터(SCHEDULED/IN_PROGRESS·가까운 순)는 서버가 한다.
+    serverApi<BeUpcomingMeetingsResponse>(ep.meetingsUpcoming({ limit: MEETING_MAX_ITEMS }), {
+      accessToken,
+    }),
+  ]);
   const dueSoonActions = page.content
     .filter((action) => action.actionType === "PERSONAL")
     .map(toMemberAction)
     .filter(isDueSoon)
     .sort((a, b) => getDaysUntilDue(a.dueDate) - getDaysUntilDue(b.dueDate));
-
-  // "참석 회의" = 내 예정 회의(MEET-03) — 정렬·필터(SCHEDULED/IN_PROGRESS·가까운 순)는 서버가 한다.
-  const { meetings } = await serverApi<BeUpcomingMeetingsResponse>(
-    ep.meetingsUpcoming({ limit: MEETING_MAX_ITEMS }),
-    { accessToken },
-  );
 
   return { dueSoonActions, attendedMeetings: meetings.map(toDashboardMeeting) };
 }

--- a/src/features/rooms/actions.ts
+++ b/src/features/rooms/actions.ts
@@ -5,6 +5,7 @@ import { revalidatePath } from "next/cache";
 import { requireAccessToken } from "@/features/auth/session";
 import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
 import { PROJECT_TEAM_ACTIONS_MOCK } from "@/features/project/mock/team-actions";
+import { getViewer } from "@/features/shell/viewer";
 import { ApiError, serverApi } from "@/lib/api";
 import { ep } from "@/lib/endpoints";
 import { getMockActor } from "@/lib/mock-actor";
@@ -144,7 +145,7 @@ export async function createRoomReservationAction(
   formData: FormData,
 ): Promise<RoomReservationFormState> {
   const draft = readDraft(formData);
-  const actor = getMockActor();
+  const actor = isMock ? getMockActor() : await getViewer();
   const errors = validateRoomReservationDraft(draft, { role: actor.role });
   if (Object.keys(errors).length > 0) return { errors };
 
@@ -319,8 +320,7 @@ export async function deleteMeetingRoomAction(formData: FormData): Promise<void>
     try {
       await serverApi<null>(ep.meetingRoom(Number(id)), { method: "DELETE", accessToken });
     } catch (error) {
-      if (error instanceof ApiError && error.status === 404) return;
-      throw error;
+      if (!(error instanceof ApiError) || error.status !== 404) throw error;
     }
     revalidatePath(MANAGE_ROOMS_PATH);
     revalidatePath(ROOMS_PATH);

--- a/src/features/rooms/mapper.ts
+++ b/src/features/rooms/mapper.ts
@@ -7,6 +7,7 @@
 import type {
   MeetingRoom,
   MeetingRoomDraft,
+  MeetingTopicInput,
   RoomCalendarEvent,
   RoomDayAvailability,
   RoomReservation,
@@ -101,8 +102,10 @@ function toDayCalendarEvents(day: RoomDayAvailability, slotMinutes: number): Roo
 
   const flush = () => {
     if (!current) return;
+    // ⚠️ `meetingId`만 쓰면 같은 회의가 주 전체에서 겹칠 일은 없어도, 여러 날짜를 flatMap하는
+    //    `toRoomCalendarEvents`에서 React key로 그대로 쓰이니 날짜까지 더해 겹칠 여지를 없앤다.
     events.push({
-      id: current.meetingId,
+      id: `${current.meetingId}-${day.date}`,
       title: current.title,
       start: current.start,
       end: current.end,
@@ -209,10 +212,23 @@ function toLocalDateTime(date: Date): string {
   );
 }
 
+/**
+ * 계약이 실제로 받는 안건 모양(대주제 1개 + 소주제 여러 개)으로 좁힌다 — `toCreateMeetingPayload`와
+ * `toReservationFromCreatedMeeting`이 같은 값을 써야 "폼엔 여러 대주제가 있었는데 화면은 하나만
+ * 보여준다" 같은 불일치가 안 생긴다(§정직성: 버려진 값을 저장된 것처럼 보이면 안 된다).
+ */
+function toSentTopics(topics: MeetingTopicInput[]): { mainTopic: string; subTopics: string[] } {
+  return {
+    mainTopic: topics[0]?.main.trim() ?? "",
+    subTopics: topics.map((topic) => topic.sub.trim()).filter((sub) => sub.length > 0),
+  };
+}
+
 export function toCreateMeetingPayload(
   draft: RoomReservationDraft,
   range: { start: Date; end: Date },
 ): BeCreateMeetingPayload {
+  const { mainTopic, subTopics } = toSentTopics(draft.topics);
   return {
     title: draft.title.trim(),
     projectId: Number(draft.projectId),
@@ -222,8 +238,8 @@ export function toCreateMeetingPayload(
     recordingConsent: false,
     relatedActionId: draft.parentTeamActionId,
     attendeeMemberIds: draft.attendeeIds,
-    mainTopic: draft.topics[0]?.main.trim() ?? "",
-    subTopics: draft.topics.map((topic) => topic.sub.trim()).filter((sub) => sub.length > 0),
+    mainTopic,
+    subTopics,
   };
 }
 
@@ -251,12 +267,16 @@ export interface BeCreateMeetingResponse {
  *    `getMeetingRooms()`를 따로 불러 이름을 찾을 필요가 없다.
  * ⚠️ `projectTag`만 빈 문자열로 남는다 — 계약 확정본에 `project`가 없다(BE가 안 준다, 추측
  *    아님). `revalidatePath` 뒤 캘린더 재조회(ROOM-02, 연동 완료)에는 정확한 값이 나온다.
+ * ⚠️ `topics`는 폼 입력을 그대로 echo하지 않는다 — 계약이 대주제 1개만 받아서(위 `toSentTopics`
+ *    참고) 둘째 쌍부터 `main`은 서버에 안 갔다. 그 값을 화면에 "저장됨"으로 보여주면 거짓말이라
+ *    실제로 보낸 값(첫 대주제 + 소주제 목록)으로만 되짚는다.
  */
 export function toReservationFromCreatedMeeting(
   response: BeCreateMeetingResponse,
   draft: RoomReservationDraft,
   range: { start: Date; end: Date },
 ): RoomReservation {
+  const { mainTopic, subTopics } = toSentTopics(draft.topics);
   return {
     id: String(response.meetingId),
     title: draft.title.trim(),
@@ -266,7 +286,7 @@ export function toReservationFromCreatedMeeting(
     roomName: response.meetingRoom.name,
     projectId: draft.projectId,
     projectTag: "",
-    topics: draft.topics.map((topic) => ({ main: topic.main.trim(), sub: topic.sub.trim() })),
+    topics: subTopics.map((sub) => ({ main: mainTopic, sub })),
     attendeeIds: draft.attendeeIds,
     ownerId: response.host.memberId,
   };

--- a/src/features/rooms/server.ts
+++ b/src/features/rooms/server.ts
@@ -10,6 +10,7 @@ import { ep } from "@/lib/endpoints";
 import { type Actor, requiresParentTeamAction } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
+import { RESERVATION_DURATION_MINUTES } from "./constants";
 import {
   type BeMeetingRoom,
   type BeRoomWeekAvailability,
@@ -30,7 +31,6 @@ import type {
 } from "./types";
 
 const WEEKDAYS_PER_WEEK = 5;
-const SLOT_MINUTES = 30;
 
 function toMinutesOfDay(hhmm: string): number {
   const [hours, minutes] = hhmm.split(":").map(Number);
@@ -51,11 +51,11 @@ function buildMockDaySlots(date: Date, room: MeetingRoom): RoomDayAvailability {
   for (
     let minutesOfDay = toMinutesOfDay(room.openTime);
     minutesOfDay < toMinutesOfDay(room.closeTime);
-    minutesOfDay += SLOT_MINUTES
+    minutesOfDay += RESERVATION_DURATION_MINUTES
   ) {
     const startTime = toHHMM(minutesOfDay);
     const slotStart = new Date(`${format(date, "yyyy-MM-dd")}T${startTime}:00`);
-    const slotEnd = new Date(slotStart.getTime() + SLOT_MINUTES * 60_000);
+    const slotEnd = new Date(slotStart.getTime() + RESERVATION_DURATION_MINUTES * 60_000);
     const overlapping = reservations.find(
       (reservation) => reservation.start < slotEnd && reservation.end > slotStart,
     );
@@ -91,7 +91,7 @@ export async function getRoomWeekAvailability(
 
     return {
       weekStart: format(weekStart, "yyyy-MM-dd"),
-      slotMinutes: SLOT_MINUTES,
+      slotMinutes: RESERVATION_DURATION_MINUTES,
       meetingRoom: room,
       days,
     };

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -64,6 +64,12 @@ export const ep = {
   meetingsUpcoming: (params?: { limit?: number }) => `/api/meetings/upcoming${toQuery(params)}`,
   /** 참석자 명단 교체(MEET-09, 구현 완료) — 전체 명단 교체(부분 추가·삭제 아님). */
   meetingAttendees: (meetingId: number) => `/api/meetings/${meetingId}/attendees`,
+  /**
+   * 확정 대기 회의 목록(MEET-10, 구현 완료 — PR #233) — 마이페이지 "미확정 액션" 위젯용.
+   * [확인] D도메인 REST API 명세(2026-08-12) 대조. 파라미터 없음 — host 본인 회의만 서버가
+   * 자동 스코프한다(전 롤 호출 가능, 판정은 역할이 아니라 `hostMemberId` 일치).
+   */
+  meetingsPendingActionDistributions: () => "/api/meetings/pending-action-distributions",
 
   /*
    * 캡처 — [확인] BE 실코드 대조(2026-08-12, 커밋 `51b5482f` "회의·회의실·공지사항 API 경로 통일" 리팩터 반영)


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

- `ep.meetingsPendingActionDistributions()` 엔드포인트 등록(`/api/meetings/pending-action-distributions`)
- `review/mapper.ts` 신규 — BE 응답을 기존 UI 계약(`PendingReviewSummary`)으로 변환
- `review/server.ts`의 `listPendingReviewsForViewer`에 `isMock` 분기 추가 — 실서버 경로 연동
- 화면(`/app/me` "미확정 액션" 위젯)은 그대로 재사용, 컴포넌트 변경 없음

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/meeting-pending-actions#{이슈번호}`, base `develop`)
- [x] 커밋 컨벤션 준수 (`feat: 확정 대기 회의 목록 API 연동 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 역할 조건 없음, 리소스 소유권(host)은 BE가 서버에서 스코프. 프론트는 별도 판정을 추가하지 않음(중복 판정 아님)
- [ ] 🧬 **zod** — 아직 이 레포에 zod 도입 전, 기존 `isMock` 분기·타입 단언 패턴을 따름(다른 MEET API 연동과 동일)
- [x] 🕵️ **정직성** — 응답에 있는 필드만 매핑, 없는 값을 추측하지 않음
- [x] 🎨 디자인 토큰 — 화면 변경 없음(기존 위젯 재사용)

**품질**

- [x] ⚡ 최적화 — 해당 없음(화면 변경 없음)
- [x] ♿ a11y — 해당 없음(화면 변경 없음)
- [x] ♻️ 재사용 확인 — 기존 컴포넌트·UI 계약 그대로 재사용
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 기존 페이지의 처리 그대로(에러는 `error.tsx`로 throw)
- [ ] 브라우저 전용 API — 해당 없음

---

## 🔗 연관 이슈

Closes #390

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
| (목 데이터, 동일 화면) | (실서버 데이터, 동일 화면 — UI 변경 없음) |

---

## 💬 리뷰 포인트

- `endpoints.ts`에 추가한 경로가 API 명세 아티팩트(2026-08-12)와 일치하는지
- `review/server.ts`의 `isMock` 분기가 다른 회의 API(MEET-03·09 등)와 같은 패턴을 따르는지
- `pendingActionCount` 0건 방어 필터를 넣지 않은 이유(BE 계약이 `count >= 1` 보장) — 매퍼·서버 코드 주석 참고

---

## 📝 추가 메모

같은 명세 문서에서 MEET-15(요약 중단 회의 목록) 스펙도 함께 확인했다 — 다음 작업으로 이어서 진행할 예정.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 미확정 액션이 있는 회의 목록을 실제 서버에서 조회할 수 있습니다.
  - 회의 제목과 미확정 액션 수를 검토 화면에 표시합니다.
  - 회의 식별자가 화면에서 일관된 형식으로 처리됩니다.

- **개선 및 버그 수정**
  - 회의 상태에 따라 참석자 수정 및 회의 취소 가능 여부를 올바르게 적용합니다.
  - 진행 중인 회의를 예정 회의와 동일하게 시작 시간순으로 표시합니다.
  - 예약 생성 시 회의 주제와 일정이 더 정확하게 반영됩니다.
  - 예약 시간 간격을 일관되게 적용합니다.

- **테스트**
  - 서버 응답을 화면용 회의 요약으로 변환하는 동작을 검증했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
