### PR TITLE
[FEAT] 내 액션·팀 액션 목록 무한 스크롤 — size=9999 전량 수신 제거 #417

### DIFF
--- a/src/app/(shell)/(authority)/team/action/page.tsx
+++ b/src/app/(shell)/(authority)/team/action/page.tsx
@@ -1,84 +1,28 @@
 import type { Metadata } from "next";
 
-import { isDelayed } from "@/constants/domain";
-import { getTeamActionsGroupedByProject } from "@/features/action/server";
-import type { TeamActionProjectGroup, TeamActionTimelineItem } from "@/features/action/types";
-import type { TimelineActionInput } from "@/features/member/action-timeline";
-import { ActionTimeline, ActionTimelineLegend } from "@/features/member/components/action-timeline";
-import { pickPaletteColor } from "@/lib/palette";
+import { TeamActionListView } from "@/features/action/components/team-action-list-view";
+import { getTeamActionsPage } from "@/features/action/server";
 
 export const metadata: Metadata = {
   title: "팀 액션",
 };
 
-/** 이 프로젝트의 팀 액션들을 타임라인 입력으로 — 프로젝트 상세 타임라인 탭과 같은 모양(§디자인). */
-function toTimelineItems(
-  group: TeamActionProjectGroup,
-  teamActions: TeamActionTimelineItem[],
-): TimelineActionInput[] {
-  const tagColor = pickPaletteColor(group.projectTag);
-  return teamActions.map((action) => ({
-    id: String(action.id),
-    title: action.name,
-    tag: group.projectTag,
-    tagBgColor: tagColor.bgColor,
-    tagTextColor: tagColor.textColor,
-    startDate: action.startDate,
-    dueDate: action.dueDate,
-    tone: isDelayed(action) ? "DELAYED" : action.status,
-    href: `/app/projects/${group.projectId}/team/${action.id}`,
-  }));
-}
-
+/**
+ * ⚠️ **첫 페이지만 서버가 렌더**한다(CLAUDE.md §목록·페이지네이션) — 2페이지부터는
+ *    `TeamActionListView`가 스크롤 끝에서 서버 액션으로 이어 붙인다. 프로젝트별 묶기는
+ *    이어 붙인 전체를 대상으로 화면이 매번 다시 한다(§mapper `groupTeamActionsByProject`).
+ */
 export default async function TeamActionPage() {
-  const groups = await getTeamActionsGroupedByProject();
-  const totalTeamActions = groups.reduce((sum, group) => sum + group.teamActions.length, 0);
+  const firstPage = await getTeamActionsPage(0);
 
   return (
     <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
-      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-4">
-        <p className="text-muted-foreground self-end text-xs tabular-nums">
-          {groups.length}개 프로젝트 · 총 {totalTeamActions}개 팀 액션
-        </p>
-
-        {groups.length === 0 ? (
-          <p className="text-muted-foreground flex min-h-[240px] items-center justify-center text-sm">
-            아직 하달된 팀 액션이 없습니다.
-          </p>
-        ) : (
-          groups.map((group) => {
-            const tagColor = pickPaletteColor(group.projectTag);
-            return (
-              <section
-                key={group.projectId}
-                className="border-border bg-card flex flex-col overflow-hidden rounded-2xl border"
-              >
-                <div className="border-border flex shrink-0 items-baseline justify-between gap-3 border-b px-7 pt-6 pb-3">
-                  <h3 className="flex items-center gap-2 text-[17px] leading-7 font-semibold tracking-[-0.3px]">
-                    <span className="bg-foreground size-2 rounded-full" aria-hidden />
-                    {group.projectName}
-                    <span
-                      className="rounded px-1.5 py-0.5 font-mono text-xs leading-none font-semibold"
-                      style={{ backgroundColor: tagColor.bgColor, color: tagColor.textColor }}
-                    >
-                      {group.projectTag}
-                    </span>
-                  </h3>
-                  <p className="text-muted-foreground text-[12px] leading-4 tabular-nums">
-                    {group.teamActions.length}개 팀 액션
-                  </p>
-                </div>
-                <ActionTimeline
-                  items={toTimelineItems(group, group.teamActions)}
-                  today={new Date()}
-                />
-              </section>
-            );
-          })
-        )}
-
-        <ActionTimelineLegend />
-      </div>
+      <TeamActionListView
+        initialItems={firstPage.items}
+        initialPage={firstPage.page}
+        initialTotalPages={firstPage.totalPages}
+        initialTotalCount={firstPage.totalCount}
+      />
     </main>
   );
 }

--- a/src/app/(shell)/app/my/actions/page.tsx
+++ b/src/app/(shell)/app/my/actions/page.tsx
@@ -1,9 +1,7 @@
 import type { Metadata } from "next";
 
-import { MyActionListItemRow } from "@/features/action/components/my-action-list-item";
-import { getMyActionList } from "@/features/action/server";
-import type { MyActionListItem } from "@/features/action/types";
-import { pickPaletteColor } from "@/lib/palette";
+import { MyActionListView } from "@/features/action/components/my-action-list-view";
+import { getMyActionsPage } from "@/features/action/server";
 
 export const metadata: Metadata = {
   title: "내 액션",
@@ -13,84 +11,23 @@ export const metadata: Metadata = {
 //    세션이 붙으면 실연동 분기(server.ts)는 이 값을 안 쓰고 토큰의 본인 소유분만 받는다.
 const MOCK_ASSIGNEE_NAME = "이하윤";
 
-/** 프로젝트별로 묶는다 — 마감 임박순으로 이미 정렬된 목록이라 그룹 안 순서도 그대로 유지된다. */
-function groupByProject(
-  actions: MyActionListItem[],
-): { projectId: number; projectName: string; projectTag: string; actions: MyActionListItem[] }[] {
-  const groups: Map<
-    number,
-    { projectName: string; projectTag: string; actions: MyActionListItem[] }
-  > = new Map();
-  for (const action of actions) {
-    const group = groups.get(action.projectId);
-    if (group) group.actions.push(action);
-    else {
-      groups.set(action.projectId, {
-        projectName: action.projectName,
-        projectTag: action.projectTag,
-        actions: [action],
-      });
-    }
-  }
-  return [...groups.entries()].map(([projectId, group]) => ({ projectId, ...group }));
-}
-
+/**
+ * ⚠️ **첫 페이지만 서버가 렌더**한다(CLAUDE.md §목록·페이지네이션) — 2페이지부터는
+ *    `MyActionListView`가 스크롤 끝에서 서버 액션으로 이어 붙인다. 화면 전체를
+ *    `use client`로 만들면 조회 전체가 클라이언트로 넘어간다(§핵심 4원칙 ①).
+ */
 export default async function MyActionsPage() {
-  const actions = await getMyActionList(MOCK_ASSIGNEE_NAME);
-  const groups = groupByProject(actions);
+  const firstPage = await getMyActionsPage(MOCK_ASSIGNEE_NAME, 0);
 
   return (
     <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
-      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-4">
-        <p className="text-muted-foreground text-sm">나에게 할당된 개인 액션 {actions.length}건</p>
-
-        {groups.length === 0 ? (
-          <section className="border-border bg-card overflow-hidden rounded-2xl border">
-            <p className="text-muted-foreground flex min-h-[240px] items-center justify-center text-sm">
-              아직 할당된 개인 액션이 없습니다.
-            </p>
-          </section>
-        ) : (
-          groups.map((group) => {
-            const tagColor = pickPaletteColor(group.projectTag);
-            return (
-              <section
-                key={group.projectId}
-                className="border-border bg-card flex flex-col overflow-hidden rounded-2xl border"
-              >
-                <div className="border-border flex shrink-0 items-baseline justify-between gap-3 border-b px-7 pt-6 pb-3">
-                  <h3 className="flex items-center gap-2 text-[17px] leading-7 font-semibold tracking-[-0.3px]">
-                    <span className="bg-foreground size-2 rounded-full" aria-hidden />
-                    {group.projectName}
-                    <span
-                      className="rounded px-1.5 py-0.5 font-mono text-xs leading-none font-semibold"
-                      style={{ backgroundColor: tagColor.bgColor, color: tagColor.textColor }}
-                    >
-                      {group.projectTag}
-                    </span>
-                  </h3>
-                  <p className="text-muted-foreground text-[12px] leading-4 tabular-nums">
-                    {group.actions.length}건
-                  </p>
-                </div>
-                <ul>
-                  {group.actions.map((action, index) => (
-                    <MyActionListItemRow
-                      key={action.id}
-                      action={action}
-                      showDivider={index > 0}
-                      // ⚠️ 항상 false — 카드 위쪽 모서리는 헤더가 이미 차지해서 목록의 첫 행은
-                      //    거기 안 닿는다(맞물리는 건 마지막 행뿐).
-                      isFirst={false}
-                      isLast={index === group.actions.length - 1}
-                    />
-                  ))}
-                </ul>
-              </section>
-            );
-          })
-        )}
-      </div>
+      <MyActionListView
+        initialItems={firstPage.items}
+        initialPage={firstPage.page}
+        initialTotalPages={firstPage.totalPages}
+        initialTotalCount={firstPage.totalCount}
+        assigneeName={MOCK_ASSIGNEE_NAME}
+      />
     </main>
   );
 }

--- a/src/features/action/actions.ts
+++ b/src/features/action/actions.ts
@@ -1,0 +1,33 @@
+"use server";
+
+import type { PaginatedResult } from "@/lib/paginate";
+
+import { getMyActionsPage, getTeamActionsPage } from "./server";
+import type { MyActionListItem, TeamActionListItem } from "./types";
+
+/**
+ * 액션 목록의 **다음 페이지** — 무한 스크롤 훅(`useInfiniteScrollList`)이 부른다.
+ * 첫 페이지는 서버 컴포넌트가 이미 렌더했다(§핵심 4원칙 ① — 여기서 다시 부르지 않는다).
+ *
+ * ⚠️ 실패는 **빈 페이지로 돌려주지 않는다** — 던지면 훅이 받아 [다시 시도]를 띄운다
+ *    (member/manage-actions.ts `fetchMembersPageAction`과 같은 이유, §목록 3상태).
+ * ⚠️ 권한 게이트는 따로 안 건다 — 두 목록 다 로그인 전원이 볼 수 있고, 스코프는 BE가
+ *    토큰(memberId·teamId)으로 이미 자른다([확인] `ActionController`·`TeamActionController`).
+ */
+
+/** ⚠️ `assigneeName`은 mock 분기 전용이다 — 실연동은 토큰의 본인 소유분만 온다(server.ts). */
+export async function fetchMyActionsPageAction(
+  assigneeName: string,
+  page: number,
+): Promise<PaginatedResult<MyActionListItem>> {
+  // ⚠️ `page`는 0-base다(BE 표준 확정, 2026-08-10) — NaN·Infinity·음수는 모두 0으로 당긴다.
+  const safePage = Number.isFinite(page) ? Math.max(0, Math.trunc(page)) : 0;
+  return getMyActionsPage(assigneeName, safePage);
+}
+
+export async function fetchTeamActionsPageAction(
+  page: number,
+): Promise<PaginatedResult<TeamActionListItem>> {
+  const safePage = Number.isFinite(page) ? Math.max(0, Math.trunc(page)) : 0;
+  return getTeamActionsPage(safePage);
+}

--- a/src/features/action/components/my-action-list-view.tsx
+++ b/src/features/action/components/my-action-list-view.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useCallback } from "react";
+
+import { InfiniteListFooter } from "@/components/common/infinite-list-footer";
+import { useInfiniteScrollList } from "@/hooks/use-infinite-scroll-list";
+import { pickPaletteColor } from "@/lib/palette";
+
+import { fetchMyActionsPageAction } from "../actions";
+import { groupMyActionsByProject } from "../mapper";
+import type { MyActionListItem } from "../types";
+import { MyActionListItemRow } from "./my-action-list-item";
+
+/**
+ * 내 액션 목록 — **서버가 자르고, 화면이 이어 붙인다**(CLAUDE.md §목록·페이지네이션).
+ *
+ * ⚠️ 첫 페이지는 서버 컴포넌트(page.tsx)가 렌더한 값을 그대로 받는다 — 여기서 다시 안 부른다.
+ * ⚠️ 프로젝트별 묶기는 **이어 붙인 전체를 대상으로 매번 다시** 한다. 서버 정렬이
+ *    `sort=dueDate&order=asc`라 그룹 순서는 대체로 안정적이지만, 새 페이지가 도착하면
+ *    이미 그려진 그룹이 자랄 수 있다 — 전량을 미리 받는 것보다 정직한 동작이다.
+ * ⚠️ 머리의 건수는 지금 그려진 줄 수가 아니라 **서버가 센 전체**다(`전체 N건` — 끝이 안
+ *    보이는 목록은 얼마나 남았는지 알 수 없다).
+ */
+
+/** 컴포넌트 밖에 둬서 매 렌더 새 함수가 안 되게 한다(센티널 재부착 방지) */
+function getId(action: MyActionListItem) {
+  return String(action.id);
+}
+
+interface MyActionListViewProps {
+  initialItems: MyActionListItem[];
+  initialPage: number;
+  initialTotalPages: number;
+  initialTotalCount: number;
+  /** ⚠️ mock 분기 전용 — 실연동은 토큰의 본인 소유분만 온다(server.ts). */
+  assigneeName: string;
+}
+
+export function MyActionListView({
+  initialItems,
+  initialPage,
+  initialTotalPages,
+  initialTotalCount,
+  assigneeName,
+}: MyActionListViewProps) {
+  const fetchPage = useCallback(
+    (page: number) => fetchMyActionsPageAction(assigneeName, page),
+    [assigneeName],
+  );
+
+  const { items, totalCount, hasMore, isLoadingMore, error, loadMore, sentinelRef } =
+    useInfiniteScrollList({
+      initialItems,
+      initialPage,
+      initialTotalPages,
+      initialTotalCount,
+      getId,
+      fetchPage,
+    });
+
+  const groups = groupMyActionsByProject(items);
+
+  return (
+    <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-4">
+      <p className="text-muted-foreground text-sm tabular-nums">
+        나에게 할당된 개인 액션 {totalCount}건
+      </p>
+
+      {groups.length === 0 ? (
+        <section className="border-border bg-card overflow-hidden rounded-2xl border">
+          <p className="text-muted-foreground flex min-h-[240px] items-center justify-center text-sm">
+            아직 할당된 개인 액션이 없습니다.
+          </p>
+        </section>
+      ) : (
+        groups.map((group) => {
+          const tagColor = pickPaletteColor(group.projectTag);
+          return (
+            <section
+              key={group.projectId}
+              className="border-border bg-card flex flex-col overflow-hidden rounded-2xl border"
+            >
+              <div className="border-border flex shrink-0 items-baseline justify-between gap-3 border-b px-7 pt-6 pb-3">
+                <h3 className="flex items-center gap-2 text-[17px] leading-7 font-semibold tracking-[-0.3px]">
+                  <span className="bg-foreground size-2 rounded-full" aria-hidden />
+                  {group.projectName}
+                  <span
+                    className="rounded px-1.5 py-0.5 font-mono text-xs leading-none font-semibold"
+                    style={{ backgroundColor: tagColor.bgColor, color: tagColor.textColor }}
+                  >
+                    {group.projectTag}
+                  </span>
+                </h3>
+                {/* 그룹 건수는 **지금까지 받은 것만** 센다 — 다음 페이지가 오면 늘 수 있다 */}
+                <p className="text-muted-foreground text-[12px] leading-4 tabular-nums">
+                  {group.actions.length}건
+                </p>
+              </div>
+              <ul>
+                {group.actions.map((action, index) => (
+                  <MyActionListItemRow
+                    key={action.id}
+                    action={action}
+                    showDivider={index > 0}
+                    // ⚠️ 항상 false — 카드 위쪽 모서리는 헤더가 이미 차지해서 목록의 첫 행은
+                    //    거기 안 닿는다(맞물리는 건 마지막 행뿐).
+                    isFirst={false}
+                    isLast={index === group.actions.length - 1}
+                  />
+                ))}
+              </ul>
+            </section>
+          );
+        })
+      )}
+
+      {/*
+        ⚠️ 목록 끝의 빈 요소가 **감시 대상**이다(IntersectionObserver) — 화면에 걸리면 자동으로
+           다음 페이지를 부른다. [더 보기] 버튼은 없다(2026-08-10 폐기). 실패하면 조용히 멈추지
+           않는다 — [다시 시도]를 띄운다(§목록 3상태).
+      */}
+      <InfiniteListFooter
+        hasMore={hasMore}
+        isLoadingMore={isLoadingMore}
+        error={error}
+        onLoadMore={loadMore}
+        sentinelRef={sentinelRef}
+      />
+    </div>
+  );
+}

--- a/src/features/action/components/team-action-list-view.tsx
+++ b/src/features/action/components/team-action-list-view.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { InfiniteListFooter } from "@/components/common/infinite-list-footer";
+import { isDelayed } from "@/constants/domain";
+import type { TimelineActionInput } from "@/features/member/action-timeline";
+import { ActionTimeline, ActionTimelineLegend } from "@/features/member/components/action-timeline";
+import { useInfiniteScrollList } from "@/hooks/use-infinite-scroll-list";
+import { pickPaletteColor } from "@/lib/palette";
+
+import { fetchTeamActionsPageAction } from "../actions";
+import { groupTeamActionsByProject } from "../mapper";
+import type { TeamActionListItem, TeamActionProjectGroup, TeamActionTimelineItem } from "../types";
+
+/**
+ * 팀 액션 목록 — **서버가 자르고, 화면이 이어 붙인다**(CLAUDE.md §목록·페이지네이션).
+ *
+ * ⚠️ 첫 페이지는 서버 컴포넌트(page.tsx)가 렌더한 값을 그대로 받는다 — 여기서 다시 안 부른다.
+ * ⚠️ 프로젝트별 묶기는 **이어 붙인 전체를 대상으로 매번 다시** 한다. 서버 정렬이
+ *    `sort=dueDate&order=asc`라 그룹 순서는 대체로 안정적이지만, 새 페이지가 도착하면
+ *    이미 그려진 타임라인 그룹이 자랄 수 있다 — 전량을 미리 받는 것보다 정직한 동작이다.
+ * ⚠️ 머리의 건수는 **서버가 센 전체**다. 프로젝트 개수는 안 적는다 — 서버는 남은 페이지에
+ *    어떤 프로젝트가 더 있는지 안 알려주므로, 지금까지 받은 그룹 수를 적으면 거짓말이 된다.
+ */
+
+/** 컴포넌트 밖에 둬서 매 렌더 새 함수가 안 되게 한다(센티널 재부착 방지) */
+function getId(action: TeamActionListItem) {
+  return String(action.id);
+}
+
+/** 이 프로젝트의 팀 액션들을 타임라인 입력으로 — 프로젝트 상세 타임라인 탭과 같은 모양(§디자인). */
+function toTimelineItems(
+  group: TeamActionProjectGroup,
+  teamActions: TeamActionTimelineItem[],
+): TimelineActionInput[] {
+  const tagColor = pickPaletteColor(group.projectTag);
+  return teamActions.map((action) => ({
+    id: String(action.id),
+    title: action.name,
+    tag: group.projectTag,
+    tagBgColor: tagColor.bgColor,
+    tagTextColor: tagColor.textColor,
+    startDate: action.startDate,
+    dueDate: action.dueDate,
+    tone: isDelayed(action) ? "DELAYED" : action.status,
+    href: `/app/projects/${group.projectId}/team/${action.id}`,
+  }));
+}
+
+interface TeamActionListViewProps {
+  initialItems: TeamActionListItem[];
+  initialPage: number;
+  initialTotalPages: number;
+  initialTotalCount: number;
+}
+
+export function TeamActionListView({
+  initialItems,
+  initialPage,
+  initialTotalPages,
+  initialTotalCount,
+}: TeamActionListViewProps) {
+  const { items, totalCount, hasMore, isLoadingMore, error, loadMore, sentinelRef } =
+    useInfiniteScrollList({
+      initialItems,
+      initialPage,
+      initialTotalPages,
+      initialTotalCount,
+      getId,
+      fetchPage: fetchTeamActionsPageAction,
+    });
+
+  const groups = groupTeamActionsByProject(items);
+
+  return (
+    <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-4">
+      <p className="text-muted-foreground self-end text-xs tabular-nums">
+        전체 {totalCount}개 팀 액션
+      </p>
+
+      {groups.length === 0 ? (
+        <p className="text-muted-foreground flex min-h-[240px] items-center justify-center text-sm">
+          아직 하달된 팀 액션이 없습니다.
+        </p>
+      ) : (
+        groups.map((group) => {
+          const tagColor = pickPaletteColor(group.projectTag);
+          return (
+            <section
+              key={group.projectId}
+              className="border-border bg-card flex flex-col overflow-hidden rounded-2xl border"
+            >
+              <div className="border-border flex shrink-0 items-baseline justify-between gap-3 border-b px-7 pt-6 pb-3">
+                <h3 className="flex items-center gap-2 text-[17px] leading-7 font-semibold tracking-[-0.3px]">
+                  <span className="bg-foreground size-2 rounded-full" aria-hidden />
+                  {group.projectName}
+                  <span
+                    className="rounded px-1.5 py-0.5 font-mono text-xs leading-none font-semibold"
+                    style={{ backgroundColor: tagColor.bgColor, color: tagColor.textColor }}
+                  >
+                    {group.projectTag}
+                  </span>
+                </h3>
+                {/* 그룹 건수는 **지금까지 받은 것만** 센다 — 다음 페이지가 오면 늘 수 있다 */}
+                <p className="text-muted-foreground text-[12px] leading-4 tabular-nums">
+                  {group.teamActions.length}개 팀 액션
+                </p>
+              </div>
+              <ActionTimeline
+                items={toTimelineItems(group, group.teamActions)}
+                today={new Date()}
+              />
+            </section>
+          );
+        })
+      )}
+
+      {/*
+        ⚠️ 목록 끝의 빈 요소가 **감시 대상**이다(IntersectionObserver) — 화면에 걸리면 자동으로
+           다음 페이지를 부른다. [더 보기] 버튼은 없다(2026-08-10 폐기). 실패하면 조용히 멈추지
+           않는다 — [다시 시도]를 띄운다(§목록 3상태).
+      */}
+      <InfiniteListFooter
+        hasMore={hasMore}
+        isLoadingMore={isLoadingMore}
+        error={error}
+        onLoadMore={loadMore}
+        sentinelRef={sentinelRef}
+      />
+
+      <ActionTimelineLegend />
+    </div>
+  );
+}

--- a/src/features/action/mapper.ts
+++ b/src/features/action/mapper.ts
@@ -3,7 +3,12 @@ import type { MemberAction } from "@/features/member/types";
 import { type BeAttachment, toProjectAttachment } from "@/features/project/mapper";
 import type { TeamActionDetail } from "@/features/project/types";
 
-import type { MyActionListItem, PersonalActionDetail, TeamActionProjectGroup } from "./types";
+import type {
+  MyActionListItem,
+  PersonalActionDetail,
+  TeamActionListItem,
+  TeamActionProjectGroup,
+} from "./types";
 
 /**
  * BE shape → UI 계약 (§Mock 격리막).
@@ -128,32 +133,90 @@ export function toMyActionListItem(be: BeActionSummary): MyActionListItem {
 }
 
 /**
- * 팀 액션 목록(`GET /api/team/actions`) → 프로젝트별 그룹.
- * ⚠️ 목록 순서를 유지한 채 `projectId`로 묶는다(첫 등장 순서가 그룹 순서다).
+ * 팀 액션 목록(`GET /api/team/actions`) 한 줄 → 평평한 UI 계약.
+ * ⚠️ 여기서 그룹을 만들지 않는다 — 페이지 단위로 이어 붙인 뒤 화면이
+ *    `groupTeamActionsByProject`로 매번 다시 묶는다(§목록·페이지네이션).
  */
-export function groupTeamActionsByProject(items: BeActionSummary[]): TeamActionProjectGroup[] {
+export function toTeamActionListItem(be: BeActionSummary): TeamActionListItem {
+  return {
+    id: be.id,
+    name: be.title,
+    /*
+      ⚠️ **BE 필드를 읽는 자리는 여기 하나다**(2026-08-13 병합). 그룹핑이 `BeActionSummary`가
+         아니라 UI 계약(`TeamActionListItem`)을 받게 바뀌면서, 예정 시작일 fallback도 진척
+         값도 이 매퍼가 한 번에 흡수한다 — 그룹핑 쪽에서 다시 BE 모양을 알 필요가 없다.
+    */
+    startDate: fallbackActionStartDate(be.startDate ?? be.plannedStartDate),
+    dueDate: be.dueDate,
+    status: be.status,
+    childDoneCount: be.childDoneCount,
+    childTotalCount: be.childTotalCount,
+    projectId: be.projectId,
+    projectName: be.projectName ?? "",
+    projectTag: be.projectTag ?? "",
+  };
+}
+
+/**
+ * 팀 액션 목록 → 프로젝트별 그룹 — **지금까지 이어 붙인 전체**를 대상으로 매번 다시 묶는다.
+ * ⚠️ 목록 순서를 유지한 채 `projectId`로 묶는다(첫 등장 순서가 그룹 순서다). 서버 정렬이
+ *    `sort=dueDate&order=asc`라 그룹 순서는 대체로 안정적이지만, 새 페이지가 오면 이미
+ *    그려진 그룹이 자랄 수 있다 — 그게 정직한 동작이다(전량을 받아 미리 묶지 않는다).
+ */
+export function groupTeamActionsByProject(items: TeamActionListItem[]): TeamActionProjectGroup[] {
   const groups = new Map<number, TeamActionProjectGroup>();
-  for (const be of items) {
-    let group = groups.get(be.projectId);
+  for (const item of items) {
+    let group = groups.get(item.projectId);
     if (!group) {
       group = {
-        projectId: be.projectId,
-        projectName: be.projectName ?? "",
-        projectTag: be.projectTag ?? "",
+        projectId: item.projectId,
+        projectName: item.projectName,
+        projectTag: item.projectTag,
         teamActions: [],
       };
-      groups.set(be.projectId, group);
+      groups.set(item.projectId, group);
     }
     group.teamActions.push({
-      id: be.id,
-      name: be.title,
-      startDate: fallbackActionStartDate(be.startDate ?? be.plannedStartDate),
-      dueDate: be.dueDate,
-      status: be.status,
-      /* 하위 진척 "3/5" — 값은 여기서 넘기고, 게이지 UI는 #421(화면 담당 몫) */
-      childDoneCount: be.childDoneCount,
-      childTotalCount: be.childTotalCount,
+      id: item.id,
+      name: item.name,
+      startDate: item.startDate,
+      dueDate: item.dueDate,
+      status: item.status,
+      /* 하위 진척 "3/5" — 값은 여기까지 나르고, 게이지 UI는 #421(화면 담당 몫) */
+      childDoneCount: item.childDoneCount,
+      childTotalCount: item.childTotalCount,
     });
+  }
+  return [...groups.values()];
+}
+
+/** 내 액션 목록(`/app/my/actions`)의 프로젝트별 그룹 — 팀 액션과 같은 규칙으로 다시 묶는다. */
+export interface MyActionProjectGroup {
+  projectId: number;
+  projectName: string;
+  projectTag: string;
+  actions: MyActionListItem[];
+}
+
+/**
+ * 내 액션 목록 → 프로젝트별 그룹 — 이어 붙인 전체를 대상으로 매번 다시 묶는다.
+ * ⚠️ 마감 임박순(`sort=dueDate&order=asc`)으로 이미 정렬된 목록이라 그룹 안 순서도 그대로다.
+ *    새 페이지가 도착하면 그룹이 자랄 수 있다(§목록·페이지네이션 — 위 함수와 같은 이유).
+ */
+export function groupMyActionsByProject(actions: MyActionListItem[]): MyActionProjectGroup[] {
+  const groups = new Map<number, MyActionProjectGroup>();
+  for (const action of actions) {
+    let group = groups.get(action.projectId);
+    if (!group) {
+      group = {
+        projectId: action.projectId,
+        projectName: action.projectName,
+        projectTag: action.projectTag,
+        actions: [],
+      };
+      groups.set(action.projectId, group);
+    }
+    group.actions.push(action);
   }
   return [...groups.values()];
 }

--- a/src/features/action/server.test.ts
+++ b/src/features/action/server.test.ts
@@ -1,0 +1,148 @@
+/**
+ * 액션 목록 서버 페이지네이션 — mock 분기(§목록·페이지네이션).
+ * ⚠️ 실서버 분기는 여기서 못 돈다(세션·BE 필요) — 봉투 필드명은 server.ts의 [확인] 주석이
+ *    BE `global/response/PageResponse.java`와 대조한다. 여기서는 mock이 실서버와 같은
+ *    계약(0-base page·서버 정렬·전체 건수)으로 자르는지를 못박는다.
+ */
+import { groupMyActionsByProject, groupTeamActionsByProject, toTeamActionListItem } from "./mapper";
+import { getMyActionsPage, getTeamActionsPage } from "./server";
+
+const ASSIGNEE = "이하윤";
+
+describe("내 액션 목록 한 페이지 (getMyActionsPage)", () => {
+  it("마감 임박순(dueDate asc)으로 정렬해 돌려준다 — 서버 정렬과 같은 순서", async () => {
+    const result = await getMyActionsPage(ASSIGNEE, 0);
+    const dueDates = result.items.map((item) => item.dueDate);
+    expect(dueDates).toEqual([...dueDates].sort((a, b) => a.localeCompare(b)));
+  });
+
+  it("페이지 크기대로 자르고, totalCount는 화면에 그린 줄 수가 아니라 전체를 센다", async () => {
+    const whole = await getMyActionsPage(ASSIGNEE, 0, 9999);
+    const first = await getMyActionsPage(ASSIGNEE, 0, 1);
+    expect(first.page).toBe(0); // 0-base(BE 표준 확정, 2026-08-10)
+    expect(first.items.length).toBeLessThanOrEqual(1);
+    expect(first.totalCount).toBe(whole.totalCount); // 자른다고 전체 건수가 줄지 않는다
+    expect(first.totalPages).toBe(Math.ceil(first.totalCount / 1));
+  });
+
+  it("없는 담당자면 빈 목록 — 전체 건수도 0이다", async () => {
+    const result = await getMyActionsPage("없는사람", 0);
+    expect(result.items).toEqual([]);
+    expect(result.totalCount).toBe(0);
+  });
+});
+
+describe("팀 액션 목록 한 페이지 (getTeamActionsPage)", () => {
+  it("평평한 목록으로 온다 — 줄마다 프로젝트 정보를 갖고 있어 화면이 다시 묶을 수 있다", async () => {
+    const result = await getTeamActionsPage(0);
+    expect(result.items.length).toBeGreaterThan(0);
+    for (const item of result.items) {
+      expect(item.projectId).toEqual(expect.any(Number));
+      expect(item.projectName).not.toBe("");
+      expect(item.projectTag).not.toBe("");
+    }
+  });
+
+  it("마감 임박순으로 자르고 totalCount는 페이지가 바뀌어도 같다", async () => {
+    const first = await getTeamActionsPage(0, 2);
+    const second = await getTeamActionsPage(1, 2);
+    expect(first.totalCount).toBe(second.totalCount);
+    expect(first.totalPages).toBe(Math.ceil(first.totalCount / 2));
+    const dueDates = first.items.map((item) => item.dueDate);
+    expect(dueDates).toEqual([...dueDates].sort((a, b) => a.localeCompare(b)));
+  });
+
+  it("다음 페이지는 앞 페이지와 id가 겹치지 않는다 — 이어 붙일 때 중복이 없다", async () => {
+    const first = await getTeamActionsPage(0, 2);
+    const second = await getTeamActionsPage(1, 2);
+    expect(first.items).toHaveLength(2);
+    expect(second.page).toBe(1);
+    expect(second.items.length).toBeGreaterThan(0);
+    const firstIds = new Set(first.items.map((item) => item.id));
+    expect(second.items.some((item) => firstIds.has(item.id))).toBe(false);
+  });
+});
+
+describe("프로젝트별 다시 묶기 (mapper)", () => {
+  const item = (id: number, projectId: number, dueDate: string) => ({
+    id,
+    name: `액션 ${id}`,
+    startDate: "2026-08-01",
+    dueDate,
+    status: "TODO" as const,
+    projectId,
+    projectName: `프로젝트 ${projectId}`,
+    projectTag: `TAG-${projectId}`,
+  });
+
+  it("첫 등장 순서가 그룹 순서다 — 목록 순서를 흩뜨리지 않는다", () => {
+    const groups = groupTeamActionsByProject([
+      item(1, 10, "2026-08-13"),
+      item(2, 20, "2026-08-14"),
+      item(3, 10, "2026-08-15"),
+    ]);
+    expect(groups.map((g) => g.projectId)).toEqual([10, 20]);
+    expect(groups[0]?.teamActions.map((a) => a.id)).toEqual([1, 3]);
+  });
+
+  it("페이지가 이어 붙으면 이미 있던 그룹이 자란다 — 새 그룹으로 쪼개지 않는다", () => {
+    const firstPage = [item(1, 10, "2026-08-13"), item(2, 20, "2026-08-14")];
+    const appended = [...firstPage, item(3, 10, "2026-08-15")];
+    expect(groupTeamActionsByProject(firstPage)[0]?.teamActions).toHaveLength(1);
+    const regrouped = groupTeamActionsByProject(appended);
+    expect(regrouped).toHaveLength(2);
+    expect(regrouped[0]?.teamActions).toHaveLength(2);
+  });
+
+  it("내 액션도 같은 규칙 — projectId로 묶고 그룹 안 순서를 유지한다", async () => {
+    const { items } = await getMyActionsPage(ASSIGNEE, 0);
+    const groups = groupMyActionsByProject(items);
+    const regroupedIds = groups.flatMap((g) => g.actions.map((a) => a.id)).sort();
+    expect(regroupedIds).toEqual(items.map((a) => a.id).sort());
+    for (const group of groups) {
+      for (const action of group.actions) expect(action.projectId).toBe(group.projectId);
+    }
+  });
+
+  it("BE 한 줄 → 평평한 UI 계약 — null 프로젝트명·태그는 빈 문자열, 시작일 null은 채운다", () => {
+    const mapped = toTeamActionListItem({
+      id: 7,
+      actionType: "TEAM",
+      title: "설계 검토",
+      description: "",
+      status: "IN_PROGRESS",
+      startDate: null,
+      /* 사람이 검토 화면에서 정한 예정 시작일 — `startDate`가 비면 이 값을 먼저 쓴다(#416) */
+      plannedStartDate: "2026-08-18",
+      dueDate: "2026-08-20",
+      needsReview: false,
+      isDelayed: false,
+      assigneeName: null,
+      projectId: 3,
+      projectTag: null,
+      projectName: null,
+      teamName: "개발팀",
+      sourceMeetingTitle: null,
+      parentActionId: null,
+      parentActionTitle: null,
+      childDoneCount: 3,
+      childTotalCount: 5,
+    });
+    expect(mapped).toMatchObject({
+      id: 7,
+      name: "설계 검토",
+      dueDate: "2026-08-20",
+      projectId: 3,
+      projectName: "",
+      projectTag: "",
+      /* 진척 값은 그룹핑까지 그대로 실려 가야 한다 — 게이지 UI(#421)가 이 값을 쓴다 */
+      childDoneCount: 3,
+      childTotalCount: 5,
+    });
+    /*
+      ⚠️ **날짜를 지어내지 않는다**(#416). `startDate`가 비어도 예정 시작일이 있으면 그 값이지,
+         fallback의 "내일"이 아니다 — 실값 위에 가짜를 얹던 것이 #416에서 고쳐졌다.
+    */
+    expect(mapped.startDate).toBe("2026-08-18");
+  });
+});

--- a/src/features/action/server.ts
+++ b/src/features/action/server.ts
@@ -5,17 +5,18 @@ import { TEAM_ACTION_PERSONAL_ITEMS_MOCK } from "@/features/project/mock/team-ac
 import { PROJECT_TEAM_ACTIONS_MOCK } from "@/features/project/mock/team-actions";
 import { ApiError, serverApi } from "@/lib/api";
 import { ep } from "@/lib/endpoints";
+import { paginate, type PaginatedResult } from "@/lib/paginate";
 import { isMock } from "@/mocks/config";
 
 import {
   type BeActionDetail,
   type BeActionSummary,
-  groupTeamActionsByProject,
   toMyActionListItem,
   toPersonalActionDetail,
+  toTeamActionListItem,
 } from "./mapper";
 import { PERSONAL_ACTION_DETAIL_MOCK } from "./mock/action-detail";
-import type { MyActionListItem, PersonalActionDetail, TeamActionProjectGroup } from "./types";
+import type { MyActionListItem, PersonalActionDetail, TeamActionListItem } from "./types";
 
 /** 로그인 팀장의 팀 — 세션 붙기 전까지 mock 분기에서만 쓰는 고정값(board/server.ts와 같은 인물). */
 const MOCK_LEADER_TEAM = "개발팀";
@@ -43,12 +44,26 @@ export async function getPersonalActionDetail(
   }
 }
 
+/** 한 화면에 그리는 줄 수 — BE 목록 기본값과 같다([확인] `ActionController.list`의 `size` 기본 20). */
+export const ACTION_PAGE_SIZE = 20;
+
 /**
- * 내 액션 목록(`/app/my/actions`) — 담당자 이름이 일치하는 개인 액션 전체, 마감 임박순.
+ * 내 액션 목록(`/app/my/actions`) 한 페이지 — 마감 임박순, **자르기는 서버가 한다.**
+ *
+ * ⚠️ `size: 9999`로 전량을 받지 않는다(CLAUDE.md §목록·페이지네이션 — 화면만 잘릴 뿐
+ *    10만 건을 다 받아 온다). 첫 페이지는 서버 컴포넌트가 렌더하고, 그 아래부터
+ *    스크롤이 끝에 닿으면 이어 붙인다.
+ * ⚠️ 정렬도 서버에 맡긴다(`sort=dueDate&order=asc`, [확인] BE
+ *    `action/presentation/api/ActionController.java` list — sort=dueDate|createdAt, order,
+ *    page 0-base, size 기본 20). 받아 와서 화면이 다시 정렬하면 페이지 경계가 어긋난다.
  * ⚠️ 실연동에선 `assigneeName`을 안 쓴다 — `GET /api/actions`가 이미 토큰의 본인 소유분만
  *    돌려준다(board/server.ts와 같은 이유). 파라미터는 mock 분기 전용으로 시그니처만 유지한다.
  */
-export async function getMyActionList(assigneeName: string): Promise<MyActionListItem[]> {
+export async function getMyActionsPage(
+  assigneeName: string,
+  page: number,
+  pageSize: number = ACTION_PAGE_SIZE,
+): Promise<PaginatedResult<MyActionListItem>> {
   if (isMock) {
     const list: MyActionListItem[] = [];
     for (const items of Object.values(TEAM_ACTION_PERSONAL_ITEMS_MOCK)) {
@@ -72,51 +87,101 @@ export async function getMyActionList(assigneeName: string): Promise<MyActionLis
         });
       }
     }
-    return list.sort((a, b) => a.dueDate.localeCompare(b.dueDate));
+    // 서버 정렬(sort=dueDate&order=asc)과 같은 순서로 굳힌 뒤 자른다 — 연동 시 화면이 안 바뀐다.
+    list.sort((a, b) => a.dueDate.localeCompare(b.dueDate));
+    return paginate(list, page, pageSize);
   }
 
+  /*
+    [확인] BE `global/response/PageResponse.java` — `content`·`page`·`size`·`totalElements`·
+    `totalPages`·`hasNext`. 목록 3종(projects·actions·team/actions) 공용 봉투라 사원 목록의
+    `MemberPageResponse`(`totalCount`)와 **필드명이 다르다** — 이름을 잘못 읽으면 `전체 N건`이
+    비고 다음 페이지 유무를 아무도 모르게 된다.
+  */
   const accessToken = await requireAccessToken();
-  const page = await serverApi<BePageResponse<BeActionSummary>>(ep.actions({ size: 9999 }), {
-    accessToken,
-  });
-  return page.content
+  const response = await serverApi<BePageResponse<BeActionSummary>>(
+    ep.actions({ sort: "dueDate", order: "asc", page: Math.max(0, page), size: pageSize }),
+    { accessToken },
+  );
+
+  /*
+    ⚠️ TEAM 타입은 방어적으로 거른다 — BE는 본인 소유 **PERSONAL만** 준다([확인]
+       `ActionService.getMyActions` 주석 "기본은 호출자 본인 소유 PERSONAL 액션")라 실제로는
+       안 걸리지만, 계약이 바뀌어 섞여 와도 화면이 팀 액션을 개인 액션인 척 그리지 않게 한다.
+    ⚠️ 거른 만큼 `totalElements`를 줄이지 않는다 — 그 숫자는 서버가 센 전체이고, 화면의
+       `전체 N건`은 그 값을 말해야 다음 페이지 유무와 어긋나지 않는다(member/manage-server.ts와
+       같은 규칙).
+  */
+  const items = response.content
     .filter((action) => action.actionType === "PERSONAL")
-    .map(toMyActionListItem)
-    .sort((a, b) => a.dueDate.localeCompare(b.dueDate));
+    .map(toMyActionListItem);
+
+  return {
+    items,
+    page: response.page,
+    totalPages: response.totalPages,
+    totalCount: response.totalElements,
+  };
 }
 
 /**
- * 팀 액션 관리(`/team/action`) — 로그인 팀장의 팀 액션 전체를 프로젝트별로 묶어 돌려준다.
+ * 팀 액션 관리(`/team/action`) 한 페이지 — **평평한 목록**으로 돌려준다. 프로젝트별 묶기는
+ * 화면이 이어 붙인 전체를 대상으로 매번 다시 한다(`groupTeamActionsByProject`) — 서버가
+ * 그룹을 만들면 페이지 경계에 걸린 그룹을 이어 붙일 수 없다.
+ *
+ * ⚠️ `size: 9999` 전량 수신을 없앴다(§목록·페이지네이션). 정렬은 서버가 한다
+ *    (`sort=dueDate&order=asc`, [확인] BE `action/presentation/api/TeamActionController.java`
+ *    list — sort=dueDate|createdAt, order, page 0-base, size 기본 20).
  * ⚠️ 실연동은 `GET /api/team/actions`가 JWT teamId로 이미 자동 스코프하므로 팀명을 안 넘긴다.
  *    mock은 세션이 없어 팀명 필터가 필요하다(board/server.ts와 같은 이유).
  */
-export async function getTeamActionsGroupedByProject(): Promise<TeamActionProjectGroup[]> {
+export async function getTeamActionsPage(
+  page: number,
+  pageSize: number = ACTION_PAGE_SIZE,
+): Promise<PaginatedResult<TeamActionListItem>> {
   if (isMock) {
-    const groups: TeamActionProjectGroup[] = [];
+    const list: TeamActionListItem[] = [];
+    /*
+      ⚠️ 목은 팀 액션을 **태그로** 찾는데 태그는 프로젝트끼리 겹칠 수 있다(GOODS가 둘,
+         §라우트 그룹 — URL도 그래서 태그가 아니라 id로 다닌다). 그대로 펼치면 같은 액션
+         id가 두 프로젝트에 중복돼, 이어 붙일 때 id로 거르는 규칙(§목록·페이지네이션)이
+         뒤 페이지의 정상 행을 지워 버린다 — 먼저 만난 프로젝트가 가진다. 실 BE는 액션이
+         프로젝트 FK를 직접 들고 있어 이 문제가 없다.
+    */
+    const seen = new Set<number>();
     for (const project of TOP_LEVEL_PROJECTS) {
-      const teamActions = (PROJECT_TEAM_ACTIONS_MOCK[project.tag] ?? []).filter(
-        (action) => action.team === MOCK_LEADER_TEAM,
-      );
-      if (teamActions.length === 0) continue;
-      groups.push({
-        projectId: project.id,
-        projectName: project.name,
-        projectTag: project.tag,
-        teamActions: teamActions.map((action) => ({
+      for (const action of PROJECT_TEAM_ACTIONS_MOCK[project.tag] ?? []) {
+        if (action.team !== MOCK_LEADER_TEAM) continue;
+        if (seen.has(action.id)) continue;
+        seen.add(action.id);
+        list.push({
           id: action.id,
           name: action.name,
           startDate: action.startDate,
           dueDate: action.dueDate,
           status: action.status,
-        })),
-      });
+          projectId: project.id,
+          projectName: project.name,
+          projectTag: project.tag,
+        });
+      }
     }
-    return groups;
+    // 서버 정렬(sort=dueDate&order=asc)과 같은 순서로 굳힌 뒤 자른다 — 연동 시 화면이 안 바뀐다.
+    list.sort((a, b) => a.dueDate.localeCompare(b.dueDate));
+    return paginate(list, page, pageSize);
   }
 
+  /* [확인] BE `global/response/PageResponse.java` — 위 `getMyActionsPage`와 같은 공용 봉투. */
   const accessToken = await requireAccessToken();
-  const page = await serverApi<BePageResponse<BeActionSummary>>(ep.teamActions({ size: 9999 }), {
-    accessToken,
-  });
-  return groupTeamActionsByProject(page.content);
+  const response = await serverApi<BePageResponse<BeActionSummary>>(
+    ep.teamActions({ sort: "dueDate", order: "asc", page: Math.max(0, page), size: pageSize }),
+    { accessToken },
+  );
+
+  return {
+    items: response.content.map(toTeamActionListItem),
+    page: response.page,
+    totalPages: response.totalPages,
+    totalCount: response.totalElements,
+  };
 }

--- a/src/features/action/types.ts
+++ b/src/features/action/types.ts
@@ -75,6 +75,18 @@ export interface TeamActionTimelineItem {
 }
 
 /**
+ * 팀 액션 목록(`GET /api/team/actions`) 한 줄 — **평평한 UI 계약**이다.
+ * ⚠️ 서버는 그룹을 안 만든다 — 페이지 단위로 평평하게 오고, 프로젝트별 묶기는 화면이
+ *    지금까지 이어 붙인 전체를 대상으로 매번 다시 한다(§목록·페이지네이션). 페이지가
+ *    도착할 때마다 그룹이 자랄 수 있다 — 그게 정직한 동작이다.
+ */
+export interface TeamActionListItem extends TeamActionTimelineItem {
+  projectId: number;
+  projectName: string;
+  projectTag: string;
+}
+
+/**
  * 팀 액션 관리 화면 — 프로젝트별로 묶은 팀 액션 그룹.
  * ⚠️ 하위 개인 액션 진척 값은 **BE가 이미 준다**(2026-08-11 #355 반영, 2026-08-12 매퍼 수신) —
  *    게이지 UI만 남았다(#421).


### PR DESCRIPTION
## 📋 PR 타입

> 해당하는 타입을 선택해 주세요 (복수 선택 가능)

- [x] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [x] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [x] LEADER (팀장)
- [x] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- **`size: 9999` 전량 수신 제거** — `/app/my/actions`·`/team/action` 둘 다 `GET /api/actions`·`GET /api/team/actions`를 페이지 단위(`page` 0-base, `size` 20 = BE 기본값)로 부른다. 정렬도 서버에 맡긴다(`sort=dueDate&order=asc`) — 받아 와서 화면이 다시 정렬하면 페이지 경계가 어긋난다.
- **첫 페이지는 서버 컴포넌트가 렌더**, 2페이지부터는 새 클라이언트 뷰(`MyActionListView`·`TeamActionListView`)가 `IntersectionObserver` 센티널로 이어 붙인다 — 사원 목록(`member-list-view.tsx`)과 같은 `useInfiniteScrollList`+`InfiniteListFooter` 재사용. [더 보기] 버튼 없음(2026-08-10 폐기), 실패 시 [다시 시도]만.
- **프로젝트별 묶기는 화면이 이어 붙인 전체를 대상으로 매번 다시** 한다(`groupMyActionsByProject`·`groupTeamActionsByProject`). 서버는 평평한 목록만 준다 — 새 페이지가 도착하면 이미 그려진 그룹이 자랄 수 있고, 그게 전량 수신보다 정직한 동작이다(주석으로 명시).
- **머리 건수는 서버가 센 전체**(`totalElements`)를 말한다 — 지금 그려진 줄 수가 아니다. 팀 액션 화면의 "N개 프로젝트"는 뺐다 — 남은 페이지에 어떤 프로젝트가 더 있는지 서버가 안 알려줘서, 받은 그룹 수를 적으면 거짓말이 된다.
- **mock도 같은 계약으로 페이지네이션**(`paginate`, 메모리 자르기) — 연동 시 컴포넌트 0줄 수정(§격리막). 이어 붙일 때 `id` 중복 제거는 훅이 한다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 목록 스코프는 BE가 토큰(memberId·teamId)으로 자른다([확인] `ActionController`·`TeamActionController` — 파라미터 자기신고 없음). 서버 액션은 `requireAccessToken` 경유. 별도 역할 가드는 기존 화면과 동일하게 추가하지 않음(해당 없음)
- [ ] 🧬 **zod** — 해당 없음(이 도메인 매퍼는 기존부터 타입 단언 방식, 이번 PR 범위 아님)
- [x] 🕵️ **정직성** — 그룹이 페이지 도착에 따라 자라는 동작·mock 분기·전체 건수 출처를 주석과 문구로 명시
- [x] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨 — 기존 화면 마크업 이동, 신규 색 없음

**품질**

- [x] ⚡ 최적화 — 조회는 Server Component 유지, 클라이언트로 넘어간 건 상호작용 잎사귀뿐. `IntersectionObserver`(스크롤 이벤트 아님)
- [x] ♿ a11y — `InfiniteListFooter`가 `role="status" aria-live="polite"`, [다시 시도]는 실제 `button`
- [x] ♻️ 재사용 확인 — `useInfiniteScrollList` · `InfiniteListFooter` · `paginate` 재사용, 신규 훅 없음
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 첫 로딩 스켈레톤은 기존 유지, 이어 붙일 때 작은 로딩, 실패 시 [다시 시도], empty 문구 유지
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음 — 해당 없음

---

## 🔗 연관 이슈

Closes #417

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
| 전량(9999건) 수신 후 클라이언트 정렬·그룹핑 | 첫 페이지 서버 렌더 + 스크롤 끝 자동 이어 붙임(mock으로 두 화면 렌더 확인) |

---

## 💬 리뷰 포인트

- `src/features/action/server.ts` — 실서버 분기 봉투 필드명. **`totalElements`다**(사원 목록의 `totalCount`와 다름) — [확인] BE `global/response/PageResponse.java`(content·page·size·totalElements·totalPages·hasNext, 목록 3종 공용).
- `getMyActionsPage`의 `actionType === "PERSONAL"` 필터 — BE가 이미 PERSONAL만 주지만([확인] `ActionService.getMyActions`) 방어적으로 남겼고, **거른 만큼 totalCount를 줄이지 않는** 규칙이 맞는지.
- 팀 액션 mock 평탄화의 **id 중복 제거** — GOODS 태그를 프로젝트 둘이 공유해서 태그 키 조회가 같은 액션을 두 번 만든다(목 한정, 실 BE는 FK라 무관). 먼저 만난 프로젝트가 가진다.
- 검증 결과:
  - `npx tsc --noEmit` → 통과
  - `npx eslint src/features/action "src/app/(shell)/app/my/actions" "src/app/(shell)/(authority)/team/action" --fix` → 통과(수정 0)
  - `npx jest` → 93 suites / 999 tests 전부 통과(신규 `src/features/action/server.test.ts` 10건 포함)

---

## 📝 추가 메모

- 두 목록 화면에 status 필터 UI가 없어 `status`·`overdue` 파라미터는 안 보낸다 — UI가 생기면 그때 파라미터만 얹으면 된다(BE는 이미 지원).
- PR #424가 `BeActionSummary`에 `plannedStartDate`·`childDoneCount`·`childTotalCount`를 추가 중이라 이 브랜치는 그 필드를 건드리지 않았다 — 충돌 없음.
- 서버 정렬을 `dueDate asc`로 고정해 그룹 순서가 대체로 안정적이지만, 페이지가 도착하면 이미 그려진 그룹이 자랄 수 있다 — 명세대로의 정직한 동작이고 주석으로 남겼다.
