### PR TITLE
[FEAT] 팀 액션 하위 진척 게이지 #421

### DIFF
--- a/src/features/action/components/team-action-list-view.tsx
+++ b/src/features/action/components/team-action-list-view.tsx
@@ -43,6 +43,14 @@ function toTimelineItems(
     dueDate: action.dueDate,
     tone: isDelayed(action) ? "DELAYED" : action.status,
     href: `/app/projects/${group.projectId}/team/${action.id}`,
+    /*
+      하위 개인 액션 진척(`3/5`) — BE가 이미 주는 값이라 그대로 넘긴다(#355 · 매퍼 수신 #416).
+      ⚠️ `null`을 `0`으로 바꾸지 않는다. 계약상 `null`은 "하위 개념 자체가 없음"이고
+         `0/0`은 "하위가 아직 비어 있음"이라 뜻이 갈린다 — 여기서 뭉개면 타임라인이
+         없는 사실을 지어낸다(DESIGN §9 — 화면은 사실만 말한다).
+    */
+    childDoneCount: action.childDoneCount,
+    childTotalCount: action.childTotalCount,
   }));
 }
 

--- a/src/features/action/server.ts
+++ b/src/features/action/server.ts
@@ -1,3 +1,4 @@
+import { ACTION_STATUS } from "@/constants/domain";
 import { requireAccessToken } from "@/features/auth/session";
 import type { BePageResponse } from "@/features/project/mapper";
 import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
@@ -154,12 +155,21 @@ export async function getTeamActionsPage(
         if (action.team !== MOCK_LEADER_TEAM) continue;
         if (seen.has(action.id)) continue;
         seen.add(action.id);
+        /*
+          하위 개인 액션 진척 — 목도 **같은 데이터에서 센다**(BE `childDoneCount`·`childTotalCount`,
+          #355). 상수를 박으면 상세 탭의 하위 목록과 숫자가 어긋나 목이 거짓말을 한다(§정직한 목업).
+          ⚠️ 목에 하위가 아예 안 잡힌 팀 액션은 `0/0`이다 — `null`이 아니다. 팀 액션은 하위를
+             가질 수 있는 개념이고, `null`은 "하위 개념 자체가 없음"을 뜻한다(#421 판정 참고).
+        */
+        const children = TEAM_ACTION_PERSONAL_ITEMS_MOCK[action.id] ?? [];
         list.push({
           id: action.id,
           name: action.name,
           startDate: action.startDate,
           dueDate: action.dueDate,
           status: action.status,
+          childDoneCount: children.filter((child) => child.status === ACTION_STATUS.DONE).length,
+          childTotalCount: children.length,
           projectId: project.id,
           projectName: project.name,
           projectTag: project.tag,

--- a/src/features/member/action-timeline.ts
+++ b/src/features/member/action-timeline.ts
@@ -35,6 +35,14 @@ export interface TimelineActionInput {
   tone: StatusTone;
   /** 클릭 시 이동할 상세 경로. 상세 라우트가 아직 없으면 비워서 클릭 불가로 둔다. */
   href?: string;
+  /**
+   * 하위 액션 진척(`3/5`) — **`null`·필드 없음과 `0/0`은 뜻이 다르다**(BE #355, #421).
+   * `null`(또는 아예 안 넘김) = 하위라는 개념 자체가 없는 줄(개인 액션·인수인계 등),
+   * `0/0` = 하위를 가질 수 있는데 아직 비어 있음.
+   * ⚠️ 이 계층은 **값을 나르기만 한다** — 그릴지 말지는 컴포넌트(`hasChildProgress`)가 정한다.
+   */
+  childDoneCount?: number | null;
+  childTotalCount?: number | null;
 }
 
 /** 축의 하루 칸. */

--- a/src/features/member/components/action-timeline.test.tsx
+++ b/src/features/member/components/action-timeline.test.tsx
@@ -71,4 +71,24 @@ describe("ActionTimeline — 하위 진척", () => {
 
     expect(screen.queryByRole("link", { name: /하위 액션/ })).not.toBeInTheDocument();
   });
+
+  /*
+    ⚠️ 상세 라우트가 없는 행(인수인계 보드·팀 액션 상세)은 `div`로 그려진다. 맨 `div`는
+       암묵 역할이 `generic`이라 `aria-label`이 이름으로 안 나가서, 막대(`aria-hidden`)까지
+       더하면 이 줄만 통째로 안 들렸다 — `role="group"`으로 이름을 되살린다.
+  */
+  it("href 없는 행도 하위 진척을 행 이름으로 전한다", () => {
+    render(
+      <ActionTimeline
+        items={[buildItem({ href: undefined, childDoneCount: 2, childTotalCount: 4 })]}
+        today={TODAY}
+      />,
+    );
+
+    const row = screen.getByRole("group", { name: /하위 액션 4개 중 2개 완료/ });
+    expect(row).toHaveTextContent("2/4");
+    /* 이름이 살아 있으니 상태·D-day·기간도 같이 들린다(막대는 aria-hidden이다) */
+    expect(row).toHaveAccessibleName(/진행중/);
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
 });

--- a/src/features/member/components/action-timeline.test.tsx
+++ b/src/features/member/components/action-timeline.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react";
+
+import type { TimelineActionInput } from "../action-timeline";
+import { ActionTimeline } from "./action-timeline";
+
+/** 2026-08-05는 수요일 — 축 계산 테스트(`action-timeline.test.ts`)와 같은 고정 오늘을 쓴다. */
+const TODAY = new Date("2026-08-05T00:00:00");
+
+function buildItem(overrides: Partial<TimelineActionInput> = {}): TimelineActionInput {
+  return {
+    id: "t1",
+    title: "앱 개발 착수",
+    tag: "GOODS",
+    tagBgColor: "var(--tag-purple-bg)",
+    tagTextColor: "var(--tag-purple-fg)",
+    startDate: "2026-08-01",
+    dueDate: "2026-08-20",
+    tone: "IN_PROGRESS",
+    href: "/app/projects/1/team/1",
+    ...overrides,
+  };
+}
+
+/*
+  하위 진척 게이지(#421). ⚠️ 여기서 갈리는 건 **`null`과 `0/0`이 다른 뜻**이라는 것이다
+  (BE #355) — `null`은 하위 개념 자체가 없는 줄이라 안 그리고, `0/0`은 하위가 비어 있는
+  팀 액션이라 그린다. 둘을 뭉개면 "아직 안 쪼갠 팀 액션"이 화면에서 사라진다.
+*/
+describe("ActionTimeline — 하위 진척", () => {
+  it("하위 진척 값이 있으면 3/5로 그리고 행 이름에도 실어 보낸다", () => {
+    render(
+      <ActionTimeline
+        items={[buildItem({ childDoneCount: 3, childTotalCount: 5 })]}
+        today={TODAY}
+      />,
+    );
+
+    /* ⚠️ 날짜 축에도 맨숫자가 깔려 있어 `getByText("3")`은 여러 개를 문다 — 행 안에서 본다 */
+    const row = screen.getByRole("link", { name: /하위 액션 5개 중 3개 완료/ });
+    /* 행이 Link면 aria-label이 안쪽 글자를 덮는다 — 숫자가 이름에도 있어야 들린다(§a11y) */
+    expect(row).toHaveTextContent("3/5");
+  });
+
+  it("0/0은 하위가 비어 있다는 사실이라 그대로 그린다", () => {
+    render(
+      <ActionTimeline
+        items={[buildItem({ childDoneCount: 0, childTotalCount: 0 })]}
+        today={TODAY}
+      />,
+    );
+
+    const row = screen.getByRole("link", { name: /하위 액션 0개 중 0개 완료/ });
+    expect(row).toHaveTextContent("0/0");
+  });
+
+  it("null은 하위 개념 자체가 없는 줄이라 아무것도 안 그린다", () => {
+    render(
+      <ActionTimeline
+        items={[buildItem({ childDoneCount: null, childTotalCount: null })]}
+        today={TODAY}
+      />,
+    );
+
+    const row = screen.getByRole("link", { name: /앱 개발 착수/ });
+    expect(row).not.toHaveTextContent("0/0");
+    expect(screen.queryByRole("link", { name: /하위 액션/ })).not.toBeInTheDocument();
+  });
+
+  it("값을 아예 안 넘기는 화면(개인 액션·인수인계)도 조용하다", () => {
+    render(<ActionTimeline items={[buildItem()]} today={TODAY} />);
+
+    expect(screen.queryByRole("link", { name: /하위 액션/ })).not.toBeInTheDocument();
+  });
+});

--- a/src/features/member/components/action-timeline.tsx
+++ b/src/features/member/components/action-timeline.tsx
@@ -79,8 +79,54 @@ function barClassName(tone: StatusTone): string {
   );
 }
 
+/**
+ * 하위 진척을 그릴 줄인지 판정 — **`null`과 `0/0`은 다른 뜻이다**(BE #355 주석, #421).
+ *
+ * - `null` / 필드 없음 = **하위라는 개념 자체가 없는 줄**(개인 액션·인수인계 보드 등)
+ *   → 아무것도 안 그린다. 이 타임라인은 여러 화면이 같이 쓰는데, 팀 액션 말고는
+ *   값을 안 넘기므로 그쪽은 자동으로 조용하다.
+ * - `0/0` = **하위를 가질 수 있는데 아직 비어 있음**(아직 안 쪼갠 팀 액션) → `0/0`으로 그린다.
+ *
+ * ⚠️ 둘을 `!count`로 한데 묶어 거르면 "아직 안 쪼갠 팀 액션"이 "하위가 없는 줄"처럼
+ *    사라져 화면이 사실을 덜 말하게 된다(DESIGN §9 — 화면은 사실만 말한다).
+ * ⚠️ `0/0`에 `없음` 같은 말을 따로 붙이지 않는다. 문구를 만들면 **안 그리는 `null`과
+ *    화면에서 구분이 안 되고**, 숫자 자리에 글자가 섞여 줄 폭도 흔들린다.
+ */
+function hasChildProgress(
+  bar: TimelineBar,
+): bar is TimelineBar & { childDoneCount: number; childTotalCount: number } {
+  return typeof bar.childDoneCount === "number" && typeof bar.childTotalCount === "number";
+}
+
 function barAriaLabel(bar: TimelineBar): string {
-  return `${bar.title}, ${bar.tag}, ${TONE_LABEL[bar.tone]}, ${bar.ddayLabel}, ${bar.periodLabel}`;
+  const base = `${bar.title}, ${bar.tag}, ${TONE_LABEL[bar.tone]}, ${bar.ddayLabel}, ${bar.periodLabel}`;
+  /*
+    ⚠️ 행이 `Link`면 `aria-label`이 **안쪽 글자를 통째로 덮는다** — 진척 숫자를 span으로만
+       두면 스크린리더는 영영 못 듣는다. 뜻을 폭·명도에 담지 않고 여기에도 적는다(§a11y).
+  */
+  return hasChildProgress(bar)
+    ? `${base}, 하위 액션 ${bar.childTotalCount}개 중 ${bar.childDoneCount}개 완료`
+    : base;
+}
+
+/**
+ * 하위 개인 액션 진척 — **막대가 아니라 숫자다**(`3/5`).
+ *
+ * ⚠️ 왼쪽 열은 200px(`LABEL_COL_PX`)뿐인데 점·액션명·태그 칩이 이미 서 있다. 막대를 더
+ *    얹으면 액션명 자리가 50px대로 눌려 정작 무슨 액션인지가 안 읽힌다. 행 높이(44px)를
+ *    안 늘리기로 했으니 아래로 쌓을 수도 없다 — DESIGN §10이 "얼마나 찼나"에 막대를
+ *    허용하긴 하지만, **이 칸이 그걸 감당 못 한다**. 숫자는 20px 남짓이고 값 자체가 정확하다.
+ * ⚠️ 색을 안 쓴다 — 완료 수만 `foreground`, 나머지는 `muted-foreground`로 **명도**가 가른다
+ *    (DESIGN §5: 색으로 알리는 건 에러뿐 / §10: 조각은 색이 아니라 명도로).
+ * ⚠️ 숫자라 `tabular-nums`다(DESIGN §4) — 없으면 `9/10`으로 넘어갈 때 칩이 좌우로 흔들린다.
+ */
+function ChildProgress({ done, total }: { done: number; total: number }) {
+  return (
+    <span className="shrink-0 text-[11px] leading-4 tabular-nums">
+      <span className="text-foreground font-semibold">{done}</span>
+      <span className="text-muted-foreground">/{total}</span>
+    </span>
+  );
 }
 
 /** 마감 지점 캡 — Link·div 양쪽에서 같이 쓴다. */
@@ -101,8 +147,17 @@ function dayToneClass(day: TimelineDay): string {
   return "text-muted-foreground";
 }
 
-/** 왼쪽 아이템 열 폭 — 축 머리·그리드·행이 같은 값을 공유한다. 스크롤 중에도 고정(sticky). */
-const LABEL_COL_PX = 200;
+/**
+ * 왼쪽 아이템 열 폭 — 축 머리·그리드·행이 같은 값을 공유한다. 스크롤 중에도 고정(sticky).
+ *
+ * ⚠️ **200 → 224로 넓혔다**(#421). 하위 진척(`3/5`)이 칩 뒤에 붙으면서 200px에서는 액션명
+ *    자리가 72px밖에 안 남아 `협업툴 리뉴얼 착수`가 `협업툴 리뉴...`로 잘렸다 — 이 열의
+ *    요점은 **무슨 액션인지**라, 보조 숫자를 넣겠다고 이름을 깎으면 앞뒤가 바뀐다.
+ *    24px(8의 배수)면 목의 액션명이 전부 들어간다. 타임라인 쪽은 어차피 가로 스크롤이라
+ *    잃는 게 없고, 이 열을 함께 쓰는 다른 화면(대시보드·프로젝트 상세·인수인계 보드)도
+ *    이름이 더 보일 뿐 손해가 없다.
+ */
+const LABEL_COL_PX = 224;
 const LABEL_COL_STYLE = { width: LABEL_COL_PX, minWidth: LABEL_COL_PX };
 /** 행 높이(px) — 그리드 오버레이 높이 계산에 쓴다(행 수 × 이 값). */
 const ROW_HEIGHT_PX = 44;
@@ -239,6 +294,14 @@ export function ActionTimeline({
                   >
                     {bar.tag}
                   </span>
+                  {/*
+                    하위 진척은 **칩 뒤 맨 끝**에 붙인다 — 줄마다 같은 자리에 서야 여러 줄을
+                    세로로 훑을 때 눈이 안 흔들린다. 없는 줄은 그 자리가 비고, 액션명이
+                    그만큼 더 보인다(자리를 비워 두지 않는다 — 빈 칸을 남기면 200px이 더 준다).
+                  */}
+                  {hasChildProgress(bar) ? (
+                    <ChildProgress done={bar.childDoneCount} total={bar.childTotalCount} />
+                  ) : null}
                 </div>
 
                 {/* 우: 기간 바 */}

--- a/src/features/member/components/action-timeline.tsx
+++ b/src/features/member/components/action-timeline.tsx
@@ -324,7 +324,14 @@ export function ActionTimeline({
               bar.href && "transition-colors hover:bg-foreground/[0.03]",
             );
 
-            // ⚠️ 상세 라우트가 없으면(`href` 없음) 클릭 안 되는 행으로만 표시
+            /*
+              ⚠️ 상세 라우트가 없으면(`href` 없음) 클릭 안 되는 행으로만 표시한다.
+              ⚠️ 이때도 `role="group"`을 준다 — 맨 `div`는 암묵 역할이 `generic`이라
+                 **`aria-label`이 접근 가능한 이름으로 안 나간다**(ARIA: generic은 이름을
+                 못 가진다). 막대는 `aria-hidden`이라, 이름이 날아가면 상태·D-day·기간·하위
+                 진척이 스크린리더에 통째로 안 들린다 — 링크 행은 들리고 이 행만 안 들리면
+                 같은 표가 줄마다 다른 말을 한다(§a11y).
+            */
             return bar.href ? (
               <Link
                 key={bar.id}
@@ -338,6 +345,7 @@ export function ActionTimeline({
             ) : (
               <div
                 key={bar.id}
+                role="group"
                 aria-label={barAriaLabel(bar)}
                 className={rowClassName}
                 style={{ height: ROW_HEIGHT_PX }}


### PR DESCRIPTION
## 📋 PR 타입

> 해당하는 타입을 선택해 주세요 (복수 선택 가능)

- [x] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [x] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [x] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- **팀 액션 관리(`/team/action`) 타임라인 각 줄에 하위 개인 액션 진척(`3/5`)을 붙였다.** BE가 `childDoneCount`·`childTotalCount`를 이미 주고(#355) 매퍼도 이미 받고 있었는데(#416) 화면에만 안 나오고 있었다 — 팀장이 팀 액션이 얼마나 쪼개져 얼마나 끝났는지를 목록에서 못 봤다.
- **`null`과 `0/0`을 갈랐다.** BE 계약대로 `null`(·필드 없음)은 "하위라는 개념 자체가 없는 줄"이라 **아무것도 안 그리고**, `0/0`은 "하위를 가질 수 있는데 아직 비어 있음"이라 **`0/0`으로 그린다**. 판정은 `hasChildProgress()` 한 곳(타입 가드)에 모았다. 둘을 `!count`로 뭉개면 *아직 안 쪼갠 팀 액션*이 *하위가 없는 줄*처럼 화면에서 사라진다(DESIGN §9 — 화면은 사실만 말한다).
- **막대가 아니라 숫자로 그렸다.** 왼쪽 아이템 열은 점·액션명·태그 칩이 이미 서 있어 막대를 더 얹으면 액션명 자리가 사라진다. 행 높이(44px)는 그대로 두고 숫자만 칩 뒤에 붙였다.
- **색을 안 쓴다.** 완료 수만 `foreground`, `/전체`는 `muted-foreground` — **명도**가 가른다(DESIGN §5: 색으로 알리는 건 에러뿐 / §10: 조각은 색이 아니라 명도로). 새 토큰·새 색은 없다.
- **왼쪽 아이템 열을 200 → 224px로 넓혔다.** 진척 숫자가 붙으면서 액션명 자리가 72px로 눌려 `협업툴 리뉴얼 착수`가 `협업툴 리뉴...`로 잘렸다 — 이 열의 요점은 *무슨 액션인지*라 보조 숫자 때문에 이름을 깎을 수는 없었다. 24px(8의 배수)면 목의 액션명이 전부 들어간다(실측 확인). 이 열을 같이 쓰는 다른 화면(대시보드·프로젝트 상세·팀 액션 상세·인수인계 보드)은 이름이 더 보일 뿐 손해가 없고, 타임라인은 어차피 가로 스크롤이라 잃는 칸이 없다.
- **목도 같은 데이터에서 센다.** `getTeamActionsPage`의 mock 분기가 `TEAM_ACTION_PERSONAL_ITEMS_MOCK`에서 완료 수를 직접 세게 했다 — 상수를 박으면 상세 탭의 하위 목록과 숫자가 어긋나 목이 거짓말을 한다(§정직한 목업).

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**(회의 담당자 등), 그리고 **서버(Server Action/BFF)에서 재검사** — 기존 `/team/action` 가드 그대로다. 읽기 전용 표시라 새 진입점·새 변경 경로가 없다.
- [x] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse` — 매퍼는 안 건드렸다(#416에서 이미 받고 있다).
- [x] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시 (조용히 "되는 척" 금지) — `null`을 `0`으로 바꾸지 않는다. 목 진척은 하위 목록에서 실제로 센다.
- [x] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨 — `foreground`/`muted-foreground`만 쓴다. `dark:` 없음(다크 확인 완료).

**품질**

- [x] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그) — 렌더 대상 두 span 추가가 전부다. 새 의존성 없음.
- [x] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로 — 행이 `Link`면 `aria-label`이 안쪽 글자를 **덮으므로**, 진척을 span으로만 두면 스크린리더가 영영 못 듣는다. `하위 액션 5개 중 3개 완료`를 행 이름에도 넣었다. 뜻을 폭·색에 담지 않는다.
- [x] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인) — `ui/progress`(base-ui)를 먼저 봤지만 44px 행·224px 열에 트랙을 넣을 자리가 없어 안 썼다. 판정·표시 둘 다 타임라인 컴포넌트 안에 뒀다.
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 기존 목록 3상태 그대로(`EmptyState`·`InfiniteListFooter`). 이번 변경이 새로 만드는 상태는 없다.
- [x] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음 — 해당 없음.

---

## 🔗 연관 이슈

Closes #421

---

## 📸 스크린샷 (선택)

| Before                                              | After                                                             |
| --------------------------------------------------- | ----------------------------------------------------------------- |
| `● 결제 시스템 연동  GOODS`                          | `● 결제 시스템 연동  GOODS  0/1`                                   |
| 하위 액션이 몇 개인지·몇 개 끝났는지 목록에 없었다. | 칩 뒤에 `완료/전체`. 완료 수만 진하고 `/전체`는 옅다(명도로 가름). |

---

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

**화면에서 볼 것 (`/team/action`)**

- 각 줄 왼쪽 열 **태그 칩 바로 뒤**에 `0/3` 꼴 숫자가 붙는지. 완료 수는 진하고 `/전체`는 옅다 — 색은 안 썼다.
- **행이 안 높아졌는지**(44px 그대로). 왼쪽 열만 200 → 224px로 넓혔다.
- 액션명이 **안 잘리는지**. `협업툴 리뉴얼 착수`가 224px에서 온전히 들어간다(200px에선 잘렸다).
- **다른 화면은 조용한지** — `/my` 대시보드·`/app/projects/:id`·인수인계 보드는 같은 타임라인을 쓰지만 값을 안 넘기므로 숫자가 안 붙는다. `/my`에서 숫자가 보이면 잘못된 것이다.
- 다크에서 한 번 — `dark:` 없이 토큰만 쓴다.

**코드에서 볼 것**

- `hasChildProgress()`의 `typeof === "number"` 판정. `!count`나 `??`로 바꾸면 **`0/0`이 `null`과 같이 사라진다** — 그 구분이 이 PR의 요점이다.
- 왼쪽 열 폭 200 → 224(`LABEL_COL_PX`)가 이 타임라인을 쓰는 다섯 화면에 다 걸린다. 그 절충이 맞는지(다른 방법은 액션명을 72px로 깎는 것뿐이었다).

**검증 결과**

| 항목                    | 결과                                                                  |
| ----------------------- | --------------------------------------------------------------------- |
| `npx tsc --noEmit`      | ✅ 통과 (`any` 없음, 타입 가드로 좁힘)                                |
| `npx eslint <changed>`  | ✅ 통과                                                               |
| `npx jest`              | ✅ 94 suites · **1019 tests** 통과 (신규 `action-timeline.test.tsx` 4건 포함) |
| `npx next build`        | ✅ 통과                                                               |
| 브라우저 실측(`/team/action`) | 행 높이 44px · 왼쪽 열 224px · 액션명 3건 전부 안 잘림 · `aria-label`에 `하위 액션 N개 중 M개 완료` 실림 · `/my`는 숫자 없음 — 라이트·다크 둘 다 확인 |

신규 테스트 4건은 이슈가 갈라 달라고 한 경우를 그대로 덮는다 — `3/5` 표시 + 행 이름 / `0/0`은 그린다 / `null`은 안 그린다 / 값을 아예 안 넘기는 화면은 조용하다.

---

## 📝 추가 메모

- 매퍼·서버 응답 파싱은 안 건드렸다. `server.ts` 변경은 **mock 분기 한 곳뿐**이고, 실연동 경로(`toTeamActionListItem`)는 #416에서 이미 값을 싣고 있다.
- 목에는 완료된 하위 액션이 없어 화면 숫자가 전부 `0/n`으로 보인다. 이건 목 데이터가 그런 것이고(하위 액션 상태가 `할 일`·`진행중`뿐), 실연동에서는 BE 값이 그대로 나온다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 팀 액션의 하위 개인 액션 진행률을 타임라인에서 완료 수/전체 수 형식으로 확인할 수 있습니다.
  * 하위 액션이 없는 경우에도 `0/0` 진행률을 표시합니다.
  * 진행률 정보가 없는 항목은 기존과 같이 진행률을 표시하지 않습니다.
  * 진행률 정보가 접근성 라벨에도 포함됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->