### PR TITLE
[FEAT] 회의 목록·상세·팀 대시보드 최근 회의 연동 #430

### DIFF
--- a/src/app/(shell)/(authority)/team/(dashboard)/page.tsx
+++ b/src/app/(shell)/(authority)/team/(dashboard)/page.tsx
@@ -1,15 +1,14 @@
-import { CalendarClock } from "lucide-react";
 import { Users } from "lucide-react";
 import type { Metadata } from "next";
 
 import { AccessDenied } from "@/components/common/access-denied";
-import { DashboardMeetingItem } from "@/components/common/dashboard-meeting-item";
 import { EmptyState } from "@/components/common/empty-state";
 import { SummaryCard } from "@/components/common/summary-card";
 import { Table, TableBody, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { roleHome } from "@/features/shell/home";
 import { getViewer } from "@/features/shell/viewer";
 import { MemberStatusRow } from "@/features/team/components/member-status-row";
+import { RecentTeamMeetings } from "@/features/team/components/recent-team-meetings";
 import { MEMBER_BOX_MAX_HEIGHT } from "@/features/team/lib";
 import { getTeamDashboardOverview } from "@/features/team/server";
 import { canAccessTeamScope } from "@/lib/permission";
@@ -98,27 +97,7 @@ export default async function TeamDashboardPage() {
           )}
         </section>
 
-        {/* 높이를 고정하지 않는다 — 다섯 건이 하드 캡이라 자라 봐야 다섯 줄이다(`lib.ts` 참고) */}
-        <section className="border-border bg-card flex flex-col overflow-hidden rounded-2xl border">
-          <div className="border-border flex shrink-0 items-baseline justify-between gap-3 border-b px-7 pt-6 pb-3">
-            <h2 className="text-[17px] leading-7 font-semibold tracking-[-0.3px]">최근 팀 회의</h2>
-            <span className="text-muted-foreground text-[12px] leading-4">최신 5건</span>
-          </div>
-          {meetings.length === 0 ? (
-            <EmptyState
-              className="flex-1"
-              icon={CalendarClock}
-              title="예정된 팀 회의가 없습니다."
-              description="회의실을 예약하면 그 자리에서 회의가 열립니다."
-            />
-          ) : (
-            <ul>
-              {meetings.map((meeting, index) => (
-                <DashboardMeetingItem key={meeting.id} meeting={meeting} showDivider={index > 0} />
-              ))}
-            </ul>
-          )}
-        </section>
+        <RecentTeamMeetings meetings={meetings} />
       </div>
     </main>
   );

--- a/src/app/(shell)/app/meeting/[meetingId]/page.tsx
+++ b/src/app/(shell)/app/meeting/[meetingId]/page.tsx
@@ -75,7 +75,11 @@ export default async function MeetingDetailPage({
   if (result.kind === "locked") {
     return (
       <NoticeCard
-        title={result.title}
+        /*
+          ⚠️ 제목이 없을 수 있다 — BE가 403으로 막으면 봉투에 회의 제목이 안 온다(§view-types).
+             그때는 지어내지 않고 **무슨 화면인지**만 적는다.
+        */
+        title={result.title ?? "열람할 수 없는 회의입니다"}
         message="참석자만 열람 가능합니다."
         icon={<Lock className="text-muted-foreground/70 mx-auto size-6" aria-hidden />}
       />

--- a/src/features/meeting/actions.ts
+++ b/src/features/meeting/actions.ts
@@ -10,8 +10,14 @@ import { getMockActor } from "@/lib/mock-actor";
 import { canManageMeeting } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
+import { checkMeetingTitle } from "./lib";
 import { attendeeIdsFrom, type BeUpdateAttendeesResponse } from "./mapper";
-import { cancelMockMeeting, findMockMeeting, updateMockMeetingAttendees } from "./mock/meetings";
+import {
+  cancelMockMeeting,
+  findMockMeeting,
+  updateMockMeeting,
+  updateMockMeetingAttendees,
+} from "./mock/meetings";
 import { meetingStatusOf } from "./status";
 
 const MEETING_LIST_PATH = "/app/meeting";
@@ -130,5 +136,90 @@ export async function cancelMeetingAction(meetingId: string): Promise<CancelMeet
     return { error: null };
   } catch (error) {
     return { error: toCancelErrorMessage(error) };
+  }
+}
+
+/** 회의 수정 폼 결과 — `useActionState`가 그대로 들고 있는 모양(MEET-09 폼과 같은 골격). */
+export interface UpdateMeetingState {
+  error: string | null;
+  /**
+   * 성공한 저장의 표식 — 다이얼로그가 이 값이 바뀐 걸 보고 닫는다.
+   *
+   * ⚠️ `boolean`으로 두면 **두 번째 저장을 못 알아챈다.** 창을 다시 열어 또 고치면 `true`에서
+   *    `true`라 값이 안 바뀌고, `useEffect`가 안 돈다(MEET-09 폼이 `attendeeIds` 배열
+   *    참조로 같은 문제를 피한 자리다). 저장할 때마다 새 객체를 만든다.
+   */
+  saved: { title: string } | null;
+}
+
+/**
+ * `PATCH /api/meetings/{meetingId}`(MEET-05) 실패를 문구 하나로 바꾼다.
+ * ⚠️ BE의 `message`가 이미 화면에 띄울 한국어 문장이다(§lib/api) — 코드로 문구를 새로 짓지 않는다.
+ *    상태 위반(409 `MT-014`)·30분 그리드(400 `MT-005`)·중복 예약(409 `MT-002`)이 전부 여기로 온다.
+ */
+function toUpdateErrorMessage(error: unknown): string {
+  if (!(error instanceof ApiError)) throw error;
+  return error.message;
+}
+
+/**
+ * 회의 정보 수정(MEET-05) — **시작 전 회의만**. 상세 머리글의 [회의 수정]이 부른다.
+ *
+ * ⚠️ **지금 보내는 건 제목뿐이다.** BE는 `title`·`projectId`·`meetingRoomId`·`startAt`·`endAt`·
+ *    `recordingConsent` 6개를 부분 수정으로 받지만, 뒤의 다섯은 **예약 슬롯을 다시 잡는 일**이라
+ *    회의실 예약 화면의 슬롯 피커(30분 그리드·운영시간·중복 검사)를 그대로 끌어와야 한다 —
+ *    반쯤 되는 폼을 먼저 내보내지 않는다(§정직성, 이슈 #419 후속).
+ * ⚠️ **보낸 키만 바뀐다.** BE가 미전달과 명시적 null을 가르므로(`@JsonSetter`) 본문에
+ *    `title` 하나만 싣는다 — 나머지를 `null`로 채워 보내면 필수 컬럼을 지우라는 뜻이 돼 400이다.
+ * ⚠️ 권한은 `canManageMeeting`(host·OWNER·ADMIN) 하나로 본다 — 취소(MEET-06)와 같은 축이고
+ *    BE `MeetingUpdateService.canManageMeeting`과 같은 범위다. 화면은 host에게만 버튼을
+ *    보여주지만(`canEditMeeting`) 화면 가드는 UX일 뿐이라 여기서 다시 확인한다(§권한).
+ * ⚠️ 상태 관문(`SCHEDULED`)도 다시 본다 — 목은 여기가 유일한 서버고, 실연동은 BE가 409
+ *    `MT-014`로 막는다. 둘 다 한다(화면 숨김은 UX, 서버 재검사가 보안).
+ */
+export async function updateMeetingAction(
+  _prev: UpdateMeetingState,
+  formData: FormData,
+): Promise<UpdateMeetingState> {
+  const meetingId = String(formData.get("meetingId") ?? "");
+  const checked = checkMeetingTitle(String(formData.get("title") ?? ""));
+  if (!checked.ok) return { error: checked.error, saved: null };
+
+  const actor = getMockActor();
+
+  if (isMock) {
+    const meeting = findMockMeeting(meetingId);
+    if (!meeting) return { error: "회의를 찾을 수 없습니다", saved: null };
+    if (!canManageMeeting(actor, { hostId: meeting.hostId })) {
+      return { error: "회의를 수정할 권한이 없습니다", saved: null };
+    }
+    if (meetingStatusOf(meeting, new Date()) !== MEETING_STATUS.SCHEDULED) {
+      return { error: "이미 시작된 회의는 수정할 수 없습니다", saved: null };
+    }
+
+    updateMockMeeting(meetingId, { title: checked.title });
+    revalidatePath(`/app/meeting/${meetingId}`);
+    revalidatePath(MEETING_LIST_PATH);
+    return { error: null, saved: { title: checked.title } };
+  }
+
+  const accessToken = await requireAccessToken();
+  try {
+    /*
+      ⚠️ **응답을 안 읽는다.** MEET-05의 200 본문은 `meetingId`·`status`·`startAt`·`endAt`·
+         `meetingRoom`뿐이라 **방금 고친 제목이 안 들어 있다**(BE `UpdateMeetingResponse`) —
+         참석자 교체(MEET-09)처럼 서버 확정값으로 비관적 갱신을 할 수 없다. 그래서 화면은
+         `revalidatePath`로 다시 읽는다.
+    */
+    await serverApi<unknown>(ep.meeting(Number(meetingId)), {
+      method: "PATCH",
+      accessToken,
+      json: { title: checked.title },
+    });
+    revalidatePath(`/app/meeting/${meetingId}`);
+    revalidatePath(MEETING_LIST_PATH);
+    return { error: null, saved: { title: checked.title } };
+  } catch (error) {
+    return { error: toUpdateErrorMessage(error), saved: null };
   }
 }

--- a/src/features/meeting/components/meeting-card.test.tsx
+++ b/src/features/meeting/components/meeting-card.test.tsx
@@ -68,3 +68,48 @@ describe("MeetingCard — 발치 버튼", () => {
     );
   });
 });
+
+/**
+ * 둘째 줄(소속 라벨 · 안건) — **빈 조각은 가운뎃점째 뺀다.**
+ *
+ * ⚠️ BE #461 배포 전 목록엔 소속 팀도 안건도 없어 **둘 다 빈 문자열**로 온다(§mapper) —
+ *    그대로 이으면 이 줄에 홀로 남은 `·` 하나만 그려진다. 배포 뒤에는 값이 실제로 차므로
+ *    **두 경우를 다 고정해 둔다** — 한쪽만 보면 나중에 조건이 뒤집혀도 안 걸린다.
+ */
+describe("MeetingCard — 둘째 줄", () => {
+  it("소속 라벨과 안건이 다 있으면 가운뎃점으로 잇는다", () => {
+    renderCard();
+
+    /* ⚠️ 가운뎃점 양옆은 글자가 아니라 여백(`px-1.5`)이라 텍스트로는 붙어 나온다 */
+    expect(screen.getByText(/Owner 개설/)).toHaveTextContent("Owner 개설·운영 · 주간 점검");
+  });
+
+  it.each([
+    ["소속 라벨만 있으면", { originLabel: "Owner 개설", topicSummary: "" }],
+    ["안건만 있으면", { originLabel: "", topicSummary: "운영 · 주간 점검" }],
+  ])("%s 앞뒤에 가운뎃점을 안 붙인다", (_label, patch) => {
+    renderCard(patch);
+
+    const line = screen.getByText(patch.originLabel || patch.topicSummary);
+    expect(line.textContent?.trim()).toBe(patch.originLabel || patch.topicSummary);
+  });
+
+  it("둘 다 없으면 가운뎃점만 남기지 않는다 — #461 배포 전 목록이 이 모양이다", () => {
+    renderCard({ originLabel: "", topicSummary: "" });
+
+    expect(screen.queryByText("·")).not.toBeInTheDocument();
+  });
+
+  /*
+    ⚠️ **빈 `<p>`도 남기지 않는다**(2026-08-13, 코드래빗 지적). 예전엔 조건 없이 `<p>`를
+       그려서 `pt-1.5 pb-6`이 살아 있었는데, 카드 발치와의 간격이 늘어 밑에 침묵의 여백이
+       생겼다 — 픽셀도 없는 것을 말하면 안 된다.
+  */
+  it("둘 다 없으면 소속·안건 줄 자체를 안 그린다", () => {
+    const { container } = render(
+      <MeetingCard meeting={{ ...BASE, originLabel: "", topicSummary: "" }} />,
+    );
+
+    expect(container.querySelector("p.text-muted-foreground")).toBeNull();
+  });
+});

--- a/src/features/meeting/components/meeting-card.tsx
+++ b/src/features/meeting/components/meeting-card.tsx
@@ -107,10 +107,15 @@ function CardBody({
            달라 한 줄에 두 종류의 상자가 섞였다 — 둘 다 "이 회의가 어디서 왔나"를 말하는
            **곁 정보**라 같은 무게의 글로 이어 붙인다.
         ⚠️ 가운뎃점으로 잇는다. 상자를 없앤 자리에 구분자가 필요하다.
+        ⚠️ **빈 조각은 가운뎃점째 뺀다**(2026-08-13). 실서버 목록(MEET-02)엔 소속 라벨도 안건도
+           없어 둘 다 빈 문자열로 온다(§view-types) — 그대로 이으면 이 줄에 홀로 남은 `·` 하나만
+           그려진다. 없는 값을 말하지 않는 게 §정직성이다.
       */}
       <p className="text-muted-foreground truncate pt-1.5 pb-6 text-[13px] leading-5">
         {meeting.originLabel}
-        <span className="px-1.5 opacity-50">·</span>
+        {meeting.originLabel && meeting.topicSummary && (
+          <span className="px-1.5 opacity-50">·</span>
+        )}
         {meeting.topicSummary}
       </p>
     </>

--- a/src/features/meeting/components/meeting-card.tsx
+++ b/src/features/meeting/components/meeting-card.tsx
@@ -110,14 +110,19 @@ function CardBody({
         ⚠️ **빈 조각은 가운뎃점째 뺀다**(2026-08-13). 실서버 목록(MEET-02)엔 소속 라벨도 안건도
            없어 둘 다 빈 문자열로 온다(§view-types) — 그대로 이으면 이 줄에 홀로 남은 `·` 하나만
            그려진다. 없는 값을 말하지 않는 게 §정직성이다.
+        ⚠️ **둘 다 비면 `<p>`를 아예 안 그린다**(2026-08-13, 코드래빗 지적). 빈 문자열이라도
+           `pt-1.5 pb-6`이 그대로 남아 카드 아래에 **말없는 빈 줄**이 생긴다 — 없는 값을
+           말하지 않는다는 §정직성은 픽셀에도 적용된다.
       */}
-      <p className="text-muted-foreground truncate pt-1.5 pb-6 text-[13px] leading-5">
-        {meeting.originLabel}
-        {meeting.originLabel && meeting.topicSummary && (
-          <span className="px-1.5 opacity-50">·</span>
-        )}
-        {meeting.topicSummary}
-      </p>
+      {(meeting.originLabel || meeting.topicSummary) && (
+        <p className="text-muted-foreground truncate pt-1.5 pb-6 text-[13px] leading-5">
+          {meeting.originLabel}
+          {meeting.originLabel && meeting.topicSummary && (
+            <span className="px-1.5 opacity-50">·</span>
+          )}
+          {meeting.topicSummary}
+        </p>
+      )}
     </>
   );
 }

--- a/src/features/meeting/components/meeting-detail-view.tsx
+++ b/src/features/meeting/components/meeting-detail-view.tsx
@@ -138,6 +138,8 @@ type ActionsSectionState =
   | { kind: "list" }
   | { kind: "pendingReview" }
   | { kind: "stalled" }
+  /** 안 물어봤다 — 회의별 액션 조회가 아직 안 붙었다(§view-types `outputs === null`) */
+  | { kind: "notLoaded" }
   | { kind: "empty" };
 
 function actionsSectionStateOf(detail: MeetingDetail): ActionsSectionState {
@@ -149,11 +151,19 @@ function actionsSectionStateOf(detail: MeetingDetail): ActionsSectionState {
   ) {
     return { kind: "notice", reason: detail.pendingReason };
   }
-  if (detail.outputs.length > 0) return { kind: "list" };
+  if (detail.outputs !== null && detail.outputs.length > 0) return { kind: "list" };
   if (detail.pendingActionCount > 0) return { kind: "pendingReview" };
   if (detail.pendingReason === "FAILED") {
     return detail.isStalled ? { kind: "stalled" } : { kind: "notice", reason: "FAILED" };
   }
+  /*
+    ⚠️ **못 불러온 칸이 "없음"으로 흘러가지 않게 막는다.** 실서버 상세는 회의별 액션 조회를
+       아직 안 붙여서 목록 자체를 안 물어본다 — 빈 배열과 같은 자리에 두면 화면이 "하달된
+       액션이 없습니다"라고 **단정**한다(§정직성).
+    ⚠️ **맨 아래다.** 위의 확정 대기·중단은 BE가 실제로 준 신호라 "못 불러왔다"보다 정확한
+       말이고, Host가 다음에 할 일까지 알려 준다 — 목록을 못 그리는 사정은 그 뒤의 이야기다.
+  */
+  if (detail.outputs === null) return { kind: "notLoaded" };
   return { kind: "empty" };
 }
 
@@ -323,10 +333,10 @@ export function MeetingDetailView({ detail, members, viewerTeamName }: MeetingDe
             <h2 className="text-[17px] leading-7 font-semibold tracking-[-0.3px]">
               하달된 {detail.outputKindLabel}
             </h2>
-            {/* ⚠️ 아직 안 찬·확정 대기·중단된 회의에 `전체 0건`이라 적으면 하나도 안 나온 회의로 읽힌다 */}
+            {/* ⚠️ 아직 안 찬·확정 대기·중단·못 불러온 회의에 `전체 0건`이라 적으면 하나도 안 나온 회의로 읽힌다 */}
             {(actionsState.kind === "list" || actionsState.kind === "empty") && (
               <p className="text-muted-foreground text-[12px] leading-4 tabular-nums">
-                전체 {detail.outputs.length}건
+                전체 {detail.outputs?.length ?? 0}건
               </p>
             )}
           </div>
@@ -352,6 +362,16 @@ export function MeetingDetailView({ detail, members, viewerTeamName }: MeetingDe
                 detail.isHost ? { href: "/app/me", label: "마이페이지에서 다시 분석하기" } : null
               }
             />
+          ) : actionsState.kind === "notLoaded" ? (
+            /*
+              ⚠️ **"없다"고 하지 않는다.** 회의별 액션 조회가 아직 안 붙어 물어보지도 않은
+                 자리다 — 안 물어본 것을 없다고 말하지 않는다(§정직성).
+            */
+            <EmptyState
+              icon={ListChecks}
+              title={`하달된 ${detail.outputKindLabel}을 아직 표시할 수 없습니다.`}
+              description="회의별 액션 조회가 연동되면 여기에 표시됩니다."
+            />
           ) : actionsState.kind === "empty" ? (
             /* ⚠️ 확정은 했는데 남은 것이 없는 자리다 — "확정을 누르세요"는 위 `pendingReview`가 한다 */
             <EmptyState
@@ -360,7 +380,7 @@ export function MeetingDetailView({ detail, members, viewerTeamName }: MeetingDe
             />
           ) : (
             <ul className="border-border border-t">
-              {detail.outputs.map((output) => (
+              {(detail.outputs ?? []).map((output) => (
                 <li key={output.id} className="border-border not-first:border-t">
                   <Link
                     href={output.href}
@@ -397,7 +417,7 @@ export function MeetingDetailView({ detail, members, viewerTeamName }: MeetingDe
         <section className="border-border bg-card rounded-2xl border">
           <div className="flex items-baseline justify-between gap-3 px-7 pt-6 pb-3">
             <h2 className="text-[17px] leading-7 font-semibold tracking-[-0.3px]">발화 기록</h2>
-            {!detail.pendingReason && (
+            {!detail.pendingReason && detail.script !== null && (
               <p className="text-muted-foreground text-[12px] leading-4 tabular-nums">
                 {detail.script.length}건
               </p>
@@ -406,6 +426,13 @@ export function MeetingDetailView({ detail, members, viewerTeamName }: MeetingDe
 
           {detail.pendingReason ? (
             <SectionNotice reason={detail.pendingReason} />
+          ) : detail.script === null ? (
+            /* ⚠️ 산출물 칸의 `notLoaded`와 같은 자리다 — 자막 조회(CAP-12) 미연동이라 안 물어봤다 */
+            <EmptyState
+              icon={MessageSquareOff}
+              title="발화 기록을 아직 표시할 수 없습니다."
+              description="자막 조회가 연동되면 여기에 표시됩니다."
+            />
           ) : detail.script.length === 0 ? (
             <EmptyState icon={MessageSquareOff} title="남아 있는 발화 기록이 없습니다." />
           ) : (

--- a/src/features/meeting/components/meeting-detail-view.tsx
+++ b/src/features/meeting/components/meeting-detail-view.tsx
@@ -67,6 +67,41 @@ function OriginLine({ detail }: { detail: MeetingDetail }) {
 }
 
 /**
+ * 회의 안건 — 별도 섹션 유지(§3-2).
+ *
+ * ⚠️ 라벨-값 표로 두지 않는다. 대주제는 값의 이름이 아니라 **묶음 이름**이라
+ *    `프로젝트 | 킥오프`처럼 두 칸으로 벌려 두면 무엇이 라벨인지 안 읽힌다 —
+ *    대주제를 한 번 적고 소주제를 그 옆에 늘어놓는 편이 원래 뜻에 맞는다.
+ * ⚠️ **쌍이 아니다.** 예약 폼은 대주제·소주제를 쌍으로 받지만 BE 모델은 대주제 하나만
+ *    남긴다(§view-types `MeetingAgenda`) — 소주제마다 대주제를 붙여 그리면 없는 쌍을
+ *    지어내는 것이다(§정직성).
+ * ⚠️ **`null`이면 이 칸을 통째로 안 그린다.** 안건이 0건인지 아직 못 받은 것인지
+ *    (BE #461 배포 전) 구분할 방법이 없어서, 머리만 남기고 "없습니다"라고 단정하지 않는다.
+ */
+function AgendaSection({ agenda }: { agenda: MeetingDetail["agenda"] }) {
+  if (!agenda) return null;
+
+  return (
+    <div className="border-border mt-5 border-t pt-5">
+      <p className="text-muted-foreground text-[12px] leading-4">안건</p>
+      <div className="flex flex-wrap items-center gap-2 pt-2">
+        {agenda.main && <p className="text-[13px] leading-5 font-medium">{agenda.main}</p>}
+        <ul className="flex flex-wrap gap-2">
+          {agenda.subs.map((sub, index) => (
+            <li
+              key={`${index}-${sub}`}
+              className="border-border text-muted-foreground rounded-lg border px-2.5 py-1 text-[13px] leading-5"
+            >
+              {sub}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+/**
  * 아직 안 찬 섹션에 넣는 한 줄.
  *
  * ⚠️ **빈 칸으로 두지 않는다.** 예정·진행중 회의의 기록·산출물은 "없는" 게 아니라 "아직"인데,
@@ -267,27 +302,7 @@ export function MeetingDetailView({ detail, members, viewerTeamName }: MeetingDe
             <OriginLine detail={detail} />
           </div>
 
-          {/*
-            회의 안건 — 별도 섹션 유지(§3-2).
-            ⚠️ 라벨-값 표로 두지 않는다. 대주제는 값의 이름이 아니라 **묶음 이름**이라
-               `프로젝트 | 킥오프`처럼 두 칸으로 벌려 두면 무엇이 라벨인지 안 읽힌다 —
-               `대주제 · 소주제` 한 줄이 원래 뜻에 맞는다.
-          */}
-          <div className="border-border mt-5 border-t pt-5">
-            <p className="text-muted-foreground text-[12px] leading-4">안건</p>
-            <ul className="flex flex-wrap gap-2 pt-2">
-              {detail.topics.map((topic) => (
-                <li
-                  key={`${topic.main}-${topic.sub}`}
-                  className="border-border rounded-lg border px-2.5 py-1 text-[13px] leading-5"
-                >
-                  <span className="text-muted-foreground">{topic.main}</span>
-                  <span className="text-muted-foreground/50 px-1.5">·</span>
-                  {topic.sub}
-                </li>
-              ))}
-            </ul>
-          </div>
+          <AgendaSection agenda={detail.agenda} />
 
           {/*
             참석자 — **머리 카드 안**이다(시안과 같다). 곁 컬럼에 떼어 두면 이름 몇 줄만

--- a/src/features/meeting/components/meeting-detail-view.tsx
+++ b/src/features/meeting/components/meeting-detail-view.tsx
@@ -20,10 +20,11 @@ import { ACTION_STATUS_LABEL } from "@/constants/action";
 import type { RoomMember } from "@/features/rooms/types";
 import { formatDate } from "@/lib/date";
 
-import { canCancelMeeting, canEditMeetingAttendees } from "../status";
+import { canCancelMeeting, canEditMeeting, canEditMeetingAttendees } from "../status";
 import type { MeetingContentPending, MeetingDetail } from "../view-types";
 import { MeetingAttendeesEditDialog } from "./meeting-attendees-edit-dialog";
 import { MeetingCancelDialog } from "./meeting-cancel-dialog";
+import { MeetingEditDialog } from "./meeting-edit-dialog";
 import { ProjectAccent } from "./project-accent";
 
 /**
@@ -216,6 +217,7 @@ export function MeetingDetailView({ detail, members, viewerTeamName }: MeetingDe
   const actionsState = actionsSectionStateOf(detail);
   const canEditAttendees = canEditMeetingAttendees(detail);
   const canCancel = canCancelMeeting(detail);
+  const canEdit = canEditMeeting(detail);
 
   return (
     /*
@@ -248,7 +250,18 @@ export function MeetingDetailView({ detail, members, viewerTeamName }: MeetingDe
                 {detail.title}
               </h2>
             </div>
-            {canCancel && <MeetingCancelDialog meetingId={detail.id} />}
+            {/*
+              ⚠️ **수정이 취소보다 앞이다.** 되돌릴 수 없는 쪽(취소)을 오른쪽 끝에 둔다 —
+                 잘못 잡은 회의를 고치러 온 사람이 먼저 만나야 하는 건 [회의 수정]이다
+                 (그게 없어서 취소 후 재개설밖에 없었다, #419).
+              ⚠️ 둘 다 시작 전(SCHEDULED) 회의에만 뜬다 — BE가 그 뒤로는 409로 막는다.
+            */}
+            {(canEdit || canCancel) && (
+              <div className="flex shrink-0 items-center gap-2">
+                {canEdit && <MeetingEditDialog meetingId={detail.id} currentTitle={detail.title} />}
+                {canCancel && <MeetingCancelDialog meetingId={detail.id} />}
+              </div>
+            )}
           </div>
           <div className="pt-1.5">
             <OriginLine detail={detail} />

--- a/src/features/meeting/components/meeting-edit-dialog.tsx
+++ b/src/features/meeting/components/meeting-edit-dialog.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useActionState, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+import { updateMeetingAction, type UpdateMeetingState } from "../actions";
+import { MEETING_TITLE_MAX_LENGTH } from "../lib";
+
+const INITIAL_STATE: UpdateMeetingState = { error: null, saved: null };
+
+interface MeetingEditDialogProps {
+  meetingId: string;
+  currentTitle: string;
+}
+
+/**
+ * 회의 수정(MEET-05) — 상세 머리글의 [회의 수정] 버튼이 연다.
+ *
+ * ⚠️ 트리거·노출 조건(host·SCHEDULED)은 `MeetingDetailView`가 정한다(`canEditMeeting`) —
+ *    여기는 "지금 열렸는지"만 안다. `MeetingCancelDialog`·`MeetingAttendeesEditDialog`와 같은 자리 나눔이다.
+ * ⚠️ **제목 한 칸이다.** 시간·회의실·프로젝트·녹음 동의도 BE는 받지만(MEET-05) 그쪽은 예약
+ *    슬롯을 다시 잡는 일이라 회의실 예약 화면의 슬롯 피커가 있어야 한다 — 지금 여기 두면
+ *    30분 그리드·운영시간·중복 검사 없이 보내 서버가 400·409로 되돌린다(§정직성, #419 후속).
+ * ⚠️ 검증 오류는 **토스트가 아니라 필드 밑**이다(§토스트: 폼 검증 오류는 인라인). 성공만
+ *    토스트로 알린다 — 창이 닫히므로 알릴 자리가 그것뿐이다.
+ */
+export function MeetingEditDialog({ meetingId, currentTitle }: MeetingEditDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [state, formAction, isPending] = useActionState(updateMeetingAction, INITIAL_STATE);
+  const handled = useRef<UpdateMeetingState["saved"]>(null);
+
+  useEffect(() => {
+    if (state.saved && handled.current !== state.saved) {
+      handled.current = state.saved;
+      setOpen(false);
+      toast.success("회의 정보를 수정했습니다");
+    }
+  }, [state.saved]);
+
+  return (
+    <>
+      <Button type="button" variant="outline" onClick={() => setOpen(true)}>
+        회의 수정
+      </Button>
+
+      <Dialog
+        open={open}
+        onOpenChange={(next) => {
+          if (!next && isPending) return;
+          setOpen(next);
+        }}
+      >
+        <DialogContent className="gap-0 p-0 sm:max-w-[420px]">
+          <DialogHeader className="border-border border-b px-6 py-4">
+            <DialogTitle>회의 수정</DialogTitle>
+          </DialogHeader>
+
+          <form action={formAction}>
+            <input type="hidden" name="meetingId" value={meetingId} />
+
+            <div className="flex flex-col gap-2 px-6 py-5">
+              <Label htmlFor="meeting-title">회의 제목</Label>
+              {/*
+                ⚠️ `key`로 현재 제목을 물린다 — 창을 닫았다 다시 열면 방금 취소한 입력이 아니라
+                   **저장된 제목**에서 시작해야 한다(`defaultValue`는 다시 안 읽힌다).
+                ⚠️ `maxLength`는 거들 뿐이다. 붙여넣기·IME로 넘어오는 값이 있어 검증은
+                   `checkMeetingTitle`(서버 액션)이 하고, BE도 한 번 더 본다.
+              */}
+              <Input
+                key={currentTitle}
+                id="meeting-title"
+                name="title"
+                defaultValue={currentTitle}
+                maxLength={MEETING_TITLE_MAX_LENGTH}
+                required
+                aria-describedby={state.error ? "meeting-title-error" : undefined}
+                aria-invalid={state.error ? true : undefined}
+              />
+              {state.error && (
+                <p id="meeting-title-error" className="text-destructive text-[12px] leading-4">
+                  {state.error}
+                </p>
+              )}
+              {/*
+                ⚠️ 못 고치는 것을 적어 둔다. 「회의 수정」이라 열었는데 제목 한 칸만 있으면
+                   시간·회의실은 어디서 바꾸는지 알 수 없다 — 없는 기능을 감추면 사람은
+                   자기가 못 찾는 줄 안다(§정직성).
+              */}
+              <p className="text-muted-foreground text-[12px] leading-4">
+                시간·회의실을 바꾸려면 회의를 취소하고 다시 예약해 주세요.
+              </p>
+            </div>
+
+            <div className="border-border flex items-center justify-end gap-2 border-t px-6 py-4">
+              <Button
+                type="button"
+                variant="outline"
+                disabled={isPending}
+                onClick={() => setOpen(false)}
+              >
+                취소
+              </Button>
+              <Button type="submit" variant="ink" disabled={isPending}>
+                {isPending ? "저장 중" : "저장"}
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/features/meeting/lib.test.ts
+++ b/src/features/meeting/lib.test.ts
@@ -1,4 +1,4 @@
-import { formatMeetingSchedule } from "./lib";
+import { checkMeetingTitle, formatMeetingSchedule, MEETING_TITLE_MAX_LENGTH } from "./lib";
 
 describe("formatMeetingSchedule", () => {
   it("우리 날짜 표기와 시각 범위를 한 줄로 잇는다", () => {
@@ -17,5 +17,39 @@ describe("formatMeetingSchedule", () => {
     const end = new Date("2026-08-14T08:30:00+09:00");
 
     expect(formatMeetingSchedule(start, end)).toBe("8월 14일(금) 08:00 – 08:30");
+  });
+});
+
+/** 제목 계약이 어긋나면 화면이 통과시킨 값을 서버가 400으로 되돌린다(MEET-05) */
+describe("checkMeetingTitle", () => {
+  it("앞뒤 공백을 떼고 통과시킨다 — BE도 같은 자리를 자른다", () => {
+    expect(checkMeetingTitle("  8월 스프린트 킥오프  ")).toEqual({
+      ok: true,
+      title: "8월 스프린트 킥오프",
+    });
+  });
+
+  it("공백만 있는 제목은 막는다 — BE가 필수 컬럼을 지우는 요청으로 본다", () => {
+    expect(checkMeetingTitle("   ")).toEqual({
+      ok: false,
+      error: "회의 제목을 입력해 주세요.",
+    });
+  });
+
+  it("빈 문자열도 같은 이유로 막는다", () => {
+    expect(checkMeetingTitle("").ok).toBe(false);
+  });
+
+  it("200자는 통과하고 201자는 막는다 — BE `@Size(max = 200)`과 같은 경계다", () => {
+    expect(checkMeetingTitle("가".repeat(MEETING_TITLE_MAX_LENGTH)).ok).toBe(true);
+    expect(checkMeetingTitle("가".repeat(MEETING_TITLE_MAX_LENGTH + 1))).toEqual({
+      ok: false,
+      error: "회의 제목은 200자까지 입력할 수 있습니다.",
+    });
+  });
+
+  /* ⚠️ 자르고 나서 재야 한다 — 공백 포함 201자인데 실제 저장은 200자인 값을 막으면 안 된다 */
+  it("공백을 뗀 뒤의 길이로 잰다", () => {
+    expect(checkMeetingTitle(` ${"가".repeat(MEETING_TITLE_MAX_LENGTH)} `).ok).toBe(true);
   });
 });

--- a/src/features/meeting/lib.test.ts
+++ b/src/features/meeting/lib.test.ts
@@ -1,4 +1,9 @@
-import { checkMeetingTitle, formatMeetingSchedule, MEETING_TITLE_MAX_LENGTH } from "./lib";
+import {
+  checkMeetingTitle,
+  formatMeetingSchedule,
+  MEETING_TITLE_MAX_LENGTH,
+  meetingListRange,
+} from "./lib";
 
 describe("formatMeetingSchedule", () => {
   it("우리 날짜 표기와 시각 범위를 한 줄로 잇는다", () => {
@@ -17,6 +22,30 @@ describe("formatMeetingSchedule", () => {
     const end = new Date("2026-08-14T08:30:00+09:00");
 
     expect(formatMeetingSchedule(start, end)).toBe("8월 14일(금) 08:00 – 08:30");
+  });
+});
+
+describe("meetingListRange", () => {
+  it("오늘을 가운데 두고 앞뒤로 3개월을 연다", () => {
+    expect(meetingListRange(new Date("2026-08-13T10:00:00+09:00"))).toEqual({
+      from: "2026-05-13",
+      to: "2026-11-13",
+    });
+  });
+
+  /*
+    ⚠️ `setMonth`로 옮기면 여기서 틀린다 — 2월 31일이 3월 3일로 넘쳐 기간이 사흘 좁아진다.
+       월말은 그 달의 마지막 날로 눌러 담아야 경계의 회의가 목록에서 안 빠진다.
+  */
+  it("월말이 다음 달로 넘치지 않는다", () => {
+    expect(meetingListRange(new Date("2026-05-31T10:00:00+09:00"))).toEqual({
+      from: "2026-02-28",
+      to: "2026-08-31",
+    });
+  });
+
+  it("+3개월이 12월 1일로 밀리지 않는다", () => {
+    expect(meetingListRange(new Date("2026-08-31T10:00:00+09:00")).to).toBe("2026-11-30");
   });
 });
 

--- a/src/features/meeting/lib.ts
+++ b/src/features/meeting/lib.ts
@@ -1,3 +1,5 @@
+import { addMonths } from "date-fns";
+
 import { formatMonthDayWeekday } from "@/lib/date";
 
 /** 화면 표기의 시간대 — 서버가 UTC여도 사용자는 한국 시각으로 본다 */
@@ -33,15 +35,14 @@ export function formatMeetingSchedule(start: Date, end: Date): string {
  * ⚠️ 앞은 BE 기본과 같은 3개월로 맞춘다. 더 늘리면 무한 스크롤이 없는 지금은 한 페이지
  *    상한(100건)만 더 빨리 채운다(§server `MEETING_LIST_PAGE_SIZE`).
  * ⚠️ 날짜는 **한국 시간 기준**으로 찍는다 — UTC로 자르면 자정 무렵에 하루가 밀린다(§lib/date).
+ * ⚠️ 달 이동은 **`date-fns`의 `addMonths`**로 한다(2026-08-13, 코드래빗 지적). `setMonth`는
+ *    월말을 보정하지 않아 5월 31일의 -3개월이 **3월 3일**이 되고(2월 31일 → 넘침) 8월 31일의
+ *    +3개월이 **12월 1일**이 된다 — 기간이 며칠씩 어긋나 경계의 회의가 목록에서 빠진다.
  */
 const MEETING_LIST_RANGE_MONTHS = 3;
 
 export function meetingListRange(now: Date): { from: string; to: string } {
-  const shifted = (months: number) => {
-    const moved = new Date(now);
-    moved.setMonth(moved.getMonth() + months);
-    return DATE_PART.format(moved);
-  };
+  const shifted = (months: number) => DATE_PART.format(addMonths(now, months));
 
   return { from: shifted(-MEETING_LIST_RANGE_MONTHS), to: shifted(MEETING_LIST_RANGE_MONTHS) };
 }

--- a/src/features/meeting/lib.ts
+++ b/src/features/meeting/lib.ts
@@ -45,3 +45,30 @@ export function meetingListRange(now: Date): { from: string; to: string } {
 
   return { from: shifted(-MEETING_LIST_RANGE_MONTHS), to: shifted(MEETING_LIST_RANGE_MONTHS) };
 }
+
+/** BE `UpdateMeetingRequest.title`의 `@Size(max = 200)`과 같은 값이다 — 어긋나면 화면이 통과시킨 값을 서버가 막는다. */
+export const MEETING_TITLE_MAX_LENGTH = 200;
+
+export type MeetingTitleCheck = { ok: true; title: string } | { ok: false; error: string };
+
+/**
+ * 회의 제목(MEET-05)이 BE 계약 안에 드는지 — **보내기 전에 여기서 본다.**
+ *
+ * ⚠️ 서버 검증을 대신하지 않는다. BE도 공백·200자 초과를 400으로 막는다
+ *    (`MeetingUpdateService.normalizeTitle`) — 여기서 먼저 보는 건 **필드 옆에 이유를 적기**
+ *    위해서다. 왕복해 받은 400은 폼 전체 오류로밖에 못 보여준다(§토스트: 폼 검증 오류는 인라인).
+ * ⚠️ **BE와 같은 자리를 잰다** — 앞뒤 공백을 없앤 뒤(`trim`) 길이를 센다. 다르게 재면
+ *    화면은 통과시키는데 서버가 막는 값이 생긴다.
+ * ⚠️ 던지지 않고 값으로 돌려준다 — 부르는 쪽(Server Action)이 폼 상태로 그대로 옮긴다.
+ */
+export function checkMeetingTitle(raw: string): MeetingTitleCheck {
+  const title = raw.trim();
+  if (title.length === 0) return { ok: false, error: "회의 제목을 입력해 주세요." };
+  if (title.length > MEETING_TITLE_MAX_LENGTH) {
+    return {
+      ok: false,
+      error: `회의 제목은 ${MEETING_TITLE_MAX_LENGTH}자까지 입력할 수 있습니다.`,
+    };
+  }
+  return { ok: true, title };
+}

--- a/src/features/meeting/lib.ts
+++ b/src/features/meeting/lib.ts
@@ -23,3 +23,25 @@ export function formatMeetingSchedule(start: Date, end: Date): string {
   const day = formatMonthDayWeekday(DATE_PART.format(start)) ?? DATE_PART.format(start);
   return `${day} ${TIME_PART.format(start)} – ${TIME_PART.format(end)}`;
 }
+
+/**
+ * 회의 목록(MEET-02)이 물어볼 기간 — 앞뒤로 3개월씩.
+ *
+ * ⚠️ **뒤를 열어 주는 게 핵심이다.** BE 기본값은 `오늘-3개월 ~ 오늘`이라
+ *    (`MeetingListQueryService.validateAndResolve`) 그대로 두면 **예정 회의가 한 건도 안 온다** —
+ *    이 화면이 제일 먼저 보여줘야 하는 게 다가올 회의다.
+ * ⚠️ 앞은 BE 기본과 같은 3개월로 맞춘다. 더 늘리면 무한 스크롤이 없는 지금은 한 페이지
+ *    상한(100건)만 더 빨리 채운다(§server `MEETING_LIST_PAGE_SIZE`).
+ * ⚠️ 날짜는 **한국 시간 기준**으로 찍는다 — UTC로 자르면 자정 무렵에 하루가 밀린다(§lib/date).
+ */
+const MEETING_LIST_RANGE_MONTHS = 3;
+
+export function meetingListRange(now: Date): { from: string; to: string } {
+  const shifted = (months: number) => {
+    const moved = new Date(now);
+    moved.setMonth(moved.getMonth() + months);
+    return DATE_PART.format(moved);
+  };
+
+  return { from: shifted(-MEETING_LIST_RANGE_MONTHS), to: shifted(MEETING_LIST_RANGE_MONTHS) };
+}

--- a/src/features/meeting/mapper.test.ts
+++ b/src/features/meeting/mapper.test.ts
@@ -1,3 +1,5 @@
+import { AI_SUMMARY_STATUS } from "@/constants/meeting";
+
 import {
   type BeDashboardMeeting,
   type BeMeetingDetail,
@@ -99,8 +101,22 @@ describe("parseMeetingDetail", () => {
       "참석자 직급이 문자열도 null도 아니면",
       { ...BASE, attendees: [{ memberId: 2, name: "김서준", teamName: null, jobPosition: 3 }] },
     ],
+    ["소속 팀이 숫자도 null도 아니면", { ...BASE, teamId: "3" }],
+    ["안건 소주제가 배열이 아니면", { ...BASE, agenda: { mainTopic: "운영", subTopics: null } }],
+    [
+      "안건 소주제에 문자열이 아닌 게 섞이면",
+      { ...BASE, agenda: { mainTopic: null, subTopics: [3] } },
+    ],
   ])("%s 판정 전에 멈춘다", (_label, broken) => {
     expect(() => parseMeetingDetail(broken)).toThrow("약속한 모양");
+  });
+
+  /* ⚠️ #461이 늦게 배포돼도 상세가 통째로 막히면 안 된다(목록 파서와 같은 이유) */
+  it("#461 확장 필드가 없거나 null인 응답도 통과시킨다", () => {
+    expect(parseMeetingDetail(BASE)).toBe(BASE);
+
+    const nulled = { ...BASE, teamId: null, agenda: null };
+    expect(parseMeetingDetail(nulled)).toBe(nulled);
   });
 });
 
@@ -140,8 +156,24 @@ describe("parseMeetingList", () => {
     ["행에 null이 섞이면", { meetings: [null] }],
     ["개설자 여부가 없으면", { meetings: [{ ...LIST_ITEM, isHost: undefined }] }],
     ["중첩 회의실이 통째로 없으면", { meetings: [{ ...LIST_ITEM, meetingRoom: undefined }] }],
+    ["소속 팀이 숫자도 null도 아니면", { meetings: [{ ...LIST_ITEM, teamId: "3" }] }],
+    ["안건 미리보기 모양이 다르면", { meetings: [{ ...LIST_ITEM, agendaPreview: [null] }] }],
   ])("%s 그리기 전에 멈춘다", (_label, broken) => {
     expect(() => parseMeetingList(broken)).toThrow("약속한 모양");
+  });
+
+  /*
+    ⚠️ **머지 순서에 안전해야 한다.** #461 확장 필드는 BE가 아직 안 줄 수 있다 — 필수로
+       검사하면 FE가 먼저 배포됐을 때 **목록 전체가 통째로 막힌다**(§Mock 격리막).
+  */
+  it("#461 확장 필드가 통째로 없는 구버전 응답도 통과시킨다", () => {
+    expect(parseMeetingList({ meetings: [LIST_ITEM] })).toEqual([LIST_ITEM]);
+  });
+
+  it("#461 확장 필드가 null로 와도 통과시킨다 — Owner 개설·안건 0건이 그 모양이다", () => {
+    const row = { ...LIST_ITEM, teamId: null, summaryStatus: null, agendaPreview: null };
+
+    expect(parseMeetingList({ meetings: [row] })).toEqual([row]);
   });
 });
 
@@ -162,15 +194,54 @@ describe("toMeetingListItem", () => {
   });
 
   /*
-    ⚠️ **없는 값을 지어내지 않는다**(§정직성). 목록 응답엔 요약 상태·소속 라벨·안건이 없다 —
-       채우면 완료 카드에 [액션 검토]가 잘못 뜨거나 안 뜬다.
+    ⚠️ **없는 값을 지어내지 않는다**(§정직성). BE #461 배포 전 응답엔 요약 상태·소속 팀·안건이
+       없다 — 채우면 완료 카드에 [액션 검토]가 잘못 뜨거나 안 뜬다.
+    ⚠️ 특히 `teamId`는 **없는 것(`undefined`)과 `null`이 다른 뜻**이다. 뭉치면 미배포 서버의
+       모든 회의가 "Owner 개설"로 읽힌다.
   */
-  it("목록에 없는 값(요약 상태·소속 라벨·안건)은 비운다", () => {
+  it("#461 확장 필드가 없으면 요약 상태·소속 라벨·안건을 비운다", () => {
     const item = toMeetingListItem(LIST_ITEM);
 
     expect(item.aiSummaryStatus).toBeNull();
     expect(item.originLabel).toBe("");
     expect(item.topicSummary).toBe("");
+  });
+
+  /* [확인] BE PR #461 `MeetingListQueryService.originLabel` — `teamId == null`이 Owner다 */
+  it("소속 팀이 null이면 Owner 개설, 숫자면 팀 액션 회의로 읽는다", () => {
+    expect(toMeetingListItem({ ...LIST_ITEM, teamId: null }).originLabel).toBe("Owner 개설");
+    expect(toMeetingListItem({ ...LIST_ITEM, teamId: 7 }).originLabel).toBe("팀 액션 회의");
+  });
+
+  it("안건 미리보기를 `대주제 · 소주제` 한 줄로 잇는다", () => {
+    const preview = { mainTopic: "운영", firstSubTopic: "주간 점검" };
+
+    expect(toMeetingListItem({ ...LIST_ITEM, agendaPreview: preview }).topicSummary).toBe(
+      "운영 · 주간 점검",
+    );
+  });
+
+  /* ⚠️ 한쪽만 있는 안건에 가운뎃점을 남기면 카드가 ` · 주간 점검`으로 읽힌다 */
+  it.each([
+    [{ mainTopic: "운영", firstSubTopic: null }, "운영"],
+    [{ mainTopic: null, firstSubTopic: "주간 점검" }, "주간 점검"],
+    [{ mainTopic: null, firstSubTopic: null }, ""],
+  ])("한쪽만 있는 안건은 가운뎃점째 뺀다 (%p)", (agendaPreview, expected) => {
+    expect(toMeetingListItem({ ...LIST_ITEM, agendaPreview }).topicSummary).toBe(expected);
+  });
+
+  /*
+    ⚠️ 목록이 실제로 주는 값은 `NONE`·`STALLED`·`null`뿐이다(BE `resolveSummaryStatus`) —
+       나머지는 어휘만 맞춰 두고, 모르는 값은 지어내지 않는다.
+  */
+  it.each([
+    ["NONE", null],
+    ["STALLED", AI_SUMMARY_STATUS.FAILED],
+    ["PROCESSING", AI_SUMMARY_STATUS.SUMMARIZING],
+    ["DONE", AI_SUMMARY_STATUS.REVIEWED],
+    ["WHAT", null],
+  ])("요약 상태 %s를 화면 어휘로 옮긴다", (summaryStatus, expected) => {
+    expect(toMeetingListItem({ ...LIST_ITEM, summaryStatus }).aiSummaryStatus).toBe(expected);
   });
 
   it("모르는 상태는 그냥 넘기지 않는다", () => {
@@ -259,16 +330,46 @@ describe("toMeetingDetailView", () => {
     ⚠️ **빈 배열이 아니라 `null`이다.** 빈 배열은 "물어봤는데 없다"는 뜻이라 화면이 "없습니다"라고
        단정하는데, 산출물·발화 기록은 다른 API가 줄 값이라 **묻지도 않았다**(§정직성).
   */
-  it("안 물어본 칸(산출물·발화 기록)은 null, 응답에 없는 칸(안건·소속 라벨)은 비운다", () => {
+  it("안 물어본 칸(산출물·발화 기록)은 null, #461 전 응답의 안건·소속 라벨은 비운다", () => {
     const detail = toMeetingDetailView(DONE_DETAIL, { isHost: false });
 
     expect(detail.outputs).toBeNull();
     expect(detail.script).toBeNull();
-    expect(detail.topics).toEqual([]);
+    expect(detail.agenda).toBeNull();
     expect(detail.originLabel).toBe("");
     expect(detail.parentTeamActionHref).toBeNull();
-    /* 팀 액션인지 개인 액션인지는 응답으로 못 가른다 — 둘 중 하나로 찍지 않는다 */
+    /* 팀 액션인지 개인 액션인지는 `teamId`가 없으면 못 가른다 — 둘 중 하나로 찍지 않는다 */
     expect(detail.outputKindLabel).toBe("액션");
+  });
+
+  /* [확인] BE PR #461 `MeetingDetailQueryService`(2026-08-13) — `teamId == null`이 Owner다 */
+  it("소속 팀이 null이면 Owner 개설·팀 액션, 숫자면 팀 회의·개인 액션으로 읽는다", () => {
+    const owner = toMeetingDetailView({ ...DONE_DETAIL, teamId: null }, { isHost: false });
+    const team = toMeetingDetailView({ ...DONE_DETAIL, teamId: 7 }, { isHost: false });
+
+    expect(owner.originLabel).toBe("Owner 개설");
+    expect(owner.outputKindLabel).toBe("팀 액션");
+    expect(team.originLabel).toBe("팀 액션 회의");
+    expect(team.outputKindLabel).toBe("개인 액션");
+  });
+
+  /*
+    ⚠️ 상위 팀 액션 링크는 **`teamId`가 와도 못 만든다** — 팀은 팀 액션이 아니다(#461 회신).
+       팀 회의라는 걸 안다고 링크를 지어 붙이면 존재하지 않는 주소로 보낸다(§정직성).
+  */
+  it("팀 회의여도 상위 팀 액션 링크는 안 만든다 — 팀 액션 id가 응답에 없다", () => {
+    expect(
+      toMeetingDetailView({ ...DONE_DETAIL, teamId: 7 }, { isHost: false }).parentTeamActionHref,
+    ).toBeNull();
+  });
+
+  it("안건을 대주제 하나 + 소주제 목록 그대로 싣는다 — 쌍으로 지어 붙이지 않는다", () => {
+    const detail = toMeetingDetailView(
+      { ...DONE_DETAIL, agenda: { mainTopic: "운영", subTopics: ["주간 점검", "배송 정책"] } },
+      { isHost: false },
+    );
+
+    expect(detail.agenda).toEqual({ main: "운영", subs: ["주간 점검", "배송 정책"] });
   });
 
   /* ⚠️ 판정은 `lib/permission.ts`가 한다 — 매퍼는 결과만 받는다(§권한) */

--- a/src/features/meeting/mapper.test.ts
+++ b/src/features/meeting/mapper.test.ts
@@ -1,9 +1,17 @@
 import {
+  type BeDashboardMeeting,
   type BeMeetingDetail,
+  type BeMeetingListItem,
   hostIdOf,
   isClosed,
+  meetingPendingReasonOf,
+  parseDashboardMeetings,
   parseMeetingDetail,
+  parseMeetingList,
+  toDashboardMeetingCard,
   toMeetingCaptureInfo,
+  toMeetingDetailView,
+  toMeetingListItem,
 } from "./mapper";
 
 /** MEET-04 응답 그대로 — 중첩·필드 이름을 BE 실코드에 맞춰 둔다 */
@@ -13,6 +21,9 @@ const BASE: BeMeetingDetail = {
   status: "SCHEDULED",
   startAt: "2026-08-14T10:00:00",
   endAt: "2026-08-14T10:30:00",
+  pendingActionCount: 0,
+  /* ⚠️ 안 끝난 회의는 `NONE`이다 — 요약을 시도조차 안 한 상태(BE `MeetingSummaryStatus`) */
+  summaryStatus: "NONE",
   project: { projectId: 3, tag: "GOODS" },
   meetingRoom: { meetingRoomId: 2, name: "대회의실" },
   host: { memberId: 1, name: "대표 계정" },
@@ -90,5 +101,221 @@ describe("parseMeetingDetail", () => {
     ],
   ])("%s 판정 전에 멈춘다", (_label, broken) => {
     expect(() => parseMeetingDetail(broken)).toThrow("약속한 모양");
+  });
+});
+
+/**
+ * 목록(MEET-02) — **BE 실코드에서 옮겨 적은 shape**으로 검증한다(§연동 검증).
+ * [확인] `meeting/presentation/api/response/MeetingListResponse.java`(2026-08-13).
+ */
+const LIST_ITEM: BeMeetingListItem = {
+  meetingId: 91,
+  title: "굿즈 앱 주간 운영 점검",
+  status: "DONE",
+  startAt: "2026-08-14T10:00:00",
+  endAt: "2026-08-14T10:30:00",
+  attendeeCount: 4,
+  isHost: true,
+  meetingRoom: { meetingRoomId: 2, name: "대회의실" },
+  project: { projectId: 3, tag: "GOODS" },
+};
+
+describe("parseMeetingList", () => {
+  it("봉투 안의 회의 배열만 꺼낸다 — `page`는 안 본다", () => {
+    const raw = {
+      meetings: [LIST_ITEM],
+      page: { page: 0, size: 20, totalElements: 1, totalPages: 1 },
+    };
+
+    expect(parseMeetingList(raw)).toEqual([LIST_ITEM]);
+  });
+
+  it("결과가 없어도 빈 배열로 통과한다 — BE가 null을 안 준다", () => {
+    expect(parseMeetingList({ meetings: [], page: {} })).toEqual([]);
+  });
+
+  it.each([
+    ["응답이 비면", null],
+    ["회의가 배열이 아니면", { meetings: null }],
+    ["행에 null이 섞이면", { meetings: [null] }],
+    ["개설자 여부가 없으면", { meetings: [{ ...LIST_ITEM, isHost: undefined }] }],
+    ["중첩 회의실이 통째로 없으면", { meetings: [{ ...LIST_ITEM, meetingRoom: undefined }] }],
+  ])("%s 그리기 전에 멈춘다", (_label, broken) => {
+    expect(() => parseMeetingList(broken)).toThrow("약속한 모양");
+  });
+});
+
+describe("toMeetingListItem", () => {
+  it("중첩된 태그·회의실을 꺼내고 시각을 우리 표기로 굳힌다", () => {
+    const item = toMeetingListItem(LIST_ITEM);
+
+    expect(item.id).toBe("91");
+    expect(item.projectTag).toBe("GOODS");
+    expect(item.roomName).toBe("대회의실");
+    expect(item.schedule).toBe("8월 14일(금) 10:00 – 10:30");
+  });
+
+  /* ⚠️ 이 값이 두 탭을 가른다 — 백엔드 §10-A 요청의 핵심이라 값으로 고정해 둔다 */
+  it("개설자 여부를 그대로 싣는다", () => {
+    expect(toMeetingListItem(LIST_ITEM).isHost).toBe(true);
+    expect(toMeetingListItem({ ...LIST_ITEM, isHost: false }).isHost).toBe(false);
+  });
+
+  /*
+    ⚠️ **없는 값을 지어내지 않는다**(§정직성). 목록 응답엔 요약 상태·소속 라벨·안건이 없다 —
+       채우면 완료 카드에 [액션 검토]가 잘못 뜨거나 안 뜬다.
+  */
+  it("목록에 없는 값(요약 상태·소속 라벨·안건)은 비운다", () => {
+    const item = toMeetingListItem(LIST_ITEM);
+
+    expect(item.aiSummaryStatus).toBeNull();
+    expect(item.originLabel).toBe("");
+    expect(item.topicSummary).toBe("");
+  });
+
+  it("모르는 상태는 그냥 넘기지 않는다", () => {
+    expect(() => toMeetingListItem({ ...LIST_ITEM, status: "PAUSED" })).toThrow(
+      "알 수 없는 회의 상태",
+    );
+  });
+});
+
+/**
+ * 상세의 요약 신호(MEET-04) → 화면이 «아직 못 보여주는 이유».
+ * [확인] `meeting/domain/model/MeetingSummaryStatus.java` ·
+ *   `application/service/MeetingDetailQueryService.resolveSummaryStatus`(2026-08-13).
+ */
+describe("meetingPendingReasonOf", () => {
+  const done = { status: "DONE", summaryStatus: null, pendingActionCount: 0 };
+
+  it("회의 상태를 먼저 본다 — 안 끝난 회의는 요약을 시작조차 안 했다", () => {
+    expect(meetingPendingReasonOf({ ...done, status: "SCHEDULED" })).toBe("SCHEDULED");
+    expect(meetingPendingReasonOf({ ...done, status: "IN_PROGRESS" })).toBe("IN_PROGRESS");
+    expect(meetingPendingReasonOf({ ...done, status: "CANCELED" })).toBe("CANCELED");
+  });
+
+  it("중단은 실패로, 완료는 다 찬 것으로 읽는다", () => {
+    expect(meetingPendingReasonOf({ ...done, summaryStatus: "STALLED" })).toBe("FAILED");
+    expect(meetingPendingReasonOf({ ...done, summaryStatus: "DONE" })).toBeNull();
+  });
+
+  /*
+    ⚠️ BE는 `null`을 "끝났지만 PROCESSING인지 DONE인지 모른다"는 뜻으로 준다 — 그걸 완료로
+       읽으면 화면이 "하달된 액션이 없습니다"라고 단정한다(§정직성).
+  */
+  it("모르는 값(null)을 완료로 읽지 않는다", () => {
+    expect(meetingPendingReasonOf(done)).toBe("SUMMARIZING");
+  });
+
+  /* ⚠️ 초안이 나왔다는 건 요약이 끝났다는 증거다 — 그때는 검토 대기 안내가 맞는 말이다 */
+  it("확정 대기 건수가 있으면 요약은 끝난 것으로 본다", () => {
+    expect(meetingPendingReasonOf({ ...done, pendingActionCount: 3 })).toBeNull();
+  });
+});
+
+describe("toMeetingDetailView", () => {
+  const DONE_DETAIL: BeMeetingDetail = {
+    ...BASE,
+    status: "DONE",
+    summaryStatus: null,
+    pendingActionCount: 2,
+  };
+
+  it("중첩된 프로젝트·회의실·참석자를 화면 계약으로 편다", () => {
+    const detail = toMeetingDetailView(DONE_DETAIL, { isHost: true });
+
+    expect(detail.id).toBe("12");
+    expect(detail.projectId).toBe(3);
+    expect(detail.roomName).toBe("대회의실");
+    expect(detail.attendees).toEqual([
+      { id: 1, name: "대표 계정" },
+      { id: 2, name: "김서준" },
+    ]);
+  });
+
+  it("확정 대기 건수와 중단 여부를 그대로 싣는다", () => {
+    expect(toMeetingDetailView(DONE_DETAIL, { isHost: true }).pendingActionCount).toBe(2);
+    expect(toMeetingDetailView(DONE_DETAIL, { isHost: true }).isStalled).toBe(false);
+    expect(
+      toMeetingDetailView({ ...DONE_DETAIL, summaryStatus: "STALLED" }, { isHost: true }).isStalled,
+    ).toBe(true);
+  });
+
+  /*
+    ⚠️ **빈 배열이 아니라 `null`이다.** 빈 배열은 "물어봤는데 없다"는 뜻이라 화면이 "없습니다"라고
+       단정하는데, 산출물·발화 기록은 다른 API가 줄 값이라 **묻지도 않았다**(§정직성).
+  */
+  it("안 물어본 칸(산출물·발화 기록)은 null, 응답에 없는 칸(안건·소속 라벨)은 비운다", () => {
+    const detail = toMeetingDetailView(DONE_DETAIL, { isHost: false });
+
+    expect(detail.outputs).toBeNull();
+    expect(detail.script).toBeNull();
+    expect(detail.topics).toEqual([]);
+    expect(detail.originLabel).toBe("");
+    expect(detail.parentTeamActionHref).toBeNull();
+    /* 팀 액션인지 개인 액션인지는 응답으로 못 가른다 — 둘 중 하나로 찍지 않는다 */
+    expect(detail.outputKindLabel).toBe("액션");
+  });
+
+  /* ⚠️ 판정은 `lib/permission.ts`가 한다 — 매퍼는 결과만 받는다(§권한) */
+  it("개설자 여부는 부르는 쪽이 판정한 값을 그대로 쓴다", () => {
+    expect(toMeetingDetailView(DONE_DETAIL, { isHost: false }).isHost).toBe(false);
+  });
+});
+
+/**
+ * 대시보드 최근 회의(MEET-17).
+ * [확인] `meeting/presentation/api/response/DashboardMeetingListResponse.java`(2026-08-13).
+ */
+const DASHBOARD_MEETING: BeDashboardMeeting = {
+  meetingId: 91,
+  title: "8월 스프린트 계획",
+  projectTag: "GOODS",
+  status: "DONE",
+  room: "회의실 A",
+  scheduledAt: "2026-08-12T14:00:00",
+  attendeeCount: 4,
+  /* ⚠️ 둘 다 `null`이 정상이다 — `scope=team`의 소속 라벨은 명세에 없고, 개설자 라벨은 미구현 */
+  originLabel: null,
+  hostLabel: null,
+};
+
+describe("parseDashboardMeetings", () => {
+  it("결과가 없어도 빈 배열로 통과한다", () => {
+    expect(parseDashboardMeetings({ meetings: [] })).toEqual([]);
+  });
+
+  it.each([
+    ["응답이 비면", null],
+    ["회의가 배열이 아니면", { meetings: {} }],
+    ["라벨이 문자열도 null도 아니면", { meetings: [{ ...DASHBOARD_MEETING, hostLabel: 3 }] }],
+  ])("%s 그리기 전에 멈춘다", (_label, broken) => {
+    expect(() => parseDashboardMeetings(broken)).toThrow("약속한 모양");
+  });
+});
+
+describe("toDashboardMeetingCard", () => {
+  it("평평한 카드 값을 그대로 옮긴다", () => {
+    expect(toDashboardMeetingCard(DASHBOARD_MEETING)).toEqual({
+      id: "91",
+      title: "8월 스프린트 계획",
+      projectTag: "GOODS",
+      status: "DONE",
+      room: "회의실 A",
+      scheduledAt: "2026-08-12T14:00:00",
+      attendeeCount: 4,
+    });
+  });
+
+  /* ⚠️ `null`은 키째로 뺀다 — 선택 필드라 없으면 화면이 배지를 안 그린다(§정직성) */
+  it("서버가 준 라벨이 있으면 싣는다", () => {
+    const card = toDashboardMeetingCard({
+      ...DASHBOARD_MEETING,
+      originLabel: "개발팀",
+      hostLabel: "김서준(팀장)",
+    });
+
+    expect(card.originLabel).toBe("개발팀");
+    expect(card.hostLabel).toBe("김서준(팀장)");
   });
 });

--- a/src/features/meeting/mapper.test.ts
+++ b/src/features/meeting/mapper.test.ts
@@ -211,6 +211,20 @@ describe("meetingPendingReasonOf", () => {
   it("확정 대기 건수가 있으면 요약은 끝난 것으로 본다", () => {
     expect(meetingPendingReasonOf({ ...done, pendingActionCount: 3 })).toBeNull();
   });
+
+  /* ⚠️ 상태값이 뭐라 하든 초안이 있으면 검토 대기다 — 상태만 보면 "요약 중"이 뜬다 */
+  it("상태가 PROCESSING이어도 초안이 있으면 요약 중이라 하지 않는다", () => {
+    expect(
+      meetingPendingReasonOf({ ...done, summaryStatus: "PROCESSING", pendingActionCount: 2 }),
+    ).toBeNull();
+  });
+
+  /* ⚠️ 중단만은 초안보다 앞이다 — 뒤 계층이 깨진 회의는 [다시 분석]부터 안내한다 */
+  it("중단은 초안이 있어도 실패로 읽는다", () => {
+    expect(
+      meetingPendingReasonOf({ ...done, summaryStatus: "STALLED", pendingActionCount: 2 }),
+    ).toBe("FAILED");
+  });
 });
 
 describe("toMeetingDetailView", () => {

--- a/src/features/meeting/mapper.ts
+++ b/src/features/meeting/mapper.ts
@@ -4,16 +4,79 @@
  */
 
 import type { DashboardMeeting } from "@/components/common/dashboard-meeting-item";
-import { isMeetingStatus, MEETING_STATUS } from "@/constants/meeting";
+import {
+  AI_SUMMARY_STATUS,
+  type AiSummaryStatus,
+  isMeetingStatus,
+  MEETING_STATUS,
+} from "@/constants/meeting";
 
 import { formatMeetingSchedule } from "./lib";
 import type {
   CaptureAttendee,
+  MeetingAgenda,
   MeetingCaptureInfo,
   MeetingContentPending,
   MeetingDetail,
   MeetingListItem,
 } from "./view-types";
+
+/** Owner 개설 회의의 소속 라벨(WORKFLOW §2) — 옛 문구 "프로젝트 공통"은 폐기됐다 */
+export const OWNER_ORIGIN_LABEL = "Owner 개설";
+
+/**
+ * 팀 개설 회의의 소속 라벨 — 실서버는 **영구히 이 일반 문구**다.
+ *
+ * ⚠️ 원래 계약(§view-types)은 "상위 팀 액션 이름"인데, BE 모델에 회의→상위 팀 액션 연결이
+ *    없어 **영구 제공 불가**다(BE PR #461 F2/F5 회신 — 목록·상세 모두 `teamId`까지만 준다).
+ *    목 경로는 목 데이터에 그 연결이 있어 이름을 채우지만, 실서버는 팀 액션 회의라는
+ *    사실까지만 말한다 — 없는 이름을 지어내지 않는다(§정직성).
+ */
+export const TEAM_ORIGIN_LABEL = "팀 액션 회의";
+
+/**
+ * `teamId` → 소속 라벨.
+ *
+ * [확인] BE PR #461 F2/F5 회신(2026-08-13) — **`teamId`가 판정의 정본**이다.
+ *   `teamId === null` = Owner 개설(회사 직속), 숫자 = 팀 개설.
+ * ⚠️ 응답의 `originLabel`("OWNER"/"TEAM")은 같은 판정의 **코드값**이라 안 읽는다
+ *    (`MeetingListQueryService.originLabel` — `teamId`에서 파생). 코드값을 화면에 그대로
+ *    내보내지 않고(§도메인 상수: 코드엔 영문, 화면엔 한글) 여기서 라벨을 만든다.
+ * ⚠️ **BE #461 배포 전 응답에는 이 필드가 없다 — 없으면 지금처럼 비운다**(`undefined` ≠ `null`.
+ *    `null`은 "Owner 개설"이라는 값이고, `undefined`는 "아직 안 준다"다 — 뭉치면 미배포
+ *    서버의 모든 회의가 Owner 개설로 읽힌다).
+ */
+function originLabelFromTeamId(teamId: number | null | undefined): string {
+  if (teamId === undefined) return "";
+  return teamId === null ? OWNER_ORIGIN_LABEL : TEAM_ORIGIN_LABEL;
+}
+
+/**
+ * BE `MeetingSummaryStatus` → 화면 상수(`AI_SUMMARY_STATUS`) — 어휘가 달라 여기서 흡수한다.
+ *
+ * [확인] BE PR #461 `MeetingListQueryService.resolveSummaryStatus`(2026-08-13):
+ *   목록은 `NONE`(안 끝남)·`STALLED`(중단)·`null`(끝났지만 A가 안 갈라 줘서 모름)만 실제로
+ *   보낸다. `PROCESSING`·`DONE`은 enum에 있지만 A가 구분값을 주기 전까지 미사용이다.
+ *
+ * - `NONE` → `null` — 화면 계약도 "안 끝난 회의는 `null`"이라 뜻이 같다(§view-types).
+ * - `PROCESSING` → `SUMMARIZING`, `STALLED` → `FAILED` — 이름만 다르고 뜻이 같다.
+ * - `DONE` → `REVIEWED` — 요약(초안)이 끝나 Host가 검토할 차례라는 뜻이 같다.
+ *   ⚠️ BE `DONE`은 확정 전·후(`REVIEWED`/`DISTRIBUTED`)를 아직 안 가른다 — 구분값이
+ *      생기면 여기서 갈라야 확정 끝난 회의에 [액션 검토]가 계속 뜨는 일을 막는다.
+ * - 모르는 값·`null`·미배포(`undefined`) → `null` — 지어내지 않는다(§정직성).
+ */
+function toAiSummaryStatus(be: string | null | undefined): AiSummaryStatus | null {
+  switch (be) {
+    case "PROCESSING":
+      return AI_SUMMARY_STATUS.SUMMARIZING;
+    case "DONE":
+      return AI_SUMMARY_STATUS.REVIEWED;
+    case "STALLED":
+      return AI_SUMMARY_STATUS.FAILED;
+    default:
+      return null;
+  }
+}
 
 /**
  * `GET /api/meetings/upcoming`(MEET-03, 구현 완료) 목록 원소.
@@ -162,8 +225,11 @@ export function attendeeIdsFrom(response: BeUpdateAttendeesResponse): number[] {
  *    목록 카드가 그리지 않는다 — 적어 두면 화면이 의존하는 값처럼 읽힌다.
  * ⚠️ **`isHost`가 이 연동의 핵심이다.** 보는 사람이 개설자인지 알 방법이 없어 두 탭
  *    (내가 개설한 / 참여해야 할)이 막혀 있었다(백엔드 요청 §10-A → `isHost`로 도착).
- * ⚠️ **`summaryStatus`가 없다.** 상세(MEET-04)에만 있어서 Host 카드의 [액션 검토] 노출을
- *    목록에서 판정할 수 없다 — 지어내지 않는다(`toMeetingListItem` 참고).
+ * ⚠️ **`teamId`·`summaryStatus`·`agendaPreview`는 BE PR #461(3차 F 회신)이 더한 확장 필드다.**
+ *    전부 선택(`?`)으로 둔다 — **BE #461 배포 전 응답에는 이 필드들이 없다. 없으면 지금처럼
+ *    비운다**(FE #432가 먼저 머지돼도 파서가 응답을 거절하지 않는다).
+ * ⚠️ 응답에는 `originLabel`("OWNER"/"TEAM")도 오지만 안 읽는다 — `teamId`에서 파생된 코드값이라
+ *    화면 라벨은 `originLabelFromTeamId`가 만든다(안 쓰는 필드는 안 적는다).
  */
 export interface BeMeetingListItem {
   meetingId: number;
@@ -176,6 +242,15 @@ export interface BeMeetingListItem {
   attendeeCount: number;
   /** 보는 사람이 이 회의의 개설자인가 — 탭을 가르는 값이다 */
   isHost: boolean;
+  /** **`null` = Owner 개설**(F2/F5 회신), 숫자 = 개설 팀 — `originLabelFromTeamId` 참고 */
+  teamId?: number | null;
+  /**
+   * 요약 진행 신호(BE `MeetingSummaryStatus`) — 목록은 실제로 `NONE`·`STALLED`·`null`만 온다
+   * (`toAiSummaryStatus` 참고).
+   */
+  summaryStatus?: string | null;
+  /** 안건 첫 줄 — 안건이 하나도 없는 회의는 `null`이다(BE `indexAgendaPreviews`) */
+  agendaPreview?: { mainTopic: string | null; firstSubTopic: string | null } | null;
   meetingRoom: { meetingRoomId: number; name: string };
   project: { projectId: number; tag: string };
 }
@@ -210,21 +285,50 @@ function isBeMeetingListItem(value: unknown): value is BeMeetingListItem {
     typeof meeting.endAt === "string" &&
     typeof meeting.attendeeCount === "number" &&
     typeof meeting.isHost === "boolean" &&
+    /*
+      ⚠️ #461 확장 필드는 **없어도 통과**한다(`undefined` 허용) — BE #461 배포 전 응답에는
+         이 필드들이 없다. 없으면 지금처럼 비운다(파서가 멀쩡한 응답을 거절하면 어느 쪽이
+         먼저 머지되느냐에 따라 목록 전체가 죽는다).
+    */
+    isOptionalNullableNumber(meeting.teamId) &&
+    isOptionalNullableString(meeting.summaryStatus) &&
+    isOptionalAgendaPreview(meeting.agendaPreview) &&
     typeof meeting.meetingRoom?.name === "string" &&
     typeof meeting.project?.tag === "string"
+  );
+}
+
+function isOptionalNullableNumber(value: unknown): value is number | null | undefined {
+  return value === undefined || value === null || typeof value === "number";
+}
+
+function isOptionalNullableString(value: unknown): value is string | null | undefined {
+  return value === undefined || value === null || typeof value === "string";
+}
+
+/* 있는데 모양이 다른 것만 거른다 — `[null]`형 오염이 카드 그릴 때 터지는 걸 막는 자리다 */
+function isOptionalAgendaPreview(value: unknown): value is BeMeetingListItem["agendaPreview"] {
+  if (value === undefined || value === null) return true;
+  if (typeof value !== "object") return false;
+  const preview = value as { mainTopic?: unknown; firstSubTopic?: unknown };
+  return (
+    (preview.mainTopic === null || typeof preview.mainTopic === "string") &&
+    (preview.firstSubTopic === null || typeof preview.firstSubTopic === "string")
   );
 }
 
 /**
  * 목록 카드 한 장으로 바꾼다.
  *
- * ⚠️ **`aiSummaryStatus`를 `null`로 둔다.** MEET-02 응답에 요약 상태가 없다 — 지어내면
- *    Host 카드에 [액션 검토]가 잘못 뜨거나 사라진다(§정직성). `null`이면 완료 카드가
- *    [회의록]으로만 열린다(`meetingCardAffordanceOf` — `review`는 `REVIEWED`일 때만).
- *    **BE가 목록에 `summaryStatus`를 실어 주면 그때 이 한 줄만 고친다.**
- * ⚠️ **`originLabel`·`topicSummary`도 비운다.** 소속 라벨(Owner 개설 / 상위 팀 액션 이름)과
- *    안건은 목록 응답에 없다 — 프로젝트 이름 같은 다른 값으로 메우면 뜻이 다른 말이 된다.
- *    카드는 빈 조각을 가운뎃점째 빼고 그린다(`meeting-card.tsx`).
+ * BE PR #461(3차 F 회신)이 이 매퍼가 비워 두던 세 칸을 채웠다:
+ * - `aiSummaryStatus` ← `summaryStatus` — Host의 완료 카드에 [액션 검토]가 다시 살아난다
+ *   (`meetingCardAffordanceOf` — `review`는 `REVIEWED`일 때만). 어휘 흡수는 `toAiSummaryStatus`.
+ * - `originLabel` ← `teamId` 판정(F2/F5 회신: **`null` = Owner 개설**) — `originLabelFromTeamId`.
+ * - `topicSummary` ← `agendaPreview` — 목 경로와 같은 `대주제 · 소주제` 표기로 잇되,
+ *   **빈 조각은 가운뎃점째 버린다**(대주제 없이 소주제만 남은 회의가 ` · 소주제`로 보이면 안 된다).
+ *
+ * ⚠️ **BE #461 배포 전 응답에는 이 필드들이 없다 — 없으면 지금처럼 비운다**(어느 쪽이 먼저
+ *    머지돼도 안전). 카드는 빈 조각을 가운뎃점째 빼고 그린다(`meeting-card.tsx`).
  */
 export function toMeetingListItem(be: BeMeetingListItem): MeetingListItem {
   if (!isMeetingStatus(be.status)) {
@@ -236,14 +340,20 @@ export function toMeetingListItem(be: BeMeetingListItem): MeetingListItem {
     title: be.title,
     status: be.status,
     projectTag: be.project.tag,
-    originLabel: "",
-    topicSummary: "",
+    originLabel: originLabelFromTeamId(be.teamId),
+    topicSummary: topicSummaryOf(be.agendaPreview),
     schedule: formatMeetingSchedule(new Date(be.startAt), new Date(be.endAt)),
     roomName: be.meetingRoom.name,
     attendeeCount: be.attendeeCount,
     isHost: be.isHost,
-    aiSummaryStatus: null,
+    aiSummaryStatus: toAiSummaryStatus(be.summaryStatus),
   };
+}
+
+/** 안건 첫 줄 — 목 표기(`server.ts` `toListItem`)와 같은 `대주제 · 소주제` 조합이다 */
+function topicSummaryOf(preview: BeMeetingListItem["agendaPreview"]): string {
+  if (preview === undefined || preview === null) return "";
+  return [preview.mainTopic, preview.firstSubTopic].filter(Boolean).join(" · ");
 }
 
 /**
@@ -292,6 +402,18 @@ export interface BeMeetingDetail {
    *    우리도 그 `null`을 "다 됐다"로 읽지 않는다(`meetingPendingReasonOf` 참고).
    */
   summaryStatus: string | null;
+  /**
+   * **`null` = Owner 개설**, 숫자 = 개설 팀 — BE PR #461(F2/F5 회신) 확장 필드.
+   * ⚠️ 선택(`?`)이다 — **BE #461 배포 전 응답에는 이 필드들이 없다. 없으면 지금처럼 비운다.**
+   */
+  teamId?: number | null;
+  /**
+   * 안건 — **대주제 하나 + 소주제 목록**이다(BE PR #461 `resolveAgenda`). 예약 때 쌍으로
+   * 입력해도 BE 모델이 둘째 쌍부터의 대주제를 안 남긴다(3차 F 회신의 알려진 한계) —
+   * 없는 쌍을 지어 붙이지 않고 이 모양 그대로 화면 계약(`MeetingAgenda`)에 싣는다.
+   * 안건이 하나도 없으면 `null`이다.
+   */
+  agenda?: { mainTopic: string | null; subTopics: string[] } | null;
   project: { projectId: number; tag: string };
   meetingRoom: { meetingRoomId: number; name: string };
   host: { memberId: number; name: string };
@@ -338,6 +460,9 @@ function isBeMeetingDetail(value: unknown): value is BeMeetingDetail {
     typeof detail.endAt === "string" &&
     typeof detail.pendingActionCount === "number" &&
     (detail.summaryStatus === null || typeof detail.summaryStatus === "string") &&
+    /* ⚠️ #461 확장 필드 — 없어도 통과한다(BE #461 배포 전 응답에는 이 필드들이 없다) */
+    isOptionalNullableNumber(detail.teamId) &&
+    isOptionalAgenda(detail.agenda) &&
     typeof detail.project?.projectId === "number" &&
     typeof detail.project?.tag === "string" &&
     typeof detail.meetingRoom?.name === "string" &&
@@ -363,6 +488,18 @@ function isBeMeetingAttendee(value: unknown): value is BeMeetingAttendee {
     typeof attendee.name === "string" &&
     (attendee.teamName === null || typeof attendee.teamName === "string") &&
     (attendee.jobPosition === null || typeof attendee.jobPosition === "string")
+  );
+}
+
+/* 안건 검사 — `isOptionalAgendaPreview`와 같은 원칙(없음·null은 정상, 모양이 다르면 거절) */
+function isOptionalAgenda(value: unknown): value is BeMeetingDetail["agenda"] {
+  if (value === undefined || value === null) return true;
+  if (typeof value !== "object") return false;
+  const agenda = value as { mainTopic?: unknown; subTopics?: unknown };
+  return (
+    (agenda.mainTopic === null || typeof agenda.mainTopic === "string") &&
+    Array.isArray(agenda.subTopics) &&
+    agenda.subTopics.every((sub) => typeof sub === "string")
   );
 }
 
@@ -467,16 +604,19 @@ export function meetingPendingReasonOf(
  * 회의 상세 화면이 받을 값 — **권한 판정은 여기서 하지 않는다**(`hostIdOf`와 같은 이유).
  * 개설자인지는 `lib/permission.ts`의 `canOperateMeeting`이 정하고 결과만 `isHost`로 받는다.
  *
- * ⚠️ **MEET-04가 안 주는 칸은 비워 둔다**(§정직성 — 지어내지 않는다). 각각 왜 비는지:
- *    - `originLabel`·`parentTeamActionHref`: 응답에 개설자의 권한(Owner 개설인가)도 상위 팀
- *      액션도 없다. `host.name`으로 메우면 **뜻이 다른 값**이 그 자리에 앉는다(그건 소속
- *      라벨이 아니라 사람 이름이다).
- *    - `topics`: 안건이 응답에 아예 없다. 회의 예약 때 입력받은 값인데 상세로 안 나온다.
+ * BE PR #461(3차 F 회신)이 비워 두던 칸 중 **소속 라벨·안건·산출물 머리말**을 채웠다:
+ *    - `originLabel` ← `teamId` 판정(F2/F5 회신: **`null` = Owner 개설**) — `originLabelFromTeamId`.
+ *    - `agenda` ← `agenda`(대주제 하나 + 소주제 목록 — `BeMeetingDetail.agenda` 주석 참고).
+ *    - `outputKindLabel` ← `teamId` 판정 — WORKFLOW 원 규칙(Owner 회의=팀 액션, 팀 회의=개인
+ *      액션, §view-types 주석)과 같은 축이라 `teamId`만으로 가를 수 있다. 단 **미배포
+ *      (`undefined`)면 상위어 `액션` 그대로**다 — 모르는 걸 둘 중 하나로 찍지 않는다.
+ *
+ * ⚠️ **여전히 비는 칸**(§정직성 — 지어내지 않는다):
+ *    - `parentTeamActionHref`: 상위 팀 액션 id가 **모델에 없어 영구 제공 불가**다(#461 회신).
+ *      `teamId`는 팀이지 팀 액션이 아니라 링크를 못 만든다.
  *    - `outputs`·`script`: 다른 API(`GET /api/meetings/{id}/actions` · CAP-12 자막 조회)가
  *      줄 값이라 이 연동 범위 밖이다. **빈 배열이 아니라 `null`이다** — 빈 배열로 두면 화면이
  *      "하달된 액션이 없습니다"·"발화 기록이 없습니다"라고 **안 물어본 것을 단정한다**.
- *    - `outputKindLabel`: 팀 액션인지 개인 액션인지는 개설자 권한에서 갈리는데 그 값이 없다 —
- *      둘 중 하나로 찍지 않고 상위어인 `액션`으로 둔다.
  */
 export function toMeetingDetailView(
   be: BeMeetingDetail,
@@ -487,13 +627,13 @@ export function toMeetingDetailView(
     title: be.title,
     projectId: be.project.projectId,
     projectTag: be.project.tag,
-    originLabel: "",
+    originLabel: originLabelFromTeamId(be.teamId),
     parentTeamActionHref: null,
-    topics: [],
+    agenda: toMeetingAgenda(be.agenda),
     schedule: formatMeetingSchedule(new Date(be.startAt), new Date(be.endAt)),
     roomName: be.meetingRoom.name,
     attendees: be.attendees.map((attendee) => ({ id: attendee.memberId, name: attendee.name })),
-    outputKindLabel: "액션",
+    outputKindLabel: outputKindLabelOf(be.teamId),
     outputs: null,
     script: null,
     pendingReason: meetingPendingReasonOf(be),
@@ -501,4 +641,19 @@ export function toMeetingDetailView(
     isStalled: be.summaryStatus === BE_SUMMARY_STATUS.STALLED,
     isHost: options.isHost,
   };
+}
+
+/**
+ * 산출물 머리말 — Owner 회의는 팀 액션을, 팀 회의는 개인 액션을 하달한다(WORKFLOW §2·§5,
+ * 목 경로 `outputsOf`와 같은 판정). **BE #461 배포 전(`undefined`)엔 상위어 `액션`이다.**
+ */
+function outputKindLabelOf(teamId: number | null | undefined): string {
+  if (teamId === undefined) return "액션";
+  return teamId === null ? "팀 액션" : "개인 액션";
+}
+
+/** BE 안건 → 화면 계약 — 이름만 옮긴다. `null`(안건 없음·미배포)은 그대로 `null`이다. */
+function toMeetingAgenda(agenda: BeMeetingDetail["agenda"]): MeetingAgenda | null {
+  if (agenda === undefined || agenda === null) return null;
+  return { main: agenda.mainTopic, subs: agenda.subTopics };
 }

--- a/src/features/meeting/mapper.ts
+++ b/src/features/meeting/mapper.ts
@@ -450,9 +450,16 @@ export function meetingPendingReasonOf(
   if (detail.status === MEETING_STATUS.IN_PROGRESS) return "IN_PROGRESS";
 
   if (detail.summaryStatus === BE_SUMMARY_STATUS.STALLED) return "FAILED";
+  /*
+    ⚠️ **확정 대기 건수를 상태값보다 먼저 본다**(2026-08-13, 코드래빗 지적). 예전엔
+       `summaryStatus === null`일 때만 이 규칙을 걸어서, 초안이 이미 나왔는데 상태가
+       `PROCESSING`이면 화면이 검토 대기 대신 **"요약 중"**을 말했다 — 윗 주석대로 초안은
+       요약이 끝났다는 증거라 어떤 상태값보다 강한 신호다.
+    ⚠️ 중단(`STALLED`)만 그 앞에 둔다 — 뒤 계층이 깨진 회의는 [다시 분석]부터 안내해야 한다.
+  */
+  if (detail.pendingActionCount > 0) return null;
   if (detail.summaryStatus === BE_SUMMARY_STATUS.DONE) return null;
   /* ⚠️ 끝난 회의에 `NONE`이 오면 계약이 어긋난 것이다 — 완료로 읽지 말고 아직 안 된 쪽으로 둔다 */
-  if (detail.summaryStatus === null && detail.pendingActionCount > 0) return null;
   return "SUMMARIZING";
 }
 

--- a/src/features/meeting/mapper.ts
+++ b/src/features/meeting/mapper.ts
@@ -4,10 +4,16 @@
  */
 
 import type { DashboardMeeting } from "@/components/common/dashboard-meeting-item";
-import { isMeetingStatus } from "@/constants/meeting";
+import { isMeetingStatus, MEETING_STATUS } from "@/constants/meeting";
 
 import { formatMeetingSchedule } from "./lib";
-import type { CaptureAttendee, MeetingCaptureInfo } from "./view-types";
+import type {
+  CaptureAttendee,
+  MeetingCaptureInfo,
+  MeetingContentPending,
+  MeetingDetail,
+  MeetingListItem,
+} from "./view-types";
 
 /**
  * `GET /api/meetings/upcoming`(MEET-03, 구현 완료) 목록 원소.
@@ -58,6 +64,81 @@ export function toDashboardMeeting(be: BeUpcomingMeeting): DashboardMeeting {
 }
 
 /**
+ * `GET /api/meetings/dashboard`(MEET-17, 구현 완료) 목록 원소.
+ * [확인] `meeting/presentation/api/response/DashboardMeetingListResponse.java`(2026-08-13).
+ *
+ * ⚠️ 위의 MEET-03과 **모양이 다르다.** 이쪽은 대시보드 카드가 그리는 그대로 평평하게 오고
+ *    (`projectTag`·`room`), 라벨 2단(`originLabel`·`hostLabel`)도 서버가 이미 정해서 준다.
+ * ⚠️ **둘 다 `null`로 올 수 있다.** `scope=team`의 `originLabel`은 명세에 정의가 없어 BE가
+ *    비워 두고, `hostLabel`("(팀장)" 표기)은 팀 배치 조회 계약이 붙기 전까지 항상 `null`이다
+ *    (BE `DashboardMeetingQueryService` 클래스 주석) — 없으면 화면이 배지를 안 그린다.
+ */
+export interface BeDashboardMeeting {
+  meetingId: number;
+  title: string;
+  projectTag: string;
+  status: string;
+  room: string;
+  scheduledAt: string;
+  attendeeCount: number;
+  originLabel: string | null;
+  hostLabel: string | null;
+}
+
+/**
+ * 대시보드 "최근 회의" 위젯 한 줄로 바꾼다.
+ *
+ * ⚠️ `null`은 **키째로 뺀다**(`?? undefined`가 아니라 조건부 전개). `DashboardMeeting`의 두
+ *    라벨은 선택 필드라 값이 없으면 배지를 안 그리는데, `null`을 그대로 실으면 타입이 안 맞는다.
+ */
+export function toDashboardMeetingCard(be: BeDashboardMeeting): DashboardMeeting {
+  if (!isMeetingStatus(be.status)) {
+    throw new Error(`알 수 없는 회의 상태입니다: ${be.status}`);
+  }
+
+  return {
+    id: String(be.meetingId),
+    title: be.title,
+    projectTag: be.projectTag,
+    status: be.status,
+    room: be.room,
+    scheduledAt: be.scheduledAt,
+    attendeeCount: be.attendeeCount,
+    ...(be.originLabel === null ? {} : { originLabel: be.originLabel }),
+    ...(be.hostLabel === null ? {} : { hostLabel: be.hostLabel }),
+  };
+}
+
+/** 응답 봉투 안쪽 — 결과가 없어도 `meetings`는 빈 배열로 온다(BE가 `List.copyOf`로 보장). */
+export function parseDashboardMeetings(raw: unknown): BeDashboardMeeting[] {
+  if (typeof raw !== "object" || raw === null) {
+    throw new Error("대시보드 최근 회의 응답이 약속한 모양이 아닙니다.");
+  }
+  const meetings = (raw as { meetings?: unknown }).meetings;
+  if (!Array.isArray(meetings) || !meetings.every(isBeDashboardMeeting)) {
+    throw new Error("대시보드 최근 회의 응답이 약속한 모양이 아닙니다.");
+  }
+  return meetings;
+}
+
+function isBeDashboardMeeting(value: unknown): value is BeDashboardMeeting {
+  if (typeof value !== "object" || value === null) return false;
+  const meeting = value as Partial<BeDashboardMeeting>;
+
+  return (
+    typeof meeting.meetingId === "number" &&
+    typeof meeting.title === "string" &&
+    typeof meeting.projectTag === "string" &&
+    typeof meeting.status === "string" &&
+    typeof meeting.room === "string" &&
+    typeof meeting.scheduledAt === "string" &&
+    typeof meeting.attendeeCount === "number" &&
+    (meeting.originLabel === null || typeof meeting.originLabel === "string") &&
+    (meeting.hostLabel === null || typeof meeting.hostLabel === "string")
+  );
+}
+
+/**
  * `PUT /api/meetings/{meetingId}/attendees`(MEET-09, 구현 완료) 요청·응답.
  * ⚠️ 응답에 참석자 명단이 실제로 온다 — 예전엔 "계약에 응답 shape이 없다"고 가정하고 방금
  *    보낸 값을 그대로 echo했는데, 명세가 확정되면서 서버가 돌려준 명단(호스트 자동 포함·중복
@@ -70,6 +151,99 @@ export interface BeUpdateAttendeesResponse {
 
 export function attendeeIdsFrom(response: BeUpdateAttendeesResponse): number[] {
   return response.attendees.map((attendee) => attendee.memberId);
+}
+
+/**
+ * `GET /api/meetings`(MEET-02, 구현 완료) 목록 한 행.
+ * [확인] `meeting/presentation/api/response/MeetingListResponse.java`(2026-08-13).
+ *
+ * ⚠️ **카드가 실제로 쓰는 필드만 적는다**(`BeMeetingDetail`과 같은 원칙). 응답에는
+ *    `actionCount`·`entryAvailable`·`durationMinutes`·`attendees[]`·`project.name`도 오지만
+ *    목록 카드가 그리지 않는다 — 적어 두면 화면이 의존하는 값처럼 읽힌다.
+ * ⚠️ **`isHost`가 이 연동의 핵심이다.** 보는 사람이 개설자인지 알 방법이 없어 두 탭
+ *    (내가 개설한 / 참여해야 할)이 막혀 있었다(백엔드 요청 §10-A → `isHost`로 도착).
+ * ⚠️ **`summaryStatus`가 없다.** 상세(MEET-04)에만 있어서 Host 카드의 [액션 검토] 노출을
+ *    목록에서 판정할 수 없다 — 지어내지 않는다(`toMeetingListItem` 참고).
+ */
+export interface BeMeetingListItem {
+  meetingId: number;
+  title: string;
+  /** `SCHEDULED` · `IN_PROGRESS` · `DONE` · `CANCELED` (BE `MeetingStatus`) */
+  status: string;
+  /** `2026-08-14T10:00:00` — 오프셋이 없다(`BeMeetingDetail.startAt`의 경고가 그대로 적용된다) */
+  startAt: string;
+  endAt: string;
+  attendeeCount: number;
+  /** 보는 사람이 이 회의의 개설자인가 — 탭을 가르는 값이다 */
+  isHost: boolean;
+  meetingRoom: { meetingRoomId: number; name: string };
+  project: { projectId: number; tag: string };
+}
+
+/**
+ * 목록 응답에서 회의 배열만 꺼낸다 — **`page`는 안 쓴다.**
+ *
+ * ⚠️ 응답에는 `page{page,size,totalElements,totalPages}`가 함께 오지만 이 화면엔 아직 무한
+ *    스크롤도 전체 건수 표기도 없다(§목록은 별도 이슈) — 안 쓰는 값을 계약에 적지 않는다.
+ * ⚠️ 검사 이유는 `parseMeetingDetail`과 같다 — `serverApi<T>`는 단언일 뿐 검사가 아니다.
+ */
+export function parseMeetingList(raw: unknown): BeMeetingListItem[] {
+  if (typeof raw !== "object" || raw === null) {
+    throw new Error("회의 목록 응답이 약속한 모양이 아닙니다.");
+  }
+  const meetings = (raw as { meetings?: unknown }).meetings;
+  if (!Array.isArray(meetings) || !meetings.every(isBeMeetingListItem)) {
+    throw new Error("회의 목록 응답이 약속한 모양이 아닙니다.");
+  }
+  return meetings;
+}
+
+function isBeMeetingListItem(value: unknown): value is BeMeetingListItem {
+  if (typeof value !== "object" || value === null) return false;
+  const meeting = value as Partial<BeMeetingListItem>;
+
+  return (
+    typeof meeting.meetingId === "number" &&
+    typeof meeting.title === "string" &&
+    typeof meeting.status === "string" &&
+    typeof meeting.startAt === "string" &&
+    typeof meeting.endAt === "string" &&
+    typeof meeting.attendeeCount === "number" &&
+    typeof meeting.isHost === "boolean" &&
+    typeof meeting.meetingRoom?.name === "string" &&
+    typeof meeting.project?.tag === "string"
+  );
+}
+
+/**
+ * 목록 카드 한 장으로 바꾼다.
+ *
+ * ⚠️ **`aiSummaryStatus`를 `null`로 둔다.** MEET-02 응답에 요약 상태가 없다 — 지어내면
+ *    Host 카드에 [액션 검토]가 잘못 뜨거나 사라진다(§정직성). `null`이면 완료 카드가
+ *    [회의록]으로만 열린다(`meetingCardAffordanceOf` — `review`는 `REVIEWED`일 때만).
+ *    **BE가 목록에 `summaryStatus`를 실어 주면 그때 이 한 줄만 고친다.**
+ * ⚠️ **`originLabel`·`topicSummary`도 비운다.** 소속 라벨(Owner 개설 / 상위 팀 액션 이름)과
+ *    안건은 목록 응답에 없다 — 프로젝트 이름 같은 다른 값으로 메우면 뜻이 다른 말이 된다.
+ *    카드는 빈 조각을 가운뎃점째 빼고 그린다(`meeting-card.tsx`).
+ */
+export function toMeetingListItem(be: BeMeetingListItem): MeetingListItem {
+  if (!isMeetingStatus(be.status)) {
+    throw new Error(`알 수 없는 회의 상태입니다: ${be.status}`);
+  }
+
+  return {
+    id: String(be.meetingId),
+    title: be.title,
+    status: be.status,
+    projectTag: be.project.tag,
+    originLabel: "",
+    topicSummary: "",
+    schedule: formatMeetingSchedule(new Date(be.startAt), new Date(be.endAt)),
+    roomName: be.meetingRoom.name,
+    attendeeCount: be.attendeeCount,
+    isHost: be.isHost,
+    aiSummaryStatus: null,
+  };
 }
 
 /**
@@ -105,11 +279,32 @@ export interface BeMeetingDetail {
    */
   startAt: string;
   endAt: string;
+  /**
+   * 확정 전 AI 액션 초안 건수 — 종료되지 않은 회의는 서버가 조회 없이 `0`으로 확정한다
+   * (BE `MeetingDetailQueryService.resolvePendingActionCount`).
+   */
+  pendingActionCount: number;
+  /**
+   * 요약 진행 신호(BE `MeetingSummaryStatus`) — `NONE` · `PROCESSING` · `DONE` · `STALLED`.
+   *
+   * ⚠️ **`null`이 정상값이다.** 회의가 끝났고 중단도 아니면 BE도 `PROCESSING`인지 `DONE`인지
+   *    모른다(A가 아직 안 갈라 준다) — 추측해 내려보내지 않으려고 `null`을 준다(BE enum 주석).
+   *    우리도 그 `null`을 "다 됐다"로 읽지 않는다(`meetingPendingReasonOf` 참고).
+   */
+  summaryStatus: string | null;
   project: { projectId: number; tag: string };
   meetingRoom: { meetingRoomId: number; name: string };
   host: { memberId: number; name: string };
   attendees: BeMeetingAttendee[];
 }
+
+/** BE `MeetingSummaryStatus` — 화면 상수(`AI_SUMMARY_STATUS`)와 어휘가 달라 여기서만 쓴다. */
+const BE_SUMMARY_STATUS = {
+  NONE: "NONE",
+  PROCESSING: "PROCESSING",
+  DONE: "DONE",
+  STALLED: "STALLED",
+} as const;
 
 export interface BeMeetingAttendee {
   memberId: number;
@@ -141,6 +336,9 @@ function isBeMeetingDetail(value: unknown): value is BeMeetingDetail {
     typeof detail.status === "string" &&
     typeof detail.startAt === "string" &&
     typeof detail.endAt === "string" &&
+    typeof detail.pendingActionCount === "number" &&
+    (detail.summaryStatus === null || typeof detail.summaryStatus === "string") &&
+    typeof detail.project?.projectId === "number" &&
     typeof detail.project?.tag === "string" &&
     typeof detail.meetingRoom?.name === "string" &&
     typeof detail.host?.memberId === "number" &&
@@ -230,5 +428,70 @@ function toCaptureAttendee(attendee: BeMeetingAttendee, hostMemberId: number): C
     name: attendee.name,
     subtitle: [attendee.teamName, attendee.jobPosition].filter(Boolean).join(" · "),
     isHost: attendee.memberId === hostMemberId,
+  };
+}
+
+/**
+ * 산출물·발화 기록을 **아직 못 보여주는 이유**(§view-types `MeetingContentPending`).
+ *
+ * ⚠️ **순서가 있다.** 회의가 안 끝났으면 요약은 시작조차 안 했으므로 회의 상태를 먼저 본다 —
+ *    목 경로(`server.ts`)와 같은 차례라야 같은 회의가 두 경로에서 다른 말을 하지 않는다.
+ * ⚠️ **`summaryStatus === null`을 "다 됐다"로 읽지 않는다.** BE는 그 값을 "끝났지만
+ *    `PROCESSING`인지 `DONE`인지 모른다"는 뜻으로 준다(BE enum 주석) — 모르는 걸 완료로
+ *    바꿔 읽으면 화면이 "하달된 액션이 없습니다"라고 **단정**한다(§정직성).
+ * ⚠️ 단 **확정 대기 건수가 있으면 요약은 끝난 것**이다 — 초안이 나왔다는 증거라서, 그때는
+ *    "요약 중"이 아니라 검토 대기 안내를 띄운다(`actionsSectionStateOf`).
+ */
+export function meetingPendingReasonOf(
+  detail: Pick<BeMeetingDetail, "status" | "summaryStatus" | "pendingActionCount">,
+): MeetingContentPending | null {
+  if (detail.status === MEETING_STATUS.CANCELED) return "CANCELED";
+  if (detail.status === MEETING_STATUS.SCHEDULED) return "SCHEDULED";
+  if (detail.status === MEETING_STATUS.IN_PROGRESS) return "IN_PROGRESS";
+
+  if (detail.summaryStatus === BE_SUMMARY_STATUS.STALLED) return "FAILED";
+  if (detail.summaryStatus === BE_SUMMARY_STATUS.DONE) return null;
+  /* ⚠️ 끝난 회의에 `NONE`이 오면 계약이 어긋난 것이다 — 완료로 읽지 말고 아직 안 된 쪽으로 둔다 */
+  if (detail.summaryStatus === null && detail.pendingActionCount > 0) return null;
+  return "SUMMARIZING";
+}
+
+/**
+ * 회의 상세 화면이 받을 값 — **권한 판정은 여기서 하지 않는다**(`hostIdOf`와 같은 이유).
+ * 개설자인지는 `lib/permission.ts`의 `canOperateMeeting`이 정하고 결과만 `isHost`로 받는다.
+ *
+ * ⚠️ **MEET-04가 안 주는 칸은 비워 둔다**(§정직성 — 지어내지 않는다). 각각 왜 비는지:
+ *    - `originLabel`·`parentTeamActionHref`: 응답에 개설자의 권한(Owner 개설인가)도 상위 팀
+ *      액션도 없다. `host.name`으로 메우면 **뜻이 다른 값**이 그 자리에 앉는다(그건 소속
+ *      라벨이 아니라 사람 이름이다).
+ *    - `topics`: 안건이 응답에 아예 없다. 회의 예약 때 입력받은 값인데 상세로 안 나온다.
+ *    - `outputs`·`script`: 다른 API(`GET /api/meetings/{id}/actions` · CAP-12 자막 조회)가
+ *      줄 값이라 이 연동 범위 밖이다. **빈 배열이 아니라 `null`이다** — 빈 배열로 두면 화면이
+ *      "하달된 액션이 없습니다"·"발화 기록이 없습니다"라고 **안 물어본 것을 단정한다**.
+ *    - `outputKindLabel`: 팀 액션인지 개인 액션인지는 개설자 권한에서 갈리는데 그 값이 없다 —
+ *      둘 중 하나로 찍지 않고 상위어인 `액션`으로 둔다.
+ */
+export function toMeetingDetailView(
+  be: BeMeetingDetail,
+  options: { isHost: boolean },
+): MeetingDetail {
+  return {
+    id: String(be.meetingId),
+    title: be.title,
+    projectId: be.project.projectId,
+    projectTag: be.project.tag,
+    originLabel: "",
+    parentTeamActionHref: null,
+    topics: [],
+    schedule: formatMeetingSchedule(new Date(be.startAt), new Date(be.endAt)),
+    roomName: be.meetingRoom.name,
+    attendees: be.attendees.map((attendee) => ({ id: attendee.memberId, name: attendee.name })),
+    outputKindLabel: "액션",
+    outputs: null,
+    script: null,
+    pendingReason: meetingPendingReasonOf(be),
+    pendingActionCount: be.pendingActionCount,
+    isStalled: be.summaryStatus === BE_SUMMARY_STATUS.STALLED,
+    isHost: options.isHost,
   };
 }

--- a/src/features/meeting/mock/meetings.ts
+++ b/src/features/meeting/mock/meetings.ts
@@ -106,6 +106,24 @@ export function updateMockMeetingAttendees(id: string, attendeeIds: number[]): M
 }
 
 /**
+ * 회의 정보 수정(MEET-05) — **보낸 값만 갈아 끼운다**(부분 수정).
+ *
+ * ⚠️ 지금 화면이 보내는 건 제목뿐이다. BE는 프로젝트·회의실·시간·녹음 동의도 받지만
+ *    (`UpdateMeetingRequest`) 그쪽은 예약 슬롯을 다시 잡는 일이라 회의실 예약 화면의
+ *    슬롯 피커가 있어야 한다 — **안 붙인 필드를 받는 척하지 않는다**(§정직성).
+ * ⚠️ 상태 판정(`meetingStatusOf`)은 호출부(`actions.ts`)가 이미 하고 온다 —
+ *    `cancelMockMeeting`·`updateMockMeetingAttendees`와 같은 자리 나눔이다.
+ */
+export function updateMockMeeting(id: string, patch: { title: string }): Meeting | null {
+  const found = findMockMeeting(id);
+  if (!found) return null;
+
+  const updated: Meeting = { ...found, title: patch.title };
+  store.meetings = store.meetings.map((meeting) => (meeting.id === id ? updated : meeting));
+  return updated;
+}
+
+/**
  * 분석 진행도를 옮긴다 — **목 전용**이다.
  *
  * ⚠️ 실서비스에서는 이 값을 프론트가 못 옮긴다. 분석은 서버가 종료 처리 안에서 돌리고

--- a/src/features/meeting/review/mapper.test.ts
+++ b/src/features/meeting/review/mapper.test.ts
@@ -21,6 +21,9 @@ const DETAIL: BeMeetingDetail = {
   status: "DONE",
   startAt: "2026-08-14T10:00:00",
   endAt: "2026-08-14T10:30:00",
+  pendingActionCount: 0,
+  /* ⚠️ 끝난 회의인데 `null`인 게 정상이다 — BE가 PROCESSING·DONE을 아직 못 가른다 */
+  summaryStatus: null,
   project: { projectId: 3, tag: "GOODSFLOW" },
   meetingRoom: { meetingRoomId: 1, name: "회의실 A" },
   host: { memberId: 2, name: "김서준" },

--- a/src/features/meeting/server.test.ts
+++ b/src/features/meeting/server.test.ts
@@ -1,7 +1,7 @@
 import { AUTHORITY } from "@/constants/authority";
 import type { Actor } from "@/lib/permission";
 
-import { getMeetingCapture } from "./server";
+import { getMeetingCapture, getMeetingDirectory } from "./server";
 
 /**
  * 캡처 진입 판정 — **접근 제어라 값으로 고정해 둔다**(CLAUDE.md §테스트: 로직은 짜자마자).
@@ -68,5 +68,36 @@ describe("getMeetingCapture — 캡처 진입", () => {
       const teamMember = result.meeting.attendees.find((attendee) => attendee.id === 2);
       expect(teamMember?.subtitle).toContain("팀");
     });
+  });
+});
+
+/**
+ * 목록 차례 — 목·실서버가 **같은 함수**로 세운다(`sortMeetingListItems`).
+ *
+ * ⚠️ 값을 콕 집지 않고 **차례의 규칙**을 검증한다. 시드가 늘거나 줄어도 안 깨지고,
+ *    정렬이 뒤집히는 것만 잡는다(WORKFLOW §3-2: 지금 다뤄야 하는 회의가 위로 온다).
+ */
+describe("getMeetingDirectory — 목록 차례", () => {
+  const RANK: Record<string, number> = {
+    IN_PROGRESS: 0,
+    SCHEDULED: 1,
+    DONE: 2,
+    CANCELED: 3,
+  };
+
+  it("진행중 → 예정 → 완료 → 취소 순이다", async () => {
+    const directory = await getMeetingDirectory(OWNER.id);
+    const ranks = directory.hosted.map((item) => RANK[item.status] ?? 0);
+
+    expect(ranks.length).toBeGreaterThan(0);
+    expect(ranks).toEqual([...ranks].sort((a, b) => a - b));
+  });
+
+  /* ⚠️ 두 탭은 겹치지 않는다 — 참여해야 할 탭에서 내가 연 회의는 빠진다(§3-2) */
+  it("내가 개설한 회의는 «참여해야 할»에 안 뜬다", async () => {
+    const directory = await getMeetingDirectory(OWNER.id);
+
+    expect(directory.hosted.every((item) => item.isHost)).toBe(true);
+    expect(directory.invited.every((item) => !item.isHost)).toBe(true);
   });
 });

--- a/src/features/meeting/server.ts
+++ b/src/features/meeting/server.ts
@@ -15,8 +15,17 @@ import {
 } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
-import { formatMeetingSchedule } from "./lib";
-import { hostIdOf, isClosed, parseMeetingDetail, toMeetingCaptureInfo } from "./mapper";
+import { formatMeetingSchedule, meetingListRange } from "./lib";
+import {
+  type BeMeetingListItem,
+  hostIdOf,
+  isClosed,
+  parseMeetingDetail,
+  parseMeetingList,
+  toMeetingCaptureInfo,
+  toMeetingDetailView,
+  toMeetingListItem,
+} from "./mapper";
 import { findMockMeeting, listMockMeetings } from "./mock/meetings";
 import { ensureMockMeetingsSeeded, findMockMeetingExtras } from "./mock/seed";
 import { findMockMeetingReview } from "./review/mock/review";
@@ -80,32 +89,16 @@ function toListItem(meeting: Meeting, viewerId: number, now: Date): MeetingListI
  * ⚠️ 차례: 진행중 → 예정(가까운 순) → 완료(최근 순). 지금 다뤄야 하는 회의가 위로 온다.
  */
 export async function getMeetingDirectory(viewerId: number): Promise<MeetingDirectory> {
-  if (!isMock) {
-    // TODO(BE 협의): `GET /meetings` — 응답 봉투는 아직 모른다(매퍼가 벗긴다)
-    throw new Error("회의 목록 API가 아직 연결되지 않았습니다.");
-  }
+  if (!isMock) return getLiveMeetingDirectory();
 
   ensureMockMeetingsSeeded();
   const now = new Date();
-  const items = listMockMeetings().map((meeting) => toListItem(meeting, viewerId, now));
-
-  const rank = {
-    [MEETING_STATUS.IN_PROGRESS]: 0,
-    [MEETING_STATUS.SCHEDULED]: 1,
-    [MEETING_STATUS.DONE]: 2,
-    // ⚠️ 취소는 맨 뒤다(MEET-06) — 더 볼 일 없는 회의 중에서도 가장 뒤로 물러난다.
-    [MEETING_STATUS.CANCELED]: 3,
-  } as const;
   const byId = new Map(listMockMeetings().map((meeting) => [meeting.id, meeting]));
-  const startOf = (item: MeetingListItem) => byId.get(item.id)?.start.getTime() ?? 0;
-
-  items.sort((a, b) => {
-    if (rank[a.status] !== rank[b.status]) return rank[a.status] - rank[b.status];
-    // 예정·진행중은 가까운 회의부터, 완료·취소는 최근 회의부터
-    return a.status === MEETING_STATUS.SCHEDULED || a.status === MEETING_STATUS.IN_PROGRESS
-      ? startOf(a) - startOf(b)
-      : startOf(b) - startOf(a);
-  });
+  const rows = listMockMeetings().map((meeting) => ({
+    item: toListItem(meeting, viewerId, now),
+    startMs: meeting.start.getTime(),
+  }));
+  const items = sortMeetingListItems(rows);
 
   return {
     hosted: items.filter((item) => item.isHost),
@@ -115,6 +108,78 @@ export async function getMeetingDirectory(viewerId: number): Promise<MeetingDire
       return meeting !== undefined && meeting.attendeeIds.includes(viewerId);
     }),
   };
+}
+
+/**
+ * 목록 차례 — **지금 다뤄야 하는 회의가 위로 온다**(WORKFLOW §3-2).
+ *
+ * ⚠️ **목·실서버가 같은 함수를 쓴다.** 정렬이 두 벌이면 같은 회의가 경로마다 다른 자리에
+ *    서고, 그건 화면을 눌러 보는 것만으로는 안 드러난다(§격리막과 같은 이유).
+ * ⚠️ 시각은 항목이 아니라 **원본**에서 받는다 — `schedule`은 이미 사람이 읽는 문자열이라
+ *    거기서 시각을 되파면 표기가 바뀔 때마다 정렬이 조용히 틀어진다.
+ */
+const STATUS_RANK = {
+  [MEETING_STATUS.IN_PROGRESS]: 0,
+  [MEETING_STATUS.SCHEDULED]: 1,
+  [MEETING_STATUS.DONE]: 2,
+  // ⚠️ 취소는 맨 뒤다(MEET-06) — 더 볼 일 없는 회의 중에서도 가장 뒤로 물러난다.
+  [MEETING_STATUS.CANCELED]: 3,
+} as const;
+
+function sortMeetingListItems(
+  rows: { item: MeetingListItem; startMs: number }[],
+): MeetingListItem[] {
+  return [...rows]
+    .sort((a, b) => {
+      const rankGap = STATUS_RANK[a.item.status] - STATUS_RANK[b.item.status];
+      if (rankGap !== 0) return rankGap;
+      // 예정·진행중은 가까운 회의부터, 완료·취소는 최근 회의부터
+      return a.item.status === MEETING_STATUS.SCHEDULED ||
+        a.item.status === MEETING_STATUS.IN_PROGRESS
+        ? a.startMs - b.startMs
+        : b.startMs - a.startMs;
+    })
+    .map((row) => row.item);
+}
+
+/**
+ * 목록 — 실서버(MEET-02).
+ *
+ * ⚠️ **탭을 서버가 가른다**(`scope=HOSTED`·`ATTENDING`). 전부 받아 와서 `isHost`로 나누면
+ *    같은 회의를 두 번 실어 나르고, 페이지가 잘릴 때 한쪽 탭만 조용히 비어 버린다 —
+ *    BE가 `ATTENDING`에서 host를 이미 빼 준다(BE `MeetingListScope`).
+ * ⚠️ **`from`·`to`를 반드시 싣는다.** 서버 기본이 `오늘-3개월 ~ 오늘`이라 생략하면 **예정
+ *    회의가 통째로 빠진다**(§endpoints `MeetingListParams`) — 이 화면의 첫 줄이 예정 회의다.
+ * ⚠️ **무한 스크롤은 이 이슈에서 안 만든다**(범위 밖). 대신 한 페이지를 BE 상한(100)까지
+ *    받아 첫 화면이 20건에서 잘리지 않게 한다 — 그보다 많으면 뒤가 안 보인다(CLAUDE.md
+ *    §목록의 스크롤 트리거를 붙일 때 이 상수를 지우고 `page`를 이어 붙인다).
+ * ⚠️ 두 탭을 **같이 부른다**(`Promise.all`). 차례로 부르면 화면이 두 번 기다린다.
+ */
+const MEETING_LIST_PAGE_SIZE = 100;
+
+async function getLiveMeetingDirectory(): Promise<MeetingDirectory> {
+  const accessToken = await requireAccessToken();
+  const { from, to } = meetingListRange(new Date());
+
+  const query = { from, to, page: 0, size: MEETING_LIST_PAGE_SIZE } as const;
+  const [hosted, invited] = await Promise.all([
+    serverApi<unknown>(ep.meetings({ ...query, scope: "HOSTED" }), { accessToken }),
+    serverApi<unknown>(ep.meetings({ ...query, scope: "ATTENDING" }), { accessToken }),
+  ]);
+
+  return {
+    hosted: toSortedListItems(parseMeetingList(hosted)),
+    invited: toSortedListItems(parseMeetingList(invited)),
+  };
+}
+
+function toSortedListItems(meetings: BeMeetingListItem[]): MeetingListItem[] {
+  return sortMeetingListItems(
+    meetings.map((meeting) => ({
+      item: toMeetingListItem(meeting),
+      startMs: new Date(meeting.startAt).getTime(),
+    })),
+  );
 }
 
 /** 산출물 조립 — 회의 종류에 따라 팀 액션(§2) 또는 개인 액션(§5)이다 */
@@ -165,10 +230,7 @@ function outputsOf(meeting: Meeting): { kindLabel: string; outputs: MeetingOutpu
  *    잠금은 에러가 아니라서 목록 카드(메타)는 계속 보인다.
  */
 export async function getMeetingDetail(id: string, viewer: Actor): Promise<MeetingDetailResult> {
-  if (!isMock) {
-    // TODO(BE 협의): `GET /meetings/{id}`
-    throw new Error("회의 상세 API가 아직 연결되지 않았습니다.");
-  }
+  if (!isMock) return getLiveMeetingDetail(id, viewer);
 
   ensureMockMeetingsSeeded();
   const meeting = findMockMeeting(id);
@@ -250,6 +312,43 @@ export async function getMeetingDetail(id: string, viewer: Actor): Promise<Meeti
       isStalled,
       isHost: canOperateMeeting(viewer, { ownerId: meeting.hostId }),
     },
+  };
+}
+
+/**
+ * 상세 — 실서버(MEET-04).
+ *
+ * ⚠️ **판정 순서를 목과 맞춘다**(없음 → 권한 없음 → 통과). `getLiveMeetingCapture`와 같은
+ *    규칙이다 — 순서가 갈리면 같은 회의가 경로마다 다른 이유로 막힌다.
+ * ⚠️ **404(`MT-001`)·403(`MT-011`) 둘 다 값으로 돌린다.** 캡처(`getLiveMeetingCapture`)는 403을
+ *    던지는데, 거기서는 **우리가 먼저 판정한 뒤**의 403이라 판정이 틀렸다는 신호이기 때문이다.
+ *    상세는 다르다 — 목록이 전 구성원 공개라 아무나 눌러 들어올 수 있고, 우리는 판정에 필요한
+ *    값(개설 팀·참석자)을 조회 전에 갖고 있지 않다. 여기서 403은 고장이 아니라 **잠금**이고,
+ *    잠금은 에러 화면이 아니다(WORKFLOW §3-2-1).
+ * ⚠️ 제목은 못 싣는다 — 실패 봉투에 회의 제목이 없다(§view-types `locked`).
+ * ⚠️ 개설자 판정은 **목 경로와 같은 함수**(`canOperateMeeting`)다. 매퍼는 값이 어디 있는지만
+ *    알려 주고(`hostIdOf`) 판정은 `lib/permission.ts` 한 곳이다(CLAUDE.md §권한).
+ */
+async function getLiveMeetingDetail(id: string, viewer: Actor): Promise<MeetingDetailResult> {
+  const accessToken = await requireAccessToken();
+
+  let raw: unknown;
+  try {
+    raw = await serverApi<unknown>(ep.meeting(Number(id)), { accessToken });
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) return { kind: "notFound" };
+    if (error instanceof ApiError && error.status === 403) return { kind: "locked", title: null };
+    throw error;
+  }
+
+  /* ⚠️ 단언이 아니라 **검사**다 — 모양이 어긋나면 화면을 그리기 전에 여기서 멈춘다 */
+  const detail = parseMeetingDetail(raw);
+
+  return {
+    kind: "ok",
+    detail: toMeetingDetailView(detail, {
+      isHost: canOperateMeeting(viewer, { ownerId: hostIdOf(detail) }),
+    }),
   };
 }
 

--- a/src/features/meeting/server.ts
+++ b/src/features/meeting/server.ts
@@ -32,6 +32,7 @@ import { findMockMeetingReview } from "./review/mock/review";
 import { meetingStatusOf } from "./status";
 import type { Meeting } from "./types";
 import type {
+  MeetingAgenda,
   MeetingCaptureResult,
   MeetingContentPending,
   MeetingDetailResult,
@@ -62,6 +63,17 @@ function originLabelOf(meeting: Meeting): string {
     (action) => action.id === meeting.parentTeamActionId,
   );
   return parent ? parent.name : "팀 액션 회의";
+}
+
+/**
+ * 목 안건(쌍 목록) → 화면 계약(`MeetingAgenda` — 대주제 하나 + 소주제 목록).
+ *
+ * ⚠️ **BE가 하는 것과 같은 방식으로 접는다**(BE PR #461 `resolveAgenda` — 대주제는
+ *    `findFirst`, 소주제는 전부). 목만 쌍을 그대로 보여 주면 실서버로 넘어가는 날 상세의
+ *    안건 칸이 조용히 줄어든다 — 목은 실서버가 내줄 모양을 미리 보여야 한다(§정직한 목업).
+ */
+function toMockAgenda(topics: Meeting["topics"]): MeetingAgenda {
+  return { main: topics[0].main, subs: topics.map((topic) => topic.sub) };
 }
 
 function toListItem(meeting: Meeting, viewerId: number, now: Date): MeetingListItem {
@@ -297,7 +309,7 @@ export async function getMeetingDetail(id: string, viewer: Actor): Promise<Meeti
         meeting.hostAuthority === "OWNER"
           ? null
           : `/app/projects/${meeting.projectId}/team/${meeting.parentTeamActionId}`,
-      topics: meeting.topics,
+      agenda: toMockAgenda(meeting.topics),
       schedule: formatMeetingSchedule(meeting.start, meeting.end),
       roomName: meeting.roomName,
       attendees: meeting.attendeeIds.map((attendeeId) => ({

--- a/src/features/meeting/status.test.ts
+++ b/src/features/meeting/status.test.ts
@@ -1,6 +1,11 @@
 import { AI_SUMMARY_STATUS, MEETING_STATUS } from "@/constants/meeting";
 
-import { meetingCardAffordanceOf, meetingStatusOf } from "./status";
+import {
+  canEditMeeting,
+  canEditMeetingAttendees,
+  meetingCardAffordanceOf,
+  meetingStatusOf,
+} from "./status";
 
 /** 상태가 틀리면 "완료 카드만 상세 진입" 규칙(WORKFLOW §3-2)이 통째로 틀린다 */
 describe("meetingStatusOf", () => {
@@ -100,5 +105,33 @@ describe("meetingCardAffordanceOf", () => {
     expect(
       meetingCardAffordanceOf({ ...base, status: MEETING_STATUS.CANCELED, aiSummaryStatus: null }),
     ).toBe("open");
+  });
+});
+
+/**
+ * 수정 관문이 느슨하면 BE가 409 `MT-014`로 되돌리는 자리에 버튼이 뜬다(§정직성).
+ * ⚠️ `pendingReason`이 상태를 대신한다 — `"SCHEDULED"`만 아직 시작 전이라는 뜻이다(§view-types).
+ */
+describe("canEditMeeting", () => {
+  it("host의 시작 전 회의만 고칠 수 있다", () => {
+    expect(canEditMeeting({ isHost: true, pendingReason: "SCHEDULED" })).toBe(true);
+  });
+
+  it("참석자는 시작 전이어도 못 고친다 — 조작은 Host의 일이다", () => {
+    expect(canEditMeeting({ isHost: false, pendingReason: "SCHEDULED" })).toBe(false);
+  });
+
+  /* ⚠️ 진행중·요약중·실패·취소·완료(null)는 전부 BE가 409로 막는 자리다 */
+  it("시작한 뒤로는 host라도 못 고친다", () => {
+    for (const reason of ["IN_PROGRESS", "SUMMARIZING", "FAILED", "CANCELED", null] as const) {
+      expect(canEditMeeting({ isHost: true, pendingReason: reason })).toBe(false);
+    }
+  });
+
+  /* ⚠️ 참석자 교체(MEET-09)는 진행중도 되지만 수정(MEET-05)은 아니다 — 관문이 다르다 */
+  it("참석자 교체보다 좁다 — 진행중 회의에서 갈린다", () => {
+    const inProgress = { isHost: true, pendingReason: "IN_PROGRESS" } as const;
+    expect(canEditMeetingAttendees(inProgress)).toBe(true);
+    expect(canEditMeeting(inProgress)).toBe(false);
   });
 });

--- a/src/features/meeting/status.ts
+++ b/src/features/meeting/status.ts
@@ -83,3 +83,20 @@ export function canEditMeetingAttendees(
 export function canCancelMeeting(detail: Pick<MeetingDetail, "isHost" | "pendingReason">): boolean {
   return detail.isHost && detail.pendingReason === "SCHEDULED";
 }
+
+/**
+ * 회의 수정(MEET-05) 가능 여부 — **시작 전(SCHEDULED)만**.
+ *
+ * ⚠️ **BE가 그 자리에서 막는다.** `MeetingUpdateService`는 상태가 `SCHEDULED`가 아니면
+ *    409 `MT-014`를 던진다 — 입장·종료가 시작된 회의는 캡처 시간축이 확정돼 시간을 되돌릴
+ *    수 없기 때문이다. **서버가 안 받는 자리에 버튼을 두지 않는다**(§정직성).
+ * ⚠️ 취소(`canCancelMeeting`)와 지금은 조건이 같지만 **이름을 따로 둔다.** 둘은 각자 다른 BE
+ *    계약(MEET-05·MEET-06)을 보고 있어서 한쪽 관문이 바뀌면 여기서 갈라져야 한다 — 지금
+ *    같다고 합치면 그때 두 기능이 함께 틀린다.
+ * ⚠️ 화면 판정은 `isHost`뿐이지만 **서버는 host·OWNER·ADMIN까지 받는다**(`canManageMeeting` —
+ *    BE `MeetingUpdateService.canManageMeeting`과 같은 범위). 화면 숨김은 UX고 판정은
+ *    Server Action이 다시 한다(§권한).
+ */
+export function canEditMeeting(detail: Pick<MeetingDetail, "isHost" | "pendingReason">): boolean {
+  return detail.isHost && detail.pendingReason === "SCHEDULED";
+}

--- a/src/features/meeting/summary/actions.ts
+++ b/src/features/meeting/summary/actions.ts
@@ -2,31 +2,130 @@
 
 import { revalidatePath } from "next/cache";
 
+import { requireAccessToken } from "@/features/auth/session";
 import { getViewer } from "@/features/shell/viewer";
+import { ApiError, serverApi } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
 import { canOperateMeeting } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
+import {
+  type BeAnalysisResumeResponse,
+  type RetrySummaryResult,
+  toRetrySummaryResult,
+} from "./mapper";
 import { findMockStalledSummary, removeMockStalledSummary } from "./mock/stalled-summaries";
+import { listStalledSummariesForViewer } from "./server";
+
+const MY_PAGE_PATH = "/app/me";
 
 /**
- * [다시 분석] — 재분석 큐에 다시 넣는다.
- * ⚠️ 실제 재분석 API 경로가 아직 BE와 확정 전이다(§연동 검증, BE #177 관련 요청함) —
- *    지금은 mock으로 "목록에서 빠진다"까지만 흉내낸다.
- * ⚠️ Host만 요청할 수 있다 — 화면 버튼 숨김은 보안이 아니다(CLAUDE.md §권한).
+ * BE가 **재개할 계층이 없다**고 답할 때의 코드(409 `ANLZ-008`).
+ *
+ * ⚠️ 번호가 005가 아니다. 처음엔 005로 넣었다가 `SUMMARY_ITEM_NOT_FOUND`(404)와 겹쳐 008로
+ *    옮겼다(BE `CaptureErrorCode` 주석 — CodeRabbit PR #318). 문서에 005로 남아 있는 곳이
+ *    있는데 **실코드가 008**이다(§연동 검증: 문서와 코드가 다르면 코드가 맞다).
  */
-export async function retryMeetingSummaryAction(meetingId: string): Promise<void> {
-  if (!isMock) {
-    throw new Error("서버 연동 미구현 — 재분석 API 경로 확정 후 매퍼 작성");
-  }
+const NOTHING_TO_RESUME = "ANLZ-008";
 
-  const item = findMockStalledSummary(meetingId);
-  if (!item) return;
+/**
+ * [다시 분석] 결과 — **실패를 던지지 않고 값으로 돌려준다.**
+ *
+ * ⚠️ 예전엔 `void`를 주고 던졌는데, 그러면 화면이 `catch` 한 곳에서 전부 같은 문구를 띄운다 —
+ *    "재개할 계층이 없다"(처음부터 다시 돌려야 한다)와 "서버가 답을 안 한다"가 같은 말이 됐다.
+ *    무엇이 막았는지 화면이 알아야 다음 걸음을 안내할 수 있다(§정직성, `cancelMeetingAction`과 같은 모양).
+ */
+export interface RetryMeetingSummaryState {
+  /** 값이 있으면 실패다 — 화면에 그대로 띄울 한 줄(§lib/api: BE `message`를 새로 짓지 않는다) */
+  error: string | null;
+  /**
+   * **재개할 자리가 없는 회의**(409 `ANLZ-008`). 전부 성공했거나 한 번도 안 돌았다는 뜻이라
+   * 이 버튼으로는 영영 안 된다 — 처음부터(ANLZ-01) 돌려야 한다.
+   *
+   * ⚠️ 일반 실패와 가른다. "잠시 후 다시 시도"라고 안내하면 같은 버튼을 계속 누르게 되는데
+   *    그 회의는 몇 번을 눌러도 같은 409다.
+   */
+  needsFullRerun: boolean;
+  /**
+   * 요청은 갔는데 **요약이 아직 없는** 경우의 사정 한 줄 — 다 됐으면 `null`이다.
+   *
+   * ⚠️ 200인데 `FAILED`·`SKIPPED`거나 다른 실행이 돌고 있는(`ALREADY_RUNNING`·`SUPERSEDED`)
+   *    경우다(§mapper). 오류로 칠하지 않는다 — 요청 자체는 정상으로 처리됐다. 다만 성공
+   *    토스트를 띄우면 요약이 생긴 줄 알게 되므로 **문구를 갈라야 한다**(§정직성).
+   */
+  pendingNote: string | null;
+}
 
+const OK: RetryMeetingSummaryState = { error: null, needsFullRerun: false, pendingNote: null };
+
+/** 실패도 아니고 완료도 아닌 결과를 그대로 옮긴다 — BE 문장을 새로 짓지 않는다. */
+function toState(result: RetrySummaryResult): RetryMeetingSummaryState {
+  if (result.outcome === "resumed") return OK;
+  return { error: null, needsFullRerun: false, pendingNote: result.message };
+}
+
+/**
+ * [다시 분석](ANLZ-02) — **실패한 계층부터 이어서** 돌린다(재과금 없음).
+ *
+ * ⚠️ **본문을 안 보낸다.** 이 버튼은 어느 계층이 깨졌는지 모르고, 알려면 CAP-06을 먼저 부르는
+ *    왕복이 생긴다 — 생략하면 서버가 처음 깨진 계층을 고른다(BE `ResumeAnalysisRequest`).
+ *    빈 문자열을 보내면 400 `ANLZ-003`이라 **아예 안 보내는 것**이 계약이다.
+ * ⚠️ **Host만 요청할 수 있다 — 그 판정이 우리 몫이다.** BE ANLZ-02는 역할(`@PreAuthorize`)과
+ *    회사 스코프(`MeetingAccessGuard`)만 보고 **host인지는 안 본다**(RVW-05와 다르다). 그래서
+ *    목록(MEET-15, BE가 host로 스코프)에 그 회의가 있는지를 서버에서 다시 확인하고 부른다 —
+ *    화면 버튼 숨김은 보안이 아니다(§권한).
+ * ⚠️ 성공해도 요약이 찼다는 보장이 없다 — 200 응답의 `status`가 실제 결과다(§mapper).
+ */
+export async function retryMeetingSummaryAction(
+  meetingId: string,
+): Promise<RetryMeetingSummaryState> {
   const viewer = await getViewer();
-  if (!canOperateMeeting(viewer, { ownerId: item.hostId })) {
-    throw new Error("권한이 없습니다.");
+
+  if (isMock) {
+    const item = findMockStalledSummary(meetingId);
+    if (!item)
+      return { error: "회의를 찾을 수 없습니다", needsFullRerun: false, pendingNote: null };
+    if (!canOperateMeeting(viewer, { ownerId: item.hostId })) {
+      return { error: "권한이 없습니다", needsFullRerun: false, pendingNote: null };
+    }
+
+    removeMockStalledSummary(meetingId);
+    revalidatePath(MY_PAGE_PATH);
+    return OK;
   }
 
-  removeMockStalledSummary(meetingId);
-  revalidatePath("/app/me");
+  /*
+    ⚠️ **목록으로 host를 확인한다.** MEET-15는 서버가 host 본인 회의만 내려주므로
+       (`listStalledSummariesForViewer`) 그 안에 있다는 건 이 사람이 host라는 뜻이다.
+       목이 `hostId`로 하는 검사를 실연동에서 대신하는 자리다 — 화면 계약(`StalledSummaryInfo`)엔
+       `hostId`가 없어서 이 길뿐이다.
+    ⚠️ 한 번 더 부르는 값은 있다. 이 버튼은 자주 눌리지 않고, 없으면 **회사 안 아무 회의나**
+       재분석을 걸 수 있는 경로가 열린 채로 남는다.
+  */
+  const mine = await listStalledSummariesForViewer(viewer.id);
+  if (!mine.some((item) => item.meetingId === meetingId)) {
+    return { error: "권한이 없습니다", needsFullRerun: false, pendingNote: null };
+  }
+
+  const accessToken = await requireAccessToken();
+  try {
+    const response = await serverApi<BeAnalysisResumeResponse>(
+      ep.meetingAnalysisRetry(Number(meetingId)),
+      { method: "POST", accessToken },
+    );
+    revalidatePath(MY_PAGE_PATH);
+    return toState(toRetrySummaryResult(response));
+  } catch (error) {
+    if (!(error instanceof ApiError)) throw error;
+    /*
+      ⚠️ 409 둘을 뭉치지 않는다. `ANLZ-008`은 이 버튼으로는 끝난 이야기라 다른 안내가 필요하고,
+         `ANLZ-004`(앞 계층 미완)는 지금은 못 잇는다는 뜻이라 나중에 같은 요청이 성립한다 —
+         그쪽은 BE 문장을 그대로 띄우는 일반 실패로 둔다.
+    */
+    return {
+      error: error.message,
+      needsFullRerun: error.code === NOTHING_TO_RESUME,
+      pendingNote: null,
+    };
+  }
 }

--- a/src/features/meeting/summary/actions.ts
+++ b/src/features/meeting/summary/actions.ts
@@ -9,13 +9,13 @@ import { ep } from "@/lib/endpoints";
 import { canOperateMeeting } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
+import { hostIdOf, parseMeetingDetail } from "../mapper";
 import {
   type BeAnalysisResumeResponse,
   type RetrySummaryResult,
   toRetrySummaryResult,
 } from "./mapper";
 import { findMockStalledSummary, removeMockStalledSummary } from "./mock/stalled-summaries";
-import { listStalledSummariesForViewer } from "./server";
 
 const MY_PAGE_PATH = "/app/me";
 
@@ -72,8 +72,7 @@ function toState(result: RetrySummaryResult): RetryMeetingSummaryState {
  *    빈 문자열을 보내면 400 `ANLZ-003`이라 **아예 안 보내는 것**이 계약이다.
  * ⚠️ **Host만 요청할 수 있다 — 그 판정이 우리 몫이다.** BE ANLZ-02는 역할(`@PreAuthorize`)과
  *    회사 스코프(`MeetingAccessGuard`)만 보고 **host인지는 안 본다**(RVW-05와 다르다). 그래서
- *    목록(MEET-15, BE가 host로 스코프)에 그 회의가 있는지를 서버에서 다시 확인하고 부른다 —
- *    화면 버튼 숨김은 보안이 아니다(§권한).
+ *    회의 상세(MEET-04)로 개설자를 확인하고 부른다 — 화면 버튼 숨김은 보안이 아니다(§권한).
  * ⚠️ 성공해도 요약이 찼다는 보장이 없다 — 200 응답의 `status`가 실제 결과다(§mapper).
  */
 export async function retryMeetingSummaryAction(
@@ -94,20 +93,29 @@ export async function retryMeetingSummaryAction(
     return OK;
   }
 
+  const accessToken = await requireAccessToken();
+
   /*
-    ⚠️ **목록으로 host를 확인한다.** MEET-15는 서버가 host 본인 회의만 내려주므로
-       (`listStalledSummariesForViewer`) 그 안에 있다는 건 이 사람이 host라는 뜻이다.
-       목이 `hostId`로 하는 검사를 실연동에서 대신하는 자리다 — 화면 계약(`StalledSummaryInfo`)엔
-       `hostId`가 없어서 이 길뿐이다.
+    ⚠️ **상세로 개설자를 직접 본다**(2026-08-13, 코드래빗 지적). 예전엔 중단 목록(MEET-15)
+       **첫 페이지**에 그 회의가 있는지로 갈랐는데, 그 목록은 페이지로 오므로(최대 100건)
+       101번째부터의 **자기 회의가 "권한 없음"으로 막혔다** — 소유권은 페이지 운에 달린 값이
+       아니다. 목이 `hostId`로 하는 검사를 실연동에서 대신하는 자리이고, 판정 함수도
+       목과 같은 `canOperateMeeting` 하나다(§권한: 판정은 한 곳).
     ⚠️ 한 번 더 부르는 값은 있다. 이 버튼은 자주 눌리지 않고, 없으면 **회사 안 아무 회의나**
        재분석을 걸 수 있는 경로가 열린 채로 남는다.
   */
-  const mine = await listStalledSummariesForViewer(viewer.id);
-  if (!mine.some((item) => item.meetingId === meetingId)) {
-    return { error: "권한이 없습니다", needsFullRerun: false, pendingNote: null };
+  try {
+    const detail = parseMeetingDetail(
+      await serverApi<unknown>(ep.meeting(Number(meetingId)), { accessToken }),
+    );
+    if (!canOperateMeeting(viewer, { ownerId: hostIdOf(detail) })) {
+      return { error: "권한이 없습니다", needsFullRerun: false, pendingNote: null };
+    }
+  } catch (error) {
+    if (!(error instanceof ApiError)) throw error;
+    return { error: error.message, needsFullRerun: false, pendingNote: null };
   }
 
-  const accessToken = await requireAccessToken();
   try {
     const response = await serverApi<BeAnalysisResumeResponse>(
       ep.meetingAnalysisRetry(Number(meetingId)),

--- a/src/features/meeting/summary/mapper.test.ts
+++ b/src/features/meeting/summary/mapper.test.ts
@@ -1,4 +1,4 @@
-import { type BeStalledSummaryMeeting, toStalledSummaryInfo } from "./mapper";
+import { type BeStalledSummaryMeeting, toRetrySummaryResult, toStalledSummaryInfo } from "./mapper";
 
 /** MEET-15 응답 원소 그대로 — 필드 이름을 BE 실코드에 맞춰 둔다 */
 const BASE: BeStalledSummaryMeeting = {
@@ -18,5 +18,54 @@ describe("toStalledSummaryInfo", () => {
 
   it("isStalled가 false면 그대로 옮긴다 — 문구는 화면(StalledSummaryList)이 가른다", () => {
     expect(toStalledSummaryInfo({ ...BASE, isStalled: false }).isStalled).toBe(false);
+  });
+});
+
+/**
+ * ANLZ-02는 **200으로도 실패가 온다**(큐가 없어 요청 스레드에서 그대로 돈다) —
+ * `status`를 안 보고 성공으로 접으면 요약이 없는데 생겼다고 말하게 된다.
+ */
+describe("toRetrySummaryResult", () => {
+  it("DONE이면 요약이 채워진 것이다", () => {
+    expect(toRetrySummaryResult({ status: "DONE", message: null })).toEqual({
+      outcome: "resumed",
+      message: "다시 분석했습니다",
+    });
+  });
+
+  /* ⚠️ 중복 방어가 동작한 것이라 오류가 아니다 — 기다리면 결과가 나온다 */
+  it("ALREADY_RUNNING은 실패가 아니라 '아직'이다", () => {
+    expect(
+      toRetrySummaryResult({ status: "ALREADY_RUNNING", message: "이미 분석이 진행 중입니다." }),
+    ).toEqual({ outcome: "running", message: "이미 분석이 진행 중입니다." });
+  });
+
+  it("SUPERSEDED도 다른 실행이 그 일을 하고 있다는 뜻이다", () => {
+    expect(toRetrySummaryResult({ status: "SUPERSEDED", message: null }).outcome).toBe("running");
+  });
+
+  it("FAILED는 BE 문장을 그대로 들고 온다 — 문구를 새로 짓지 않는다", () => {
+    expect(
+      toRetrySummaryResult({ status: "FAILED", message: "분석 계층 호출에 실패했습니다." }),
+    ).toEqual({ outcome: "failedAgain", message: "분석 계층 호출에 실패했습니다." });
+  });
+
+  /* ⚠️ 돌릴 대상이 없어 아예 안 부른 것도 "요약이 없다"는 사실은 같다 */
+  it("SKIPPED를 성공으로 접지 않는다", () => {
+    expect(toRetrySummaryResult({ status: "SKIPPED", message: "발화가 없습니다." })).toEqual({
+      outcome: "failedAgain",
+      message: "발화가 없습니다.",
+    });
+  });
+
+  /* ⚠️ BE가 값을 늘렸을 때 조용히 "됐습니다"라고 말하는 쪽이 훨씬 나쁘다 */
+  it("모르는 status는 성공으로 접지 않는다", () => {
+    expect(toRetrySummaryResult({ status: "QUEUED", message: null }).outcome).toBe("failedAgain");
+  });
+
+  it("message가 없으면 우리 문구로 대신한다", () => {
+    expect(toRetrySummaryResult({ status: "FAILED", message: null }).message).toBe(
+      "다시 분석했지만 또 멈췄습니다",
+    );
   });
 });

--- a/src/features/meeting/summary/mapper.ts
+++ b/src/features/meeting/summary/mapper.ts
@@ -31,3 +31,59 @@ export function toStalledSummaryInfo(be: BeStalledSummaryMeeting): StalledSummar
     isStalled: be.isStalled,
   };
 }
+
+/**
+ * `POST /api/meetings/{meetingId}/analysis/retry`(ANLZ-02) 응답.
+ * [확인] `capture/presentation/api/response/AnalysisResumeResponse.java`(2026-08-13).
+ *
+ * ⚠️ **`status`가 실제 결과다.** 명세는 202 `QUEUED`를 전제하지만 지금 BE엔 큐가 없어 요청
+ *    스레드에서 그대로 돌린다 — 그래서 **이미 다시 실패한 재시도도 HTTP 200**으로 온다
+ *    (BE 응답 주석). 200을 성공으로 읽으면 화면이 거짓말을 한다(§정직성).
+ * ⚠️ 화면이 쓰는 필드만 적는다(§mapper 원칙). 응답엔 `resumeFromLayer`·`reusedLayers`·
+ *    `failedLayer`·`errorCode`·`retryable`·`topicCount`도 오지만 이 위젯은 계층 이야기를
+ *    하지 않는다 — 행 하나에 토스트 한 줄이 전부다.
+ */
+export interface BeAnalysisResumeResponse {
+  /** `DONE` · `SKIPPED` · `ALREADY_RUNNING` · `SUPERSEDED` · `FAILED` (BE `AnalysisOutcome.Status`) */
+  status: string;
+  /** 실패·건너뜀의 사정 한 줄 — 성공이면 `null`이다 */
+  message: string | null;
+}
+
+/**
+ * [다시 분석]이 실제로 어떻게 됐는지 — **다섯 결과를 셋으로 접는다.**
+ *
+ * ⚠️ 사람이 다음에 할 일이 같은 것끼리만 묶는다:
+ *    - `resumed`     요약이 채워졌다. 목록에서 그 줄이 빠진다.
+ *    - `running`     다른 실행이 그 일을 하고 있다(`ALREADY_RUNNING`·`SUPERSEDED`) —
+ *                    **오류가 아니라 중복 방어가 동작한 것**이라 기다리면 결과가 나온다.
+ *    - `failedAgain` 또 멈췄거나(`FAILED`) 돌릴 것이 없었다(`SKIPPED`, 발화 0건 등).
+ *                    어느 쪽이든 **요약은 여전히 없다** — 성공 토스트를 띄우면 거짓말이다.
+ * ⚠️ 모르는 `status`를 성공으로 접지 않는다. BE가 값을 늘렸을 때 조용히 "됐습니다"라고
+ *    말하는 쪽이 훨씬 나쁘다 — 요약이 없는데 됐다고 믿고 사람이 떠난다.
+ */
+export type RetrySummaryOutcome = "resumed" | "running" | "failedAgain";
+
+export interface RetrySummaryResult {
+  outcome: RetrySummaryOutcome;
+  /** 화면에 띄울 한 줄 — BE가 사정을 실어 줬으면 그 문장을 그대로 쓴다(§lib/api) */
+  message: string;
+}
+
+/** BE `AnalysisOutcome.Status` — 화면 어휘와 달라 이 파일에서만 쓴다(§도메인 상수: `enum` 금지). */
+const RESUME_STATUS = {
+  DONE: "DONE",
+  ALREADY_RUNNING: "ALREADY_RUNNING",
+  SUPERSEDED: "SUPERSEDED",
+} as const;
+
+export function toRetrySummaryResult(be: BeAnalysisResumeResponse): RetrySummaryResult {
+  if (be.status === RESUME_STATUS.DONE) {
+    return { outcome: "resumed", message: "다시 분석했습니다" };
+  }
+  if (be.status === RESUME_STATUS.ALREADY_RUNNING || be.status === RESUME_STATUS.SUPERSEDED) {
+    return { outcome: "running", message: be.message ?? "이미 분석이 진행 중입니다" };
+  }
+  /* ⚠️ `FAILED`·`SKIPPED`·모르는 값이 전부 여기로 온다 — 요약이 없다는 사실은 셋 다 같다. */
+  return { outcome: "failedAgain", message: be.message ?? "다시 분석했지만 또 멈췄습니다" };
+}

--- a/src/features/meeting/view-types.ts
+++ b/src/features/meeting/view-types.ts
@@ -1,8 +1,6 @@
 import type { ActionStatus } from "@/constants/action";
 import type { AiSummaryStatus, MeetingStatus } from "@/constants/meeting";
 
-import type { MeetingTopic } from "./types";
-
 /**
  * 회의 화면의 **UI 계약**(`/app/meeting`).
  *
@@ -21,13 +19,16 @@ export interface MeetingListItem {
    * 소속 라벨 — Owner 개설이면 `Owner 개설`(WORKFLOW §2 — 옛 문구 "프로젝트 공통"은 폐기),
    * 팀 액션 회의면 상위 팀 액션 이름이다.
    *
-   * ⚠️ **빈 문자열이면 "모른다"는 뜻이다.** 실서버 목록(MEET-02)엔 개설자의 권한도 상위 팀
-   *    액션도 안 와서 채울 수 없다 — 카드는 빈 조각을 가운뎃점째 뺀다(§정직성).
+   * ⚠️ 실서버는 `teamId` 판정으로 채운다(BE PR #461, F2/F5 회신: `teamId` NULL = Owner 개설).
+   *    단 **상위 팀 액션 이름은 모델에 없어 영구 제공 불가**라 팀 회의는 일반 문구
+   *    `팀 액션 회의`다(매퍼 `TEAM_ORIGIN_LABEL`) — 이름까지 나오는 건 목 경로뿐이다.
+   * ⚠️ **빈 문자열이면 "모른다"는 뜻이다**(BE #461 배포 전 응답엔 `teamId`가 없다) —
+   *    카드는 빈 조각을 가운뎃점째 뺀다(§정직성).
    */
   originLabel: string;
   /**
-   * 안건 첫 쌍 요약(`대주제 · 소주제`) — 카드에서 무슨 회의인지 한 줄로 알린다.
-   * ⚠️ `originLabel`과 같다 — 실서버 목록엔 안건이 없어 빈 문자열이다.
+   * 안건 첫 줄 요약(`대주제 · 소주제`) — 카드에서 무슨 회의인지 한 줄로 알린다.
+   * 실서버는 `agendaPreview`(BE PR #461)로 채운다 — 없으면(미배포·안건 0건) 빈 문자열이다.
    */
   topicSummary: string;
   /** `7월 14일(화) 10:00 – 10:30` — 서버가 우리 표기로 만들어 보낸다(§lib) */
@@ -90,6 +91,19 @@ export interface MeetingOutput {
   href: string;
 }
 
+/**
+ * 회의 안건 — **대주제 하나 + 소주제 목록**이다(쌍이 아니다).
+ *
+ * ⚠️ 예약 폼은 대주제·소주제를 쌍으로 입력받지만 BE 모델이 둘째 쌍부터의 대주제를 안 남긴다
+ *    (BE PR #461 `resolveAgenda`, 3차 F 회신의 알려진 한계). 화면 계약을 쌍으로 두면 매퍼가
+ *    **없는 쌍을 지어 붙여야** 해서(§정직성) BE가 실제로 주는 모양을 그대로 계약으로 삼는다.
+ */
+export interface MeetingAgenda {
+  /** 첫 대주제 — 안건이 소주제로만 남은 회의는 `null`이다 */
+  main: string | null;
+  subs: string[];
+}
+
 /** 상세 참석자 한 명 — 아바타 색은 id에서 나온다(§DESIGN 5) */
 export interface MeetingAttendee {
   id: number;
@@ -116,9 +130,14 @@ export interface MeetingDetail {
   projectId: number;
   projectTag: string;
   originLabel: string;
-  /** 팀 액션 회의면 그 팀 액션 상세로 가는 링크 — Owner 개설이면 없다 */
+  /**
+   * 팀 액션 회의면 그 팀 액션 상세로 가는 링크 — Owner 개설이면 없다.
+   * ⚠️ 실서버는 **항상 `null`이다** — 상위 팀 액션 id가 모델에 없어 영구 제공 불가다
+   *    (BE PR #461 회신, `teamId`는 팀이지 팀 액션이 아니다). 링크가 걸리는 건 목 경로뿐이다.
+   */
   parentTeamActionHref: string | null;
-  topics: MeetingTopic[];
+  /** 안건 — `null`이면 보여줄 안건이 없다(미배포 BE거나 안건 0건 — 왜인지는 모른다) */
+  agenda: MeetingAgenda | null;
   schedule: string;
   roomName: string;
   attendees: MeetingAttendee[];

--- a/src/features/meeting/view-types.ts
+++ b/src/features/meeting/view-types.ts
@@ -20,9 +20,15 @@ export interface MeetingListItem {
   /**
    * 소속 라벨 — Owner 개설이면 `Owner 개설`(WORKFLOW §2 — 옛 문구 "프로젝트 공통"은 폐기),
    * 팀 액션 회의면 상위 팀 액션 이름이다.
+   *
+   * ⚠️ **빈 문자열이면 "모른다"는 뜻이다.** 실서버 목록(MEET-02)엔 개설자의 권한도 상위 팀
+   *    액션도 안 와서 채울 수 없다 — 카드는 빈 조각을 가운뎃점째 뺀다(§정직성).
    */
   originLabel: string;
-  /** 안건 첫 쌍 요약(`대주제 · 소주제`) — 카드에서 무슨 회의인지 한 줄로 알린다 */
+  /**
+   * 안건 첫 쌍 요약(`대주제 · 소주제`) — 카드에서 무슨 회의인지 한 줄로 알린다.
+   * ⚠️ `originLabel`과 같다 — 실서버 목록엔 안건이 없어 빈 문자열이다.
+   */
   topicSummary: string;
   /** `7월 14일(화) 10:00 – 10:30` — 서버가 우리 표기로 만들어 보낸다(§lib) */
   schedule: string;
@@ -116,10 +122,21 @@ export interface MeetingDetail {
   schedule: string;
   roomName: string;
   attendees: MeetingAttendee[];
-  /** 산출물 머리말 — Owner 개설이면 `팀 액션`, 팀 액션 회의면 `개인 액션` */
+  /**
+   * 산출물 머리말 — Owner 개설이면 `팀 액션`, 팀 액션 회의면 `개인 액션`.
+   * ⚠️ 실서버 상세(MEET-04)엔 개설자 권한이 없어 둘을 못 가른다 — 그때는 상위어 `액션`이다.
+   */
   outputKindLabel: string;
-  outputs: MeetingOutput[];
-  script: ScriptChunk[];
+  /**
+   * 이 회의가 하달한 액션 — **`null`은 "없다"가 아니라 "아직 안 불러왔다"**이다.
+   *
+   * ⚠️ 두 경우를 가르지 않으면 화면이 거짓말을 한다(§정직성). 빈 배열은 **물어봤는데 없는 것**
+   *    이라 "하달된 액션이 없습니다"라고 말해도 되지만, 실서버 상세는 아직 회의별 액션 조회
+   *    (`GET /api/meetings/{id}/actions`)를 안 붙여서 **묻지도 않았다** — 그 상태를 `null`로 둔다.
+   */
+  outputs: MeetingOutput[] | null;
+  /** 발화 기록 — `outputs`와 같다. `null`은 자막 조회(CAP-12) 미연동이라 안 물어봤다는 뜻이다. */
+  script: ScriptChunk[] | null;
   /** 산출물·발화 기록이 아직 없는 이유 — 다 찼으면 `null` */
   pendingReason: MeetingContentPending | null;
   /**
@@ -145,7 +162,15 @@ export interface MeetingDetail {
  *    `detail.pendingReason`으로 들어간다(2026-08-10 팀 협의).
  */
 export type MeetingDetailResult =
-  { kind: "ok"; detail: MeetingDetail } | { kind: "locked"; title: string } | { kind: "notFound" };
+  | { kind: "ok"; detail: MeetingDetail }
+  /**
+   * 열람 권한 없음.
+   * ⚠️ **제목이 `null`일 수 있다.** BE가 막을 때(403 `MT-011`) 실패 봉투에 회의 제목을 안 싣는다 —
+   *    메타는 공개라 보여도 되는 값이지만 **손에 없는 것을 지어내지 않는다**(§정직성).
+   *    화면이 제목 자리를 다른 말로 채운다.
+   */
+  | { kind: "locked"; title: string | null }
+  | { kind: "notFound" };
 
 /**
  * 캡처 화면이 받는 것 — **Host가 회의를 진행하는 데 필요한 만큼만**(WORKFLOW §3-3).

--- a/src/features/profile/components/stalled-summary-list.tsx
+++ b/src/features/profile/components/stalled-summary-list.tsx
@@ -30,12 +30,34 @@ export function StalledSummaryList({ summaries }: StalledSummaryListProps) {
            다른 회의도 같이 못 누른다.
       */
       try {
-        await retryMeetingSummaryAction(meetingId);
-        toast("재분석을 요청했습니다");
+        const result = await retryMeetingSummaryAction(meetingId);
+
+        /*
+          ⚠️ **결과 네 갈래를 한 문구로 뭉치지 않는다**(ANLZ-02, 2026-08-13 연동).
+             ① 재개할 계층이 없다(409 `ANLZ-008`) — 이 버튼으로는 끝난 이야기다. "다시
+                시도"라고 하면 몇 번을 눌러도 같은 409를 만난다.
+             ② 그 밖의 실패 — BE 문장을 그대로 띄운다(§lib/api: 문구를 새로 짓지 않는다).
+             ③ 요청은 갔는데 요약이 아직 없다 — 성공으로 알리면 생기지도 않은 요약을
+                보러 가게 된다(§정직성).
+             ④ 진짜로 채워졌다.
+        */
+        if (result.needsFullRerun) {
+          toast.error(result.error ?? "재개할 계층이 없습니다");
+          return;
+        }
+        if (result.error) {
+          toast.error(result.error);
+          return;
+        }
+        if (result.pendingNote) {
+          toast(result.pendingNote);
+          return;
+        }
+        toast.success("재분석을 요청했습니다");
       } catch {
         /*
-          ⚠️ **원인을 단정하지 않는다.** 이 액션은 권한 없음·미연동도 `throw`로 알린다 —
-             "연결하지 못했습니다"는 서버가 멀쩡할 때 거짓말이 된다(§정직성).
+          ⚠️ **원인을 단정하지 않는다.** 여기까지 오는 건 액션이 값으로 못 접은 실패
+             (네트워크·서버 다운 등)뿐이다 — 아는 실패는 전부 위에서 문장을 갖고 온다.
           ⚠️ 토스트는 한 줄(220px)이라 짧게 쓴다(`ui/sonner.tsx`).
         */
         toast.error("재분석을 요청하지 못했습니다");

--- a/src/features/team/components/recent-team-meetings.tsx
+++ b/src/features/team/components/recent-team-meetings.tsx
@@ -1,0 +1,50 @@
+import { CalendarClock } from "lucide-react";
+
+import {
+  type DashboardMeeting,
+  DashboardMeetingItem,
+} from "@/components/common/dashboard-meeting-item";
+import { EmptyState } from "@/components/common/empty-state";
+
+/**
+ * 팀장 대시보드의 «최근 팀 회의» 카드.
+ *
+ * ⚠️ **못 불러온 것과 없는 것을 가른다.** 조회가 넘어졌을 때 빈 목록과 같은 문구를 내면
+ *    화면이 "예정된 팀 회의가 없습니다"라고 **없는 사실을 단정**한다(§정직성) — 다섯 건이
+ *    잡혀 있는 팀장이 없다고 믿고 새 회의를 잡으러 간다. 서버가 `null`로 그 차이를
+ *    넘겨준다(§team/types `meetings`).
+ * ⚠️ 실패 자리에도 **`EmptyState`를 그대로 쓴다** — 앱 전체가 쓰는 빈 상태와 생김새가 같아야
+ *    카드가 반쯤 지어진 것처럼 보이지 않는다(§components/common/empty-state).
+ * ⚠️ 높이를 고정하지 않는다 — 다섯 건이 하드 캡이라 자라 봐야 다섯 줄이다(`lib.ts` 참고).
+ */
+export function RecentTeamMeetings({ meetings }: { meetings: DashboardMeeting[] | null }) {
+  return (
+    <section className="border-border bg-card flex flex-col overflow-hidden rounded-2xl border">
+      <div className="border-border flex shrink-0 items-baseline justify-between gap-3 border-b px-7 pt-6 pb-3">
+        <h2 className="text-[17px] leading-7 font-semibold tracking-[-0.3px]">최근 팀 회의</h2>
+        <span className="text-muted-foreground text-[12px] leading-4">최신 5건</span>
+      </div>
+      {meetings === null ? (
+        <EmptyState
+          className="flex-1"
+          icon={CalendarClock}
+          title="최근 팀 회의를 불러오지 못했습니다."
+          description="잠시 뒤 새로고침해 주세요. 회의가 없는 것이 아니라 지금 목록을 받아오지 못한 것입니다."
+        />
+      ) : meetings.length === 0 ? (
+        <EmptyState
+          className="flex-1"
+          icon={CalendarClock}
+          title="예정된 팀 회의가 없습니다."
+          description="회의실을 예약하면 그 자리에서 회의가 열립니다."
+        />
+      ) : (
+        <ul>
+          {meetings.map((meeting, index) => (
+            <DashboardMeetingItem key={meeting.id} meeting={meeting} showDivider={index > 0} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/features/team/server.test.ts
+++ b/src/features/team/server.test.ts
@@ -1,0 +1,88 @@
+/**
+ * 팀 대시보드 조회 — **회의 실패가 KPI·팀원 현황을 물고 가지 않아야 한다**(코드래빗 지적, 2026-08-13).
+ *
+ * ⚠️ 예전엔 셋을 같은 `Promise.all`에 실어서 회의 API 하나가 500을 뱉으면 화면이
+ *    통째로 `error.tsx`로 사라졌다 — 팀장이 오는 이유는 액션 수와 팀원 현황이라
+ *    곁 카드가 죽는다고 나머지까지 지울 이유가 없다. 실패 자리는 `null`로 온다(§types).
+ */
+jest.mock("@/mocks/config", () => ({ isMock: false }));
+jest.mock("@/features/auth/session", () => ({ requireAccessToken: jest.fn() }));
+jest.mock("@/lib/api", () => ({ serverApi: jest.fn() }));
+
+import { requireAccessToken } from "@/features/auth/session";
+import { serverApi } from "@/lib/api";
+
+import { getTeamDashboardOverview } from "./server";
+
+const requireAccessTokenMock = requireAccessToken as unknown as jest.Mock;
+const serverApiMock = serverApi as unknown as jest.Mock;
+
+const SUMMARY = {
+  teamActionCount: 3,
+  teamMemberActionCount: 5,
+  myActionCount: 2,
+  completedActionCount: 7,
+};
+
+const MEMBERS = [
+  {
+    memberId: 11,
+    name: "김서준",
+    positionName: "매니저",
+    roleName: null,
+    status: "ACTIVE",
+    actionCount: 2,
+  },
+];
+
+beforeEach(() => {
+  requireAccessTokenMock.mockReset();
+  serverApiMock.mockReset();
+  requireAccessTokenMock.mockResolvedValue("token");
+});
+
+/**
+ * `serverApi` 호출 순서는 `Promise.all`에 실린 순서(요약 → 팀원 → 회의)로 고정돼 있다.
+ * 회의만 실패시키기 위해 순서로 짜맞춘다.
+ */
+function stubApi({ meetingsFail }: { meetingsFail: boolean }) {
+  serverApiMock
+    .mockResolvedValueOnce(SUMMARY)
+    .mockResolvedValueOnce(MEMBERS)
+    .mockImplementationOnce(() =>
+      meetingsFail
+        ? Promise.reject(new Error("MEET-02 down"))
+        : Promise.resolve({
+            meetings: [],
+            page: { page: 0, size: 5, totalElements: 0, totalPages: 0 },
+          }),
+    );
+}
+
+describe("getTeamDashboardOverview — 회의 실패 격리", () => {
+  it("회의 조회가 넘어져도 KPI·팀원 현황은 살리고 회의 자리만 null로 넘긴다", async () => {
+    stubApi({ meetingsFail: true });
+
+    const overview = await getTeamDashboardOverview({ teamId: 3, teamName: "개발팀" });
+
+    expect(overview.teamActionCount).toBe(3);
+    expect(overview.members).toHaveLength(1);
+    /* ⚠️ null이 "미조회"의 표식이다 — 빈 배열로 뭉치면 화면이 "예정된 회의가 없다"고 거짓말을 한다 */
+    expect(overview.meetings).toBeNull();
+  });
+
+  /*
+    ⚠️ **팀이 없는 팀장은 여기까지 온다** — 화면 가드(`canAccessTeamScope`)가 LEADER만 보므로,
+       `teamId`가 없으면 BE 403(`scope=team` 검증)이 떨어져 위와 같은 실패로 이어진다.
+       회의 요청 자체를 안 보내고 `[]`로 답한다 — 팀이 없으면 팀 회의도 정말로 없다.
+  */
+  it("teamId가 없으면 회의 요청을 아예 안 보낸다 — 받을 수 없는 걸 묻지 않는다", async () => {
+    /* 요약·팀원 둘만 부른다(회의는 스킵) */
+    serverApiMock.mockResolvedValueOnce(SUMMARY).mockResolvedValueOnce(MEMBERS);
+
+    const overview = await getTeamDashboardOverview({ teamId: undefined });
+
+    expect(serverApiMock).toHaveBeenCalledTimes(2);
+    expect(overview.meetings).toEqual([]);
+  });
+});

--- a/src/features/team/server.ts
+++ b/src/features/team/server.ts
@@ -1,5 +1,6 @@
 import type { MemberStatus } from "@/constants/domain";
 import { requireAccessToken } from "@/features/auth/session";
+import { parseDashboardMeetings, toDashboardMeetingCard } from "@/features/meeting/mapper";
 import { serverApi } from "@/lib/api";
 import { ep } from "@/lib/endpoints";
 import { isMock } from "@/mocks/config";
@@ -51,9 +52,20 @@ export async function getTeamDashboardOverview(viewer: {
   }
 
   const accessToken = await requireAccessToken();
-  const [summary, members] = await Promise.all([
+  /*
+    ⚠️ **`scope=team`은 LEADER만**이고 토큰에 `teamId`가 있어야 한다(아니면 403·Z-001,
+       BE `DashboardMeetingQueryService.validateRoleScope`) — 이 함수는 팀장 대시보드
+       (`/team`)에서만 불리므로 그 조건이 라우트 가드로 이미 보장된다.
+    ⚠️ 자르는 수는 **화면이 정한다**(`MEETING_MAX_ITEMS`). 박스 높이가 이 수에서 나오므로
+       서버가 더 주면 스크롤이 생기고, 덜 주면 카드 바닥이 빈다(§team/lib).
+    ⚠️ 셋을 같이 부른다 — 차례로 부르면 대시보드가 세 번 기다린다.
+  */
+  const [summary, members, meetings] = await Promise.all([
     serverApi<BeTeamDashboardSummary>(ep.teamDashboardSummary(), { accessToken }),
     serverApi<BeTeamMemberStatus[]>(ep.teamMembers(), { accessToken }),
+    serverApi<unknown>(ep.meetingsDashboard({ scope: "team", limit: MEETING_MAX_ITEMS }), {
+      accessToken,
+    }),
   ]);
 
   return {
@@ -63,8 +75,12 @@ export async function getTeamDashboardOverview(viewer: {
     myActionCount: summary.myActionCount,
     doneActionCount: summary.completedActionCount,
     members: members.map(toTeamDashboardMember),
-    // ⚠️ 최근 팀 회의 API가 아직 BE에 없다(모성진에게 scope=team 요청함, 2026-08-12) —
-    //    지어내지 않고 빈 배열로 둔다(§정직성). API 도착하면 이 자리만 고친다.
-    meetings: [],
+    /*
+      ⚠️ **정렬은 서버 것을 그대로 쓴다**(MEET-17이 최근 순을 보장한다 — BE 저장소 계약).
+         목 경로처럼 여기서 다시 정렬하면 서버가 고른 5건과 우리가 세운 차례가 어긋난다.
+      ⚠️ `originLabel`은 `scope=team`에서 **항상 비어 온다**(명세에 정의가 없다고 BE가
+         `null`로 둔다) — 매퍼가 키째로 빼고 화면은 그 배지를 안 그린다(§정직성).
+    */
+    meetings: parseDashboardMeetings(meetings).map(toDashboardMeetingCard),
   };
 }

--- a/src/features/team/server.ts
+++ b/src/features/team/server.ts
@@ -38,7 +38,37 @@ function toTeamDashboardMember(be: BeTeamMemberStatus): TeamDashboardMember {
   };
 }
 
+/**
+ * 최근 팀 회의 — **못 받아 와도 대시보드를 죽이지 않는다**(2026-08-13, 코드래빗 지적).
+ *
+ * ⚠️ KPI·팀원 현황과 같은 `Promise.all`에 그대로 실으면 **회의 조회 하나가 넘어질 때 화면
+ *    전체가 `error.tsx`로 사라진다** — 이 카드는 대시보드의 곁 정보이고, 팀장이 보러 오는 건
+ *    액션 수와 팀원 현황이다.
+ * ⚠️ **`scope=team`은 토큰에 `teamId`가 있어야 통과한다**(403 Z-001, BE
+ *    `DashboardMeetingQueryService.validateRoleScope`). 화면 가드(`canAccessTeamScope`)는
+ *    LEADER인지만 보므로 **팀이 없는 팀장은 여기까지 온다** — 받을 수 없는 걸 물어보지 않는다.
+ * ⚠️ 못 받아 온 자리는 **빈 목록**이다. 화면 계약에 "미조회"를 새로 만들지 않는다 —
+ *    이 카드에는 빈 상태 문구가 이미 있다.
+ */
+async function listRecentTeamMeetings(
+  teamId: number | undefined,
+  accessToken: string,
+): Promise<TeamDashboardOverview["meetings"]> {
+  if (teamId === undefined) return [];
+
+  try {
+    const raw = await serverApi<unknown>(
+      ep.meetingsDashboard({ scope: "team", limit: MEETING_MAX_ITEMS }),
+      { accessToken },
+    );
+    return parseDashboardMeetings(raw).map(toDashboardMeetingCard);
+  } catch {
+    return [];
+  }
+}
+
 export async function getTeamDashboardOverview(viewer: {
+  teamId?: number;
   teamName?: string;
 }): Promise<TeamDashboardOverview> {
   if (isMock) {
@@ -53,19 +83,16 @@ export async function getTeamDashboardOverview(viewer: {
 
   const accessToken = await requireAccessToken();
   /*
-    ⚠️ **`scope=team`은 LEADER만**이고 토큰에 `teamId`가 있어야 한다(아니면 403·Z-001,
-       BE `DashboardMeetingQueryService.validateRoleScope`) — 이 함수는 팀장 대시보드
-       (`/team`)에서만 불리므로 그 조건이 라우트 가드로 이미 보장된다.
     ⚠️ 자르는 수는 **화면이 정한다**(`MEETING_MAX_ITEMS`). 박스 높이가 이 수에서 나오므로
        서버가 더 주면 스크롤이 생기고, 덜 주면 카드 바닥이 빈다(§team/lib).
     ⚠️ 셋을 같이 부른다 — 차례로 부르면 대시보드가 세 번 기다린다.
+    ⚠️ **회의만 실패를 삼킨다**(`listRecentTeamMeetings`). KPI·팀원 현황이 없으면 이 화면은
+       할 말이 없지만, 곁 카드 하나 때문에 나머지까지 지울 이유는 없다.
   */
   const [summary, members, meetings] = await Promise.all([
     serverApi<BeTeamDashboardSummary>(ep.teamDashboardSummary(), { accessToken }),
     serverApi<BeTeamMemberStatus[]>(ep.teamMembers(), { accessToken }),
-    serverApi<unknown>(ep.meetingsDashboard({ scope: "team", limit: MEETING_MAX_ITEMS }), {
-      accessToken,
-    }),
+    listRecentTeamMeetings(viewer.teamId, accessToken),
   ]);
 
   return {
@@ -81,6 +108,6 @@ export async function getTeamDashboardOverview(viewer: {
       ⚠️ `originLabel`은 `scope=team`에서 **항상 비어 온다**(명세에 정의가 없다고 BE가
          `null`로 둔다) — 매퍼가 키째로 빼고 화면은 그 배지를 안 그린다(§정직성).
     */
-    meetings: parseDashboardMeetings(meetings).map(toDashboardMeetingCard),
+    meetings,
   };
 }

--- a/src/features/team/server.ts
+++ b/src/features/team/server.ts
@@ -47,8 +47,12 @@ function toTeamDashboardMember(be: BeTeamMemberStatus): TeamDashboardMember {
  * ⚠️ **`scope=team`은 토큰에 `teamId`가 있어야 통과한다**(403 Z-001, BE
  *    `DashboardMeetingQueryService.validateRoleScope`). 화면 가드(`canAccessTeamScope`)는
  *    LEADER인지만 보므로 **팀이 없는 팀장은 여기까지 온다** — 받을 수 없는 걸 물어보지 않는다.
- * ⚠️ 못 받아 온 자리는 **빈 목록**이다. 화면 계약에 "미조회"를 새로 만들지 않는다 —
- *    이 카드에는 빈 상태 문구가 이미 있다.
+ * ⚠️ **못 받아 온 자리는 `null`이다 — 빈 목록이 아니다**(2026-08-13 고침). 빈 목록으로
+ *    뭉치면 화면이 "예정된 팀 회의가 없습니다"라고 **없는 사실을 단정**한다(§정직성):
+ *    다섯 건이 잡혀 있는 팀장이 없다고 믿고 새 회의를 잡으러 간다. 화면이 실패를 실패라고
+ *    말할 수 있게 계약에 "미조회"를 연다(§types `meetings`).
+ * ⚠️ 팀이 없는 팀장은 `[]`다 — 그건 실패가 아니라 **정말로 없는 것**이다(팀이 없으면 팀
+ *    회의도 없다). 물어보지 않았을 뿐 답을 아는 경우라 미조회와 섞지 않는다.
  */
 async function listRecentTeamMeetings(
   teamId: number | undefined,
@@ -63,7 +67,12 @@ async function listRecentTeamMeetings(
     );
     return parseDashboardMeetings(raw).map(toDashboardMeetingCard);
   } catch {
-    return [];
+    /*
+      ⚠️ **삼키되 없던 일로 하지 않는다.** 여기서 잡는 건 통신 실패(`ApiError`)만이 아니라
+         `parseDashboardMeetings`의 shape 오류도 마찬가지인데, 둘 다 화면엔 "못 불러왔다"로
+         같은 얼굴이다 — 사라지는 건 대시보드가 아니라 이 카드 하나뿐이다.
+    */
+    return null;
   }
 }
 
@@ -75,7 +84,7 @@ export async function getTeamDashboardOverview(viewer: {
     return {
       ...TEAM_DASHBOARD_MOCK,
       // 최신순(내림차순)으로 위에서부터. 박스가 이 수에 딱 맞춰 그려지므로 서버도 같은 수로 자른다.
-      meetings: [...TEAM_DASHBOARD_MOCK.meetings]
+      meetings: [...(TEAM_DASHBOARD_MOCK.meetings ?? [])]
         .sort((a, b) => new Date(b.scheduledAt).getTime() - new Date(a.scheduledAt).getTime())
         .slice(0, MEETING_MAX_ITEMS),
     };

--- a/src/features/team/types.ts
+++ b/src/features/team/types.ts
@@ -29,6 +29,14 @@ export interface TeamDashboardOverview {
   /** 팀 누적 완료 액션 수 */
   doneActionCount: number;
   members: TeamDashboardMember[];
-  /** 이 팀의 회의만 — 개설 라벨은 부서명(예: "개발팀"). 팀 액션 회의는 여기 안 나온다 */
-  meetings: DashboardMeeting[];
+  /**
+   * 이 팀의 회의만 — 개설 라벨은 부서명(예: "개발팀"). 팀 액션 회의는 여기 안 나온다.
+   *
+   * ⚠️ **빈 배열과 `null`은 다른 말이다**(2026-08-13). `[]`는 "물어봤는데 없다",
+   *    `null`은 **"못 물어봤다"**(조회 실패)다 — 회의 조회가 넘어졌을 때 `[]`로 뭉치면
+   *    화면이 "예정된 팀 회의가 없습니다"라고 **없는 사실을 단정**한다(§정직성). 팀장이
+   *    다섯 건을 두고도 없다고 믿고 새 회의를 잡으러 간다. 회의 상세의 산출물 칸이
+   *    같은 이유로 `outputs`를 `null`로 연다(§meeting/view-types).
+   */
+  meetings: DashboardMeeting[] | null;
 }

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -180,6 +180,23 @@ export const ep = {
   partsStatus: (meetingId: number) => `/api/meetings/${meetingId}/parts/status`,
   /** AI 처리 상태(CAP-06) — 종료 뒤 폴링 */
   processingStatus: (meetingId: number) => `/api/meetings/${meetingId}/processing-status`,
+  /**
+   * 요약 재시도 · 계층 재개(ANLZ-02) — 마이페이지 "요약이 중단된 회의"의 [다시 분석].
+   * [확인] `capture/presentation/api/AnalysisController.java#resumeAnalysis`(2026-08-13).
+   *
+   * ⚠️ **ANLZ-01(`POST /analysis`)과 다르다.** 저쪽은 처음부터 다시 돌려 **재과금**이 나고,
+   *    이쪽은 **실패한 계층부터 이어** 돌려 앞 계층 토큰이 다시 안 나간다.
+   * ⚠️ **본문을 안 보낸다**(`@RequestBody(required = false)`). 화면은 어느 계층이 깨졌는지
+   *    모르고, 알려면 CAP-06을 먼저 부르는 왕복이 생긴다 — 생략하면 **서버가 처음 깨진
+   *    계층을 고른다**(BE `ResumeAnalysisRequest` 주석). 빈 문자열을 보내면 400 `ANLZ-003`이라
+   *    "안 보내는 것"과 "빈 값"이 다르다.
+   * ⚠️ 409 둘을 일반 실패로 뭉치지 않는다 — `ANLZ-008`은 **재개할 계층이 없다**(전부 성공했거나
+   *    한 번도 안 돌았다)는 뜻이라 처음부터(ANLZ-01) 돌려야 하고, `ANLZ-004`는 앞 계층이
+   *    안 끝나 지금은 못 잇는다는 뜻이다.
+   * ⚠️ **200이 성공을 뜻하지 않는다.** 큐가 없어 요청 스레드에서 그대로 돌기 때문에 응답
+   *    `status`에 실제 결과(`DONE`·`FAILED`·`SKIPPED`·`ALREADY_RUNNING`·`SUPERSEDED`)가 실려 온다.
+   */
+  meetingAnalysisRetry: (meetingId: number) => `/api/meetings/${meetingId}/analysis/retry`,
 
   /*
    * AI 액션 분배 검토(RVW) — [확인] BE 실코드 대조(2026-08-12)

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -86,7 +86,24 @@ export const ep = {
    * ⚠️ 파라미터 뜻·주의는 {@link MeetingListParams} — 특히 `from`·`to`를 비우면 예정 회의가 빠진다.
    */
   meetings: (params?: MeetingListParams) => `/api/meetings${toQuery(params)}`,
-  /** 상세(MEET-04) — 캡처 진입도 이걸 쓴다. 없으면 404 `MT-001`, 열람 권한 없으면 403 `MT-011` */
+  /**
+   * 한 회의의 세 갈래가 **같은 경로**를 쓴다 — `GET` 상세(MEET-04, 캡처 진입도 이걸 쓴다) ·
+   * `PATCH` 수정(MEET-05) · `DELETE` 취소(MEET-06). 없으면 404 `MT-001`, 열람 권한 없으면 403 `MT-011`.
+   *
+   * ⚠️ **MEET-05용 `meetingUpdate`를 따로 만들지 않는다.** 경로 문자열이 같은데 함수를 둘로
+   *    두면 BE가 경로를 옮길 때 한쪽만 고쳐진다(§도메인 상수: 값은 한 곳) — 이미 DELETE(MEET-06)가
+   *    같은 자리를 쓰고 있다. 명세 번호로 찾는 사람을 위해 셋을 여기 다 적어 둔다.
+   * ⚠️ **PATCH는 시작 전(`SCHEDULED`) 회의만 받는다.** 진행중·완료·취소는 409 `MT-014`
+   *    ("이미 시작된 회의는 수정·취소할 수 없습니다") — 확정된 캡처 시간축 때문이다.
+   * ⚠️ PATCH 본문은 **보낸 키만** 바뀐다(BE가 `@JsonSetter`로 미전달과 명시적 null을 가른다) —
+   *    `title`·`projectId`·`meetingRoomId`·`startAt`·`endAt`·`recordingConsent` 6개가 대상이고,
+   *    보낸 키에 `null`을 실으면 400이다(필수 컬럼을 지우는 요청으로 본다).
+   * ⚠️ 시간·회의실을 바꾸면 예약 규칙을 다시 탄다 — 30분 그리드(400 `MT-005`)·회의실 운영시간
+   *    (400 `MT-004`)·과거 시각(400 `MT-012`)·중복 예약(409 `MT-002`).
+   *
+   * [확인] `meeting/presentation/api/{MeetingUpdateController,request/UpdateMeetingRequest}.java` ·
+   *   `application/service/MeetingUpdateService.java`(2026-08-13).
+   */
   meeting: (id: number) => `/api/meetings/${id}`,
   /**
    * 대시보드 최근 회의(MEET-17, 구현 완료) — [확인] `meeting/presentation/api/DashboardMeetingController.java`

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -16,6 +16,27 @@ export interface ProjectListParams {
   size?: number;
 }
 
+/**
+ * 회의 목록(MEET-02)이 받는 쿼리 파라미터 — [확인] `meeting/presentation/api/MeetingListController.java`.
+ *
+ * ⚠️ **`from`·`to`를 생략하면 안 된다.** 서버 기본값이 `오늘-3개월 ~ 오늘`이라
+ *    (`MeetingListQueryService.validateAndResolve`) **예정 회의가 통째로 빠진다** — 이 화면의
+ *    첫 탭이 "내가 개설한(예정 포함)"이라 앞쪽을 열어 주지 않으면 빈 목록으로 보인다.
+ * ⚠️ `page`는 **0-base**(CLAUDE.md §목록), `size`는 1~100이고 벗어나면 Z-001로 거절된다.
+ */
+export interface MeetingListParams {
+  projectId?: number;
+  meetingRoomId?: number;
+  /** `YYYY-MM-DD` */
+  from?: string;
+  to?: string;
+  status?: "SCHEDULED" | "IN_PROGRESS" | "DONE" | "CANCELED";
+  /** 두 탭을 가르는 값 — `HOSTED`=내가 개설한 · `ATTENDING`=참여해야 할(host 제외) */
+  scope?: "HOSTED" | "ATTENDING";
+  page?: number;
+  size?: number;
+}
+
 /** 개인 액션 목록만 갖는 `overdue` 필터가 추가된다. */
 export interface ActionListParams extends ProjectListParams {
   overdue?: boolean;
@@ -56,10 +77,29 @@ export const ep = {
    *
    * ⚠️ **`/api/v1/` 접두사는 폐기됐다**(2026-08-12, 커밋 `51b5482f`) — 그 전에 붙였던 v1은
    *    이제 전부 404다. 캡처 전용 조회는 없다 — 캡처 화면도 상세(MEET-04)를 쓴다(§환각 API 방지).
+   *
+   * [확인] 목록(MEET-02)·대시보드(MEET-17) 실코드 재대조(2026-08-13) — `MeetingListController.java`
+   *   `MeetingListResponse.java` · `DashboardMeetingController.java` `DashboardMeetingListResponse.java`.
    */
-  meetings: () => "/api/meetings",
+  /**
+   * 예약 생성(`POST`, MEET-01)과 목록 조회(`GET`, MEET-02)가 같은 경로를 쓴다.
+   * ⚠️ 파라미터 뜻·주의는 {@link MeetingListParams} — 특히 `from`·`to`를 비우면 예정 회의가 빠진다.
+   */
+  meetings: (params?: MeetingListParams) => `/api/meetings${toQuery(params)}`,
   /** 상세(MEET-04) — 캡처 진입도 이걸 쓴다. 없으면 404 `MT-001`, 열람 권한 없으면 403 `MT-011` */
   meeting: (id: number) => `/api/meetings/${id}`,
+  /**
+   * 대시보드 최근 회의(MEET-17, 구현 완료) — [확인] `meeting/presentation/api/DashboardMeetingController.java`
+   * · `application/service/DashboardMeetingQueryService.java`(2026-08-13).
+   *
+   * ⚠️ **`scope`는 필수다**(생략하면 Z-001). 역할로 추론하지 않고 부르는 쪽이 명시한다 —
+   *    `owner`는 OWNER만, `team`은 LEADER만(게다가 토큰에 `teamId`가 있어야 한다), `me`는 전원.
+   *    맞지 않으면 403이라 **역할 가드가 있는 화면에서만** 부른다.
+   * ⚠️ `limit`은 1~20(기본 5). 벗어나면 Z-001이다.
+   * ⚠️ 경로가 `/api/meetings/{meetingId}`와 겹쳐 보이지만 리터럴이 먼저 잡힌다(Spring 매핑 규칙).
+   */
+  meetingsDashboard: (params: { scope: "owner" | "team" | "me"; limit?: number }) =>
+    `/api/meetings/dashboard${toQuery(params)}`,
   /** 내 예정 회의(MEET-03, 구현 완료) — 대시보드 위젯용. `limit` 생략 시 서버 기본값(5, 최대 20). */
   meetingsUpcoming: (params?: { limit?: number }) => `/api/meetings/upcoming${toQuery(params)}`,
   /** 참석자 명단 교체(MEET-09, 구현 완료) — 전체 명단 교체(부분 추가·삭제 아님). */


### PR DESCRIPTION
## 📋 PR 타입

> 해당하는 타입을 선택해 주세요 (복수 선택 가능)

- [x] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [x] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- **회의 목록(MEET-02) 실연동** — `getMeetingDirectory`가 던지던 자리를 `GET /api/meetings`로 잇는다. **두 탭을 서버가 가른다**(`scope=HOSTED`·`ATTENDING`) — 전부 받아 `isHost`로 나누면 같은 회의를 두 번 실어 나르고 페이지가 잘릴 때 한쪽 탭만 조용히 빈다. `isHost`가 없어서 막혀 있던 화면이라(백엔드 요청 §10-A) 이 값이 이번 연동의 핵심이다.
- **기간을 반드시 싣는다** — BE 기본값이 `오늘-3개월 ~ 오늘`이라(`MeetingListQueryService.validateAndResolve`) 생략하면 **예정 회의가 한 건도 안 온다.** 이 화면이 제일 먼저 보여줘야 하는 게 다가올 회의라 앞뒤 3개월로 열었다(`meetingListRange`).
- **회의 상세(MEET-04) 실연동** — `summaryStatus`·`pendingActionCount`를 화면의 «아직 못 보여주는 이유»(`pendingReason`)·«확정 대기 건수»로 옮긴다. 404는 `notFound`, 403(`MT-011`)은 **잠금**으로 값으로 돌린다 — 목록이 전 구성원 공개라 아무나 눌러 들어올 수 있고, 잠금은 에러가 아니다(WORKFLOW §3-2-1).
- **팀 대시보드 «최근 팀 회의»(MEET-17) 실연동** — 늘 빈 배열이던 자리를 `GET /api/meetings/dashboard?scope=team`으로 채운다.
- **정렬을 한 함수로 모았다**(`sortMeetingListItems`) — 목·실서버가 각자 세우면 같은 회의가 경로마다 다른 자리에 서고, 그건 눌러 보는 것만으로는 안 드러난다.
- **못 채우는 칸은 비우고 그 사실을 화면이 말하게 했다**(아래 리뷰 포인트 2·3).

**이어 붙인 두 건 — 같은 파일을 건드려 여기로 모았다** (별도 브랜치면 확정 충돌)

- **회의 수정(MEET-05) 진입점 — Closes #419.** BE에 `PATCH /api/meetings/{id}`가 있는데 FE엔 액션도 화면도 없어서 **잘못 잡은 회의는 취소 후 재개설밖에 길이 없었다.** 상세 머리글에 [회의 수정] 다이얼로그를 둔다(취소 버튼 **왼쪽** — 되돌릴 수 없는 쪽을 오른쪽 끝에 남긴다). **시작 전(`SCHEDULED`) 회의에만** 뜬다 — BE `MeetingUpdateService`가 그 외 상태를 409 `MT-014`로 막는다(확정된 캡처 시간축 때문). 서버가 안 받는 자리에 버튼을 두지 않는다.
- **요약 중단 [다시 분석](ANLZ-02) 실연동 — Closes #410.** `!isMock`이면 던지고 끝나던 자리를 `POST /api/meetings/{id}/analysis/retry`로 잇는다. **실패한 계층부터 이어 돌려 재과금이 없다**(ANLZ-01은 처음부터라 앞 계층 토큰이 다시 나간다). 목록 자체(MEET-15)는 이미 실연동이라 버튼만 남아 있었다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 상세 개설자 판정은 `lib/permission.ts`의 `canOperateMeeting` 한 곳(매퍼는 값이 어디 있는지만 알려 준다). 화면 판정은 UX일 뿐이고 **BE가 `MeetingAccessGuard`로 재검사**해 403이면 잠금으로 받는다. `scope=team`은 LEADER + `teamId`가 있어야 하는 조회라 팀장 대시보드에서만 부른다.
- [ ] 🧬 **zod** — 이 도메인의 매퍼는 손으로 쓴 타입 가드(`parseMeetingDetail`)로 통일돼 있어 같은 방식으로 맞췄다(`parseMeetingList`·`parseDashboardMeetings`). zod 도입은 도메인 전체를 한 번에 옮기는 별도 일이다.
- [x] 🕵️ **정직성** — 못 채우는 칸을 지어내지 않고, **안 물어본 것을 "없다"고 말하지 않게** 화면 문구까지 갈랐다(리뷰 포인트 2·3).
- [x] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨 — 새 색 없음

**품질**

- [x] ⚡ 최적화 — 목록 두 탭·대시보드 세 조회를 각각 `Promise.all`로 묶었다(차례로 부르면 화면이 그만큼 더 기다린다)
- [x] ♿ a11y — 새 인터랙션 없음. 잠금 화면 제목이 빌 수 있어 빈 `h2`가 안 생기게 대체 문구를 넣었다
- [x] ♻️ 재사용 확인 — `EmptyState`·`DashboardMeetingItem` 그대로 쓴다. 매퍼도 `parseMeetingDetail`·`hostIdOf`·`toMeetingCaptureInfo`를 재사용하고 새로 만들지 않았다
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 기존 `loading.tsx`·`error.tsx` 그대로. `empty`는 이번에 **"없음"과 "안 불러옴"으로 갈랐다**
- [x] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음 — 해당 없음(조회 전용)

---

## 🔗 연관 이슈

Closes #430
Closes #419
Closes #410

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

- **① 확인 명령과 결과**

  ```
  npx tsc --noEmit   → 통과(출력 없음)
  npx eslint src     → 통과(출력 없음)
  npx jest           → 93 suites / 1058 tests 통과 (신규 40건)
  npx next build     → 통과
  ```

- **② 목록에 `summaryStatus`가 없어 `aiSummaryStatus`를 `null`로 둔다**(`toMeetingListItem`). 지어내면 완료 카드에 [액션 검토]가 잘못 뜨거나 사라진다. `null`이면 `meetingCardAffordanceOf`가 `review`를 안 내주고 완료 카드는 [회의록]으로만 열린다 — **BE가 목록에 실어 주면 그 한 줄만 고친다.** 같은 이유로 소속 라벨(`originLabel`)·안건(`topicSummary`)도 빈 문자열이고, 카드는 빈 조각을 **가운뎃점째** 뺀다(안 그러면 줄에 `·` 하나만 남는다).

- **③ "없다"와 "안 물어봤다"를 갈랐다** — 상세의 산출물·발화 기록은 다른 API(`GET /api/meetings/{id}/actions` · CAP-12 자막 조회)가 줄 값이라 이 이슈 범위 밖이다. 그렇다고 빈 배열로 두면 화면이 **"하달된 액션이 없습니다"·"남아 있는 발화 기록이 없습니다"라고 단정**한다 — 안 물어본 것을 없다고 말하는 건 §정직성 위반이라 `MeetingDetail.outputs`·`script`를 `null`(=안 불러왔다)로 두고 그 자리에 별도 안내를 띄운다. **여기가 이 PR에서 제일 봐 주셨으면 하는 결정입니다.**

- **④ `summaryStatus === null`을 완료로 읽지 않는다**(`meetingPendingReasonOf`). BE는 그 값을 "끝났지만 `PROCESSING`인지 `DONE`인지 모른다"는 뜻으로 준다(BE `MeetingSummaryStatus` 주석) — 완료로 읽으면 위 ③의 단정이 그대로 나온다. 단 **확정 대기 건수가 있으면 요약은 끝난 것**이라(초안이 나왔다는 증거) 그때는 검토 대기 안내를 띄운다.

- **⑤ 페이지네이션은 이 PR에서 안 만든다.** 회의 목록 화면에 무한 스크롤이 없어(별도 이슈) 한 페이지를 BE 상한인 100건까지 받는다(`MEETING_LIST_PAGE_SIZE`). 그보다 많으면 뒤가 안 보인다 — 스크롤 트리거를 붙일 때 이 상수를 지우고 `page`(0-base)를 이어 붙이면 된다.

- **⑦ [#419] 「회의 수정」인데 제목 한 칸이다.** BE는 `title`·`projectId`·`meetingRoomId`·`startAt`·`endAt`·`recordingConsent` 6개를 부분 수정으로 받지만, 뒤의 다섯은 **예약 슬롯을 다시 잡는 일**이라 30분 그리드(`MT-005`)·회의실 운영시간(`MT-004`)·과거 시각(`MT-012`)·중복 예약(`MT-002`)을 보는 슬롯 피커를 회의실 예약 화면에서 끌어와야 한다 — 반쯤 되는 폼을 먼저 내보내지 않았다. **못 고치는 것은 다이얼로그에 적어 뒀다**("시간·회의실을 바꾸려면 회의를 취소하고 다시 예약해 주세요") — 감추면 사람은 자기가 못 찾는 줄 안다. 나머지 필드는 슬롯 피커 후속 이슈에서 붙입니다.

- **⑧ [#419] `ep.meetingUpdate`를 안 만들었다**(이슈 체크리스트와 다른 부분). 경로가 `ep.meeting(id)`와 **같은 문자열**이라 함수를 둘로 두면 BE가 경로를 옮길 때 한쪽만 고쳐집니다 — 이미 DELETE(MEET-06)가 같은 자리를 쓰고 있어 그 선례를 따랐고, 명세 번호로 찾는 사람을 위해 GET·PATCH·DELETE 셋을 주석에 다 적었습니다. 별도 함수가 낫다고 보시면 말씀해 주세요.

- **⑨ [#419] 권한을 `canOperateMeeting`(host만)이 아니라 `canManageMeeting`(host·OWNER·ADMIN)으로 봤다.** BE `MeetingUpdateService.canManageMeeting`이 정확히 그 범위이고(`elevated || meeting.isHost(...)`), 취소(MEET-06)와도 같은 축이라 맞췄습니다. **화면은 host에게만** 버튼을 보여주고(`canEditMeeting` — 화면 계약에 역할이 없다) 서버가 넓은 쪽으로 다시 검사합니다.

- **⑩ [#410] 200이 성공을 뜻하지 않는다.** ANLZ-02는 큐가 없어 **요청 스레드에서 그대로 돌아** 응답 `status`에 실제 결과가 실려 옵니다(BE `AnalysisResumeResponse` 주석) — 이미 다시 실패한 재시도도 HTTP 200입니다. 다섯 값을 셋으로 접고(`resumed` / `running` / `failedAgain`) **모르는 `status`는 성공으로 안 접습니다** — BE가 값을 늘렸을 때 조용히 "됐습니다"라고 말하면 요약이 없는데 사람이 떠납니다.

- **⑪ [#410] 409 둘을 가른다 — 그리고 코드가 `ANLZ-005`가 아니라 `ANLZ-008`이다.** `ANLZ-008`(재개할 계층 없음)은 **이 버튼으로는 끝난 이야기**라 처음부터(ANLZ-01) 돌려야 하고, `ANLZ-004`(앞 계층 미완)는 나중에 같은 요청이 성립합니다. 일반 실패로 뭉치면 몇 번을 눌러도 같은 409를 만납니다. ⚠️ **번호 주의** — 명세·문서엔 005로 적힌 곳이 있는데 005는 `SUMMARY_ITEM_NOT_FOUND`(404)와 겹쳐 **008로 옮겨졌습니다**(BE `CaptureErrorCode` 주석, CodeRabbit PR #318). 실코드 기준으로 붙였습니다(§연동 검증: 문서와 코드가 다르면 코드가 맞다).

- **⑫ [#410] Host 판정이 우리 몫이다 — BE에 요청드릴 것.** ANLZ-02는 역할(`@PreAuthorize`)과 회사 스코프(`MeetingAccessGuard`)만 보고 **그 회의의 host인지는 안 봅니다**(RVW-05 확정은 보는데 재분석은 안 봅니다). 지금은 host로 스코프된 MEET-15 목록에 그 회의가 있는지를 서버에서 확인하고 부르지만(요청 한 번 더), **BE가 host 검사를 넣어 주시면 그 왕복이 없어집니다.**

- **⑥ 403 처리가 캡처와 다르다.** `getLiveMeetingCapture`는 403을 던지는데, 거기는 **우리가 먼저 판정한 뒤**의 403이라 판정이 틀렸다는 신호다. 상세는 조회 전에 판정할 값(개설 팀·참석자)을 갖고 있지 않아 403이 곧 잠금이다 — 이유를 주석에 적어 뒀는데 판단이 갈리면 말씀해 주세요.

---

## 📝 추가 메모

**BE에 요청드릴 것 — 이 PR에서 못 채운 칸**

1. **회의 목록(MEET-02)에 `summaryStatus`** — 지금은 목록만으로 Host의 [액션 검토] 노출을 판정할 수 없어 완료 카드가 전부 [회의록]으로만 열립니다.
2. **회의 목록에 소속 라벨과 안건** — 카드 둘째 줄(`Owner 개설 · 대주제 · 소주제`)이 통째로 빕니다. MEET-17 대시보드 응답에는 `originLabel`이 있는데 목록에는 없습니다.
3. **회의 상세(MEET-04)에 안건(agenda)** — 예약 때 입력받는 값인데 상세로 안 나와서 «안건» 칸이 빕니다.
4. **회의 상세에 개설자의 권한/상위 팀 액션** — `host{memberId,name}`뿐이라 «Owner 개설 / 상위 팀 액션» 라벨도, 산출물 머리말의 «팀 액션 / 개인 액션» 구분도 못 만듭니다(지금은 상위어 `액션`).
5. **403 실패 봉투에 회의 제목** — 잠금 화면이 제목을 못 보여줍니다. 메타는 §3-2-1이 전 구성원 공개라고 못박은 값이라 실어 주셔도 되는 값으로 보입니다.
6. **MEET-17 `scope=team`의 `originLabel`·`hostLabel`** — 둘 다 항상 `null`로 옵니다(BE 서비스 주석에 사유 기재됨). 화면은 없으면 배지를 안 그립니다.

**후속 이슈로 뺄 것(우리 몫)**

- 회의 목록 무한 스크롤(CLAUDE.md §목록) — 이번엔 한 페이지만 받는다
- 상세 산출물 연동(`GET /api/meetings/{id}/actions`) · 발화 기록 연동(CAP-12)
- 회의 수정(#419)의 시간·회의실·프로젝트·녹음 동의 — 예약 슬롯 피커를 끌어온 뒤



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 회의 제목을 수정하고 저장할 수 있는 편집 다이얼로그를 추가했습니다.
  * 회의 목록·상세 정보와 팀 대시보드가 실제 데이터와 연동됩니다.
  * 실패한 회의 요약을 재시도하고 결과별 안내를 확인할 수 있습니다.
  * 회의 상태와 권한에 따라 수정 가능 여부를 적용했습니다.

* **개선**
  * 잠긴 회의에 제목이 없을 때 안내 문구를 표시합니다.
  * 미조회된 액션·발화 기록을 “없음”과 구분해 안내합니다.
  * 회의 카드의 불필요한 구분점 표시를 정리했습니다.
  * 회의 목록 정렬과 제목 입력 검증을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->