### PR TITLE
[FEAT] 프로젝트 첨부 업로드 배선 — 조용한 no-op 제거 #418

### DIFF
--- a/src/features/project/actions.ts
+++ b/src/features/project/actions.ts
@@ -6,16 +6,22 @@ import { redirect } from "next/navigation";
 import { FLASH_TOAST_PARAM } from "@/constants/flash-toast";
 import { requireAccessToken } from "@/features/auth/session";
 import { getViewer } from "@/features/shell/viewer";
-import { ApiError, serverApi } from "@/lib/api";
+import { ApiError, serverApi, toUserMessage } from "@/lib/api";
 import { ep } from "@/lib/endpoints";
 import { canCreateProject } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
+import type { BeIssuedUploadUrl, BeProjectSummary, ConfirmAttachmentRequestBody } from "./mapper";
 import { toCreateProjectRequestBody } from "./mapper";
 import { addMockProject } from "./mock/projects";
 import { resolveTeamIds } from "./server";
-import type { ProjectDraft, ProjectFormErrors } from "./types";
-import { validateProjectDraft } from "./validate";
+import type {
+  AttachmentConfirmResult,
+  AttachmentIssueResult,
+  ProjectDraft,
+  ProjectFormErrors,
+} from "./types";
+import { validateAttachmentFile, validateProjectDraft } from "./validate";
 
 const LIST_PATH = "/app/projects";
 /*
@@ -24,9 +30,16 @@ const LIST_PATH = "/app/projects";
 */
 const CREATED_PATH = `${LIST_PATH}?${FLASH_TOAST_PARAM}=PROJECT_CREATED`;
 
-/** 생성 폼 결과 — `useActionState`가 그대로 들고 있는 모양. */
+/**
+ * 생성 폼 결과 — `useActionState`가 그대로 들고 있는 모양.
+ * ⚠️ `createdProjectId`는 **첨부파일이 있을 때만** 실려 온다. 파일은 브라우저가 S3에 직접
+ *    PUT해야 해서(BE는 바이너리를 안 받는다 — [확인] `ProjectAttachmentController` 주석)
+ *    액션이 `redirect`로 끝나 버리면 화면이 업로드를 이어갈 프로젝트 id를 못 받는다.
+ *    파일이 없으면 기존처럼 `redirect`한다 — 이 값이 있다 = "만들어졌고, 업로드는 네 차례".
+ */
 export interface ProjectFormState {
   errors: ProjectFormErrors;
+  createdProjectId?: number;
 }
 
 function readDraft(formData: FormData): ProjectDraft {
@@ -59,29 +72,116 @@ export async function createProjectAction(
   const errors = validateProjectDraft(draft);
   if (Object.keys(errors).length > 0) return { errors };
 
+  /*
+    ⚠️ 첨부파일이 있으면 `redirect` 대신 **만들어진 id를 화면에 되돌린다** — 업로드 3단계
+       (발급→브라우저 PUT→확정)는 화면이 이어서 돈다(`use-attachment-upload.ts`).
+       redirect로 끝내면 업로드를 걸 프로젝트 id가 사라진다(§ProjectFormState 주석).
+  */
+  const hasAttachment = formData.get("hasAttachment") === "1";
+  let createdProjectId: number;
+
   if (!isMock) {
-    // ⚠️ 첨부파일은 아직 안 보낸다 — 생성 폼에 실제 파일 선택 UI가 없다(`attachmentName`은
-    //    지금도 목 단계 자리표시자다). 업로드 3단계(발급→업로드→확정)는 화면이 생기면 잇는다.
     const accessToken = await requireAccessToken();
     const teamIds = await resolveTeamIds(accessToken, draft.teamNames);
     const body = toCreateProjectRequestBody(draft, teamIds);
 
     try {
-      await serverApi(ep.projects(), { method: "POST", json: body, accessToken });
+      // [확인] BE `ProjectController.create` — `ApiResponse<ProjectSummaryResponse>`로 방금
+      // 만든 프로젝트를 되돌려 준다(`id` 포함). 첨부 업로드가 이 id에 걸린다.
+      const created = await serverApi<BeProjectSummary>(ep.projects(), {
+        method: "POST",
+        json: body,
+        accessToken,
+      });
+      createdProjectId = created.id;
     } catch (error) {
       if (error instanceof ApiError) return { errors: { name: error.message } };
       throw error;
     }
-
-    revalidatePath(LIST_PATH);
-    redirect(CREATED_PATH);
+  } else {
+    createdProjectId = addMockProject(draft).id;
   }
 
-  addMockProject(draft);
-
   revalidatePath(LIST_PATH);
+  if (hasAttachment) return { errors: {}, createdProjectId };
+
   // ⚠️ `redirect`는 내부적으로 예외를 던진다 — try/catch 밖에 둔다(§렌더링·데이터)
   redirect(CREATED_PATH);
+}
+
+/**
+ * 첨부 업로드 1단계 — presigned PUT URL 발급(격리막 §Mock 격리막).
+ * [확인] BE `POST /api/projects/{projectId}/attachments/upload-url`
+ *   (`ProjectAttachmentController.issueUploadUrl`) — 요청 `{fileName, fileSize}`
+ *   (`IssueUploadUrlRequest`), 응답 `{uploadUrl, fileUrl}`(`IssuedUploadUrl`, 15분 만료).
+ * ⚠️ **권한을 서버에서 다시 본다**(§권한) — BE도 OWNER/ADMIN만 받지만(`@PreAuthorize`),
+ *    목 단계에는 BE가 없으니 여기서도 같은 판정을 세운다.
+ * ⚠️ 실패는 던지지 않고 `message`로 돌려준다 — 던지면 error.tsx로 화면이 통째로 넘어가는데,
+ *    프로젝트는 이미 만들어진 뒤라 "파일만 실패했다"를 그 자리에서 말해야 한다(§정직성).
+ */
+export async function issueProjectAttachmentUploadUrlAction(
+  projectId: number,
+  fileName: string,
+  fileSize: number,
+): Promise<AttachmentIssueResult> {
+  const viewer = await getViewer();
+  if (!canCreateProject(viewer)) return { ok: false, message: "첨부파일을 올릴 권한이 없습니다" };
+
+  // ⚠️ 화면과 **같은 함수**로 다시 검증한다 — 화면 처리는 UX일 뿐 검증이 아니다(§권한).
+  const invalid = validateAttachmentFile(fileName, fileSize);
+  if (invalid) return { ok: false, message: invalid };
+
+  if (isMock) {
+    // 목 단계 — 올릴 S3가 없다. `uploadUrl: null`이 "PUT 건너뛰어라"는 신호다(UI 계약 주석).
+    return { ok: true, ticket: { uploadUrl: null, fileUrl: `mock/${fileName}` } };
+  }
+
+  try {
+    const accessToken = await requireAccessToken();
+    const issued = await serverApi<BeIssuedUploadUrl>(ep.projectAttachmentUploadUrl(projectId), {
+      method: "POST",
+      json: { fileName, fileSize },
+      accessToken,
+    });
+    return { ok: true, ticket: issued };
+  } catch (error) {
+    return { ok: false, message: toUserMessage(error) };
+  }
+}
+
+/**
+ * 첨부 업로드 3단계 — 업로드 확정(메타데이터 저장).
+ * [확인] BE `POST /api/projects/{projectId}/attachments/confirm`
+ *   (`ProjectAttachmentController.confirm`) — 요청 `{fileName, fileUrl, fileSize}`
+ *   (`ConfirmAttachmentRequest`), 같은 `fileUrl` 재확정은 기존 레코드 반환(idempotent)이라
+ *   재시도로 두 번 불러도 안전하다.
+ */
+export async function confirmProjectAttachmentAction(
+  projectId: number,
+  body: ConfirmAttachmentRequestBody,
+): Promise<AttachmentConfirmResult> {
+  const viewer = await getViewer();
+  if (!canCreateProject(viewer)) return { ok: false, message: "첨부파일을 올릴 권한이 없습니다" };
+
+  const invalid = validateAttachmentFile(body.fileName, body.fileSize);
+  if (invalid) return { ok: false, message: invalid };
+
+  if (isMock) return { ok: true }; // 목 단계 — 저장할 곳이 없다. 성공만 흉내낸다(발급 쪽 주석 참고).
+
+  try {
+    const accessToken = await requireAccessToken();
+    await serverApi(ep.projectAttachmentConfirm(projectId), {
+      method: "POST",
+      json: body,
+      accessToken,
+    });
+  } catch (error) {
+    return { ok: false, message: toUserMessage(error) };
+  }
+
+  // 확정돼야 상세(기획 탭)의 첨부 목록에 나타난다 — 그 화면의 캐시를 지운다.
+  revalidatePath(`/app/projects/${projectId}`);
+  return { ok: true };
 }
 
 /**

--- a/src/features/project/components/project-form.tsx
+++ b/src/features/project/components/project-form.tsx
@@ -107,8 +107,14 @@ export function ProjectForm({ action, teamOptions, cancelHref }: ProjectFormProp
     startDate.trim().length > 0 &&
     dueDate.trim().length > 0 &&
     teamRows.length > 0 &&
-    teamRows.every((row) => row.team.trim().length > 0) &&
-    !attachmentError;
+    teamRows.every((row) => row.team.trim().length > 0);
+  /*
+    ⚠️ **첨부 오류가 제출을 막지 않는다**(2026-08-13 고침). 전에는 `!attachmentError`가
+       `canSubmit`에 있었는데, 파일이 검증에 걸리면 `attachment`는 `null`이 되고 오류만 남아
+       **제출 버튼이 영영 잠겼다** — 그 상태를 풀 [첨부 제거] 버튼은 `attachment`가 있을 때만
+       그려져서 누를 수도 없었다. 첨부는 선택이고 걸린 파일은 붙지 않으므로, 오류 문구는
+       그대로 두고(왜 안 붙는지 말해 준다) 프로젝트 생성은 막지 않는다.
+  */
   const mainColor = paletteColorByName(tagColor);
   const usedTeams = new Set(teamRows.map((row) => row.team).filter(Boolean));
   const canAddTeamRow = teamRows.length < teamOptions.length;

--- a/src/features/project/components/project-form.tsx
+++ b/src/features/project/components/project-form.tsx
@@ -2,8 +2,9 @@
 
 import { Check, Paperclip, Plus, X } from "lucide-react";
 import Link from "next/link";
-import type { CSSProperties } from "react";
-import { useActionState, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import type { ChangeEvent, CSSProperties } from "react";
+import { useActionState, useCallback, useEffect, useRef, useState } from "react";
 
 import { DatePickerField } from "@/components/common/date-picker-field";
 import { FieldError } from "@/components/common/field-error";
@@ -18,11 +19,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { FLASH_TOAST_PARAM } from "@/constants/flash-toast";
 import { PROJECT_DESCRIPTION_MAX_LENGTH, PROJECT_TAG_MAX_LENGTH } from "@/constants/project";
 import { paletteColorByName, TAG_NAME_LABEL, TAG_NAMES, type TagColorName } from "@/lib/palette";
 import { cn } from "@/lib/utils";
 
 import type { ProjectFormState } from "../actions";
+import { useAttachmentUpload } from "../use-attachment-upload";
+import { validateAttachmentFile } from "../validate";
 
 interface TeamRow {
   /** React key용 — 팀명이 아니라 행 자체의 정체성(같은 팀을 지웠다 다시 골라도 행은 별개). */
@@ -47,6 +51,12 @@ function toTagInput(raw: string): string {
 
 let nextRowId = 1;
 
+/*
+  ⚠️ 액션(`actions.ts`)의 `CREATED_PATH`와 같은 주소다 — 첨부가 있으면 `redirect` 대신
+     화면이 업로드를 마치고 **여기서** 이동하므로, 도착 토스트 열쇠도 같은 것을 싣는다.
+*/
+const CREATED_HREF = `/app/projects?${FLASH_TOAST_PARAM}=PROJECT_CREATED`;
+
 /**
  * 프로젝트 생성 폼.
  * ⚠️ 참여 팀은 **드롭다운 하나가 아니라 다중 지정**이다 — 프로젝트 하나에 여러 팀이 참여할 수 있어
@@ -64,8 +74,31 @@ export function ProjectForm({ action, teamOptions, cancelHref }: ProjectFormProp
   const [tagColor, setTagColor] = useState<TagColorName>(TAG_NAMES[0]);
   const [colorPickerOpen, setColorPickerOpen] = useState(false);
   const [teamRows, setTeamRows] = useState<TeamRow[]>([{ rowId: nextRowId++, team: "" }]);
-  const [attachmentName, setAttachmentName] = useState<string | undefined>(undefined);
+  const [attachment, setAttachment] = useState<File | null>(null);
+  const [attachmentError, setAttachmentError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const router = useRouter();
+  const goToList = useCallback(() => router.replace(CREATED_HREF), [router]);
+  const { phase: uploadPhase, upload } = useAttachmentUpload(goToList);
+
+  /*
+    ⚠️ **첨부가 있으면 액션이 `redirect` 대신 만들어진 id를 되돌린다**(`ProjectFormState` 주석).
+       그 id가 도착하는 순간 업로드 3단계(발급→브라우저 PUT→확정)를 **한 번만** 건다 —
+       StrictMode의 이중 실행·리렌더에 또 걸리지 않게 ref로 잠근다. 실패 후 [다시 시도]는
+       이 잠금과 무관하게 버튼이 직접 다시 부른다.
+  */
+  const uploadStartedRef = useRef(false);
+  const createdProjectId = state.createdProjectId;
+  useEffect(() => {
+    if (createdProjectId === undefined || !attachment || uploadStartedRef.current) return;
+    uploadStartedRef.current = true;
+    void upload(createdProjectId, attachment);
+  }, [createdProjectId, attachment, upload]);
+
+  const isUploading = uploadPhase.kind === "uploading";
+  /* 프로젝트가 이미 만들어진 뒤다 — 제출을 또 받으면 같은 프로젝트가 두 개 생긴다. */
+  const isCreated = createdProjectId !== undefined;
 
   const canSubmit =
     name.trim().length > 0 &&
@@ -74,7 +107,8 @@ export function ProjectForm({ action, teamOptions, cancelHref }: ProjectFormProp
     startDate.trim().length > 0 &&
     dueDate.trim().length > 0 &&
     teamRows.length > 0 &&
-    teamRows.every((row) => row.team.trim().length > 0);
+    teamRows.every((row) => row.team.trim().length > 0) &&
+    !attachmentError;
   const mainColor = paletteColorByName(tagColor);
   const usedTeams = new Set(teamRows.map((row) => row.team).filter(Boolean));
   const canAddTeamRow = teamRows.length < teamOptions.length;
@@ -91,6 +125,29 @@ export function ProjectForm({ action, teamOptions, cancelHref }: ProjectFormProp
 
   function removeTeamRow(rowId: number) {
     setTeamRows((rows) => rows.filter((row) => row.rowId !== rowId));
+  }
+
+  function handleAttachmentChange(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0] ?? null;
+    if (!file) return; // 파일 고르기를 취소한 경우 — 기존 선택을 유지한다
+
+    /* ⚠️ 고른 **직후** 인라인으로 알린다(§토스트 ❌폼 검증 오류) — 제출까지 갔다가 BE한테
+       거절당하면 프로젝트만 만들어지고 파일이 튕기는 반쪽 결과가 된다. */
+    const invalid = validateAttachmentFile(file.name, file.size);
+    if (invalid) {
+      setAttachment(null);
+      setAttachmentError(invalid);
+      event.target.value = ""; // 비워야 같은 파일을 다시 골라도 change가 또 뜬다
+      return;
+    }
+    setAttachmentError(null);
+    setAttachment(file);
+  }
+
+  function clearAttachment() {
+    setAttachment(null);
+    setAttachmentError(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
   }
 
   return (
@@ -352,27 +409,79 @@ export function ProjectForm({ action, teamOptions, cancelHref }: ProjectFormProp
 
           <div className="flex flex-col gap-1.5">
             <Label htmlFor="project-attachment">첨부파일</Label>
+            {/*
+              ⚠️ 파일 자체는 폼으로 안 보낸다 — BE는 바이너리를 안 받고, 액션이 만든 프로젝트
+                 id로 화면이 presigned PUT을 잇는다(`use-attachment-upload.ts`). 폼에는
+                 "첨부가 기다린다"는 신호(`hasAttachment`)만 싣는다.
+            */}
             <input
               ref={fileInputRef}
               id="project-attachment"
               type="file"
               className="hidden"
-              onChange={(event) => setAttachmentName(event.target.files?.[0]?.name)}
+              onChange={handleAttachmentChange}
             />
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="w-full justify-start"
-              onClick={() => fileInputRef.current?.click()}
-            >
-              <Paperclip />
-              {attachmentName ?? "파일 첨부 (선택)"}
-            </Button>
-            {attachmentName && <input type="hidden" name="attachmentName" value={attachmentName} />}
-            <p className="text-muted-foreground text-[12px] leading-4">
-              프로젝트 기획서 등 참고 문서가 있다면 첨부해 주세요.
-            </p>
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="w-full min-w-0 justify-start"
+                disabled={isUploading || isCreated}
+                onClick={() => fileInputRef.current?.click()}
+              >
+                <Paperclip />
+                <span className="truncate">{attachment?.name ?? "파일 첨부 (선택)"}</span>
+              </Button>
+              {attachment && !isCreated && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label="첨부파일 선택 해제"
+                  onClick={clearAttachment}
+                >
+                  <X />
+                </Button>
+              )}
+            </div>
+            {attachment && <input type="hidden" name="hasAttachment" value="1" />}
+            {attachment && <input type="hidden" name="attachmentName" value={attachment.name} />}
+            <FieldError id="project-attachment-error" message={attachmentError ?? undefined} />
+            {uploadPhase.kind === "failed" ? (
+              /*
+                ⚠️ **반쪽 성공을 그대로 말한다**(§정직성) — 프로젝트는 이미 만들어졌고 파일만
+                   못 올라갔다. 조용히 목록으로 보내면 첨부가 증발한 것처럼 보인다.
+                   [다시 시도]는 안전하다 — 발급은 새 키, 확정은 idempotent(훅 주석 참고).
+              */
+              <div className="flex flex-col gap-1.5" role="alert">
+                <p className="text-destructive text-[12px] leading-4 break-keep">
+                  프로젝트는 만들어졌지만 첨부파일을 올리지 못했습니다 — {uploadPhase.message}
+                </p>
+                <div className="flex gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      if (createdProjectId !== undefined && attachment)
+                        void upload(createdProjectId, attachment);
+                    }}
+                  >
+                    다시 시도
+                  </Button>
+                  <Button type="button" variant="ghost" size="sm" onClick={goToList}>
+                    첨부 없이 이동
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <p className="text-muted-foreground text-[12px] leading-4">
+                {isUploading
+                  ? "첨부파일을 올리고 있습니다…"
+                  : "프로젝트 기획서 등 참고 문서가 있다면 첨부해 주세요."}
+              </p>
+            )}
           </div>
         </div>
       </div>
@@ -385,10 +494,11 @@ export function ProjectForm({ action, teamOptions, cancelHref }: ProjectFormProp
         <Button
           type="submit"
           size="sm"
-          disabled={isPending || !canSubmit}
+          /* ⚠️ 만들어진 뒤에는 잠근다 — 업로드가 실패한 채 또 제출하면 프로젝트가 두 개 생긴다 */
+          disabled={isPending || !canSubmit || isCreated}
           className="bg-foreground text-background hover:bg-foreground/90"
         >
-          {isPending ? "생성 중…" : "프로젝트 생성"}
+          {isPending ? "생성 중…" : isUploading ? "파일 올리는 중…" : "프로젝트 생성"}
         </Button>
       </div>
     </form>

--- a/src/features/project/components/project-form.tsx
+++ b/src/features/project/components/project-form.tsx
@@ -91,10 +91,20 @@ export function ProjectForm({ action, teamOptions, cancelHref }: ProjectFormProp
   const uploadStartedRef = useRef(false);
   const createdProjectId = state.createdProjectId;
   useEffect(() => {
-    if (createdProjectId === undefined || !attachment || uploadStartedRef.current) return;
+    if (createdProjectId === undefined || uploadStartedRef.current) return;
     uploadStartedRef.current = true;
+    /*
+      ⚠️ **첨부가 사라졌으면 그냥 목록으로 간다**(2026-08-13 고침). 액션은 `hasAttachment=1`을
+         보고 `redirect` 대신 id만 돌려주는데, 응답이 오기 전에 사람이 [첨부 선택 해제]를
+         누르면 여기서 올릴 파일이 없어진다 — 전에는 아무것도 안 하고 끝나서 **프로젝트는
+         만들어졌는데 화면이 제출 버튼만 잠긴 채 멈췄다.** 만들어진 건 사실이므로 이동은 한다.
+    */
+    if (!attachment) {
+      goToList();
+      return;
+    }
     void upload(createdProjectId, attachment);
-  }, [createdProjectId, attachment, upload]);
+  }, [createdProjectId, attachment, upload, goToList]);
 
   const isUploading = uploadPhase.kind === "uploading";
   /* 프로젝트가 이미 만들어진 뒤다 — 제출을 또 받으면 같은 프로젝트가 두 개 생긴다. */
@@ -414,7 +424,14 @@ export function ProjectForm({ action, teamOptions, cancelHref }: ProjectFormProp
           </div>
 
           <div className="flex flex-col gap-1.5">
-            <Label htmlFor="project-attachment">첨부파일</Label>
+            {/*
+              ⚠️ **`htmlFor`를 안 쓴다**(2026-08-13 고침). 실제 조작은 아래 [파일 첨부] 버튼이
+                 하고 `input`은 `hidden`이라 포커스를 못 받는다 — 라벨이 포커스 불가 요소를
+                 가리키면 라벨을 눌러도 아무 일이 없다. 라벨·오류를 **버튼**에 건다(§a11y).
+            */}
+            <span id="project-attachment-label" className="text-[13px] leading-5 font-medium">
+              첨부파일
+            </span>
             {/*
               ⚠️ 파일 자체는 폼으로 안 보낸다 — BE는 바이너리를 안 받고, 액션이 만든 프로젝트
                  id로 화면이 presigned PUT을 잇는다(`use-attachment-upload.ts`). 폼에는
@@ -434,17 +451,27 @@ export function ProjectForm({ action, teamOptions, cancelHref }: ProjectFormProp
                 size="sm"
                 className="w-full min-w-0 justify-start"
                 disabled={isUploading || isCreated}
+                aria-labelledby="project-attachment-label"
+                aria-describedby={attachmentError ? "project-attachment-error" : undefined}
                 onClick={() => fileInputRef.current?.click()}
               >
                 <Paperclip />
                 <span className="truncate">{attachment?.name ?? "파일 첨부 (선택)"}</span>
               </Button>
-              {attachment && !isCreated && (
+              {/*
+                ⚠️ **제출 중에도 잠근다** — 응답을 기다리는 사이 해제하면 올릴 파일이 사라진다.
+                   위 effect가 그 경우에도 목록으로 보내 주지만, 애초에 못 누르게 하는 편이
+                   "눌렀는데 첨부만 조용히 없어지는" 일을 안 만든다.
+                ⚠️ 파일이 검증에 걸려 `attachment`가 비었어도 **오류 문구가 남아 있으면** 지울
+                   자리가 있어야 한다 — 전에는 이 버튼이 안 그려져 오류를 치울 길이 없었다.
+              */}
+              {(attachment || attachmentError) && !isCreated && (
                 <Button
                   type="button"
                   variant="ghost"
                   size="icon-sm"
                   aria-label="첨부파일 선택 해제"
+                  disabled={isPending}
                   onClick={clearAttachment}
                 >
                   <X />

--- a/src/features/project/mapper.ts
+++ b/src/features/project/mapper.ts
@@ -140,6 +140,25 @@ export function toProjectTeamAction(be: BeProjectTimelineItem): ProjectTeamActio
   };
 }
 
+/**
+ * [확인] `ProjectAttachmentStoragePort.IssuedUploadUrl` — 업로드 3단계 중 1단계(발급) 응답.
+ * ⚠️ `fileUrl`은 브라우저로 열리는 URL이 아니라 **S3 오브젝트 키**다(BE Port 주석) —
+ *    confirm에 이 값을 그대로 되돌려 준다.
+ */
+export interface BeIssuedUploadUrl {
+  /** presigned PUT URL(15분 만료 — [확인] `ProjectAttachmentS3StorageAdapter.UPLOAD_URL_TTL`). */
+  uploadUrl: string;
+  fileUrl: string;
+}
+
+/** [확인] `ConfirmAttachmentRequest` — 업로드 3단계 중 3단계(확정) 요청 바디. */
+export interface ConfirmAttachmentRequestBody {
+  fileName: string;
+  /** 발급 응답의 `fileUrl`(S3 키) 그대로 — 다른 값이면 BE가 `ATTACHMENT_KEY_MISMATCH`로 거부한다. */
+  fileUrl: string;
+  fileSize: number;
+}
+
 /** 프로젝트 생성/수정 요청 바디. */
 export interface CreateProjectRequestBody {
   name: string;

--- a/src/features/project/types.ts
+++ b/src/features/project/types.ts
@@ -60,6 +60,25 @@ export type ProjectFormErrors = Partial<
   }
 >;
 
+/**
+ * 첨부 업로드 1단계(발급) 결과 — UI 계약(§Mock 격리막). 컴포넌트는 이 모양만 안다.
+ * ⚠️ `uploadUrl`이 `null`이면 **업로드를 건너뛴다** — mock 단계에는 올릴 곳이 없다.
+ *    컴포넌트가 `isMock`을 직접 보면 격리막이 깨지므로, 분기는 이 값 하나로 접는다.
+ */
+export interface AttachmentUploadTicket {
+  /** presigned PUT URL(15분 만료). `null`이면 브라우저 PUT 생략(목 단계). */
+  uploadUrl: string | null;
+  /** S3 오브젝트 키 — 확정(confirm)에 그대로 되돌린다. 브라우저로 열리는 URL이 아니다. */
+  fileUrl: string;
+}
+
+/** 발급 액션 결과 — 실패 `message`는 화면에 그대로 띄울 한국어 문장(§lib/api). */
+export type AttachmentIssueResult =
+  { ok: true; ticket: AttachmentUploadTicket } | { ok: false; message: string };
+
+/** 확정 액션 결과 — 발급 쪽과 같은 규약, 돌려줄 값만 없다. */
+export type AttachmentConfirmResult = { ok: true } | { ok: false; message: string };
+
 /** 프로젝트 첨부파일 한 건 — 다운로드는 클릭 시점에 별도로 URL을 발급받아 연다(5분 만료). */
 export interface ProjectAttachment {
   id: number;

--- a/src/features/project/use-attachment-upload.ts
+++ b/src/features/project/use-attachment-upload.ts
@@ -1,0 +1,79 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+import { confirmProjectAttachmentAction, issueProjectAttachmentUploadUrlAction } from "./actions";
+
+/**
+ * 업로드 진행 상태 — 화면이 이 넷만 보고 그린다.
+ * ⚠️ `failed`에는 문장이 **반드시** 실린다 — 조용히 멈추면 파일이 사라진 것처럼 보인다(§정직성).
+ */
+export type AttachmentUploadPhase =
+  { kind: "idle" } | { kind: "uploading" } | { kind: "done" } | { kind: "failed"; message: string };
+
+/**
+ * 프로젝트 첨부 업로드 3단계를 도는 훅 — 발급(서버 액션) → **브라우저가 S3에 직접 PUT** →
+ * 확정(서버 액션). 로직은 컴포넌트에 안 둔다(§폴더·네이밍: 로직=커스텀훅).
+ *
+ * ⚠️ **PUT은 브라우저에서 한다.** BE는 바이너리를 안 받고(§핵심 4원칙 ②의 예외가 아니라
+ *    설계다 — [확인] BE `ProjectAttachmentController` 주석 "BE는 바이너리를 받지 않는다"),
+ *    presigned URL은 서명 자체가 인증이라 우리 토큰이 브라우저로 나갈 일도 없다.
+ * ⚠️ **헤더를 손대지 않는다.** presign 서명에 Content-Type이 안 들어 있어([확인] BE
+ *    `ProjectAttachmentS3StorageAdapter.issueUploadUrl` — `PutObjectRequest`가 bucket·key뿐)
+ *    브라우저가 파일 타입으로 알아서 채우는 값이 그대로 통과한다. 굳이 세팅하면
+ *    서명 규약이 바뀌는 날 여기가 먼저 깨진다.
+ * ⚠️ **재시도해도 안전하다.** 발급은 매번 새 키(UUID)를 받고, 확정은 같은 `fileUrl`이면
+ *    기존 레코드를 돌려준다(idempotent — [확인] BE `ProjectAttachmentService.confirm`).
+ */
+export function useAttachmentUpload(onDone: () => void) {
+  const [phase, setPhase] = useState<AttachmentUploadPhase>({ kind: "idle" });
+
+  const upload = useCallback(
+    async (projectId: number, file: File) => {
+      setPhase({ kind: "uploading" });
+
+      const issued = await issueProjectAttachmentUploadUrlAction(projectId, file.name, file.size);
+      if (!issued.ok) {
+        setPhase({ kind: "failed", message: issued.message });
+        return;
+      }
+
+      // `uploadUrl`이 없으면 목 단계 — PUT을 건너뛰고 확정으로 간다(UI 계약 `AttachmentUploadTicket`).
+      if (issued.ticket.uploadUrl) {
+        try {
+          const response = await fetch(issued.ticket.uploadUrl, { method: "PUT", body: file });
+          if (!response.ok) {
+            // S3 오류 본문은 XML이라 사람에게 못 보여준다 — 상태 코드만 단서로 남긴다.
+            setPhase({
+              kind: "failed",
+              message: `저장소가 업로드를 거부했습니다 (HTTP ${response.status}). 다시 시도해 주세요.`,
+            });
+            return;
+          }
+        } catch {
+          setPhase({
+            kind: "failed",
+            message: "업로드 중 연결이 끊겼습니다. 네트워크를 확인하고 다시 시도해 주세요.",
+          });
+          return;
+        }
+      }
+
+      const confirmed = await confirmProjectAttachmentAction(projectId, {
+        fileName: file.name,
+        fileUrl: issued.ticket.fileUrl,
+        fileSize: file.size,
+      });
+      if (!confirmed.ok) {
+        setPhase({ kind: "failed", message: confirmed.message });
+        return;
+      }
+
+      setPhase({ kind: "done" });
+      onDone();
+    },
+    [onDone],
+  );
+
+  return { phase, upload };
+}

--- a/src/features/project/use-attachment-upload.ts
+++ b/src/features/project/use-attachment-upload.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 import { confirmProjectAttachmentAction, issueProjectAttachmentUploadUrlAction } from "./actions";
 
@@ -22,55 +22,81 @@ export type AttachmentUploadPhase =
  *    `ProjectAttachmentS3StorageAdapter.issueUploadUrl` — `PutObjectRequest`가 bucket·key뿐)
  *    브라우저가 파일 타입으로 알아서 채우는 값이 그대로 통과한다. 굳이 세팅하면
  *    서명 규약이 바뀌는 날 여기가 먼저 깨진다.
- * ⚠️ **재시도해도 안전하다.** 발급은 매번 새 키(UUID)를 받고, 확정은 같은 `fileUrl`이면
- *    기존 레코드를 돌려준다(idempotent — [확인] BE `ProjectAttachmentService.confirm`).
+ * ⚠️ **재시도가 파일을 두 벌로 만들지 않는다**(2026-08-13 고침). 확정은 같은 `fileUrl`이면
+ *    기존 레코드를 돌려주지만(idempotent — [확인] BE `ProjectAttachmentService.confirm`),
+ *    발급을 다시 하면 **새 키(UUID)**를 받아 그 멱등성이 안 걸린다 — PUT까지 성공하고 확정만
+ *    실패한 뒤 [다시 시도]를 누르면 같은 파일이 첨부 목록에 두 번 남았다. 그래서 **올라간
+ *    티켓을 기억했다가 그때는 확정만 다시 부른다.**
  */
 export function useAttachmentUpload(onDone: () => void) {
   const [phase, setPhase] = useState<AttachmentUploadPhase>({ kind: "idle" });
+  /*
+    ⚠️ **S3에 이미 올라간 파일의 자리**(위 재시도 주석). 여기 값이 있으면 그 파일은 저장소에
+       들어가 있고 확정만 남은 상태다 — 재시도는 발급·PUT을 건너뛰고 확정만 다시 부른다.
+       그래야 BE의 `fileUrl` 멱등성이 실제로 걸린다.
+  */
+  const uploadedRef = useRef<{ projectId: number; fileUrl: string } | null>(null);
 
   const upload = useCallback(
     async (projectId: number, file: File) => {
       setPhase({ kind: "uploading" });
 
-      const issued = await issueProjectAttachmentUploadUrlAction(projectId, file.name, file.size);
-      if (!issued.ok) {
-        setPhase({ kind: "failed", message: issued.message });
-        return;
-      }
+      /*
+        ⚠️ **전부 감싼다**(2026-08-13 고침). 전에는 서버 액션이 값으로 실패하는 경우만 봤는데,
+           호출 자체가 거절되면(전송 계층 오류·액션 안에서 던진 예외) 아무도 안 잡아
+           **"올리는 중…"에서 영영 멈췄다** — 실패도 재시도도 없는 화면이 남는다(§정직성).
+      */
+      try {
+        let ticket = uploadedRef.current?.projectId === projectId ? uploadedRef.current : null;
 
-      // `uploadUrl`이 없으면 목 단계 — PUT을 건너뛰고 확정으로 간다(UI 계약 `AttachmentUploadTicket`).
-      if (issued.ticket.uploadUrl) {
-        try {
-          const response = await fetch(issued.ticket.uploadUrl, { method: "PUT", body: file });
-          if (!response.ok) {
-            // S3 오류 본문은 XML이라 사람에게 못 보여준다 — 상태 코드만 단서로 남긴다.
-            setPhase({
-              kind: "failed",
-              message: `저장소가 업로드를 거부했습니다 (HTTP ${response.status}). 다시 시도해 주세요.`,
-            });
+        if (!ticket) {
+          const issued = await issueProjectAttachmentUploadUrlAction(
+            projectId,
+            file.name,
+            file.size,
+          );
+          if (!issued.ok) {
+            setPhase({ kind: "failed", message: issued.message });
             return;
           }
-        } catch {
-          setPhase({
-            kind: "failed",
-            message: "업로드 중 연결이 끊겼습니다. 네트워크를 확인하고 다시 시도해 주세요.",
-          });
+
+          // `uploadUrl`이 없으면 목 단계 — PUT을 건너뛰고 확정으로 간다(UI 계약 `AttachmentUploadTicket`).
+          if (issued.ticket.uploadUrl) {
+            const response = await fetch(issued.ticket.uploadUrl, { method: "PUT", body: file });
+            if (!response.ok) {
+              // S3 오류 본문은 XML이라 사람에게 못 보여준다 — 상태 코드만 단서로 남긴다.
+              setPhase({
+                kind: "failed",
+                message: `저장소가 업로드를 거부했습니다 (HTTP ${response.status}). 다시 시도해 주세요.`,
+              });
+              return;
+            }
+          }
+
+          /* 여기서부터 파일은 저장소에 있다 — 재시도가 새 키를 받지 않게 적어 둔다 */
+          ticket = { projectId, fileUrl: issued.ticket.fileUrl };
+          uploadedRef.current = ticket;
+        }
+
+        const confirmed = await confirmProjectAttachmentAction(projectId, {
+          fileName: file.name,
+          fileUrl: ticket.fileUrl,
+          fileSize: file.size,
+        });
+        if (!confirmed.ok) {
+          setPhase({ kind: "failed", message: confirmed.message });
           return;
         }
-      }
 
-      const confirmed = await confirmProjectAttachmentAction(projectId, {
-        fileName: file.name,
-        fileUrl: issued.ticket.fileUrl,
-        fileSize: file.size,
-      });
-      if (!confirmed.ok) {
-        setPhase({ kind: "failed", message: confirmed.message });
-        return;
+        uploadedRef.current = null;
+        setPhase({ kind: "done" });
+        onDone();
+      } catch {
+        setPhase({
+          kind: "failed",
+          message: "업로드 중 연결이 끊겼습니다. 네트워크를 확인하고 다시 시도해 주세요.",
+        });
       }
-
-      setPhase({ kind: "done" });
-      onDone();
     },
     [onDone],
   );

--- a/src/features/project/validate.test.ts
+++ b/src/features/project/validate.test.ts
@@ -1,5 +1,5 @@
 import type { ProjectDraft } from "./types";
-import { validateProjectDraft } from "./validate";
+import { validateAttachmentFile, validateProjectDraft } from "./validate";
 
 function draft(overrides: Partial<ProjectDraft>): ProjectDraft {
   return {
@@ -37,5 +37,27 @@ describe("validateProjectDraft — 날짜", () => {
   it("시작일 자체가 잘못됐으면 순서 비교 오류를 덧씌우지 않는다", () => {
     const errors = validateProjectDraft(draft({ startDate: "2026-02-30", dueDate: "2026-08-01" }));
     expect(errors.dueDate).toBeUndefined();
+  });
+});
+
+describe("validateAttachmentFile — BE가 거부하는 것만 미리 막는다", () => {
+  it("보통 파일은 통과한다", () => {
+    expect(validateAttachmentFile("기획서.pdf", 1024)).toBeNull();
+  });
+
+  it("0바이트 파일은 막는다 — BE `@Positive fileSize`", () => {
+    expect(validateAttachmentFile("빈파일.txt", 0)).toBe("빈 파일(0바이트)은 첨부할 수 없습니다");
+  });
+
+  it("'..'가 든 파일명은 막는다 — BE가 s3Key 경로 조작 오탐으로 발급을 거부한다", () => {
+    expect(validateAttachmentFile("report..pdf", 10)).toBe("파일 이름에 '..'를 포함할 수 없습니다");
+  });
+
+  it("이름이 공백뿐이면 막는다", () => {
+    expect(validateAttachmentFile("   ", 10)).toBe("파일 이름이 비어 있습니다");
+  });
+
+  it("점 하나짜리 확장자 구분(report.v2.pdf)은 정상이다 — '..'만 문제다", () => {
+    expect(validateAttachmentFile("report.v2.pdf", 10)).toBeNull();
   });
 });

--- a/src/features/project/validate.ts
+++ b/src/features/project/validate.ts
@@ -43,3 +43,21 @@ export function validateProjectDraft(draft: ProjectDraft): ProjectFormErrors {
 
   return errors;
 }
+
+/**
+ * 첨부파일 검증 — 화면(파일 고른 직후)과 서버 액션(발급·확정 직전)이 **이 함수 하나**로 본다.
+ * BE가 실제로 거부하는 것만 여기서 미리 막는다 — 없는 정책(용량 상한·확장자)을 지어내지 않는다
+ * (최대 용량·확장자는 storage 팀 소관으로 미정 — [확인] BE `ProjectAttachmentStoragePort` 주석).
+ *
+ * - 0바이트: [확인] BE `IssueUploadUrlRequest`·`ConfirmAttachmentRequest`의 `@Positive fileSize`
+ * - `..` 포함 파일명: [확인] BE `ProjectAttachmentService.issueUploadUrl` — s3Key 경로 조작
+ *   오탐 방지로 발급 자체를 거부한다
+ *
+ * @returns 통과하면 `null`, 아니면 칸에 그대로 띄울 문장.
+ */
+export function validateAttachmentFile(fileName: string, fileSize: number): string | null {
+  if (!fileName.trim()) return "파일 이름이 비어 있습니다";
+  if (fileName.includes("..")) return "파일 이름에 '..'를 포함할 수 없습니다";
+  if (fileSize <= 0) return "빈 파일(0바이트)은 첨부할 수 없습니다";
+  return null;
+}


### PR DESCRIPTION
## 📋 PR 타입

> 해당하는 타입을 선택해 주세요 (복수 선택 가능)

- [x] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [x] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [x] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- **조용한 no-op 제거**: 프로젝트 생성 폼의 파일 입력이 파일명만 들고 있다가 **아무것도 안 올리고 버리던 것**을 실제 업로드로 잇습니다(§정직성 위반이던 자리). BE 3단계 API를 실코드로 대조해 배선했습니다 — `POST …/attachments/upload-url`(발급) → **브라우저가 S3에 직접 PUT** → `POST …/attachments/confirm`(확정). `[확인] ProjectAttachmentController · IssueUploadUrlRequest · ConfirmAttachmentRequest · ProjectAttachmentS3StorageAdapter` 주석으로 근거를 남겼습니다.
- **액션이 redirect 대신 id를 되돌립니다(첨부가 있을 때만)**: BE는 바이너리를 받지 않아 PUT은 브라우저 몫인데, 기존처럼 `redirect`로 끝나면 화면이 업로드를 이어갈 프로젝트 id를 못 받습니다. 생성 응답(`ProjectSummaryResponse.id`)을 `ProjectFormState.createdProjectId`로 되돌리고, 첨부가 없으면 기존 redirect 흐름 그대로입니다.
- **실패를 정직하게 말합니다**: 업로드가 실패해도 프로젝트는 이미 만들어진 뒤라, "프로젝트는 만들어졌지만 첨부파일을 올리지 못했습니다 — {이유}"를 인라인으로 띄우고 **[다시 시도] / [첨부 없이 이동]** 을 줍니다. 재시도는 안전합니다(발급=새 UUID 키, confirm=idempotent — BE 실코드 확인). 생성 후 제출 버튼은 잠가 중복 생성을 막습니다.
- **BE가 실제 거부하는 것만 미리 막습니다**: 0바이트(`@Positive`)·파일명 `..`(s3Key 경로 조작 오탐)을 파일 고른 직후 인라인으로 알립니다. 용량 상한·확장자 정책은 BE에 없어(storage 팀 소관 미정) **지어내지 않았습니다**.
- **격리막 유지**: 컴포넌트는 `isMock`을 모릅니다 — 발급 티켓의 `uploadUrl: null`이 "PUT 건너뛰어라"는 UI 계약 신호입니다. 목 모드는 네트워크 없이 성공을 흉내냅니다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/project-attachment-upload#418`, base `develop`)
- [x] 커밋 컨벤션 준수 (`feat: 프로젝트 첨부를 실제로 올린다 — presign·PUT·confirm 배선 #418`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`) — presigned URL은 서명 자체가 인증이라 브라우저에 토큰이 안 나갑니다

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 발급·확정 서버 액션이 `canCreateProject`로 재검사(BE도 `@PreAuthorize OWNER/ADMIN`), 프로젝트 스코프 검증은 BE(`requireProjectInCompany`·`requireOwnAttachmentKey`)가 담당
- [ ] 🧬 **zod** — 미적용: project 도메인 기존 검증(`validateProjectDraft`)이 수기 함수라 `validateAttachmentFile`도 같은 패턴을 따랐습니다(도메인 내 일관성 우선, zod 전환은 별도 작업)
- [x] 🕵️ **정직성** — 조용히 버리던 파일을 실제로 올리고, 실패·반쪽 성공을 화면에 그대로 말합니다. mock 분기는 주석으로 명시
- [x] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨 — 기존 토큰 클래스만 사용

**품질**

- [x] ⚡ 최적화 — 추가 라이브러리 0, 서버 컴포넌트 구조 불변(업로드는 상호작용 잎사귀에만)
- [x] ♿ a11y — 오류는 `FieldError`(`role="alert"`)·실패 안내 `role="alert"`, 선택 해제 버튼 `aria-label`
- [x] ♻️ 재사용 확인 — `FieldError`·`Button` 등 기존 컴포넌트만 사용, 신규는 훅 1개
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 올리는 중(버튼·안내문) / 실패(인라인+재시도) / 파일 미선택(기존 안내문)
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 미지원 · 권한거부 안내 있음 — 해당 없음(`fetch` PUT뿐)

---

## 🔗 연관 이슈

Closes #418

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
| 파일을 골라도 파일명만 표시되고 아무 데도 안 올라감 | 생성 → 업로드 진행 표시 → 실패 시 인라인 오류 + [다시 시도]/[첨부 없이 이동] |

---

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

- **`actions.ts`의 흐름 분기**: 첨부가 있으면 `redirect` 대신 `createdProjectId`를 되돌리는 결정 — `redirect()`는 여전히 try/catch 밖입니다. 첨부 없는 기존 흐름(생성→목록+토스트)은 그대로인지 봐 주세요.
- **브라우저 PUT에서 헤더를 안 건드리는 이유**: BE presign 서명에 Content-Type이 안 들어 있어(`PutObjectRequest`가 bucket·key뿐 — 실코드 확인) 브라우저 기본값이 그대로 통과합니다. 수동 세팅은 서명 규약이 바뀌는 날 먼저 깨지는 자리라 뺐습니다.
- **재시도 안전성**: 실패 후 [다시 시도]가 발급부터 다시 돕니다 — 새 UUID 키를 받아 이전 반쯤 올라간 오브젝트와 충돌하지 않고, confirm은 같은 `fileUrl`이면 기존 레코드를 돌려줍니다(idempotent).
- **검증 결과** (모두 통과):
  - `npx tsc --noEmit` ✅
  - `npx eslint src/features/project --fix` ✅ (경고 0)
  - `npx jest` ✅ — 92 suites / 994 tests (신규 `validateAttachmentFile` 5케이스 포함)
  - `npx next build` ✅
  - 목 모드 실동작: 폼 작성→파일 첨부→생성→업로드(목: PUT 생략)→confirm→목록 이동+"프로젝트를 만들었습니다" 토스트 확인

---

## 📝 추가 메모

- BE의 알려진 한계(실코드 주석에 명시, FE에서 대응 불필요): presigned PUT이 `fileSize`로 실제 업로드 크기를 강제하지 않음, confirm이 HeadObject로 실존 확인을 안 함 — 둘 다 BE 측 별도 작업으로 미뤄져 있습니다.
- 목 모드에서는 확정 후에도 상세(기획 탭) 첨부 목록에 새 파일이 안 보입니다 — 목 저장소가 없어서이며 액션 주석에 명시했습니다. 실연동에서는 confirm 후 `revalidatePath`로 상세가 갱신됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 프로젝트 생성 시 첨부파일을 선택하고 업로드할 수 있습니다.
  - 파일 업로드 진행 상태와 오류 메시지를 확인할 수 있으며, 실패 시 재시도하거나 첨부 없이 계속할 수 있습니다.
  - 업로드 완료 후 프로젝트 목록으로 자동 이동합니다.
- **버그 수정**
  - 빈 파일, 잘못된 파일명, 유효하지 않은 파일 크기를 사전에 차단합니다.
  - 프로젝트 생성 및 첨부파일 업로드 실패 시 더 명확한 오류 처리를 제공합니다.
- **테스트**
  - 첨부파일 유효성 검증 사례를 보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->