### PR TITLE
[FEAT] AI 액션 분배 검토 화면 실 API 연동 — RVW-01~05·반려 사유 5종 #409

### DIFF
--- a/src/constants/meeting.ts
+++ b/src/constants/meeting.ts
@@ -90,20 +90,31 @@ export const AI_CONFIDENCE_LABEL: Record<AiConfidence, string> = {
 };
 
 /**
- * 액션 분배 리뷰에서 ✕(반려) 클릭 시 고르는 사유 3택(WORKFLOW.md §3-4).
+ * 액션 분배 리뷰에서 ✕(반려) 클릭 시 고르는 사유 5택(WORKFLOW.md §3-4).
  * 담당자·날짜만 고친 경우는 사유가 필요 없다 — ✕로 제외할 때만 고른다.
+ *
+ * ⚠️ **BE `RejectReason`에서 사람이 고르는 값(`isHumanSelectable`)과 1:1이다**
+ *    (2026-08-11 PM 확정으로 3종 → 5종 — [확인] `capture/domain/model/RejectReason.java`).
+ *    `NOT_CONFIRMED`는 `NOT_ACTION`으로 대체됐다 — 옛 값을 보내면 BE enum에 없어 거절된다.
+ * ⚠️ `WRONG_ASSIGNEE` 같은 **수정 사유는 여기 없다.** 사람이 고르는 게 아니라 바뀐 필드를
+ *    보고 BE가 자동으로 붙인다 — 보내면 422(`REVIEW_REASON_NOT_SELECTABLE`).
+ * ⚠️ `ETC`는 텍스트 입력이 없다(PM 확정) — 버튼 하나로 고르는 순수 enum 값이다.
  */
 export const ACTION_REJECT_REASON = {
   HALLUCINATION: "HALLUCINATION",
-  NOT_CONFIRMED: "NOT_CONFIRMED",
   DUPLICATE: "DUPLICATE",
+  NOT_ACTION: "NOT_ACTION",
+  NOT_ATTENDANCE: "NOT_ATTENDANCE",
+  ETC: "ETC",
 } as const;
 export type ActionRejectReason = (typeof ACTION_REJECT_REASON)[keyof typeof ACTION_REJECT_REASON];
 
 export const ACTION_REJECT_REASON_LABEL: Record<ActionRejectReason, string> = {
   HALLUCINATION: "그런 말을 한 적 없음",
-  NOT_CONFIRMED: "논의였는데 확정으로 잘못 인식됨",
   DUPLICATE: "다른 액션과 중복",
+  NOT_ACTION: "액션으로 분배할 내용이 아님",
+  NOT_ATTENDANCE: "담당자가 회의에 참석하지 않음",
+  ETC: "기타",
 };
 
 /*

--- a/src/features/meeting/review/actions.ts
+++ b/src/features/meeting/review/actions.ts
@@ -3,55 +3,184 @@
 import { revalidatePath } from "next/cache";
 
 import type { ActionRejectReason } from "@/constants/meeting";
+import { requireAccessToken } from "@/features/auth/session";
 import { getViewer } from "@/features/shell/viewer";
+import { ApiError, serverApi, toUserMessage } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
 import { assertPermission, canOperateMeeting } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
 import { findMockMeetingReview, markMockReviewConfirmed } from "./mock/review";
 import type { ManualDraftInput } from "./types";
 
-/** Host가 [확정] 누른 시점의 초안 한 건 — 반려 안 된 것만 여기 담겨 온다. */
-export interface ConfirmedDraftInput {
+/**
+ * Host가 [확정] 누른 시점의 판정 한 건 — 반려 안 된 AI 초안이 여기 담겨 온다.
+ *
+ * ⚠️ **고친 칸만 `changes`에 싣는다**(2026-08-12, BE RVW-02 대조). BE는 바뀐 필드를 보고
+ *    `WRONG_ASSIGNEE` 같은 라벨을 자동으로 만들어 AI 학습 재료로 쓴다 — 안 고친 값까지
+ *    "고쳤다"고 보내면 **틀린 배정을 AI에게 가르치는 셈**이다. `changes`가 비면 CONFIRM,
+ *    있으면 MODIFY로 나간다.
+ * ⚠️ `plannedStartDate`는 `changes` 밖이다 — AI가 내지 않는 값이라 "고침"이 아니라
+ *    "사람이 처음 정함"이고, CONFIRM에도 실을 수 있다(BE가 검사에서 일부러 뺐다).
+ */
+export interface ReviewedDraftInput {
+  /** BE `actionId` 문자열 */
   id: string;
-  title: string;
-  description: string;
-  assigneeId: number;
-  startDate: string;
-  dueDate: string;
+  /** 정했을 때만 — 빈 값이면 안 보낸다 */
+  plannedStartDate?: string;
+  changes?: {
+    title?: string;
+    description?: string;
+    assigneeId?: number;
+    dueDate?: string;
+  };
 }
 
-/** ✕로 뺀 초안 — 사유를 남긴다(WORKFLOW.md §3-4, 추후 AI 피드백용). */
+/** ✕로 뺀 초안 — 사유를 남긴다(WORKFLOW.md §3-4, AI 피드백용 라벨이 된다). */
 export interface RejectedDraftInput {
   id: string;
   reason: ActionRejectReason;
 }
 
 export interface ConfirmActionDistributionPayload {
-  confirmed: ConfirmedDraftInput[];
+  reviewed: ReviewedDraftInput[];
   rejected: RejectedDraftInput[];
   manuallyAdded: ManualDraftInput[];
 }
 
 export type ConfirmActionDistributionResult =
-  | { status: "confirmed"; createdCount: number }
-  | { status: "alreadyConfirmed" | "notFound"; createdCount: 0 };
+  | { status: "confirmed"; createdCount: number; skippedCount: number }
+  | { status: "alreadyConfirmed" | "notFound"; createdCount: 0 }
+  /** 확인되지 않은 STT 구간 등으로 BE가 확정을 멈췄다(409) — `force`로만 강행한다 */
+  | { status: "blocked"; message: string }
+  | { status: "failed"; message: string };
+
+/** BE RVW-05 응답 — [확인] `DistributionConfirmResponse.java` */
+interface BeDistributionConfirm {
+  dispatchedCount: number;
+  dispatchedAt: string | null;
+  /** reason: `STILL_PENDING` · `REJECTED` · `NO_ASSIGNEE` · `ALREADY_DISPATCHED` */
+  skipped: { actionId: number; reason: string }[];
+}
 
 /**
  * [액션 분배 확정] — 반려 안 된 초안 + 직접 추가한 항목으로 실제 팀/개인 액션을 생성한다.
  * ⚠️ **되돌릴 수 없다**(1회성 화면 정책, WORKFLOW.md §3-4) — 확정 뒤 이 화면에 다시 못 들어온다.
- * ⚠️ **Host만 확정할 수 있다** — 화면 버튼 숨김은 보안이 아니라 여기서도 다시 검사한다
- *    (`canOperateMeeting`, CLAUDE.md §권한).
- * ⚠️ 실제 액션 도메인(보드·내 액션 등)에 레코드를 만드는 매퍼는 ERD 확정 후 연결한다
- *    (CLAUDE.md §Mock 격리막) — 지금은 리뷰 화면 자체의 확정 흐름만 담당한다.
+ * ⚠️ **화면은 확정 전까지 전부 로컬 상태다**(팀 확정 2026-08-10 "자동 반영 완료 로직 폐기").
+ *    BE는 항목별 판정(RVW-02)을 따로 받는 모델이라, 이 액션이 확정 시점에 **판정 → 추가 →
+ *    확정을 순서대로 대신 보낸다** — UX는 팀 확정대로 두고 API 계약만 맞춘다.
+ * ⚠️ **중간에 끊겨도 다시 누르면 이어진다.** 판정을 다시 보내면 라벨 행이 하나 더 쌓일 뿐
+ *    값이 어긋나지는 않는다(BE 주석). 반려해 둔 항목은 재조회가 걸러 준다(매퍼).
  */
 export async function confirmActionDistributionAction(
   meetingId: string,
   payload: ConfirmActionDistributionPayload,
+  options?: { force?: boolean },
 ): Promise<ConfirmActionDistributionResult> {
-  if (!isMock) {
-    throw new Error("서버 연동 미구현 — ERD·API 스펙 확정 후 매퍼 작성");
-  }
+  if (isMock) return confirmMockDistribution(meetingId, payload);
 
+  const accessToken = await requireAccessToken();
+  const id = Number(meetingId);
+
+  try {
+    /* ① 반려 — 값은 안 실린다(BE가 무시한다). 사유 코드만 판정으로 남는다. */
+    for (const rejected of payload.rejected) {
+      await serverApi(ep.meetingReviewDecision(id, Number(rejected.id)), {
+        method: "PATCH",
+        accessToken,
+        json: { decision: "REJECT", rejectReason: rejected.reason },
+      });
+    }
+
+    /* ② 판정 — 고친 칸만 MODIFY, 그대로면 CONFIRM(값 실으면 422라 changes로 가른다) */
+    for (const draft of payload.reviewed) {
+      const changes = draft.changes ?? {};
+      const value = {
+        ...(changes.assigneeId !== undefined ? { assigneeMemberId: changes.assigneeId } : {}),
+        ...(changes.dueDate !== undefined ? { dueDate: changes.dueDate } : {}),
+        ...(changes.title !== undefined ? { title: changes.title } : {}),
+        ...(changes.description !== undefined ? { detail: changes.description } : {}),
+        ...(draft.plannedStartDate ? { plannedStartDate: draft.plannedStartDate } : {}),
+      };
+      const isModify = Object.keys(changes).length > 0;
+
+      await serverApi(ep.meetingReviewDecision(id, Number(draft.id)), {
+        method: "PATCH",
+        accessToken,
+        json: isModify
+          ? { decision: "MODIFY", value }
+          : {
+              decision: "CONFIRM",
+              ...(draft.plannedStartDate
+                ? { value: { plannedStartDate: draft.plannedStartDate } }
+                : {}),
+            },
+      });
+    }
+
+    /* ③ 직접 추가 — RVW-03에는 시작일 칸이 없어, 만들어진 id로 MODIFY를 뒤따라 보낸다 */
+    for (const manual of payload.manuallyAdded) {
+      const added = await serverApi<{ actionId: number }>(ep.meetingReviewAddAction(id), {
+        method: "POST",
+        accessToken,
+        json: {
+          assigneeMemberId: manual.assigneeId,
+          title: manual.title,
+          detail: manual.description,
+          dueDate: manual.dueDate,
+          evidenceTranscriptId: null,
+        },
+      });
+      if (manual.startDate) {
+        await serverApi(ep.meetingReviewDecision(id, added.actionId), {
+          method: "PATCH",
+          accessToken,
+          json: { decision: "MODIFY", value: { plannedStartDate: manual.startDate } },
+        });
+      }
+    }
+
+    /* ④ 확정 — 여기서부터 액션이 각자의 보드로 나간다. Host 아니면 BE가 403으로 막는다. */
+    const result = await serverApi<BeDistributionConfirm>(
+      ep.meetingReviewConfirm(id, options?.force ?? false),
+      { method: "POST", accessToken },
+    );
+
+    revalidatePath(`/app/meeting/${meetingId}/review`);
+    revalidatePath(`/app/meeting/${meetingId}`);
+
+    /* 전부 "지난 확정에서 이미 나감"이면 다른 탭이 먼저 확정한 것이다 */
+    const alreadyDispatched =
+      result.dispatchedCount === 0 &&
+      result.skipped.length > 0 &&
+      result.skipped.every((skip) => skip.reason === "ALREADY_DISPATCHED");
+    if (alreadyDispatched) return { status: "alreadyConfirmed", createdCount: 0 };
+
+    return {
+      status: "confirmed",
+      createdCount: result.dispatchedCount,
+      /*
+        ⚠️ 반려(`REJECTED`)는 **의도한 제외**라 세지 않는다. 남는 건 미검토·담당자 미정처럼
+           사람이 몰랐을 수 있는 것들이다 — 조용히 넘기면 검토가 끝난 줄 알고 화면을 닫는다
+           (BE 주석: "skipped가 절반이다").
+      */
+      skippedCount: result.skipped.filter((skip) => skip.reason !== "REJECTED").length,
+    };
+  } catch (error) {
+    if (error instanceof ApiError) {
+      if (error.status === 404) return { status: "notFound", createdCount: 0 };
+      /* 확인되지 않은 STT 구간·미검토가 남았다 — 사람이 알고 강행할지 정한다(§정직성) */
+      if (error.status === 409) return { status: "blocked", message: error.message };
+    }
+    return { status: "failed", message: toUserMessage(error) };
+  }
+}
+
+/** 목 — 기존 흐름 그대로. 권한 재검사까지 목 경로에서도 같은 함수로 한다(§권한). */
+async function confirmMockDistribution(
+  meetingId: string,
+  payload: ConfirmActionDistributionPayload,
+): Promise<ConfirmActionDistributionResult> {
   const review = findMockMeetingReview(meetingId);
   if (!review) return { status: "notFound", createdCount: 0 };
 
@@ -67,6 +196,7 @@ export async function confirmActionDistributionAction(
 
   return {
     status: "confirmed",
-    createdCount: payload.confirmed.length + payload.manuallyAdded.length,
+    createdCount: payload.reviewed.length + payload.manuallyAdded.length,
+    skippedCount: 0,
   };
 }

--- a/src/features/meeting/review/actions.ts
+++ b/src/features/meeting/review/actions.ts
@@ -10,6 +10,7 @@ import { ep } from "@/lib/endpoints";
 import { assertPermission, canOperateMeeting } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
+import { hostIdOf, parseMeetingDetail } from "../mapper";
 import { findMockMeetingReview, markMockReviewConfirmed } from "./mock/review";
 import type { ManualDraftInput } from "./types";
 
@@ -45,15 +46,38 @@ export interface RejectedDraftInput {
 export interface ConfirmActionDistributionPayload {
   reviewed: ReviewedDraftInput[];
   rejected: RejectedDraftInput[];
-  manuallyAdded: ManualDraftInput[];
+  /** ⚠️ `localId`를 함께 보낸다 — 만든 결과를 화면의 그 초안과 맞춰 주기 위해서다 */
+  manuallyAdded: (ManualDraftInput & { localId: string })[];
 }
 
-export type ConfirmActionDistributionResult =
-  | { status: "confirmed"; createdCount: number; skippedCount: number }
-  | { status: "alreadyConfirmed" | "notFound"; createdCount: 0 }
-  /** 확인되지 않은 STT 구간 등으로 BE가 확정을 멈췄다(409) — `force`로만 강행한다 */
-  | { status: "blocked"; message: string }
-  | { status: "failed"; message: string };
+/**
+ * 직접 추가한 초안이 서버에서 받은 id — **화면이 로컬 초안을 이 id로 갈아 끼운다.**
+ *
+ * ⚠️ **재시도 이중 생성을 막는 자리다**(2026-08-13, 코드래빗 지적). ③에서 액션을 만든 뒤
+ *    ④가 409로 멈추면 화면은 같은 payload를 들고 있다 — [그래도 확정]을 누르는 순간 ③이
+ *    다시 돌아 **같은 액션이 하나 더 생긴다.** 성공·실패와 무관하게 "여기까지 만들었다"를
+ *    돌려주면, 화면이 그 초안을 서버 id로 바꿔 다음 시도에서는 판정(②)으로만 나간다.
+ */
+export interface CreatedManualDraft {
+  /** 화면이 들고 있던 로컬 id(`manual-…`) */
+  localId: string;
+  /** BE가 만든 실제 액션 id */
+  actionId: number;
+}
+
+/** 어떤 결과든 **여기까지 서버에 만든 것**을 함께 돌려준다 — 재시도가 겹쳐 만들지 않게 */
+interface CreatedManuals {
+  createdManuals: CreatedManualDraft[];
+}
+
+export type ConfirmActionDistributionResult = CreatedManuals &
+  (
+    | { status: "confirmed"; createdCount: number; skippedCount: number }
+    | { status: "alreadyConfirmed" | "notFound"; createdCount: 0 }
+    /** 확인되지 않은 STT 구간 등으로 BE가 확정을 멈췄다(409) — `force`로만 강행한다 */
+    | { status: "blocked"; message: string }
+    | { status: "failed"; message: string }
+  );
 
 /** BE RVW-05 응답 — [확인] `DistributionConfirmResponse.java` */
 interface BeDistributionConfirm {
@@ -69,8 +93,12 @@ interface BeDistributionConfirm {
  * ⚠️ **화면은 확정 전까지 전부 로컬 상태다**(팀 확정 2026-08-10 "자동 반영 완료 로직 폐기").
  *    BE는 항목별 판정(RVW-02)을 따로 받는 모델이라, 이 액션이 확정 시점에 **판정 → 추가 →
  *    확정을 순서대로 대신 보낸다** — UX는 팀 확정대로 두고 API 계약만 맞춘다.
- * ⚠️ **중간에 끊겨도 다시 누르면 이어진다.** 판정을 다시 보내면 라벨 행이 하나 더 쌓일 뿐
- *    값이 어긋나지는 않는다(BE 주석). 반려해 둔 항목은 재조회가 걸러 준다(매퍼).
+ * ⚠️ **중간에 끊겨도 다시 누르면 이어진다.** 판정(①②)을 다시 보내면 라벨 행이 하나 더 쌓일 뿐
+ *    값이 어긋나지는 않는다(BE 주석).
+ * ⚠️ **직접 추가(③)만은 다르다** — 다시 보내면 액션이 하나 더 생긴다. 그래서 만든 id를
+ *    `createdManuals`로 돌려주고, 화면이 그 초안을 서버 id로 갈아 끼워 다음 시도에서는
+ *    ②(판정)로만 나가게 한다. 반려해 둔 항목을 재조회가 걸러 주는 건 **확정에 성공해
+ *    화면을 다시 연 경우**뿐이라, 409로 멈춘 자리에서는 이 교체가 유일한 방어다.
  */
 export async function confirmActionDistributionAction(
   meetingId: string,
@@ -81,6 +109,33 @@ export async function confirmActionDistributionAction(
 
   const accessToken = await requireAccessToken();
   const id = Number(meetingId);
+
+  /*
+    ⚠️ **여기서도 Host인지 본다**(2026-08-13, 코드래빗 지적). 화면은 Host에게만 열리지만
+       Server Action은 **주소만 알면 부를 수 있다**(§권한: 화면 숨김은 보안이 아니다) —
+       BE는 확정(④)만 403으로 막고 판정·반려·추가(①②③)는 참석자 전원에게 열려 있어,
+       가드가 없으면 참석자가 남의 회의 초안을 반려하거나 액션을 만들 수 있었다.
+    ⚠️ 목 경로(`confirmMockDistribution`)의 `assertPermission`과 **같은 기준**이다 —
+       판정이 두 벌이면 목과 실서버가 다른 사람을 막는다.
+  */
+  try {
+    const detail = parseMeetingDetail(await serverApi<unknown>(ep.meeting(id), { accessToken }));
+    if (!canOperateMeeting(await getViewer(), { ownerId: hostIdOf(detail) })) {
+      return {
+        status: "failed",
+        message: "이 회의의 담당자만 확정할 수 있습니다",
+        createdManuals: [],
+      };
+    }
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) {
+      return { status: "notFound", createdCount: 0, createdManuals: [] };
+    }
+    return { status: "failed", message: toUserMessage(error), createdManuals: [] };
+  }
+
+  /* 여기까지 만든 것 — 어떤 경로로 끝나든 화면에 돌려준다(위 `CreatedManualDraft` 주석) */
+  const createdManuals: CreatedManualDraft[] = [];
 
   try {
     /* ① 반려 — 값은 안 실린다(BE가 무시한다). 사유 코드만 판정으로 남는다. */
@@ -131,6 +186,9 @@ export async function confirmActionDistributionAction(
           evidenceTranscriptId: null,
         },
       });
+      /* ⚠️ **만들자마자 적는다.** 뒤 호출이 실패해도 "이건 이미 만들어졌다"가 남아야 한다 */
+      createdManuals.push({ localId: manual.localId, actionId: added.actionId });
+
       if (manual.startDate) {
         await serverApi(ep.meetingReviewDecision(id, added.actionId), {
           method: "PATCH",
@@ -154,10 +212,13 @@ export async function confirmActionDistributionAction(
       result.dispatchedCount === 0 &&
       result.skipped.length > 0 &&
       result.skipped.every((skip) => skip.reason === "ALREADY_DISPATCHED");
-    if (alreadyDispatched) return { status: "alreadyConfirmed", createdCount: 0 };
+    if (alreadyDispatched) {
+      return { status: "alreadyConfirmed", createdCount: 0, createdManuals };
+    }
 
     return {
       status: "confirmed",
+      createdManuals,
       createdCount: result.dispatchedCount,
       /*
         ⚠️ 반려(`REJECTED`)는 **의도한 제외**라 세지 않는다. 남는 건 미검토·담당자 미정처럼
@@ -168,11 +229,12 @@ export async function confirmActionDistributionAction(
     };
   } catch (error) {
     if (error instanceof ApiError) {
-      if (error.status === 404) return { status: "notFound", createdCount: 0 };
+      if (error.status === 404) return { status: "notFound", createdCount: 0, createdManuals };
       /* 확인되지 않은 STT 구간·미검토가 남았다 — 사람이 알고 강행할지 정한다(§정직성) */
-      if (error.status === 409) return { status: "blocked", message: error.message };
+      if (error.status === 409)
+        return { status: "blocked", message: error.message, createdManuals };
     }
-    return { status: "failed", message: toUserMessage(error) };
+    return { status: "failed", message: toUserMessage(error), createdManuals };
   }
 }
 
@@ -182,12 +244,13 @@ async function confirmMockDistribution(
   payload: ConfirmActionDistributionPayload,
 ): Promise<ConfirmActionDistributionResult> {
   const review = findMockMeetingReview(meetingId);
-  if (!review) return { status: "notFound", createdCount: 0 };
+  if (!review) return { status: "notFound", createdCount: 0, createdManuals: [] };
 
   const viewer = await getViewer();
   assertPermission(canOperateMeeting(viewer, { ownerId: review.hostId }));
 
-  if (review.actionsConfirmed) return { status: "alreadyConfirmed", createdCount: 0 };
+  if (review.actionsConfirmed)
+    return { status: "alreadyConfirmed", createdCount: 0, createdManuals: [] };
 
   markMockReviewConfirmed(meetingId);
 
@@ -198,5 +261,7 @@ async function confirmMockDistribution(
     status: "confirmed",
     createdCount: payload.reviewed.length + payload.manuallyAdded.length,
     skippedCount: 0,
+    /* 목은 서버에 만드는 것이 없다 — 갈아 끼울 id도 없다 */
+    createdManuals: [],
   };
 }

--- a/src/features/meeting/review/components/action-review-row.tsx
+++ b/src/features/meeting/review/components/action-review-row.tsx
@@ -78,10 +78,24 @@ export function ActionReviewRow({
                 <MessageSquareQuote className="size-3.5 shrink-0 translate-y-0.5" aria-hidden />
                 <span className="min-w-0">
                   &ldquo;{draft.evidence.quote}&rdquo;
-                  <span className="text-muted-foreground/70 ml-2 tabular-nums">
-                    · {draft.evidence.timestamp}
-                  </span>
+                  {/* 시각이 없는 발화(화자 판정 포기 등)는 가운뎃점째 감춘다 — 00:00을 지어내지 않는다 */}
+                  {draft.evidence.timestamp && (
+                    <span className="text-muted-foreground/70 ml-2 tabular-nums">
+                      · {draft.evidence.timestamp}
+                    </span>
+                  )}
                 </span>
+              </p>
+            )}
+
+            {/*
+              ⚠️ 기한이 회의에서 안 나와 **프로젝트 마감일로 채워진 액션**은 그 사실을 적는다
+                 (BE `dueDateDefaulted`). 안 적으면 AI가 판단한 날짜처럼 읽혀, 고쳐야 할
+                 기한을 그냥 넘긴다(§정직성).
+            */}
+            {draft.isDueDateDefaulted && (
+              <p className="text-muted-foreground/70 text-[12px] leading-4">
+                마감일은 회의에서 정해지지 않아 프로젝트 마감일로 채웠습니다
               </p>
             )}
           </div>
@@ -95,8 +109,9 @@ export function ActionReviewRow({
         */}
         {/* ⚠️ 좁아지면 줄을 바꾼다 — 셋(180+140+140)+✕는 1180px 아래에서 글 칸을 0으로 밀어냈다 */}
         <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+          {/* ⚠️ 미정(null)은 빈 값으로 둔다 — String(null)은 "null"이라는 가짜 값이 된다 */}
           <Select
-            value={String(draft.assigneeId)}
+            value={draft.assigneeId === null ? "" : String(draft.assigneeId)}
             onValueChange={(value) => value && onAssigneeChange(Number(value))}
           >
             <SelectTrigger aria-label="담당자 선택" className="w-[180px]">
@@ -110,7 +125,8 @@ export function ActionReviewRow({
                   const option = assigneeOptions.find(
                     (candidate) => String(candidate.id) === value,
                   );
-                  if (!option) return value;
+                  /* AI가 못 짚었거나 명단 밖을 가리킨 액션 — 숨기지 말고 미정으로 보여준다(매퍼 주석) */
+                  if (!option) return <span className="text-muted-foreground">담당자 미정</span>;
                   return (
                     <>
                       <ProfileAvatar userId={option.id} size={18} />

--- a/src/features/meeting/review/components/meeting-review-view.tsx
+++ b/src/features/meeting/review/components/meeting-review-view.tsx
@@ -48,12 +48,23 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
   const [isAddingManual, setIsAddingManual] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [confirmError, setConfirmError] = useState<string | null>(null);
+  /*
+    ⚠️ BE가 확정을 멈춘 상태(409 — 확인되지 않은 STT 구간 등). 실수가 아니라 **알고
+       강행할지**를 사람이 정할 일이라, 버튼을 [그래도 확정]으로 바꿔 `force`로 다시 보낸다.
+  */
+  const [isBlocked, setIsBlocked] = useState(false);
   const [isConfirmed, setIsConfirmed] = useState(false);
   const [isPending, startTransition] = useTransition();
 
   const visibleDrafts = drafts.filter((draft) => !(draft.id in rejectedReasons));
   const highConfidence = visibleDrafts.filter((d) => d.confidence === AI_CONFIDENCE.HIGH);
   const needsReview = visibleDrafts.filter((d) => d.confidence === AI_CONFIDENCE.NEEDS_REVIEW);
+  /*
+    ⚠️ **담당자 미정이 남아 있으면 확정을 잠근다.** AI가 담당자를 못 짚은 액션은 "담당자
+       미정"으로 온다(매퍼 주석) — BE도 그 항목을 `NO_ASSIGNEE`로 걸러 분배하지 않으므로,
+       여기서 안 잠그면 확정이 끝난 줄 알았는데 몇 건이 조용히 남는다(§정직성).
+  */
+  const hasUnassigned = visibleDrafts.some((draft) => draft.assigneeId === null);
   function updateDraft(id: string, patch: Partial<AiActionDraft>) {
     setDrafts((prev) => prev.map((draft) => (draft.id === id ? { ...draft, ...patch } : draft)));
   }
@@ -90,38 +101,88 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
     setIsAddingManual(false);
   }
 
-  function handleConfirm() {
+  /**
+   * 로컬에서 새로 만든 초안인가 — BE에서 온 초안은 id가 숫자 문자열이고, 이 화면에서
+   * [액션 직접 추가]로 만든 것만 `manual-` 접두사를 갖는다(`nextManualDraftId`).
+   * ⚠️ `isManual`로 가르면 안 된다 — 지난 확정 시도에서 서버에 이미 만들어진 수동 액션이
+   *    재조회로 돌아오면 그것도 `isManual`이라, 같은 항목이 서버에 **한 번 더** 만들어진다.
+   */
+  function isLocalManual(id: string): boolean {
+    return id.startsWith("manual-");
+  }
+
+  function handleConfirm(force: boolean) {
     setConfirmError(null);
+    /* 처음 값과 대조해 **고친 칸만** 보낸다 — 안 고친 값까지 보내면 BE가 전부 "사람이
+       고쳤다"로 라벨을 남겨 틀린 학습 재료가 된다(actions.ts 주석). */
+    const initialById = new Map(review.drafts.map((draft) => [draft.id, draft]));
+
     startTransition(async () => {
       try {
-        const result = await confirmActionDistributionAction(review.meetingId, {
-          // ⚠️ 직접 추가한 항목은 `manuallyAdded`로 따로 보낸다 — 여기 넣으면 아래와 겹쳐 이중 집계된다.
-          confirmed: visibleDrafts
-            .filter((draft) => !draft.isManual)
-            .map((draft) => ({
-              id: draft.id,
-              title: draft.title,
-              description: draft.description,
-              assigneeId: draft.assigneeId,
-              startDate: draft.startDate,
-              dueDate: draft.dueDate,
-            })),
-          rejected: Object.entries(rejectedReasons).map(([id, reason]) => ({ id, reason })),
-          manuallyAdded: drafts
-            .filter((draft) => draft.isManual && !(draft.id in rejectedReasons))
-            .map((draft) => ({
-              title: draft.title,
-              description: draft.description,
-              assigneeId: draft.assigneeId,
-              startDate: draft.startDate,
-              dueDate: draft.dueDate,
-            })),
-        });
+        const result = await confirmActionDistributionAction(
+          review.meetingId,
+          {
+            reviewed: visibleDrafts
+              .filter((draft) => !isLocalManual(draft.id))
+              .map((draft) => {
+                const initial = initialById.get(draft.id);
+                const changes = {
+                  ...(initial && draft.title !== initial.title ? { title: draft.title } : {}),
+                  ...(initial && draft.description !== initial.description
+                    ? { description: draft.description }
+                    : {}),
+                  ...(initial &&
+                  draft.assigneeId !== initial.assigneeId &&
+                  draft.assigneeId !== null
+                    ? { assigneeId: draft.assigneeId }
+                    : {}),
+                  ...(initial && draft.dueDate !== initial.dueDate
+                    ? { dueDate: draft.dueDate }
+                    : {}),
+                };
+                return {
+                  id: draft.id,
+                  ...(draft.startDate ? { plannedStartDate: draft.startDate } : {}),
+                  ...(Object.keys(changes).length > 0 ? { changes } : {}),
+                };
+              }),
+            /* 로컬에서만 만든 초안의 반려는 서버에 보낼 게 없다 — 만들지 않으면 그만이다 */
+            rejected: Object.entries(rejectedReasons)
+              .filter(([id]) => !isLocalManual(id))
+              .map(([id, reason]) => ({ id, reason })),
+            // ⚠️ 직접 추가한 항목은 `manuallyAdded`로 따로 보낸다 — 위에 넣으면 겹쳐 이중 집계된다.
+            manuallyAdded: drafts
+              .filter((draft) => isLocalManual(draft.id) && !(draft.id in rejectedReasons))
+              .map((draft) => ({
+                title: draft.title,
+                description: draft.description,
+                // 폼이 담당자 없이는 추가를 막는다(`canAdd`) — 여기 null이 올 수 없다
+                assigneeId: draft.assigneeId ?? 0,
+                startDate: draft.startDate,
+                dueDate: draft.dueDate,
+              })),
+          },
+          { force },
+        );
 
         if (result.status === "notFound") {
           setConfirmError("회의를 찾을 수 없습니다. 페이지를 새로고침해 주세요.");
           return;
         }
+        if (result.status === "failed") {
+          setConfirmError(result.message);
+          return;
+        }
+        /*
+          ⚠️ BE가 멈춘 것(409)은 실패가 아니라 **경고**다 — 확인되지 않은 STT 구간이 남아
+             액션이 빠졌을 수 있다는 뜻이라, 원인을 적고 [그래도 확정]으로만 넘어가게 한다.
+        */
+        if (result.status === "blocked") {
+          setIsBlocked(true);
+          setConfirmError(result.message);
+          return;
+        }
+
         // "alreadyConfirmed"도 결과적으로 확정된 상태다 — 다른 탭에서 먼저 확정한 경우까지 포함.
         setConfirmOpen(false);
         setIsConfirmed(true);
@@ -132,6 +193,10 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
         */
         if (result.status === "confirmed") {
           toast.success(`${result.createdCount}건의 액션을 분배했습니다`);
+          /* 반려 말고도 안 나간 게 있다 — 조용히 넘기면 검토가 끝난 줄 안다(§정직성) */
+          if (result.skippedCount > 0) {
+            toast.warning(`${result.skippedCount}건은 분배되지 않았습니다`);
+          }
         } else {
           toast("이미 확정된 회의입니다");
         }
@@ -234,10 +299,16 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
         )}
       </ActionReviewGroup>
 
-      <div className="flex justify-end">
+      <div className="flex items-center justify-end gap-3">
+        {/* 왜 잠겼는지 버튼 옆에서 말한다 — 눌리지 않는 버튼만 두면 고장으로 읽힌다(§정직성) */}
+        {hasUnassigned && (
+          <p className="text-muted-foreground text-[12px] leading-4">
+            담당자 미정인 액션이 있습니다. 담당자를 지정해 주세요.
+          </p>
+        )}
         <Button
           type="button"
-          disabled={visibleDrafts.length === 0}
+          disabled={visibleDrafts.length === 0 || hasUnassigned}
           className="bg-foreground text-background hover:bg-foreground/90"
           onClick={() => setConfirmOpen(true)}
         >
@@ -258,7 +329,10 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
         isOpen={confirmOpen}
         onOpenChange={(open) => {
           setConfirmOpen(open);
-          if (!open) setConfirmError(null);
+          if (!open) {
+            setConfirmError(null);
+            setIsBlocked(false);
+          }
         }}
         title="액션 분배를 확정할까요?"
         description={
@@ -268,11 +342,11 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
             확정 뒤에는 이 화면을 다시 열 수 없습니다.
           </>
         }
-        confirmLabel="확정"
+        confirmLabel={isBlocked ? "그래도 확정" : "확정"}
         isPending={isPending}
         pendingLabel="확정 중"
         error={confirmError}
-        onConfirm={handleConfirm}
+        onConfirm={() => handleConfirm(isBlocked)}
       />
     </div>
   );

--- a/src/features/meeting/review/components/meeting-review-view.tsx
+++ b/src/features/meeting/review/components/meeting-review-view.tsx
@@ -154,6 +154,8 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
             manuallyAdded: drafts
               .filter((draft) => isLocalManual(draft.id) && !(draft.id in rejectedReasons))
               .map((draft) => ({
+                /* 서버가 만든 id를 이 초안과 맞춰 돌려주기 위한 표식(actions.ts 주석) */
+                localId: draft.id,
                 title: draft.title,
                 description: draft.description,
                 // 폼이 담당자 없이는 추가를 막는다(`canAdd`) — 여기 null이 올 수 없다
@@ -164,6 +166,30 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
           },
           { force },
         );
+
+        /*
+          ⚠️ **어떤 결과든 먼저 갈아 끼운다**(2026-08-13, 코드래빗 지적). 서버가 이미 만든
+             수동 액션은 로컬 초안이 아니라 **서버 초안**이다 — 409로 멈춘 뒤 [그래도 확정]을
+             누르면 같은 항목이 하나 더 만들어졌다. id를 바꿔 두면 다음 시도에서 `isLocalManual`이
+             false가 되어 추가(③)가 아니라 판정(②)으로 나간다.
+        */
+        if (result.createdManuals.length > 0) {
+          const byLocalId = new Map(result.createdManuals.map((made) => [made.localId, made]));
+          setDrafts((prev) =>
+            prev.map((draft) => {
+              const made = byLocalId.get(draft.id);
+              return made ? { ...draft, id: String(made.actionId) } : draft;
+            }),
+          );
+          /* 반려해 둔 것도 같은 초안이라 키를 함께 옮긴다 — 안 옮기면 서버에 반려가 안 간다 */
+          setRejectedReasons((prev) => {
+            const next: Record<string, ActionRejectReason> = {};
+            for (const [id, reason] of Object.entries(prev)) {
+              next[byLocalId.get(id) ? String(byLocalId.get(id)!.actionId) : id] = reason;
+            }
+            return next;
+          });
+        }
 
         if (result.status === "notFound") {
           setConfirmError("회의를 찾을 수 없습니다. 페이지를 새로고침해 주세요.");

--- a/src/features/meeting/review/mapper.test.ts
+++ b/src/features/meeting/review/mapper.test.ts
@@ -1,4 +1,191 @@
-import { type BePendingActionDistributionMeeting, toPendingReviewSummary } from "./mapper";
+import { AI_CONFIDENCE } from "@/constants/meeting";
+
+import type { BeMeetingDetail } from "../mapper";
+import {
+  type BeActionReview,
+  type BePendingActionDistributionMeeting,
+  parseActionReview,
+  toClock,
+  toMeetingReviewInfo,
+  toPendingReviewSummary,
+} from "./mapper";
+
+/**
+ * 검토 매퍼 — BE(RVW-01 + MEET-04) → UI 계약.
+ * 목이 아니라 **BE 실코드에서 옮겨 적은 shape**으로 검증한다(§연동 검증).
+ */
+
+const DETAIL: BeMeetingDetail = {
+  meetingId: 7,
+  title: "8월 스프린트 계획",
+  status: "DONE",
+  startAt: "2026-08-14T10:00:00",
+  endAt: "2026-08-14T10:30:00",
+  project: { projectId: 3, tag: "GOODSFLOW" },
+  meetingRoom: { meetingRoomId: 1, name: "회의실 A" },
+  host: { memberId: 2, name: "김서준" },
+  attendees: [
+    { memberId: 2, name: "김서준", teamName: "개발팀", jobPosition: "팀장" },
+    { memberId: 5, name: "박지호", teamName: null, jobPosition: null },
+  ],
+};
+
+function makeReview(overrides?: Partial<BeActionReview>): BeActionReview {
+  return {
+    actionsByPerson: [
+      {
+        memberId: 2,
+        name: "김서준",
+        actions: [
+          {
+            actionId: 11,
+            assigneeMemberId: 2,
+            title: "결제 모듈 설계",
+            detail: "토스 빌링키 흐름 정리",
+            dueDate: "2026-08-20",
+            dueDateDefaulted: false,
+            isManual: false,
+            reviewStatus: "PENDING",
+            evidence: {
+              transcriptId: 100,
+              speakerName: "김서준",
+              content: "결제는 제가 정리할게요",
+              startOffsetMs: 754_000,
+            },
+            gate: { autoConfirmed: true, signals: {} },
+          },
+        ],
+      },
+      {
+        // 담당자 미정 묶음 — BE가 name만 채워 내려준다
+        memberId: null,
+        name: "담당자 미정",
+        actions: [
+          {
+            actionId: 12,
+            assigneeMemberId: null,
+            title: "회의록 공유",
+            detail: null,
+            dueDate: "2026-08-31",
+            dueDateDefaulted: true,
+            isManual: false,
+            reviewStatus: "PENDING",
+            evidence: {
+              transcriptId: 101,
+              speakerName: null,
+              content: "그건 나중에 공유하죠",
+              startOffsetMs: null,
+            },
+            gate: { autoConfirmed: false, signals: {} },
+          },
+          {
+            actionId: 13,
+            assigneeMemberId: 5,
+            title: "반려된 액션",
+            detail: null,
+            dueDate: "2026-08-31",
+            dueDateDefaulted: false,
+            isManual: false,
+            reviewStatus: "REJECTED",
+            evidence: null,
+            gate: { autoConfirmed: false, signals: {} },
+          },
+        ],
+      },
+    ],
+    needsReview: { count: 1, actionIds: [12] },
+    dispatchedAt: null,
+    ...overrides,
+  };
+}
+
+describe("parseActionReview", () => {
+  it("BE shape 그대로면 통과한다", () => {
+    expect(() => parseActionReview(makeReview())).not.toThrow();
+  });
+
+  it("actionsByPerson이 배열이 아니면 읽기 전에 멈춘다", () => {
+    expect(() => parseActionReview({ needsReview: { count: 0, actionIds: [] } })).toThrow(
+      "검토 응답이 우리가 아는 모양이 아닙니다",
+    );
+  });
+
+  it("액션에 actionId가 없으면 멈춘다 — 판정 요청을 보낼 수 없는 응답이다", () => {
+    const broken = makeReview();
+    // @ts-expect-error 고의로 깨뜨린다
+    delete broken.actionsByPerson[0].actions[0].actionId;
+    expect(() => parseActionReview(broken)).toThrow();
+  });
+});
+
+describe("toMeetingReviewInfo", () => {
+  it("두 응답을 화면 한 판으로 합친다 — 머리는 상세, 초안은 검토에서", () => {
+    const info = toMeetingReviewInfo({ detail: DETAIL, review: makeReview() });
+
+    expect(info.meetingId).toBe("7");
+    expect(info.meetingTitle).toBe("8월 스프린트 계획");
+    expect(info.hostId).toBe(2);
+    expect(info.projectTag).toBe("GOODSFLOW");
+    expect(info.actionsConfirmed).toBe(false);
+    // 참석자 → 담당자 선택지. 팀 없는 사람은 라벨이 이름뿐이다(빈 가운뎃점 금지)
+    expect(info.assigneeOptions).toEqual([
+      { id: 2, name: "김서준", roleLabel: "개발팀 · 팀장" },
+      { id: 5, name: "박지호", roleLabel: "" },
+    ]);
+  });
+
+  it("needsReview 목록이 묶음을 가른다 — 게이트 신호를 다시 조합하지 않는다", () => {
+    const info = toMeetingReviewInfo({ detail: DETAIL, review: makeReview() });
+    const confident = info.drafts.find((draft) => draft.id === "11");
+    const uncertain = info.drafts.find((draft) => draft.id === "12");
+
+    expect(confident?.confidence).toBe(AI_CONFIDENCE.HIGH);
+    expect(uncertain?.confidence).toBe(AI_CONFIDENCE.NEEDS_REVIEW);
+  });
+
+  it("담당자 미정은 null 그대로 둔다 — 숨기지도 지어내지도 않는다", () => {
+    const info = toMeetingReviewInfo({ detail: DETAIL, review: makeReview() });
+    const unassigned = info.drafts.find((draft) => draft.id === "12");
+
+    expect(unassigned?.assigneeId).toBeNull();
+    expect(unassigned?.isDueDateDefaulted).toBe(true);
+    // 화자 판정을 포기한 발화 — 이름·시각을 지어내지 않는다
+    expect(unassigned?.evidence).toEqual({
+      speaker: "",
+      quote: "그건 나중에 공유하죠",
+      timestamp: "",
+    });
+  });
+
+  it("REJECTED는 거른다 — 지난 확정 시도에서 반려해 둔 항목이 되살아나면 안 된다", () => {
+    const info = toMeetingReviewInfo({ detail: DETAIL, review: makeReview() });
+    expect(info.drafts.map((draft) => draft.id)).toEqual(["11", "12"]);
+  });
+
+  it("dispatchedAt이 있으면 이미 확정된 회의다", () => {
+    const info = toMeetingReviewInfo({
+      detail: DETAIL,
+      review: makeReview({ dispatchedAt: "2026-08-14T11:00:00" }),
+    });
+    expect(info.actionsConfirmed).toBe(true);
+  });
+
+  it("시작일은 비워 둔다 — BE가 안 내려주는 값이라 사람이 처음 정한다", () => {
+    const info = toMeetingReviewInfo({ detail: DETAIL, review: makeReview() });
+    expect(info.drafts.every((draft) => draft.startDate === "")).toBe(true);
+  });
+});
+
+describe("toClock", () => {
+  it("밀리초를 MM:SS로 바꾼다", () => {
+    expect(toClock(754_000)).toBe("12:34");
+    expect(toClock(0)).toBe("00:00");
+  });
+
+  it("없는 시각은 빈 문자열 — 00:00을 지어내지 않는다", () => {
+    expect(toClock(null)).toBe("");
+  });
+});
 
 /** MEET-10 응답 그대로 — 필드 이름을 BE 실코드에 맞춰 둔다 */
 const BASE: BePendingActionDistributionMeeting = {

--- a/src/features/meeting/review/mapper.ts
+++ b/src/features/meeting/review/mapper.ts
@@ -1,9 +1,195 @@
+import { AI_CONFIDENCE } from "@/constants/meeting";
+
+import { formatMeetingSchedule } from "../lib";
+import { type BeMeetingDetail, hostIdOf } from "../mapper";
+import type { AiActionDraft, AssigneeOption, MeetingReviewInfo, PendingReviewSummary } from "./types";
+
 /**
- * BE shape → UI 계약(§Mock 격리막). 컴포넌트는 이 파일을 모른다 — `server.ts`만 쓴다.
- * [확인] D도메인 REST API 명세(2026-08-12) 대조.
+ * 검토 화면(RVW-01) BE 응답 → UI 계약 매퍼.
+ *
+ * [확인] `capture/presentation/api/response/ActionReviewResponse.java` (2026-08-12 실코드 대조)
+ *
+ * ⚠️ **RVW-01에는 회의 머리 정보가 없다**(제목·일정·프로젝트·참석자). 그건 회의 상세
+ *    (MEET-04, `BeMeetingDetail`)가 들고 있어 두 응답을 합쳐 한 판(`MeetingReviewInfo`)을
+ *    만든다 — 호출은 `server.ts`가 병렬로 하고, 합치는 일은 여기 한 곳이다(§격리막).
+ * ⚠️ **`null`을 기본값으로 채우지 않는다**(BE 응답 주석과 같은 판단). `gate`가 null이면
+ *    "게이트를 안 지났다"(수동 추가)이지 "게이트가 떨어뜨렸다"가 아니고, `speakerName`이
+ *    null이면 화자 판정을 포기한 발화다 — 인용만 보여주고 이름을 지어내지 않는다.
  */
 
-import type { PendingReviewSummary } from "./types";
+/* ───────── BE shape (RVW-01) ───────── */
+
+export interface BeReviewEvidence {
+  transcriptId: number;
+  /** L1이 화자 판정을 포기한 발화는 null — 정상이다 */
+  speakerName: string | null;
+  content: string;
+  startOffsetMs: number | null;
+}
+
+export interface BeReviewGate {
+  autoConfirmed: boolean;
+  /** 신호 4종 — 화면은 아직 안 그리지만 모양 검사는 통과시킨다(안 읽는 필드는 검사 안 함) */
+  signals: unknown;
+}
+
+export interface BeReviewAction {
+  actionId: number;
+  /** 담당자 미정이면 null — 숨기지 말고 "담당자 미정"으로 보여야 한다(BE 주석) */
+  assigneeMemberId: number | null;
+  title: string;
+  /** UI의 `description`에 해당 — BE 필드명은 `detail`이다 */
+  detail: string | null;
+  dueDate: string;
+  /** 이 기한이 회의에서 나온 게 아니라 **프로젝트 마감일로 채워진 것**인지 */
+  dueDateDefaulted: boolean;
+  isManual: boolean;
+  /** `PENDING` · `HUMAN_CONFIRMED` · `REJECTED` */
+  reviewStatus: string;
+  evidence: BeReviewEvidence | null;
+  /** 수동 추가 건은 게이트를 안 지나 통째로 null이다 */
+  gate: BeReviewGate | null;
+}
+
+export interface BeActionReview {
+  actionsByPerson: {
+    /** 담당자 미정 묶음은 null */
+    memberId: number | null;
+    name: string;
+    actions: BeReviewAction[];
+  }[];
+  needsReview: { count: number; actionIds: number[] };
+  /** 확정 전이면 null — 이 값 하나가 "이미 확정된 회의" 판정이다 */
+  dispatchedAt: string | null;
+}
+
+/* ───────── 모양 검사 ───────── */
+
+function isBeReviewAction(value: unknown): value is BeReviewAction {
+  if (typeof value !== "object" || value === null) return false;
+  const action = value as Partial<BeReviewAction>;
+  return (
+    typeof action.actionId === "number" &&
+    (action.assigneeMemberId === null || typeof action.assigneeMemberId === "number") &&
+    typeof action.title === "string" &&
+    typeof action.dueDate === "string" &&
+    typeof action.isManual === "boolean" &&
+    typeof action.reviewStatus === "string"
+  );
+}
+
+/**
+ * 읽기 전에 한 번 본다 — 회의 상세 매퍼(`parseMeetingDetail`)와 같은 이유다.
+ * ⚠️ **화면이 실제로 읽는 필드만** 검사한다. 전부 검사하면 BE가 무관한 필드를 바꿀 때마다
+ *    멀쩡한 화면이 막힌다.
+ */
+export function parseActionReview(raw: unknown): BeActionReview {
+  if (typeof raw !== "object" || raw === null) {
+    throw new Error("검토 응답이 우리가 아는 모양이 아닙니다");
+  }
+  const review = raw as Partial<BeActionReview>;
+  const isValid =
+    Array.isArray(review.actionsByPerson) &&
+    review.actionsByPerson.every(
+      (person) =>
+        typeof person === "object" &&
+        person !== null &&
+        Array.isArray(person.actions) &&
+        person.actions.every(isBeReviewAction),
+    ) &&
+    typeof review.needsReview === "object" &&
+    review.needsReview !== null &&
+    Array.isArray(review.needsReview.actionIds) &&
+    (review.dispatchedAt === null || typeof review.dispatchedAt === "string");
+
+  if (!isValid) throw new Error("검토 응답이 우리가 아는 모양이 아닙니다");
+  return review as BeActionReview;
+}
+
+/* ───────── 변환 ───────── */
+
+/** `startOffsetMs` → `MM:SS`. null이면 빈 문자열 — 시각을 지어내지 않는다 */
+export function toClock(startOffsetMs: number | null): string {
+  if (startOffsetMs === null || startOffsetMs < 0) return "";
+  const totalSeconds = Math.floor(startOffsetMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
+
+function toDraft(action: BeReviewAction, needsReviewIds: ReadonlySet<number>): AiActionDraft {
+  return {
+    id: String(action.actionId),
+    title: action.title,
+    description: action.detail ?? "",
+    assigneeId: action.assigneeMemberId,
+    /*
+      묶음 판정은 BE `needsReview.actionIds`가 정본이다 — 게이트 신호를 여기서 다시 조합하면
+      BE 판정과 갈릴 수 있다. 수동 추가 건은 게이트가 없어 목록에 안 실리지만, AI 배지를
+      붙일 데이터가 없는 쪽이므로 "요약 불확실" 묶음에 둔다(기존 화면 배치 그대로).
+    */
+    confidence:
+      action.isManual || needsReviewIds.has(action.actionId)
+        ? AI_CONFIDENCE.NEEDS_REVIEW
+        : AI_CONFIDENCE.HIGH,
+    /*
+      ⚠️ **시작일은 BE가 안 내려준다**(RVW-01 응답에 `plannedStartDate` 없음 — AI가 내지 않는
+         값이라 사람이 이 화면에서 처음 정한다). 빈 값으로 시작하고, 정한 값은 확정 때
+         RVW-02에 실어 보낸다(`plannedStartDate`는 CONFIRM에도 실을 수 있다 — BE 확인).
+    */
+    startDate: "",
+    dueDate: action.dueDate,
+    isDueDateDefaulted: action.dueDateDefaulted,
+    evidence: action.evidence
+      ? {
+          speaker: action.evidence.speakerName ?? "",
+          quote: action.evidence.content,
+          timestamp: toClock(action.evidence.startOffsetMs),
+        }
+      : null,
+    isManual: action.isManual,
+  };
+}
+
+/** 참석자 → 담당자 드롭다운 선택지. 라벨은 "팀 · 직급" — 회의 상세 명부와 같은 조합이다 */
+export function toAssigneeOptions(detail: BeMeetingDetail): AssigneeOption[] {
+  return detail.attendees.map((attendee) => ({
+    id: attendee.memberId,
+    name: attendee.name,
+    roleLabel: [attendee.teamName, attendee.jobPosition].filter(Boolean).join(" · "),
+  }));
+}
+
+/**
+ * 회의 상세(MEET-04) + 검토(RVW-01) → 화면 한 판.
+ *
+ * ⚠️ **`REJECTED`는 거른다.** 지난 확정 시도가 중간에 끊긴 회의를 다시 열면 반려해 둔
+ *    항목이 서버에 남아 있는데, 그걸 다시 편집 가능한 행으로 그리면 같은 판정을 두 번 한다.
+ *    확정(RVW-05)도 그 항목들은 `skipped`로 거른다 — 화면과 서버가 같은 편이다.
+ */
+export function toMeetingReviewInfo(params: {
+  detail: BeMeetingDetail;
+  review: BeActionReview;
+}): MeetingReviewInfo {
+  const { detail, review } = params;
+  const needsReviewIds = new Set(review.needsReview.actionIds);
+
+  return {
+    meetingId: String(detail.meetingId),
+    meetingTitle: detail.title,
+    hostId: hostIdOf(detail),
+    projectTag: detail.project.tag,
+    scheduleLabel: formatMeetingSchedule(new Date(detail.startAt), new Date(detail.endAt)),
+    assigneeOptions: toAssigneeOptions(detail),
+    drafts: review.actionsByPerson
+      .flatMap((person) => person.actions)
+      .filter((action) => action.reviewStatus !== "REJECTED")
+      .map((action) => toDraft(action, needsReviewIds)),
+    actionsConfirmed: review.dispatchedAt !== null,
+  };
+}
+
+/* ───────── 마이페이지 미확정 액션(MEET-10) — #395에서 온 매퍼를 여기로 합침 ───────── */
 
 /**
  * `GET /api/meetings/pending-action-distributions`(MEET-10, 구현 완료) 목록 원소.

--- a/src/features/meeting/review/server.ts
+++ b/src/features/meeting/review/server.ts
@@ -1,11 +1,17 @@
 import { requireAccessToken } from "@/features/auth/session";
 import { getViewer } from "@/features/shell/viewer";
-import { serverApi } from "@/lib/api";
+import { ApiError, serverApi } from "@/lib/api";
 import { ep } from "@/lib/endpoints";
 import { canOperateMeeting } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
-import { type BePendingActionDistributionsResponse, toPendingReviewSummary } from "./mapper";
+import { hostIdOf, parseMeetingDetail } from "../mapper";
+import {
+  type BePendingActionDistributionsResponse,
+  parseActionReview,
+  toMeetingReviewInfo,
+  toPendingReviewSummary,
+} from "./mapper";
 import { findMockMeetingReview, listMockPendingReviewMeetingIds } from "./mock/review";
 import type { MeetingReviewInfo, MeetingReviewResult, PendingReviewSummary } from "./types";
 
@@ -17,12 +23,55 @@ import type { MeetingReviewInfo, MeetingReviewResult, PendingReviewSummary } fro
  *    화면(`page.tsx`)이 회의 상세로 리다이렉트한다.
  */
 export async function getMeetingReview(meetingId: string): Promise<MeetingReviewResult> {
-  const review = findMockMeetingReview(meetingId);
-  if (!review) return { kind: "notFound" };
+  if (isMock) {
+    const review = findMockMeetingReview(meetingId);
+    if (!review) return { kind: "notFound" };
+    const viewer = await getViewer();
+    if (!canOperateMeeting(viewer, { ownerId: review.hostId })) return { kind: "notHost" };
+    if (review.actionsConfirmed) return { kind: "alreadyConfirmed", meetingId };
+    return { kind: "ok", review };
+  }
+
+  return getLiveMeetingReview(meetingId);
+}
+
+/**
+ * 실서버 — **두 응답을 합친다.** RVW-01에는 회의 머리 정보(제목·일정·참석자)가 없어
+ * 회의 상세(MEET-04)와 병렬로 부른다. 합치는 일은 매퍼(`toMeetingReviewInfo`) 한 곳이다.
+ *
+ * ⚠️ **판정 순서를 목과 똑같이 맞춘다**(없음 → Host 아님 → 이미 확정 → 통과) — 캡처 진입
+ *    (`getLiveMeetingCapture`)과 같은 이유다. 순서가 갈리면 같은 회의가 목과 실서버에서
+ *    다르게 막혀 화면이 다른 말을 한다.
+ * ⚠️ 404는 값으로 돌린다(없는 회의는 고장이 아니다). 403·500은 던진다 — BE가 막았다면
+ *    우리 판정이 틀렸다는 뜻이라 조용히 다른 화면을 그리지 않는다(§정직성).
+ */
+async function getLiveMeetingReview(meetingId: string): Promise<MeetingReviewResult> {
+  const accessToken = await requireAccessToken();
+  const id = Number(meetingId);
+
+  let rawDetail: unknown;
+  let rawReview: unknown;
+  try {
+    [rawDetail, rawReview] = await Promise.all([
+      serverApi<unknown>(ep.meeting(id), { accessToken }),
+      serverApi<unknown>(ep.meetingReview(id), { accessToken }),
+    ]);
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) return { kind: "notFound" };
+    throw error;
+  }
+
+  /* 단언이 아니라 검사다 — 모양이 어긋나면 판정 전에 여기서 멈춘다(각 매퍼 주석 참고) */
+  const detail = parseMeetingDetail(rawDetail);
+  const review = parseActionReview(rawReview);
+
   const viewer = await getViewer();
-  if (!canOperateMeeting(viewer, { ownerId: review.hostId })) return { kind: "notHost" };
-  if (review.actionsConfirmed) return { kind: "alreadyConfirmed", meetingId };
-  return { kind: "ok", review };
+  if (!canOperateMeeting(viewer, { ownerId: hostIdOf(detail) })) {
+    return { kind: "notHost" };
+  }
+  if (review.dispatchedAt !== null) return { kind: "alreadyConfirmed", meetingId };
+
+  return { kind: "ok", review: toMeetingReviewInfo({ detail, review }) };
 }
 
 /**

--- a/src/features/meeting/review/types.ts
+++ b/src/features/meeting/review/types.ts
@@ -42,10 +42,21 @@ export interface AiActionDraft {
   title: string;
   /** 다른 액션 화면과 같은 필드(features/action/types.ts `description`) — 제목 아래 한 줄 요약. */
   description: string;
-  assigneeId: number;
+  /**
+   * ⚠️ **미정이면 null**(2026-08-12, BE RVW-01 대조). AI가 담당자를 못 짚었거나 명단 밖을
+   *    가리킨 액션은 "담당자 미정"으로 온다 — 숨기지 말고 사람이 고르게 보여준다(BE 주석).
+   *    미정이 남아 있으면 [액션 분배 확정]이 잠긴다(BE도 `NO_ASSIGNEE`로 거른다).
+   */
+  assigneeId: number | null;
   confidence: AiConfidence;
+  /** ⚠️ BE가 안 내려주는 값이다 — 사람이 이 화면에서 처음 정한다(비었으면 빈 문자열). */
   startDate: string;
   dueDate: string;
+  /**
+   * 이 기한이 회의에서 나온 게 아니라 **프로젝트 마감일로 채워진 것**인지(BE `dueDateDefaulted`).
+   * true면 "회의에서 정해지지 않음"을 함께 보여준다 — 없으면 AI가 판단한 날짜처럼 읽힌다.
+   */
+  isDueDateDefaulted?: boolean;
   evidence: DraftEvidence | null;
   isManual: boolean;
 }

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -125,6 +125,25 @@ export const ep = {
   processingStatus: (meetingId: number) => `/api/meetings/${meetingId}/processing-status`,
 
   /*
+   * AI 액션 분배 검토(RVW) — [확인] BE 실코드 대조(2026-08-12)
+   *   `capture/presentation/api/AnalysisController.java` (`@RequestMapping("/api/meetings/{meetingId}")`)
+   *
+   * ⚠️ 검토(조회·판정·직접 추가)는 참석자 전원 가능, **확정(RVW-05)만 Host 1명**이다(403은 BE가 재검사).
+   * ⚠️ RVW-04(직접 추가 취소 `DELETE /review/actions/{id}`)는 **일부러 안 등록한다** — 우리 화면은
+   *    확정 전까지 전부 로컬 상태라(WORKFLOW §3-4), 서버에 만든 적 없는 항목을 지울 일이 없다.
+   */
+  /** 검토 조회(RVW-01) — 담당자별 묶음 + `needsReview` + `dispatchedAt`(확정 전이면 null) */
+  meetingReview: (meetingId: number) => `/api/meetings/${meetingId}/review`,
+  /** 항목 판정(RVW-02) — `CONFIRM`(값 실으면 422) · `MODIFY`(고친 칸만) · `REJECT`(사유 5종 필수) */
+  meetingReviewDecision: (meetingId: number, actionId: number) =>
+    `/api/meetings/${meetingId}/review/${actionId}`,
+  /** 액션 직접 추가(RVW-03) — 담당자·기한 필수(422). ⚠️ `plannedStartDate`는 못 실어 RVW-02 MODIFY로 뒤따라 보낸다 */
+  meetingReviewAddAction: (meetingId: number) => `/api/meetings/${meetingId}/review/actions`,
+  /** 분배 확정(RVW-05) — 미검토·미확인 구간 남으면 409, `confirm=true`로만 강행. `skipped`가 응답의 절반이다 */
+  meetingReviewConfirm: (meetingId: number, force = false) =>
+    `/api/meetings/${meetingId}/review/confirm${force ? "?confirm=true" : ""}`,
+
+  /*
    * 액션 · 프로젝트 · 캘린더 — [확인] BE 실코드 대조(2026-08-10, 잇다 REST API 연동 가이드 최종본)
    *   `project/presentation/api/{ProjectController,ProjectAttachmentController}.java`
    *   `action/presentation/api/{ActionController,TeamActionController,MeetingActionController}.java`


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

AI 액션 분배 검토 화면(`/app/meeting/:id/review`)을 mock에서 실 API(RVW-01~05)로 전환한다. BE `AnalysisController` 실코드 대조(2026-08-12) 기준.

**1. 반려 사유 3종 → 5종** (`constants/meeting.ts`)

BE가 2026-08-11 PM 확정으로 `NOT_CONFIRMED`를 `NOT_ACTION`으로 대체하고 `NOT_ATTENDANCE`·`ETC`를 추가했다. 옛 값을 보내면 enum 파싱에서 거절된다 — 반려 다이얼로그는 상수만 읽어서 자동으로 5택이 된다.

**2. 매퍼 신설** (`review/mapper.ts` + 테스트 11개)

- RVW-01에는 회의 머리 정보(제목·일정·참석자)가 없어 **회의 상세(MEET-04)와 병렬 조회** 후 한 판으로 합친다
- 묶음 판정(`AI 확신도 높음`/`요약 불확실`)은 BE `needsReview.actionIds`가 정본 — 게이트 신호를 FE가 다시 조합하지 않는다
- `null`을 기본값으로 채우지 않는다: 담당자 미정(`assigneeMemberId: null`)은 그대로 노출하고, 화자 판정을 포기한 발화(`speakerName: null`)는 이름을 지어내지 않는다
- `REJECTED`는 거른다 — 지난 확정 시도가 중간에 끊긴 회의를 다시 열 때 반려해 둔 항목이 되살아나면 안 된다

**3. 확정 오케스트레이션** (`review/actions.ts`)

화면은 팀 확정대로 **확정 전까지 전부 로컬 상태**(WORKFLOW §3-4)를 유지하고, [액션 분배 확정] 시점에 서버 액션이 BE의 항목별 판정 모델을 대신 수행한다: ①반려(REJECT+사유) → ②판정(고친 칸만 MODIFY / 그대로면 CONFIRM) → ③직접 추가(RVW-03, 시작일은 필드가 없어 MODIFY로 뒤따라 전송) → ④확정(RVW-05).

- **고친 칸만 보낸다** — 안 고친 값까지 MODIFY로 보내면 BE가 `WRONG_*` 라벨을 만들어 **틀린 학습 재료**가 된다
- `plannedStartDate`는 `changes` 밖 — AI가 내지 않는 값이라 CONFIRM에도 실을 수 있다(BE가 검사에서 일부러 뺐다)
- 409(확인 안 된 STT 구간)는 실패가 아니라 경고 — 다이얼로그에 원인을 적고 [그래도 확정]으로만 `confirm=true` 강행
- `skipped` 중 반려 아닌 것(미검토·담당자 미정)은 토스트로 알린다 — 조용히 넘기면 검토가 끝난 줄 안다

**4. 화면 배선** (`meeting-review-view.tsx` · `action-review-row.tsx`)

- 담당자 미정이 남아 있으면 확정 버튼을 잠그고 이유를 적는다(BE도 `NO_ASSIGNEE`로 걸러 분배하지 않는다)
- 기한이 프로젝트 마감일로 채워진 액션(`dueDateDefaulted`)은 그 사실을 행에 적는다
- 근거 발화에 시각이 없으면 `00:00`을 지어내지 않고 감춘다

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/review-연동#409`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 조회·확정 모두 Host 판정(`canOperateMeeting`), BE도 확정을 403으로 재검사
- [x] 🧬 **zod** — 매퍼가 `parseActionReview`로 읽기 전 모양 검사(기존 `parseMeetingDetail` 패턴)
- [x] 🕵️ **정직성** — 담당자 미정·기한 기본값·시각 없음 전부 지어내지 않고 그대로 노출, skipped 알림
- [x] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 — 해당 없음(신규 라우트·이미지 없음)
- [x] ♿ a11y — 기존 행 구조 유지, 잠긴 버튼에 이유 문구 병기
- [x] ♻️ 재사용 확인 — `parseMeetingDetail`·`hostIdOf`·`formatMeetingSchedule`·`canOperateMeeting` 재사용
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 기존 화면 유지, 실패는 다이얼로그에 원인 표시
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음 — 해당 없음

---

## 🔗 연관 이슈

Closes #409

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

```
npx tsc --noEmit   # 통과
npx eslint         # 통과
npx jest           # 962개 통과 (review mapper 11개 신규)
npx next build     # 통과
```

- **UX는 팀 확정 그대로다**(확정 전 로컬 상태) — BE의 항목별 판정 모델과의 간극은 서버 액션 한 곳이 흡수한다. 중간에 끊겨도 다시 누르면 이어진다(판정 재전송은 라벨 행만 하나 더 쌓인다 — BE 주석 확인).
- 로컬에서 직접 추가한 초안은 id 접두사(`manual-`)로 가른다 — `isManual`로 가르면 지난 시도에서 서버에 이미 만들어진 수동 액션이 이중 생성된다.
- mock 흐름은 그대로다(`isMock` 분기 유지) — mock 모드에서 `/app/meeting/3/review` 진입·수정·반려·확정 전부 기존과 동일.

---

## 📝 추가 메모

- RVW-01 응답에 `plannedStartDate`가 없어 재진입 시 시작일이 비어 보인다(사람이 처음 정하는 값이라 현재 계약상 맞는 동작). BE가 응답에 실어 주면 매퍼 한 줄로 반영 가능.
- 마이페이지 미확정 액션·요약 중단 그룹 실연동은 #410에서 별도로 한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 회의 후 AI 액션을 검토하고, 수정·반려·직접 추가·최종 확정할 수 있습니다.
  * 액션 반려 사유가 5가지로 확대되었습니다.
  * 확정이 차단된 경우 상태를 확인하고 강제 재확정할 수 있습니다.
* **개선 사항**
  * 담당자 미정 액션과 프로젝트 마감일로 대체된 기한을 명확히 표시합니다.
  * 근거 타임스탬프가 없을 때 불필요한 시간 정보가 표시되지 않습니다.
  * 미분배·반려·실패한 액션을 구분하고 확정 전에 안내합니다.
* **버그 수정**
  * 회의 검토 정보와 액션 상태가 보다 정확하게 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->