### PR TITLE
[FIX] 사원 관리·기업 설정 연동 결함 7종 #415

### DIFF
--- a/src/app/(shell)/(authority)/manage/members/[memberId]/page.tsx
+++ b/src/app/(shell)/(authority)/manage/members/[memberId]/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from "next/navigation";
 import { AccessDenied } from "@/components/common/access-denied";
 import { AUTHORITY } from "@/constants/authority";
 import { MEMBER_STATUS } from "@/constants/member";
-import { getCompanySetting } from "@/features/company/server";
+import { getCompanyOrg } from "@/features/company/server";
 import { HandoverApprovalCard } from "@/features/member/components/handover-approval-card";
 import { MemberActionList } from "@/features/member/components/member-action-list";
 import { MemberDeleteCard } from "@/features/member/components/member-delete-card";
@@ -56,8 +56,11 @@ export default async function ManageMemberDetailPage({
   /*
     ⚠️ **직급 목록을 같이 받는다.** 손으로 적게 두면 회사에 없는 직급이 생긴다 —
        발급 창과 같은 이유다(직급에는 권한이 매여 있다).
+    ⚠️ `getCompanySetting`이 아니다(2026-08-13 고침) — 그건 OWNER 전용 `GET /api/companies/me`를
+       물고 있어, **Admin 겸직자가 사원 상세를 열면 403으로 페이지가 통째로 죽었다**(목록 페이지만
+       고치고 이 화면을 빠뜨렸다). 여기 필요한 건 직급·팀 역할뿐이고 둘 다 전 역할에게 열려 있다.
   */
-  const company = await getCompanySetting();
+  const company = await getCompanyOrg();
   const positionNames = company.positions.map((position) => position.name);
   /* ⚠️ **이 사람 팀의 역할만** 준다 — 역할은 팀에 매여 있고 팀은 이 화면에서 안 바꾼다 */
   const roleOptions = buildTeamRoles(company.departments)[detail.member.teamName ?? ""] ?? [];

--- a/src/app/(shell)/(authority)/manage/members/page.tsx
+++ b/src/app/(shell)/(authority)/manage/members/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
 import { AccessDenied } from "@/components/common/access-denied";
-import { getCompanySetting } from "@/features/company/server";
+import { getCompanyOrg } from "@/features/company/server";
 import { MemberListView } from "@/features/member/components/member-list-view";
 import { getManagedMembersPage } from "@/features/member/manage-server";
 import { MEMBER_FILTER, type MemberFilter, type MemberQuery } from "@/features/member/manage-types";
@@ -67,9 +67,13 @@ export default async function ManageMembersPage({
        훑어서, 이 화면 하나에 목록 조회가 두 번 나갔다 — 팀의 정본은 기업 설정의 조직 체계이고
        이미 여기서 받고 있다.
   */
+  /*
+    ⚠️ `getCompanySetting`이 아니다(2026-08-12 고침) — 그건 OWNER 전용 `companies/me`를 물고
+       있어 Admin 겸직자가 이 페이지에서 403으로 죽었다. 여기 필요한 건 팀·직급 목록뿐이다.
+  */
   const [firstPage, company] = await Promise.all([
     getManagedMembersPage(query, 0),
-    getCompanySetting(),
+    getCompanyOrg(),
   ]);
   const teamNames = company.departments.map((team) => team.name);
 

--- a/src/features/company/actions.ts
+++ b/src/features/company/actions.ts
@@ -133,12 +133,16 @@ export async function saveCompanyProfileAction(
           name: draft.name,
           businessNumber: draft.businessNumber,
           /*
-            ⚠️ **비었으면 필드째 뺀다**(2026-08-12 고침). 전에는 빈 문자열을 보냈는데 BE가
-               `@Pattern`(NOT_BLANK_IF_PRESENT)으로 빈 값을 400으로 거절해서 **주소 없는
-               회사는 기본 정보 저장이 항상 실패**했다. BE는 부분 수정이라 필드가 없으면
-               "건드리지 말라"로 읽는다 — 저장은 되고, 대신 **한 번 넣은 주소를 지우는 길은
-               지금 계약에 없다**(빈 값 거부 + 생략 = 미변경). 지우기가 필요해지면 BE와
-               별도 협의한다(요청 문서에 적어 둠, §정직성: 되는 척하지 않는다).
+            ⚠️ **빈 문자열을 보내지 않는다.** BE가 `@Pattern`(NOT_BLANK_IF_PRESENT)으로 빈 값을
+               400으로 거절한다 — 부분 수정이라 필드가 없으면 "건드리지 말라"로 읽는다.
+            ⚠️ **지금은 이 생략이 실제로 일어나지 않는다**(2026-08-13 정정, 코드래빗 지적).
+               `validateCompanyProfile`이 `place`를 **필수로 막아**(register-draft.ts의
+               `.refine(place !== null)`) 주소가 빈 채로 여기까지 오지 않는다 — 즉 화면 정책은
+               "주소는 필수"다. 그래도 생략 형태로 두는 건, 검증이 완화되는 날 곧바로 400이
+               나지 않게 하기 위한 것이다.
+            ⚠️ 따라서 **한 번 넣은 주소를 지우는 길은 지금 없다**(검증이 빈 값을 막고, BE도
+               빈 값을 거절한다). 지우기가 필요해지면 검증 완화 + BE 계약이 함께 필요하다
+               (요청 문서에 적어 둠, §정직성: 되는 척하지 않는다).
           */
           ...(draft.place?.address ? { address: draft.place.address } : {}),
         },

--- a/src/features/company/actions.ts
+++ b/src/features/company/actions.ts
@@ -133,11 +133,14 @@ export async function saveCompanyProfileAction(
           name: draft.name,
           businessNumber: draft.businessNumber,
           /*
-            ⚠️ **`null`을 보내면 안 지워진다.** BE는 부분 수정이라 `null`을 "이 필드는 건드리지
-               말라"로 읽는다 — 주소를 비우려고 지운 사람에게는 옛 주소가 그대로 남는다.
-               빈 문자열을 보내야 실제로 비워진다(`@Size`만 걸려 있어 통과한다).
+            ⚠️ **비었으면 필드째 뺀다**(2026-08-12 고침). 전에는 빈 문자열을 보냈는데 BE가
+               `@Pattern`(NOT_BLANK_IF_PRESENT)으로 빈 값을 400으로 거절해서 **주소 없는
+               회사는 기본 정보 저장이 항상 실패**했다. BE는 부분 수정이라 필드가 없으면
+               "건드리지 말라"로 읽는다 — 저장은 되고, 대신 **한 번 넣은 주소를 지우는 길은
+               지금 계약에 없다**(빈 값 거부 + 생략 = 미변경). 지우기가 필요해지면 BE와
+               별도 협의한다(요청 문서에 적어 둠, §정직성: 되는 척하지 않는다).
           */
-          address: draft.place?.address ?? "",
+          ...(draft.place?.address ? { address: draft.place.address } : {}),
         },
       });
     } catch (error) {

--- a/src/features/company/server.ts
+++ b/src/features/company/server.ts
@@ -48,3 +48,33 @@ export async function getCompanySetting(): Promise<CompanySetting> {
     teamMemberCounts: toTeamMemberCounts(teams),
   };
 }
+
+/**
+ * 팀·직급 목록만 — **사원 관리 화면들이 쓴다.**
+ *
+ * ⚠️ 이 자리에 `getCompanySetting`을 쓰면 안 된다(2026-08-12 고침). 그 함수가 부르는
+ *    `GET /api/companies/me`는 **OWNER 전용**이라(BE `@PreAuthorize("hasRole('OWNER')")`),
+ *    Admin 겸직자가 사원 관리에 들어가는 순간 403으로 **페이지가 통째로 죽었다** — FE 가드
+ *    (`canManageMembers` = owner‖is_admin)와 데이터 소스의 권한이 어긋나 있었다.
+ *    팀(`GET /api/teams`)·직급(`GET /api/job-positions`)은 로그인 전원에게 열려 있어
+ *    (`isAuthenticated()`) 이 둘만 부르면 Admin도 막히지 않는다.
+ * ⚠️ 기업 설정 화면(`/owner/setting`)은 계속 `getCompanySetting`을 쓴다 — 거긴 기본 정보
+ *    (프로필)가 필요하고 OWNER 전용 화면이라 어긋날 일이 없다.
+ */
+export async function getCompanyOrg(): Promise<Pick<CompanySetting, "departments" | "positions">> {
+  if (isMock) {
+    const setting = await getMockCompanySetting();
+    return { departments: setting.departments, positions: setting.positions };
+  }
+
+  const accessToken = await requireAccessToken();
+  const [teams, positions] = await Promise.all([
+    serverApi<BeTeam[]>(ep.teams(), { accessToken }),
+    serverApi<BePosition[]>(ep.jobPositions(), { accessToken }),
+  ]);
+
+  return {
+    departments: teams.map(toDepartmentNode),
+    positions: positions.map(toPosition),
+  };
+}

--- a/src/features/member/components/account-issue-dialog.tsx
+++ b/src/features/member/components/account-issue-dialog.tsx
@@ -125,7 +125,16 @@ export function AccountIssueDialog({
 
       setIsOpen(false);
       setIssued(result.issued ?? null);
-      toast.success("계정을 발급했습니다");
+      /*
+        ⚠️ **계정은 났는데 겸직만 못 붙은 경우를 성공으로 뭉개지 않는다**(§정직성).
+           발급과 겸직은 BE에서 두 호출이라 가운데서 끊길 수 있다 — 그때 "발급했습니다"만
+           띄우면 관리자는 겸직이 붙은 줄 알고 넘어간다. 다음에 할 일까지 말해 준다.
+      */
+      if (result.adminGrantFailed) {
+        toast.warning("계정은 발급됐지만 관리자 겸직은 붙지 않았습니다 — 사원 상세에서 켜 주세요");
+      } else {
+        toast.success("계정을 발급했습니다");
+      }
       // 목록은 서버 컴포넌트라 다시 받아온다(`revalidatePath`가 캐시를 이미 비웠다)
       router.refresh();
     });

--- a/src/features/member/components/member-list-view.tsx
+++ b/src/features/member/components/member-list-view.tsx
@@ -131,7 +131,7 @@ export function MemberListView({
                 id="member-search"
                 value={keyword}
                 onChange={(event) => setKeyword(event.target.value)}
-                placeholder="이름·팀·이메일 검색"
+                placeholder="이름·팀·직급 검색"
                 className="pl-9"
               />
               {/* 칸 이름은 자리표시자로만 두지 않는다 — 적기 시작하면 사라진다(§a11y) */}

--- a/src/features/member/manage-actions.ts
+++ b/src/features/member/manage-actions.ts
@@ -6,7 +6,7 @@ import type { Authority } from "@/constants/authority";
 import { AUTHORITY, POSITION_AUTHORITIES } from "@/constants/authority";
 import { MEMBER_STATUS } from "@/constants/member";
 import { requireAccessToken } from "@/features/auth/session";
-import { getCompanySetting } from "@/features/company/server";
+import { getCompanyOrg } from "@/features/company/server";
 import { getViewer } from "@/features/shell/viewer";
 import { serverApi, toUserMessage } from "@/lib/api";
 import { todayIso } from "@/lib/date";
@@ -128,7 +128,8 @@ export async function changeMemberGradeAction(
   const position = next.position.trim();
   if (!position) return { isSuccess: false, message: "직급을 골라 주세요" };
 
-  const company = await getCompanySetting();
+  /* ⚠️ Admin도 부르는 액션이라 OWNER 전용 `companies/me`를 물면 안 된다 — 팀·직급만 받는다 */
+  const company = await getCompanyOrg();
   if (!company.positions.some((entry) => entry.name === position)) {
     return { isSuccess: false, message: "회사에 없는 직급입니다" };
   }
@@ -187,6 +188,16 @@ export async function changeMemberGradeAction(
     const jobPosition = company.positions.find((item) => item.name === position);
     if (!jobPosition) return { isSuccess: false, message: "회사에 없는 직급입니다" };
 
+    /*
+      ⚠️ **겸직 검사를 첫 PATCH보다 먼저 한다**(2026-08-12 고침). 겸직 변경은 OWNER만 되는데
+         (BE `@PreAuthorize("hasRole('OWNER')")`), 전에는 역할·직급 PATCH를 보낸 **뒤에**
+         걸렀다 — ADMIN이 직급+겸직을 같이 바꾸면 직급은 이미 저장된 채 실패 메시지가 떠서
+         **절반만 반영**됐다. 실패할 요청이면 아무것도 저장되기 전에 멈춰야 한다.
+    */
+    if (next.isAdmin !== target.member.isAdmin && pass.viewer.role !== AUTHORITY.OWNER) {
+      return { isSuccess: false, message: "관리자 겸직은 대표만 바꿀 수 있습니다" };
+    }
+
     try {
       const accessToken = await requireAccessToken();
       await serverApi<unknown>(ep.member(id), {
@@ -195,15 +206,7 @@ export async function changeMemberGradeAction(
         json: { role: next.authority, jobPositionId: Number(jobPosition.id) },
       });
 
-      /*
-        ⚠️ **겸직 변경은 OWNER만 된다**(BE `@PreAuthorize("hasRole('OWNER')")`). ADMIN이
-           겸직을 건드리면 역할·직급은 이미 저장된 뒤 이 호출만 403으로 막혀 **절반만 반영**된다 —
-           화면은 "실패"라고 말하는데 직급은 바뀌어 있다. 부르기 전에 걸러 낸다.
-        ⚠️ 실제로 달라질 때만 부른다 — 같은 값이면 괜히 403을 만들 이유가 없다.
-      */
-      if (next.isAdmin !== target.member.isAdmin && pass.viewer.role !== AUTHORITY.OWNER) {
-        return { isSuccess: false, message: "관리자 겸직은 대표만 바꿀 수 있습니다" };
-      }
+      /* ⚠️ 실제로 달라질 때만 부른다 — 같은 값이면 괜히 왕복을 만들 이유가 없다 */
       if (next.isAdmin !== target.member.isAdmin) {
         await serverApi<unknown>(ep.memberAdmin(id), {
           method: "PATCH",
@@ -395,7 +398,8 @@ export async function issueAccountAction(draft: AccountDraft): Promise<IssueAcco
     ⚠️ 직급 목록을 **여기서 구해 넘긴다.** 화면이 보낸 값을 그대로 믿으면 회사에 없는
        직급으로도 발급된다(§권한: 화면 숨김은 보안이 아니다).
   */
-  const company = await getCompanySetting();
+  /* ⚠️ Admin도 발급할 수 있다 — OWNER 전용 `companies/me` 대신 팀·직급만 받는다(403 방지) */
+  const company = await getCompanyOrg();
   const errors = validateAccount(
     draft,
     company.positions.map((position) => position.name),
@@ -431,21 +435,50 @@ export async function issueAccountAction(draft: AccountDraft): Promise<IssueAcco
       return { errors: { position: "먼저 기업 설정에서 직급을 저장해 주세요" } };
     }
 
+    /*
+      ⚠️ **겸직 토글은 발급 요청에 못 싣는다** — BE `IssueMemberRequest`에 `isAdmin`이 없다
+         ("발급 시점엔 항상 false"). 전에는 토글 값을 **아무 데도 안 보내서** 켜고 발급해도
+         겸직이 안 붙는데 성공 토스트가 떴다(침묵 탈락, §정직성 위반). 발급 뒤
+         `PATCH /members/{id}/admin`을 이어 부르는 걸로 고쳤고, 그 경로가 **OWNER 전용**이라
+         Admin 발급자가 토글을 켰으면 보내기 전에 여기서 막는다 — 직급 변경과 같은 규칙이다.
+    */
+    if (draft.isAdmin && pass.viewer.role !== AUTHORITY.OWNER) {
+      return { errors: {}, message: "관리자 겸직 발급은 대표만 할 수 있습니다" };
+    }
+
+    /*
+      ⚠️ 응답을 버리지 않는다(2026-08-12 고침 — [확인] BE `IssuedMemberResponse`:
+         `memberId·name·email·…`). 전에는 `serverApi<unknown>`으로 버려서, 목에서는 뜨던
+         "OO님 보기" 결과 창이 라이브에서만 안 떴다.
+    */
+    let issuedMember: { memberId: number; name: string; email: string };
     try {
       const accessToken = await requireAccessToken();
-      await serverApi<unknown>(ep.manageMembers(), {
-        method: "POST",
-        accessToken,
-        json: {
-          name: draft.name,
-          email: draft.email,
-          teamId: teamId,
-          jobPositionId: positionId,
-          /* ⚠️ **`role`은 필수다**(BE `@NotNull`). 빠뜨리면 **항상 400**이다 */
-          role: draft.authority,
-          roleLabel: draft.roleLabel || null,
+      issuedMember = await serverApi<{ memberId: number; name: string; email: string }>(
+        ep.manageMembers(),
+        {
+          method: "POST",
+          accessToken,
+          json: {
+            name: draft.name,
+            email: draft.email,
+            teamId: teamId,
+            jobPositionId: positionId,
+            /* ⚠️ **`role`은 필수다**(BE `@NotNull`). 빠뜨리면 **항상 400**이다 */
+            role: draft.authority,
+            roleLabel: draft.roleLabel || null,
+          },
         },
-      });
+      );
+
+      /* 겸직 토글이 켜져 있으면 이어서 붙인다 — OWNER인 것은 위에서 이미 확인했다 */
+      if (draft.isAdmin) {
+        await serverApi<unknown>(ep.memberAdmin(issuedMember.memberId), {
+          method: "PATCH",
+          accessToken,
+          json: { isAdmin: true },
+        });
+      }
     } catch (error) {
       /* 중복 메일이 가장 흔한 실패라 이메일 칸에 붙인다 — 폼 오류는 인라인이다(DECISIONS §7) */
       return { errors: { email: toUserMessage(error) } };
@@ -453,7 +486,10 @@ export async function issueAccountAction(draft: AccountDraft): Promise<IssueAcco
 
     revalidatePath("/manage/members");
     revalidatePath(PEOPLE_PATH);
-    return { errors: {} };
+    return {
+      errors: {},
+      issued: { id: issuedMember.memberId, name: issuedMember.name, email: issuedMember.email },
+    };
   }
 
   /*

--- a/src/features/member/manage-actions.ts
+++ b/src/features/member/manage-actions.ts
@@ -14,6 +14,7 @@ import { ep } from "@/lib/endpoints";
 import type { PaginatedResult } from "@/lib/paginate";
 import {
   canApproveFinal,
+  canChangeAdminGrant,
   canChangeMemberGrade,
   canDeleteMemberAccount,
   canIssueAccount,
@@ -194,7 +195,7 @@ export async function changeMemberGradeAction(
          걸렀다 — ADMIN이 직급+겸직을 같이 바꾸면 직급은 이미 저장된 채 실패 메시지가 떠서
          **절반만 반영**됐다. 실패할 요청이면 아무것도 저장되기 전에 멈춰야 한다.
     */
-    if (next.isAdmin !== target.member.isAdmin && pass.viewer.role !== AUTHORITY.OWNER) {
+    if (next.isAdmin !== target.member.isAdmin && !canChangeAdminGrant(pass.viewer)) {
       return { isSuccess: false, message: "관리자 겸직은 대표만 바꿀 수 있습니다" };
     }
 
@@ -451,7 +452,7 @@ export async function issueAccountAction(draft: AccountDraft): Promise<IssueAcco
          `PATCH /members/{id}/admin`을 이어 부르는 걸로 고쳤고, 그 경로가 **OWNER 전용**이라
          Admin 발급자가 토글을 켰으면 보내기 전에 여기서 막는다 — 직급 변경과 같은 규칙이다.
     */
-    if (draft.isAdmin && pass.viewer.role !== AUTHORITY.OWNER) {
+    if (draft.isAdmin && !canChangeAdminGrant(pass.viewer)) {
       return { errors: {}, message: "관리자 겸직 발급은 대표만 할 수 있습니다" };
     }
 

--- a/src/features/member/manage-actions.ts
+++ b/src/features/member/manage-actions.ts
@@ -377,6 +377,15 @@ export interface IssueAccountResult {
   /** 칸과 무관한 실패 한 줄(권한 없음·미연동 등) */
   message?: string;
   issued?: { id: number; name: string; email: string };
+  /**
+   * **계정은 만들어졌는데 겸직만 못 붙은 상태**(2026-08-13, 코드래빗 지적).
+   *
+   * ⚠️ 발급(POST)과 겸직(PATCH)은 **원자적이지 않다** — BE `IssueMemberRequest`에 `isAdmin`이
+   *    없어 두 번 나눠 부를 수밖에 없다. 가운데서 끊기면 계정은 이미 있으므로, 실패로 되돌리고
+   *    다시 누르게 하면 **중복 이메일 오류만 뜨고 계정은 겸직 없이 남는다.**
+   *    그래서 실패가 아니라 **부분 성공**으로 알린다 — 사람은 사원 상세에서 겸직만 켜면 된다.
+   */
+  adminGrantFailed?: boolean;
 }
 
 /**
@@ -451,9 +460,9 @@ export async function issueAccountAction(draft: AccountDraft): Promise<IssueAcco
          `memberId·name·email·…`). 전에는 `serverApi<unknown>`으로 버려서, 목에서는 뜨던
          "OO님 보기" 결과 창이 라이브에서만 안 떴다.
     */
+    const accessToken = await requireAccessToken();
     let issuedMember: { memberId: number; name: string; email: string };
     try {
-      const accessToken = await requireAccessToken();
       issuedMember = await serverApi<{ memberId: number; name: string; email: string }>(
         ep.manageMembers(),
         {
@@ -470,25 +479,38 @@ export async function issueAccountAction(draft: AccountDraft): Promise<IssueAcco
           },
         },
       );
-
-      /* 겸직 토글이 켜져 있으면 이어서 붙인다 — OWNER인 것은 위에서 이미 확인했다 */
-      if (draft.isAdmin) {
-        await serverApi<unknown>(ep.memberAdmin(issuedMember.memberId), {
-          method: "PATCH",
-          accessToken,
-          json: { isAdmin: true },
-        });
-      }
     } catch (error) {
       /* 중복 메일이 가장 흔한 실패라 이메일 칸에 붙인다 — 폼 오류는 인라인이다(DECISIONS §7) */
       return { errors: { email: toUserMessage(error) } };
     }
 
+    /*
+      ⚠️ **여기서부터 계정은 이미 있다.** 겸직 PATCH가 실패해도 발급을 없던 일로 되돌릴 수
+         없어서(BE에 취소 경로가 없다) 실패로 돌려주면 안 된다 — 다시 누르면 중복 이메일
+         오류만 나고 계정은 겸직 없이 남는다. **부분 성공으로 알리고** 다음 할 일을 말한다
+         (§정직성: 절반 된 것을 실패나 성공으로 뭉개지 않는다).
+      ⚠️ 목록·조직도 갱신은 **어느 쪽이든 한다** — 계정이 생긴 건 사실이다.
+    */
+    let adminGrantFailed = false;
+    if (draft.isAdmin) {
+      try {
+        await serverApi<unknown>(ep.memberAdmin(issuedMember.memberId), {
+          method: "PATCH",
+          accessToken,
+          json: { isAdmin: true },
+        });
+      } catch {
+        adminGrantFailed = true;
+      }
+    }
+
     revalidatePath("/manage/members");
     revalidatePath(PEOPLE_PATH);
+    revalidatePath(pathOf(issuedMember.memberId));
     return {
       errors: {},
       issued: { id: issuedMember.memberId, name: issuedMember.name, email: issuedMember.email },
+      ...(adminGrantFailed ? { adminGrantFailed: true } : {}),
     };
   }
 

--- a/src/features/member/manage-server.ts
+++ b/src/features/member/manage-server.ts
@@ -158,12 +158,18 @@ export async function getManagedMembersPage(
   if (query.keyword.trim()) params.set("q", query.keyword.trim());
 
   /*
-    ⚠️ **`totalCount`다**(`totalElements` 아님 — [확인] BE `MemberPageResponse`). 이름을 잘못
-       읽으면 `undefined`가 되어 `전체 N건`이 비고 `totalPages`가 `NaN`이 된다 — 다음 페이지가
-       있는지 아무도 모르게 된다.
+    ⚠️ **`totalElements`다**(`totalCount` 아님 — [확인] BE `MemberPageResponse.java` record:
+       `totalElements·totalPages·hasNext·page·size·content`, 2026-08-12 재대조). 전에는
+       `totalCount`로 읽었는데 그 필드가 응답에 없어 `undefined`가 되고, `전체 N건`이 비고
+       `totalPages`가 `NaN`이라 **다음 페이지 판정이 통째로 무너졌다**. 주석의 [확인] 표시까지
+       반대로 적혀 있었다 — 이름 하나가 화면 전체를 조용히 죽이는 자리라 응답 그대로 옮긴다.
+    ⚠️ `totalPages`도 **서버 값을 그대로 쓴다.** 우리가 나눠 만들면 반올림 규칙이 갈릴 때
+       마지막 페이지가 한 번 더 불리거나 잘린다 — 세는 쪽과 자르는 쪽은 같은 곳이어야 한다.
   */
   const response = await serverApi<{
-    totalCount: number;
+    totalElements: number;
+    totalPages: number;
+    hasNext: boolean;
     page: number;
     size: number;
     content: BeMemberListItem[];
@@ -172,7 +178,7 @@ export async function getManagedMembersPage(
   /*
     ⚠️ **지워진 사람은 여기서 뺀다**(§도메인 상수). 퇴사자(`RESIGNED`)는 남는다 — 그 사람이
        남긴 회의·액션의 출처라 이름이 사라지면 추적이 끊긴다.
-    ⚠️ 거른 만큼 `totalCount`를 줄이지 않는다. 그 숫자는 **서버가 센 전체**이고, 화면의
+    ⚠️ 거른 만큼 전체 건수를 줄이지 않는다. 그 숫자는 **서버가 센 전체**이고, 화면의
        `전체 N건`은 그 값을 말해야 다음 페이지가 있는지와 어긋나지 않는다.
   */
   const items = response.content
@@ -182,9 +188,8 @@ export async function getManagedMembersPage(
   return {
     items,
     page: response.page,
-    /* ⚠️ `size`가 0으로 오면 0으로 나눠 `Infinity`가 된다 — 요청한 값으로 되돌린다 */
-    totalPages: Math.max(1, Math.ceil(response.totalCount / (response.size || pageSize))),
-    totalCount: response.totalCount,
+    totalPages: Math.max(1, response.totalPages),
+    totalCount: response.totalElements,
   };
 }
 

--- a/src/lib/permission.ts
+++ b/src/lib/permission.ts
@@ -143,6 +143,20 @@ export function canChangeMemberGrade(actor: Actor): boolean {
 }
 
 /**
+ * 관리자 겸직을 **바꿀 수 있는 사람** — OWNER 전용.
+ *
+ * ⚠️ `canGrantAdmin`은 **대상**(누구에게 겸직을 얹을 수 있나)을 보고, 이건 **주체**(누가
+ *    켤 수 있나)를 본다 — 둘을 한 함수로 합치면 인자가 섞여 어느 쪽을 물어본 건지 흐려진다.
+ * ⚠️ **BE와 같은 문이다** — `PATCH /api/members/{id}/admin`이 `hasRole('OWNER')`이라
+ *    (Admin이 자기를 복제하는 것을 끊으려고 떼어 둔 경로), Admin이 눌러도 403이 온다.
+ *    화면·발급·직급 변경 세 자리가 이 판정을 **같이** 써야 정책이 바뀔 때 한 곳만 고친다
+ *    (§권한: 판정은 `lib/permission.ts` 한 곳, 역할 상수를 화면에 하드코딩하지 않는다).
+ */
+export function canChangeAdminGrant(actor: Actor): boolean {
+  return actor.role === AUTHORITY.OWNER;
+}
+
+/**
  * 계정 탈퇴 — **OWNER 전용**.
  *
  * ⚠️ 최종 승인보다 더 뒤에 있는 일이라 같은 문을 쓴다. 승인은 사람을 퇴사 상태로 옮길


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독

---

## 🙋 관련 역할

- [x] OWNER (대표)
- [x] ADMIN (관리자)

---

## 📝 작업 내용

FE↔BE 실코드 정밀 감사(#415)에서 나온 사원 관리·기업 설정 연동 결함 7종.

| # | 뭐가 | 어떻게 |
|---|---|---|
| 1 | 목록 페이지네이션 붕괴 — `totalCount`를 읽는데 BE는 `totalElements` | 응답 타입을 BE `MemberPageResponse` record 그대로(`totalElements·totalPages·hasNext`)로 교정, `totalPages`도 서버 값 사용 |
| 2 | ADMIN이 `/manage/members`에서 403 — OWNER 전용 `companies/me`를 물고 있었음 | `getCompanyOrg()` 신설(팀·직급만, 둘 다 전 역할) — 목록 페이지·직급 검증·발급 3곳 교체. 기업 설정 화면은 기존대로 |
| 3 | 발급 시 관리자 겸직 토글 침묵 탈락 | OWNER면 발급 후 `PATCH /members/{id}/admin` 이어 호출, ADMIN이 토글 켰으면 보내기 전에 인라인으로 막음 |
| 4 | 발급 결과 창이 라이브에서 안 뜸 — 응답을 버리고 있었음 | `IssuedMemberResponse` 수신 → `issued` 반환으로 "OO님 보기" 모달 복원 |
| 5 | 직급+겸직 동시 저장 절반 반영 — 검사가 첫 PATCH 뒤에 있었음 | 겸직 권한 검사를 첫 PATCH 앞으로 |
| 6 | 주소 없는 회사는 기본 정보 저장이 항상 400 — 빈 문자열을 BE `@Pattern`이 거절 | 비었으면 필드째 생략(부분 수정 = 미변경). "주소 지우기"는 계약에 없어 BE 요청 문서에 별도 기재 |
| 7 | 검색 placeholder가 "이메일 검색"이라 거짓 — BE는 이름·팀·직급만 매칭 | 문구 교정 |

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`fix/member-company-integration#415`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 겸직 검사를 저장 전으로, 발급 겸직도 OWNER 재검사(둘 다 서버 액션)
- [x] 🧬 **zod** — 기존 검증 유지, 응답 shape은 BE record 실코드 대조
- [x] 🕵️ **정직성** — 침묵 탈락 2곳(겸직·주소) 제거, 거짓 안내문 교정, 지우기 불가는 주석에 명시
- [ ] 🎨 디자인 토큰 — 해당 없음

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [ ] ♿ a11y — 해당 없음
- [x] ♻️ 재사용 확인 — `getCompanyOrg`가 기존 매퍼 재사용
- [x] 🧪 3상태 — 기존 화면 유지
- [ ] 브라우저 전용 API — 해당 없음

---

## 🔗 연관 이슈

Closes #415

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

```
npx tsc --noEmit  # 통과
npx eslint        # 통과
npx jest          # 959개 통과
```

- ①이 제일 급했다 — 필드명 하나가 `전체 N건`·무한 스크롤을 통째로 죽이고 있었고, 주석의 [확인] 표시까지 반대로 적혀 있었다.
- ⑥의 트레이드오프: 이제 주소 저장은 되지만 **한 번 넣은 주소를 지울 수는 없다**(BE가 빈 값을 거절 + 생략 = 미변경). BE 요청 문서에 올려 둠.

---

## 📝 추가 메모

같은 감사에서 나온 계약 정합 3종은 #416으로 분리.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **개선 사항**
  - 구성원 관리에서 팀과 직급 정보를 안정적으로 불러옵니다.
  - 구성원 검색 안내 문구가 이름·팀·직급 검색으로 변경되었습니다.
  - 구성원 목록의 전체 건수와 페이지 정보가 정확하게 표시됩니다.
  - 관리자 권한 변경 및 계정 발급 과정의 권한 검증이 강화되었습니다.
  - 계정 발급 후 생성된 구성원 정보가 결과에 표시됩니다.

- **버그 수정**
  - 회사 주소가 입력되지 않은 경우 불필요한 빈 주소가 저장되지 않습니다.
  - 관리자 권한 변경 시 실제 변경이 있을 때만 관련 처리가 진행됩니다.
  - 관리자 권한 설정에 실패하면 경고 안내가 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->