### PR TITLE
[FIX] 배율 캘린더·상태 토큰·죽은 엔드포인트 정리 #141

### DIFF
--- a/src/features/action/components/my-action-list-item.test.tsx
+++ b/src/features/action/components/my-action-list-item.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+
+import { ACTION_STATUS } from "@/constants/domain";
+
+import type { MyActionListItem } from "../types";
+import { MyActionListItemRow } from "./my-action-list-item";
+
+const BASE: MyActionListItem = {
+  id: 1,
+  title: "로그인 화면 마크업",
+  description: "폼 검증까지",
+  team: "개발팀",
+  projectId: 10,
+  projectName: "Z 워크스페이스",
+  projectTag: "GOODS",
+  startDate: "2999-01-01",
+  /* ⚠️ 먼 미래로 둔다 — 마감이 지나면 `isDelayed`가 상태를 `지연`으로 덮어써 배지가 빨강이 된다 */
+  dueDate: "2999-12-31",
+  status: ACTION_STATUS.IN_PROGRESS,
+};
+
+function renderRow(status: MyActionListItem["status"]) {
+  render(
+    <ul>
+      <MyActionListItemRow
+        action={{ ...BASE, status }}
+        showDivider={false}
+        isFirst
+        isLast={false}
+      />
+    </ul>,
+  );
+}
+
+describe("MyActionListItemRow 상태 배지", () => {
+  /**
+   * ⚠️ **진행중 배지는 상태 토큰에서 색을 가져온다**(#435). `--success`와 `--status-progress`는
+   *    지금 값이 같을 뿐 별개 토큰이라, 성공 토큰을 빌려 쓰면 한쪽만 조정되는 날 같은 "진행중"이
+   *    화면마다 다른 색이 된다 — 눈으로는 안 보이는 회귀라 여기서 문자열로 못 박는다
+   *    (`action-timeline.tsx`의 BAR_CLASS와 같은 규칙).
+   */
+  it("진행중은 `--status-progress`를 쓴다 — `--success`를 빌려 쓰지 않는다", () => {
+    renderRow(ACTION_STATUS.IN_PROGRESS);
+
+    const badge = screen.getByText("진행중");
+
+    expect(badge).toHaveClass("bg-status-progress/12", "text-status-progress");
+    expect(badge.className).not.toMatch(/\bbg-success\b|\btext-success\b/);
+  });
+
+  /* 나머지 상태는 무채색이다 — 진행중만 색을 갖는다(DESIGN §5) */
+  it("할일은 무채색이다", () => {
+    renderRow(ACTION_STATUS.TODO);
+
+    expect(screen.getByText("할 일")).toHaveClass("bg-muted", "text-muted-foreground");
+  });
+});

--- a/src/features/action/components/my-action-list-item.tsx
+++ b/src/features/action/components/my-action-list-item.tsx
@@ -8,10 +8,19 @@ import { cn } from "@/lib/utils";
 
 import type { MyActionListItem } from "../types";
 
-/** 상태 배지 색 — `member/components/action-timeline`의 BAR_CLASS와 같은 결(할일·완료=무채색, 진행중=초록, 지연=빨강). */
+/**
+ * 상태 배지 색 — `member/components/action-timeline`의 BAR_CLASS와 같은 결
+ * (할일·완료=무채색, 진행중=초록, 지연=빨강).
+ *
+ * ⚠️ **진행중은 `--status-progress`다, `--success`가 아니다**(2026-08-13, #435).
+ *    두 토큰은 지금 값이 같을 뿐 **따로 선언된 별개 토큰**이라, 여기만 성공 토큰을 빌려 쓰면
+ *    한쪽만 조정되는 날 같은 "진행중"이 화면마다 다른 색이 된다 — `action-timeline.tsx`의
+ *    BAR_CLASS가 같은 함정에 경고를 달아 둔 자리다.
+ *    보이는 색은 그대로다(DESIGN §5 상태점: 진행중=초록).
+ */
 const STATUS_TONE: Record<"TODO" | "IN_PROGRESS" | "DONE" | "DELAYED", string> = {
   TODO: "bg-muted text-muted-foreground",
-  IN_PROGRESS: "bg-success/12 text-success",
+  IN_PROGRESS: "bg-status-progress/12 text-status-progress",
   DONE: "bg-muted text-muted-foreground",
   DELAYED: "bg-destructive/10 text-destructive",
 };

--- a/src/features/rooms/calendar-height.ts
+++ b/src/features/rooms/calendar-height.ts
@@ -1,6 +1,7 @@
-const START_HOUR = 8;
-const END_HOUR = 18;
-const HOURS_VISIBLE = END_HOUR - START_HOUR;
+import { GRID_END_HOUR, GRID_START_HOUR } from "./grid-slot";
+
+/** ⚠️ 시간대는 `grid-slot.ts`가 정본이다 — 여기서 8·18을 또 적으면 칸 높이와 칸 시각이 갈린다. */
+const HOURS_VISIBLE = GRID_END_HOUR - GRID_START_HOUR;
 /**
  * 요일 헤더 높이 — `weekly-room-calendar.css`의 `.rbc-time-header-content` 기준.
  * ⚠️ `.rbc-allday-cell`을 숨겨서 헤더는 이제 요일 행 하나뿐이다(예전엔 그 행까지 감안해 더 컸다).

--- a/src/features/rooms/components/weekly-room-calendar.tsx
+++ b/src/features/rooms/components/weekly-room-calendar.tsx
@@ -6,11 +6,12 @@ import "./weekly-room-calendar.css";
 import { format, getDay, parse, startOfWeek } from "date-fns";
 import { ko } from "date-fns/locale";
 import { useRouter } from "next/navigation";
-import { useCallback, useMemo } from "react";
-import { Calendar, dateFnsLocalizer, type SlotInfo, type ToolbarProps } from "react-big-calendar";
+import { type MouseEvent as ReactMouseEvent, useCallback, useMemo } from "react";
+import { Calendar, dateFnsLocalizer, type ToolbarProps } from "react-big-calendar";
 
 import { getReservationAccentColor } from "../accent-color";
 import { WEEKLY_CALENDAR_HEIGHT_PX } from "../calendar-height";
+import { findSlotStart, GRID_END_HOUR, GRID_START_HOUR, SLOT_MINUTES } from "../grid-slot";
 import type { MeetingRoom, RoomCalendarEvent, RoomMember } from "../types";
 import { RoomReservationEvent } from "./room-reservation-event";
 import { RoomsCalendarToolbar } from "./rooms-calendar-toolbar";
@@ -79,9 +80,30 @@ export function WeeklyRoomCalendar({
     [router, week],
   );
 
-  const handleSelectSlot = useCallback(
-    (slotInfo: SlotInfo) => onSelectSlot(slotInfo.start),
-    [onSelectSlot],
+  /**
+   * 빈 칸을 누르면 그 30분 칸의 시작 시각을 올려보낸다 — **RBC의 `selectable`을 안 쓴다.**
+   *
+   * ⚠️ 그쪽 좌표 계산이 화면 배율(`transform: scale()`)에서 옆 날짜·옆 시간대를 골랐다
+   *    (#141). 이유와 대안은 `grid-slot.ts`에 적었다.
+   * ⚠️ 리스너는 RBC 뿌리 `div`에 그대로 얹는다(`elementProps`) — 감싸는 `div`를 하나 더 두면
+   *    `lg:h-full`이 기대는 flex 사슬이 한 겹 끊겨 캘린더 높이가 무너진다.
+   * ⚠️ 키보드로는 `RoomListPanel`의 [회의 추가]가 같은 모달을 연다 — 격자 클릭이 유일한
+   *    길이 아니다(CLAUDE.md §a11y).
+   * ⚠️ 기준일은 `week`가 아니라 **그 주의 월요일**로 한 번 더 접는다. `work_week` 뷰는 어떤
+   *    날짜를 줘도 그 주 월~금을 그리므로, 첫 열이 곧 월요일이다 — URL이 주 중간 날짜를
+   *    들고 와도 열 번호와 날짜가 안 갈린다.
+   */
+  const weekStart = useMemo(() => startOfWeek(currentDate, { weekStartsOn: 1 }), [currentDate]);
+
+  const handleGridClick = useCallback(
+    (event: ReactMouseEvent<HTMLElement>) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+
+      const start = findSlotStart({ target, clientY: event.clientY, weekStart });
+      if (start) onSelectSlot(start);
+    },
+    [weekStart, onSelectSlot],
   );
 
   const EventComponent = useCallback(
@@ -119,12 +141,11 @@ export function WeeklyRoomCalendar({
       date={currentDate}
       onNavigate={handleNavigate}
       components={{ toolbar: ToolbarComponent, event: EventComponent }}
-      step={30}
+      step={SLOT_MINUTES}
       timeslots={2}
-      min={new Date(0, 0, 0, 8, 0, 0)}
-      max={new Date(0, 0, 0, 18, 0, 0)}
-      selectable
-      onSelectSlot={handleSelectSlot}
+      min={new Date(0, 0, 0, GRID_START_HOUR, 0, 0)}
+      max={new Date(0, 0, 0, GRID_END_HOUR, 0, 0)}
+      elementProps={{ onClick: handleGridClick }}
       className="lg:h-full!"
       style={{ height: WEEKLY_CALENDAR_HEIGHT_PX }}
       formats={{

--- a/src/features/rooms/grid-slot.test.ts
+++ b/src/features/rooms/grid-slot.test.ts
@@ -1,0 +1,179 @@
+import { findSlotStart, GRID_START_HOUR, SLOT_MINUTES } from "./grid-slot";
+
+/** 2026-08-10은 월요일 — `work_week` 첫 열이다. */
+const WEEK_START = new Date(2026, 7, 10);
+
+const DAY_COUNT = 5;
+/** 08:00~18:00을 30분으로 나눈 칸 수. */
+const SLOT_COUNT = 20;
+/** 배율이 걸리기 **전**(레이아웃) 기준 칸 높이·격자 시작 y. 실제 화면 값과 무관한 임의 수다. */
+const SLOT_HEIGHT = 40;
+const GRID_TOP = 100;
+
+/**
+ * `react-big-calendar`가 그리는 `work_week` 격자를 최소로 흉내 낸다.
+ *
+ * ⚠️ **`getBoundingClientRect`를 배율만큼 줄여서 돌려준다.** jsdom은 레이아웃을 안 하므로
+ *    전부 0이라, 그냥 두면 배율 회귀를 잴 수가 없다 — `body`에 `transform: scale()`이 걸린
+ *    실제 화면처럼 **레이아웃 좌표 × 배율**을 내놓게 해서 그 상황을 만든다
+ *    (DECISIONS §화면 배율).
+ * ⚠️ 시간 눈금(`.rbc-time-gutter`)에도 `.rbc-time-slot`을 같이 넣는다 — 열 밖의 같은 클래스를
+ *    같이 세면 칸 번호가 통째로 밀린다.
+ */
+function buildGrid(scale: number) {
+  const content = document.createElement("div");
+  content.className = "rbc-time-content";
+
+  const stubRect = (element: Element, index: number) => {
+    element.getBoundingClientRect = () =>
+      ({
+        top: (GRID_TOP + index * SLOT_HEIGHT) * scale,
+        bottom: (GRID_TOP + (index + 1) * SLOT_HEIGHT) * scale,
+        left: 0,
+        right: 0,
+        width: 0,
+        height: SLOT_HEIGHT * scale,
+        x: 0,
+        y: (GRID_TOP + index * SLOT_HEIGHT) * scale,
+        toJSON: () => ({}),
+      }) as DOMRect;
+  };
+
+  const gutter = document.createElement("div");
+  gutter.className = "rbc-time-gutter rbc-time-column";
+  for (let index = 0; index < SLOT_COUNT; index += 1) {
+    const slot = document.createElement("div");
+    slot.className = "rbc-time-slot";
+    stubRect(slot, index);
+    gutter.append(slot);
+  }
+  content.append(gutter);
+
+  const columns: HTMLElement[] = [];
+  const slotsByColumn: HTMLElement[][] = [];
+  for (let day = 0; day < DAY_COUNT; day += 1) {
+    const column = document.createElement("div");
+    column.className = "rbc-day-slot rbc-time-column";
+    const slots: HTMLElement[] = [];
+    for (let index = 0; index < SLOT_COUNT; index += 1) {
+      const slot = document.createElement("div");
+      slot.className = "rbc-time-slot";
+      stubRect(slot, index);
+      slots.push(slot);
+      column.append(slot);
+    }
+    /* 예약 막대는 칸 위를 덮는 별도 상자에 담긴다 — 그 위를 눌러도 같은 칸으로 읽혀야 한다 */
+    const eventsContainer = document.createElement("div");
+    eventsContainer.className = "rbc-events-container";
+    const eventBar = document.createElement("div");
+    eventBar.className = "rbc-event";
+    eventsContainer.append(eventBar);
+    column.append(eventsContainer);
+
+    columns.push(column);
+    slotsByColumn.push(slots);
+    content.append(column);
+  }
+
+  document.body.append(content);
+  return { content, columns, slotsByColumn };
+}
+
+/** 레이아웃 좌표 y에 찍힌 점이 화면에서 갖는 `clientY` — 배율이 걸린 뒤 값이다. */
+function clientYAt(layoutY: number, scale: number): number {
+  return layoutY * scale;
+}
+
+/** 격자를 세운 직후라 반드시 있어야 하는 자리 — 없으면 흉내 낸 DOM 자체가 틀린 것이다. */
+function at<T>(items: T[], index: number): T {
+  const item = items[index];
+  if (item === undefined) throw new Error(`흉내 낸 격자에 ${index}번째가 없다`);
+  return item;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("findSlotStart", () => {
+  /**
+   * ⚠️ 이 표가 이 파일의 요점이다 — 같은 자리를 눌렀으면 배율이 얼마든 **같은 칸**이어야 한다.
+   *    라이브러리(`Selection.getBoundsForNode`) 계산은 여기서 80%·75%가 옆 칸으로 밀렸다(#141).
+   */
+  it.each([100, 90, 80, 75])("배율 %i%%에서도 누른 칸의 시각을 그대로 읽는다", (percent) => {
+    const scale = percent / 100;
+    const { slotsByColumn } = buildGrid(scale);
+
+    /* 수요일(0-base 2번째 열) · 4번째 칸(=09:30) 한가운데 */
+    const dayIndex = 2;
+    const slotIndex = 3;
+    const layoutY = GRID_TOP + slotIndex * SLOT_HEIGHT + SLOT_HEIGHT / 2;
+
+    const start = findSlotStart({
+      target: at(at(slotsByColumn, dayIndex), slotIndex),
+      clientY: clientYAt(layoutY, scale),
+      weekStart: WEEK_START,
+    });
+
+    /* 2026-08-12(수) 09:30 */
+    expect(start).toEqual(new Date(2026, 7, 12, 9, 30));
+    expect(start?.getHours()).toBe(GRID_START_HOUR + Math.floor((slotIndex * SLOT_MINUTES) / 60));
+  });
+
+  it("예약 막대 위를 눌러도 그 아래 칸의 시각으로 읽는다", () => {
+    const scale = 0.8;
+    const { columns } = buildGrid(scale);
+    const eventBar = at(columns, 0).querySelector(".rbc-event");
+
+    const start = findSlotStart({
+      target: eventBar as Element,
+      /* 첫 칸(08:00) 한가운데 */
+      clientY: clientYAt(GRID_TOP + SLOT_HEIGHT / 2, scale),
+      weekStart: WEEK_START,
+    });
+
+    expect(start).toEqual(new Date(2026, 7, 10, 8, 0));
+  });
+
+  it("시간 눈금 칸은 날짜 열이 아니라 아무 것도 고르지 않는다", () => {
+    const scale = 0.8;
+    buildGrid(scale);
+    const gutterSlot = document.querySelector(".rbc-time-gutter .rbc-time-slot");
+
+    const start = findSlotStart({
+      target: gutterSlot as Element,
+      clientY: clientYAt(GRID_TOP + SLOT_HEIGHT / 2, scale),
+      weekStart: WEEK_START,
+    });
+
+    expect(start).toBeNull();
+  });
+
+  it("격자 밖(칸에 안 걸리는 세로 자리)이면 아무 것도 고르지 않는다", () => {
+    const scale = 0.8;
+    const { slotsByColumn } = buildGrid(scale);
+
+    const start = findSlotStart({
+      target: at(at(slotsByColumn, 0), 0),
+      /* 마지막 칸보다 아래 */
+      clientY: clientYAt(GRID_TOP + SLOT_COUNT * SLOT_HEIGHT + 20, scale),
+      weekStart: WEEK_START,
+    });
+
+    expect(start).toBeNull();
+  });
+
+  it("마지막 열·마지막 칸은 금요일 17:30이다", () => {
+    const scale = 0.75;
+    const { slotsByColumn } = buildGrid(scale);
+    const lastSlot = SLOT_COUNT - 1;
+
+    const start = findSlotStart({
+      target: at(at(slotsByColumn, DAY_COUNT - 1), lastSlot),
+      clientY: clientYAt(GRID_TOP + lastSlot * SLOT_HEIGHT + SLOT_HEIGHT / 2, scale),
+      weekStart: WEEK_START,
+    });
+
+    expect(start).toEqual(new Date(2026, 7, 14, 17, 30));
+  });
+});

--- a/src/features/rooms/grid-slot.ts
+++ b/src/features/rooms/grid-slot.ts
@@ -1,0 +1,71 @@
+import { addDays, addMinutes, startOfDay } from "date-fns";
+
+/**
+ * 주간 그리드가 보여주는 시간대와 칸 크기 — 08:00~18:00, 30분 한 칸.
+ *
+ * ⚠️ **한 곳에서만 정한다.** 예전엔 `weekly-room-calendar.tsx`의 `min`/`max`/`step`과
+ *    `calendar-height.ts`의 `START_HOUR`/`END_HOUR`가 8·18을 따로 들고 있었다 — 한쪽만 바꾸면
+ *    칸 높이와 칸 시각이 어긋나, 누른 칸과 다른 시각이 예약 모달에 뜬다.
+ * ⚠️ 30분은 임의값이 아니다. 회의 예약은 **30분 한 타임 고정**이다(CLAUDE.md §브라우저 API,
+ *    팀 확정) — 연속 예약으로 늘리지 않는다.
+ */
+export const GRID_START_HOUR = 8;
+export const GRID_END_HOUR = 18;
+export const SLOT_MINUTES = 30;
+
+/** 하루 한 열. `work_week` 뷰라 월~금 다섯 열이 `.rbc-time-content` 바로 밑에 선다. */
+const DAY_COLUMN_SELECTOR = ".rbc-day-slot";
+/**
+ * 열 안의 30분 칸.
+ * ⚠️ 왼쪽 시간 눈금(`.rbc-time-gutter`)에도 같은 클래스가 붙는다 — 반드시 **열 안에서만** 찾는다.
+ */
+const TIME_SLOT_SELECTOR = ".rbc-time-slot";
+
+interface FindSlotStartInput {
+  /** 클릭 이벤트의 `target` — 빈 칸이면 칸 자체, 예약 막대 위면 그 막대가 들어온다. */
+  target: Element;
+  /** 클릭 지점의 세로 좌표(`MouseEvent.clientY`). */
+  clientY: number;
+  /** 이 주의 월요일 — `work_week` 첫 열이 이 날이다. */
+  weekStart: Date;
+}
+
+/**
+ * 클릭한 **30분 칸의 시작 시각**을 읽는다 — 좌표 계산이 아니라 **DOM 칸**으로 찾는다.
+ *
+ * ⚠️ **`react-big-calendar`의 `selectable`을 안 쓴다**(2026-08-13, #141). 그쪽 계산
+ *    (`Selection.getBoundsForNode`)이 한 상자 안에 **좌표계 둘**을 섞어 담는다 —
+ *    `top`·`left`는 `getBoundingClientRect()`(화면 배율이 **적용된 뒤** 값)에서 가져오고
+ *    `right`·`bottom`은 `offsetWidth`/`offsetHeight`(배율이 **적용되기 전** 레이아웃 값)를
+ *    더해 만든다. `body`에 `transform: scale()`이 걸려 있어서(DECISIONS §화면 배율) 배율
+ *    100%에서만 둘이 우연히 같고, 80%면 상자가 실제보다 1.25배 커진 채
+ *    `floor((x - left) / 칸너비)`를 돌려 **옆 날짜·옆 시간대**가 골라졌다.
+ * ⚠️ **라이브러리를 고치지 않는다**(#141 본문) — 대신 **같은 상자 안에서만 잰다.**
+ *    `clientY`도 칸의 `rect`도 둘 다 배율이 적용된 값이라, 포함 여부만 보면 배율이 약분된다.
+ *    날짜는 아예 좌표를 안 쓴다 — 누른 자리가 몇 번째 열인지는 DOM이 이미 안다.
+ *    (`flow-section.tsx`가 스크롤 좌표에서 쓰는 것과 같은 수법이다: 배율 섞인 두 좌표계를
+ *    비교하지 말고, 한 좌표계 안에서 비율·포함으로만 본다.)
+ * ⚠️ 칸을 못 찾으면 `null`이다 — 눈금·헤더·칸 사이 여백을 눌렀을 때 아무 데나 열지 않는다.
+ */
+export function findSlotStart({ target, clientY, weekStart }: FindSlotStartInput): Date | null {
+  const column = target.closest(DAY_COLUMN_SELECTOR);
+  if (!column) return null;
+
+  const columns = Array.from(
+    column.parentElement?.querySelectorAll(`:scope > ${DAY_COLUMN_SELECTOR}`) ?? [],
+  );
+  const dayIndex = columns.indexOf(column);
+  if (dayIndex < 0) return null;
+
+  const slots = Array.from(column.querySelectorAll(TIME_SLOT_SELECTOR));
+  const slotIndex = slots.findIndex((slot) => {
+    const rect = slot.getBoundingClientRect();
+    return clientY >= rect.top && clientY < rect.bottom;
+  });
+  if (slotIndex < 0) return null;
+
+  return addMinutes(
+    addDays(startOfDay(weekStart), dayIndex),
+    GRID_START_HOUR * 60 + slotIndex * SLOT_MINUTES,
+  );
+}

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -6,6 +6,16 @@
  *
  * ⚠️ 아래 **[확인]** 표시가 붙은 경로는 BE 레포 실코드로 대조했다(2026-08-10).
  *   나머지는 아직 **FE 제안 경로**다 — 쓰기 전에 컨트롤러를 먼저 본다(§연동 검증).
+ *
+ * ⚠️ **부르는 곳이 없는 채로 남겨 두지 않는다**(2026-08-13, #433). 검증 안 된 빈 경로가 실제
+ *   경로 옆에 서 있으면 위 규칙이 거꾸로 작동한다 — 다음 사람이 "여기 있으니 합의된 경로"라고
+ *   읽고 집는다. 이때 `subscription`(`/api/subscription` — BE 컨트롤러 없음, 실 결제 경로는
+ *   `/api/companies/me/billing*`)과 `departments`(`/api/departments` — 조직이 부서에서
+ *   **플랫한 팀**으로 확정되며 `teams`로 대체됐다, CLAUDE.md §권한 ③)를 지웠다.
+ *   ⚠️ 반대로 **호출부가 없어도 남기는 것**이 있다 — 지금 화면이 없을 뿐 쓰기로 정해진 경로다.
+ *      `notifications`·`notificationStream`은 알림 SSE 배너가 예정돼 있고(CLAUDE.md
+ *      §렌더링·데이터: "알림=SSE, BFF가 스트림을 중계"), 캡처 조각·검색·`todos` 등은 연동이
+ *      진행 중이다. 지우기 전에 **그 도메인 담당자·이슈를 먼저 본다.**
  */
 /** 목록 3종(`GET /api/projects`·`/api/actions`·`/api/team/actions`)이 공유하는 쿼리 파라미터. */
 export interface ProjectListParams {
@@ -240,7 +250,6 @@ export const ep = {
   /** 직급 — [확인] identity/position/presentation/api/PositionController.java */
   jobPositions: () => "/api/job-positions",
   jobPosition: (id: number) => `/api/job-positions/${id}`,
-  departments: () => "/api/departments",
 
   /**
    * 회의실 — [확인] `meetingroom/presentation/api/{MeetingRoomController,MeetingRoomCommandController}.java`
@@ -268,7 +277,6 @@ export const ep = {
   notices: () => "/api/notices",
   /** 공지 상세(`GET`, NOTI-02)·수정(`PUT`, NOTI-04)·삭제(`DELETE`, NOTI-05)가 같은 경로를 쓴다. */
   notice: (noticeId: number) => `/api/notices/${noticeId}`,
-  subscription: () => "/api/subscription",
 
   /**
    * 검색 — API 스펙 전달받음(2026-08-11), **BE 실코드 미대조**(§연동 검증: 문서와 코드가


### PR DESCRIPTION
## 📋 PR 타입

> 해당하는 타입을 선택해 주세요 (복수 선택 가능)

- [ ] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [x] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- **#141 배율에서 캘린더 칸 선택이 어긋나던 것** — 회의실 주간 격자(`/app/rooms`)에서 빈 칸을 눌러도 옆 날짜·옆 시간대가 골라졌다. `react-big-calendar`의 `Selection.getBoundsForNode`가 한 상자에 **좌표계 둘**을 섞어 담는 게 원인이다 — `top`·`left`는 `getBoundingClientRect()`(배율이 **적용된 뒤** 값)에서 가져오고 `right`·`bottom`은 `offsetWidth`/`offsetHeight`(배율 **전** 레이아웃 값)를 더해 만든다. `body`에 `transform: scale()`이 걸려 있어(DECISIONS §화면 배율) 100%에서만 둘이 우연히 맞고, 80%면 상자가 1.25배 커진 채 `floor((x - left) / 칸너비)`를 돌린다. 라이브러리는 안 고치고(이슈 본문 방침) `selectable`을 떼어 낸 뒤, 새 `features/rooms/grid-slot.ts`가 칸을 찾는다 — **날짜는 좌표를 아예 안 쓰고**(몇 번째 열인지는 DOM이 안다), 시각은 칸의 `rect`와 `clientY`를 **같은 좌표계 안에서만** 비교해 배율을 약분한다(`flow-section.tsx`가 스크롤 좌표에서 쓰는 것과 같은 수법).
- 곁들여 8·18·30분이 `weekly-room-calendar.tsx`와 `calendar-height.ts`에 두 벌로 있던 것을 `grid-slot.ts` 하나로 모았다 — 한쪽만 바꾸면 칸 높이와 칸 시각이 갈린다.
- **#435 진행중 배지가 `--success`를 빌려 쓰던 것** — `my-action-list-item.tsx`가 `bg-success/12 text-success`를 쓰고 있었다. 색 규칙 위반은 아니지만(DESIGN §5가 진행중=초록을 정한다) **토큰 선택**이 틀렸다. 두 토큰은 지금 값만 같을 뿐 따로 선언된 별개라, 한쪽만 조정되는 날 같은 "진행중"이 화면마다 다른 색이 된다. `--status-progress`로 바꿨고 **보이는 색은 그대로다**. `src` 전체를 훑어 상태 목적으로 성공 토큰을 빌려 쓰는 곳은 이 한 곳뿐이었다.
- **#433 부르는 곳이 없는 엔드포인트 제거** — `endpoints.ts`에서 `subscription`(`/api/subscription`, 호출부 0건·`[확인]` 없음·BE 컨트롤러 없음)과 `departments`(`/api/departments`, 호출부 0건·조직이 **플랫한 팀**으로 확정되며 `ep.teams()`로 대체됨)를 지웠다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**(회의 담당자 등), 그리고 **서버(Server Action/BFF)에서 재검사** — 권한 경로를 건드리지 않았다(예약 생성 판정은 그대로 `RoomReservationDialog` → Server Action).
- [x] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse` — 매퍼·스키마 변경 없음.
- [x] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시 (조용히 "되는 척" 금지) — 칸을 못 찾으면 아무 모달도 안 연다(눈금·여백을 눌렀을 때 엉뚱한 시각으로 열지 않는다).
- [x] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨 — `--status-progress`는 라이트·다크 양쪽에 이미 정의돼 있다.

**품질**

- [x] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그) — 리스너 하나를 RBC 뿌리 `div`에 얹는다(`elementProps`). 감싸는 `div`를 안 둬서 `lg:h-full`의 flex 사슬이 그대로다.
- [x] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로 — 격자 클릭은 전부터 마우스 전용이었고, 같은 모달을 여는 키보드 경로가 `RoomListPanel`의 [회의 추가]로 이미 있다(이번에 나빠진 것 없음).
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 화면 상태 구조 변경 없음.
- [x] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음 — 해당 없음.

---

## 🔗 연관 이슈

Closes #141
Closes #435
Closes #433

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

- **#141을 화면에서 확인하는 법.** ① `/app/me` → 화면 배율을 **80%**(또는 75%)로 내린다. ② `/app/rooms`로 간다. ③ 격자의 **오른쪽 끝 열(금요일)** 아래쪽 칸을 누른다 — 오른쪽·아래로 갈수록 어긋남이 커져서 여기가 가장 잘 드러난다. ④ 예약 모달의 날짜·시각이 **누른 칸과 같은지** 본다. 고치기 전에는 80%에서 금요일을 누르면 목요일이, 17:30 칸을 누르면 15시대가 열렸다. 100%로 되돌려도 똑같이 맞아야 한다(회귀 확인).
- **`selectable`을 뗀 게 다른 걸 안 건드리는지.** RBC의 드래그 선택 잔상(`.rbc-slot-selection`)이 같이 없어진다 — 예약은 **30분 한 타임 고정**이라(CLAUDE.md §브라우저 API) 여러 칸을 끌어 잡을 일이 없어서 잃는 게 없다고 봤다. 반대 의견이면 알려 주세요.
- **예약 막대 위를 눌렀을 때의 동작은 그대로 뒀다.** 전에도 그 아래 칸으로 모달이 열렸다(RBC의 `isEvent`가 `elementFromPoint`로 칸을 먼저 집었다) — 이번 PR 범위 밖이라 바꾸지 않았고, 테스트로 그 동작을 못박아 뒀다.
- **`grid-slot.test.ts`가 배율을 어떻게 재현하는지.** jsdom은 레이아웃을 안 해서 `getBoundingClientRect`가 전부 0이다 — 칸마다 **레이아웃 좌표 × 배율**을 돌려주도록 stub해서 실제 화면 상황을 만든다. 100·90·80·75% 네 배율에서 같은 칸이 나오는지를 본다.

---

## 📝 추가 메모

- ⚠️ **PR #431(#429 결제 연동, 열린 상태)이 같은 `endpoints.ts`를 건드린다** — 그쪽은 `/api/companies/me/billing*` 경로를 **추가**하고 이 PR은 `subscription`·`departments`를 **삭제**해서, 나중에 머지되는 쪽에서 충돌이 날 수 있습니다. 충돌 나면 **양쪽 다 살리면 됩니다**(추가는 추가대로, 삭제는 삭제대로) — 겹치는 줄이 없습니다. #431의 변경은 이 PR에 포함하지 않았습니다.
- **호출부가 0건이어도 남긴 것들이 있습니다.** `notifications`·`notificationStream`은 알림 **SSE 배너**가 예정돼 있고(CLAUDE.md §렌더링·데이터: "알림=SSE, BFF가 스트림을 중계"), `calendar`·`todos`·`todoComplete`·`memberOrgChart`·`meetingActions`·`projectAttachment`·캡처 조각 4종(`partsPresign`·`partComplete`·`partsStatus`·`processingStatus`)은 화면이 아직 목일 뿐 **BE 실코드로 대조된** 연동 예정 경로입니다. `systemDashboard`도 `(system)/*` 화면이 실재해서 남겼습니다. 그 판단 기준을 파일 머리 주석에 남겨 뒀습니다 — 다음 감사 때 같은 줄을 다시 지우지 않도록.
- 검증: `npx tsc --noEmit` · `npx eslint` · `npx jest`(95 suites / 1025 tests 통과) · `npx next build` 전부 통과.
