### PR TITLE
[FIX] 검색 실연동 잔여 — 프로젝트 필터·결과 상한 #422

### DIFF
--- a/src/features/search/actions.ts
+++ b/src/features/search/actions.ts
@@ -2,9 +2,6 @@
 
 import { revalidatePath } from "next/cache";
 
-import { requireAccessToken } from "@/features/auth/session";
-import { serverApi } from "@/lib/api";
-import { ep } from "@/lib/endpoints";
 import { isMock } from "@/mocks/config";
 
 import { addMockRecentSearch } from "./mock/recent-searches";
@@ -17,6 +14,7 @@ import type { SearchKind } from "./types";
  *    들어왔을 때와 화면이 갈린다.
  * ⚠️ **호출부가 `void`로 던지고 결과를 안 본다**(`search-input.tsx`). 검색 기록 실패가
  *    검색 자체를 막을 이유는 없어 — 실패해도 조용히 넘어간다(최근 검색어 한 줄이 안 남을 뿐).
+ * ⚠️ **실서버에서는 지금 아무 일도 안 한다** — 아래 주석 참고(BE에 기록 API가 없다, #422).
  */
 export async function recordSearchAction(keyword: string): Promise<void> {
   const trimmed = keyword.trim();
@@ -29,18 +27,14 @@ export async function recordSearchAction(keyword: string): Promise<void> {
     return;
   }
 
-  /* [스펙 전달, BE 실코드 미대조] `POST /api/v1/search/recent-queries` — 몸통은 `{ query }` */
-  try {
-    const accessToken = await requireAccessToken();
-    await serverApi<unknown>(ep.searchRecentQueries(), {
-      method: "POST",
-      accessToken,
-      json: { query: trimmed },
-    });
-    revalidatePath("/app/search");
-  } catch {
-    // 위 주석대로 — 기록 실패를 검색 흐름에 되돌리지 않는다.
-  }
+  /*
+    ⚠️ **실서버에는 적을 곳이 없다**(2026-08-13 실코드 대조, #422). `SearchController`의 매핑은
+       `GET /api/v1/search` 하나뿐이라 `POST .../recent-queries`는 404다 — 매번 404를 내고
+       조용히 삼키면 남는 건 "기록되고 있다"는 착각뿐이라 **부르지 않는다**.
+    ⚠️ 대신 랜딩이 "최근 검색어는 아직 서버가 제공하지 않습니다"라고 밝힌다
+       (`SearchHome.unavailable`) — 못 하는 걸 아무 말 없이 안 하는 것과는 다르다(§정직성).
+    ⚠️ BE가 기록 API를 열면 이 함수 안만 되살린다(`ep.searchRecentQueries`는 남겨 뒀다).
+  */
 }
 
 /**
@@ -51,19 +45,12 @@ export async function recordSearchAction(keyword: string): Promise<void> {
  * ⚠️ 목엔 대응하는 저장소가 없다 — `SearchHome.recentlyViewed`가 정적 목이라 클릭해도
  *    안 바뀐다(§정직한 목업: 없는 걸 있는 척 안 한다).
  */
-export async function recordRecentViewAction(kind: SearchKind, id: number): Promise<void> {
-  if (isMock) return;
-
-  /* [스펙 전달, BE 실코드 미대조] `POST /api/v1/search/recent-views` — 몸통은 `{ type, id }` */
-  try {
-    const accessToken = await requireAccessToken();
-    await serverApi<unknown>(ep.searchRecentViews(), {
-      method: "POST",
-      accessToken,
-      json: { type: kind, id },
-    });
-    revalidatePath("/app/search");
-  } catch {
-    // 위 주석대로 — 기록 실패를 이동 흐름에 되돌리지 않는다.
-  }
-}
+/*
+  ⚠️ **`POST /api/v1/search/recent-views`도 BE에 없다**(`recordSearchAction`과 같은 이유).
+     링크를 누를 때마다 404를 한 번씩 내고 삼키느니 아무것도 안 보낸다.
+  ⚠️ **호출부(`record-view-link.tsx`)와 인자는 그대로 둔다.** 기록이 되살아나는 날 이 함수 안만
+     채우면 되고, 지금 링크 쪽을 걷어내면 나중에 클릭 지점을 화면마다 다시 찾아 심어야 한다 —
+     그래서 지금은 안 쓰는 인자다(아래 규칙 해제는 그 뜻).
+*/
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export async function recordRecentViewAction(kind: SearchKind, id: number): Promise<void> {}

--- a/src/features/search/components/search-landing.tsx
+++ b/src/features/search/components/search-landing.tsx
@@ -1,13 +1,41 @@
-import { Search } from "lucide-react";
+import { Info, Search } from "lucide-react";
 
 import { EmptyState } from "@/components/common/empty-state";
+import { topicParticle } from "@/lib/korean";
 
 import type { SearchHome } from "../types";
+import { SEARCH_HOME_SECTION_LABEL } from "../types";
 import { BrowsePeople, BrowseProjects } from "./browse-lists";
 import { RecentlyViewedGrid } from "./recently-viewed-grid";
 
 interface SearchLandingProps {
   home: SearchHome;
+}
+
+/**
+ * 서버가 아직 못 주는 칸을 이름으로 말하는 한 문장 — 다 채웠으면 `null`.
+ *
+ * ⚠️ **빈 목록으로 두면 "아직 없다"는 말이 된다**(§정직성). 최근 본 항목이 안 보이는 이유가
+ *    "안 봐서"인지 "못 받아서"인지 화면이 구분해 주지 않으면, 사용자는 자기가 안 본 줄 안다.
+ * ⚠️ 조사는 앞말 받침을 보고 고른다 — 어떤 칸이 빠지느냐에 따라 마지막 라벨이 바뀐다(§lib/korean).
+ */
+function unavailableSentence(sections: SearchHome["unavailable"]): string | null {
+  if (sections.length === 0) return null;
+
+  const names = sections.map((section) => SEARCH_HOME_SECTION_LABEL[section]).join(" · ");
+  return `${names}${topicParticle(names)} 아직 서버가 제공하지 않습니다.`;
+}
+
+function UnavailableNote({ sections }: { sections: SearchHome["unavailable"] }) {
+  const sentence = unavailableSentence(sections);
+  if (!sentence) return null;
+
+  return (
+    <p className="text-muted-foreground flex items-start gap-1.5 text-[12px] leading-5">
+      <Info className="mt-0.5 size-3.5 shrink-0" aria-hidden />
+      <span>{sentence}</span>
+    </p>
+  );
 }
 
 /** 검색어가 없을 때의 화면 — 최근 검색어 → 최근 본 항목 → 둘러보기 순서(CLAUDE.md §화면은 위에서 아래로) */
@@ -22,12 +50,21 @@ export function SearchLanding({ home }: SearchLandingProps) {
     home.recentlyViewed.length === 0 && home.projects.length === 0 && home.people.length === 0;
 
   if (isEmpty) {
+    /*
+      ⚠️ **둘러볼 게 없는 것과 못 받아 온 것은 다른 말이다.** 서버가 안 주는 칸이 있는데
+         "아직 둘러본 것이 없습니다"라고만 하면 사용자 탓으로 읽힌다(§정직성) — 못 받은
+         칸이 있으면 제목부터 바꿔 그 사실을 먼저 말한다.
+    */
+    const sentence = unavailableSentence(home.unavailable);
+
     return (
       <EmptyState
         className="py-24"
         icon={Search}
-        title="아직 둘러본 것이 없습니다."
-        description="검색어를 입력해 찾아 주세요."
+        title={sentence ? "지금은 둘러볼 목록이 없습니다." : "아직 둘러본 것이 없습니다."}
+        description={
+          sentence ? `${sentence} 검색어를 입력해 찾아 주세요.` : "검색어를 입력해 찾아 주세요."
+        }
       />
     );
   }
@@ -50,6 +87,12 @@ export function SearchLanding({ home }: SearchLandingProps) {
         <BrowseProjects projects={home.projects} />
         <BrowsePeople people={home.people} />
       </div>
+
+      {/*
+        ⚠️ **맨 아래에 둔다.** 못 받은 칸을 알리는 말은 이 화면이 실제로 보여주는 것(프로젝트)
+           뒤에 와야 한다 — 맨 위에 두면 쓸 수 있는 목록보다 안 되는 이야기가 먼저 읽힌다.
+      */}
+      <UnavailableNote sections={home.unavailable} />
     </div>
   );
 }

--- a/src/features/search/components/search-results-panel.test.tsx
+++ b/src/features/search/components/search-results-panel.test.tsx
@@ -1,0 +1,90 @@
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: jest.fn() }),
+  useSearchParams: () => new URLSearchParams("q=로드맵"),
+}));
+
+import { render, screen } from "@testing-library/react";
+
+import type { ProjectBrowseItem, SearchQuery, SearchResults } from "../types";
+import { SEARCH_CATEGORY, SEARCH_PERIOD } from "../types";
+import { SearchResultsPanel } from "./search-results-panel";
+
+/**
+ * 결과 화면이 **못 하는 일을 권하지 않는지** 지킨다.
+ *
+ * 두 문장 다 실제로는 아무것도 안 바뀌는 조작을 시키고 있었다(§정직성 — #455와 같은 결):
+ * ① 잘렸을 때 "탭으로 종류를 골라 주세요" — 서버는 늘 `type=ALL` 한 번이고 상한도 종류마다
+ *    걸려서, 탭을 바꿔도 같은 줄이 그대로다.
+ * ② 결과가 없을 때 "필터를 전체로 바꿔 주세요" — 서버가 `tags`·`from`·`to`를 아직 안 걸러서
+ *    (`filtersApplied: false`) 필터를 바꿔도 한 줄도 안 변한다.
+ */
+
+const PROJECTS: ProjectBrowseItem[] = [{ id: 3, name: "굿즈 앱", tag: "GOODS", meetingCount: 7 }];
+
+const QUERY: SearchQuery = {
+  keyword: "로드맵",
+  category: SEARCH_CATEGORY.ALL,
+  projectTag: null,
+  period: SEARCH_PERIOD.ALL,
+};
+
+function renderPanel(results: Partial<SearchResults>) {
+  render(
+    <SearchResultsPanel
+      results={{
+        keyword: "로드맵",
+        counts: { total: 65, meeting: 60, action: 5, project: 0, person: 0 },
+        items: [],
+        cap: null,
+        filtersApplied: true,
+        ...results,
+      }}
+      query={QUERY}
+      projects={PROJECTS}
+      baseParams={new URLSearchParams("q=로드맵")}
+    />,
+  );
+}
+
+describe("SearchResultsPanel — 상한 안내", () => {
+  it("잘렸으면 검색어를 좁히라고만 한다 — 탭을 바꿔도 더 나오지 않는다", () => {
+    renderPanel({
+      items: [
+        {
+          kind: "MEETING",
+          id: 11,
+          title: "로드맵 점검",
+          snippet: null,
+          project: "GOODS",
+          date: null,
+          role: null,
+        },
+      ],
+      cap: { total: 65, shown: 55 },
+    });
+
+    expect(screen.getByText(/나머지를 보려면 검색어를 좁혀 주세요/)).toBeInTheDocument();
+    expect(document.body.textContent).not.toMatch(/탭으로 종류를 골라/);
+  });
+
+  it("잘렸으면 몇 건 중 몇 건인지 머리에 적는다", () => {
+    renderPanel({ cap: { total: 65, shown: 55 } });
+
+    expect(screen.getByText("전체 65건 중 55건")).toBeInTheDocument();
+  });
+});
+
+describe("SearchResultsPanel — 결과 없음", () => {
+  it("서버가 필터를 안 걸면 필터를 바꾸라고 하지 않는다", () => {
+    renderPanel({ items: [], filtersApplied: false });
+
+    expect(screen.getByText("다른 검색어로 찾아 주세요.")).toBeInTheDocument();
+    expect(document.body.textContent).not.toMatch(/필터를 전체로/);
+  });
+
+  it("서버가 필터를 걸면(목) 필터를 되돌리는 길을 알려 준다", () => {
+    renderPanel({ items: [], filtersApplied: true });
+
+    expect(screen.getByText("다른 검색어로 찾거나 필터를 전체로 바꿔 주세요.")).toBeInTheDocument();
+  });
+});

--- a/src/features/search/components/search-results-panel.tsx
+++ b/src/features/search/components/search-results-panel.tsx
@@ -57,11 +57,17 @@ export function SearchResultsPanel({
       {(results.cap || !results.filtersApplied) && (
         <div className="text-muted-foreground flex flex-col gap-1 text-[12px] leading-5">
           {results.cap && (
+            /*
+              ⚠️ **탭을 고르라고 하지 않는다**(2026-08-13 고침). 서버는 늘 `type=ALL`로 한 번만
+                 부르고 상한도 종류마다 걸리므로, 탭을 바꿔도 **같은 줄이 그대로** 나온다 —
+                 "탭으로 종류를 골라 주세요"는 눌러도 아무것도 안 늘어나는 안내였다(§정직성:
+                 지원하지 않는 방법을 권하지 않는다). 실제로 듣는 수단은 검색어를 좁히는 것뿐이다.
+            */
             <p className="flex items-start gap-1.5">
               <Info className="mt-0.5 size-3.5 shrink-0" aria-hidden />
               <span>
-                서버가 상위 <span className="tabular-nums">{results.cap.shown}</span>건까지만
-                돌려줍니다. 나머지를 보려면 검색어를 좁히거나 탭으로 종류를 골라 주세요.
+                서버 상한에 걸려 <span className="tabular-nums">{results.cap.shown}</span>건만
+                왔습니다. 탭을 바꿔도 더 나오지 않으니, 나머지를 보려면 검색어를 좁혀 주세요.
               </span>
             </p>
           )}
@@ -76,10 +82,19 @@ export function SearchResultsPanel({
 
       {results.items.length === 0 ? (
         <div className="border-border bg-card rounded-2xl border">
+          {/*
+            ⚠️ **서버가 필터를 안 걸 때는 필터를 바꾸라고 하지 않는다**(2026-08-13 고침).
+               바로 위에서 "필터는 아직 반영되지 않습니다"라고 해 놓고 "필터를 전체로 바꿔
+               주세요"라고 하면 화면이 두 말을 한다 — 실제로 바꿔도 결과는 한 줄도 안 변한다.
+          */}
           <EmptyState
             icon={SearchX}
             title="검색 결과가 없습니다."
-            description="다른 검색어로 찾거나 필터를 전체로 바꿔 주세요."
+            description={
+              results.filtersApplied
+                ? "다른 검색어로 찾거나 필터를 전체로 바꿔 주세요."
+                : "다른 검색어로 찾아 주세요."
+            }
           />
         </div>
       ) : (

--- a/src/features/search/components/search-results-panel.tsx
+++ b/src/features/search/components/search-results-panel.tsx
@@ -1,4 +1,4 @@
-import { SearchX } from "lucide-react";
+import { Info, SearchX } from "lucide-react";
 
 import { EmptyState } from "@/components/common/empty-state";
 
@@ -36,10 +36,43 @@ export function SearchResultsPanel({
 
       <div className="flex items-center justify-between gap-3">
         <SearchFilterBar projects={projects} projectTag={query.projectTag} period={query.period} />
+        {/*
+          ⚠️ **잘렸으면 전체 건수를 같이 적는다**(§목록: 전체 건수를 머리에 적는다).
+             `결과 50건`만 적으면 50건이 전부인 줄 읽힌다 — 얼마 중 얼마인지가 이 줄의 일이다.
+        */}
         <p className="text-muted-foreground shrink-0 text-[12px] leading-4 tabular-nums">
-          결과 {results.items.length}건
+          {results.cap
+            ? `전체 ${results.cap.total}건 중 ${results.cap.shown}건`
+            : `결과 ${results.items.length}건`}
         </p>
       </div>
+
+      {/*
+        ⚠️ **조용히 자르지 않는다**(§정직성). 서버가 상한(종류별 50건)까지만 주고 다음 장을
+           줄 수단이 없어서 — 스크롤로 이어 붙이지도, 더 보기로 넘기지도 못한다(§목록·페이지네이션).
+           그래서 화면이 할 수 있는 정직한 일은 **잘렸다고 말하고 좁히는 법을 알려 주는 것**이다.
+        ⚠️ 필터 안내도 같은 자리에 둔다 — 서버가 프로젝트·기간을 아직 안 걸러서(BE SR-2 대기)
+           골라도 결과가 그대로다. 아무 말이 없으면 필터가 고장 난 것처럼 보인다.
+      */}
+      {(results.cap || !results.filtersApplied) && (
+        <div className="text-muted-foreground flex flex-col gap-1 text-[12px] leading-5">
+          {results.cap && (
+            <p className="flex items-start gap-1.5">
+              <Info className="mt-0.5 size-3.5 shrink-0" aria-hidden />
+              <span>
+                서버가 상위 <span className="tabular-nums">{results.cap.shown}</span>건까지만
+                돌려줍니다. 나머지를 보려면 검색어를 좁히거나 탭으로 종류를 골라 주세요.
+              </span>
+            </p>
+          )}
+          {!results.filtersApplied && (
+            <p className="flex items-start gap-1.5">
+              <Info className="mt-0.5 size-3.5 shrink-0" aria-hidden />
+              <span>프로젝트·기간 필터는 아직 검색 결과에 반영되지 않습니다.</span>
+            </p>
+          )}
+        </div>
+      )}
 
       {results.items.length === 0 ? (
         <div className="border-border bg-card rounded-2xl border">

--- a/src/features/search/mapper.test.ts
+++ b/src/features/search/mapper.test.ts
@@ -1,0 +1,175 @@
+import type { BeProjectSummary } from "@/features/project/mapper";
+
+import type { BeSearchResponse } from "./mapper";
+import { toProjectFilterOption, toResultCap, toSearchResults } from "./mapper";
+import type { SearchCategoryCounts } from "./types";
+
+/** `GET /api/v1/search` 응답 그대로 — 필드 이름·중첩을 BE 실코드(`SearchResponse.java`)에 맞춰 둔다 */
+function response(overrides: Partial<BeSearchResponse> = {}): BeSearchResponse {
+  return {
+    query: "로드맵",
+    counts: { all: 3, meeting: 1, action: 1, project: 1, person: 0 },
+    results: [
+      {
+        type: "MEETING",
+        id: 11,
+        title: "로드맵 점검",
+        snippet: "8월 로드맵을 확정했습니다.",
+        project: { id: 3, tag: "GOODS", name: "굿즈 앱", color: "#3B82F6" },
+        date: "2026-08-10",
+        role: null,
+        score: 80,
+      },
+      {
+        type: "ACTION",
+        id: 21,
+        title: "로드맵 문서 정리",
+        snippet: null,
+        project: { id: 3, tag: "GOODS", name: "굿즈 앱", color: null },
+        date: "2026-08-14",
+        role: null,
+        score: 30,
+      },
+      {
+        type: "PROJECT",
+        id: 3,
+        title: "굿즈 앱",
+        snippet: null,
+        project: null,
+        date: null,
+        role: null,
+        score: 20,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("toSearchResults", () => {
+  it("프로젝트 객체에서 태그만 꺼내 쓴다 — 화면 계약은 문구 하나다", () => {
+    const results = toSearchResults(response(), "all");
+
+    expect(results.items.map((item) => item.project)).toEqual(["GOODS", "GOODS", null]);
+  });
+
+  it("탭을 고르면 그 종류만 남긴다 — 서버는 늘 ALL로 부른다", () => {
+    const results = toSearchResults(response(), "action");
+
+    expect(results.items.map((item) => item.id)).toEqual([21]);
+  });
+
+  it("탭을 골라도 숫자는 안 흔들린다 — counts는 그대로 넘긴다", () => {
+    const results = toSearchResults(response(), "action");
+
+    expect(results.counts).toEqual({ total: 3, meeting: 1, action: 1, project: 1, person: 0 });
+  });
+
+  it("모르는 종류는 버린다 — 화면이 못 그리는 값을 흘리지 않는다", () => {
+    const be = response();
+    const withUnknown: BeSearchResponse = {
+      ...be,
+      results: [
+        ...be.results,
+        {
+          type: "DOCUMENT",
+          id: 99,
+          title: "우리가 모르는 종류",
+          snippet: null,
+          project: null,
+          date: null,
+          role: null,
+          score: 10,
+        },
+      ],
+    };
+
+    expect(toSearchResults(withUnknown, "all").items.map((item) => item.id)).toEqual([11, 21, 3]);
+  });
+
+  it("BE 정렬을 그대로 지킨다 — 여기서 다시 정렬하지 않는다", () => {
+    const be = response();
+    const reversed: BeSearchResponse = { ...be, results: [...be.results].reverse() };
+
+    expect(toSearchResults(reversed, "all").items.map((item) => item.id)).toEqual([3, 21, 11]);
+  });
+
+  it("서버가 안 걸러 주는 필터는 걸렀다고 하지 않는다(SR-1)", () => {
+    expect(toSearchResults(response(), "all").filtersApplied).toBe(false);
+  });
+
+  it("다 받았으면 잘렸다고 하지 않는다", () => {
+    expect(toSearchResults(response(), "all").cap).toBeNull();
+  });
+
+  it("센 것보다 적게 왔으면 몇 건 중 몇 건인지 알린다(상한에 걸린 경우)", () => {
+    const capped = toSearchResults(
+      response({ counts: { all: 128, meeting: 60, action: 60, project: 8, person: 0 } }),
+      "all",
+    );
+
+    expect(capped.cap).toEqual({ total: 128, shown: 3 });
+  });
+
+  it("잘림 판정은 지금 탭 기준이다 — 다른 종류가 많아도 그 탭이 다 왔으면 안 알린다", () => {
+    const results = toSearchResults(
+      response({ counts: { all: 128, meeting: 60, action: 1, project: 67, person: 0 } }),
+      "action",
+    );
+
+    expect(results.cap).toBeNull();
+  });
+});
+
+describe("toResultCap", () => {
+  const counts: SearchCategoryCounts = {
+    total: 70,
+    meeting: 50,
+    action: 20,
+    project: 0,
+    person: 0,
+  };
+
+  it("전체 탭은 4종 합계와 견준다", () => {
+    expect(toResultCap(counts, "all", 60)).toEqual({ total: 70, shown: 60 });
+  });
+
+  it("종류 탭은 그 종류 건수와 견준다", () => {
+    expect(toResultCap(counts, "meeting", 50)).toBeNull();
+    expect(toResultCap(counts, "meeting", 40)).toEqual({ total: 50, shown: 40 });
+  });
+
+  it("결과가 아예 없으면 잘린 것이 아니다 — 빈 목록과 잘린 목록은 다르다", () => {
+    expect(toResultCap({ total: 0, meeting: 0, action: 0, project: 0, person: 0 }, "all", 0)).toBe(
+      null,
+    );
+  });
+});
+
+describe("toProjectFilterOption", () => {
+  /** `GET /api/projects`의 `PageResponse.content[]` 한 줄 — 필터가 쓰는 값만 확인한다 */
+  const project: BeProjectSummary = {
+    id: 3,
+    tag: "GOODS",
+    color: "#3B82F6",
+    name: "굿즈 앱",
+    description: "굿즈 커머스",
+    status: "IN_PROGRESS",
+    startDate: "2026-07-01",
+    dueDate: "2026-09-30",
+    teamCount: 2,
+    actionCount: 10,
+    completedActionCount: 4,
+    meetingCount: 7,
+    progressPct: 40,
+    teamNames: ["개발팀", "디자인팀"],
+  };
+
+  it("필터·둘러보기가 쓰는 값만 옮긴다", () => {
+    expect(toProjectFilterOption(project)).toEqual({
+      id: 3,
+      tag: "GOODS",
+      name: "굿즈 앱",
+      meetingCount: 7,
+    });
+  });
+});

--- a/src/features/search/mapper.ts
+++ b/src/features/search/mapper.ts
@@ -1,9 +1,12 @@
 import { AUTHORITY, type Authority } from "@/constants/domain";
+import type { BeProjectSummary } from "@/features/project/mapper";
 
+import { categoryOf } from "./lib";
 import type {
-  PersonBrowseItem,
   ProjectBrowseItem,
-  SearchRecentViewItem,
+  SearchCategory,
+  SearchCategoryCounts,
+  SearchResultCap,
   SearchResultItem,
   SearchResults,
 } from "./types";
@@ -13,15 +16,12 @@ import { SEARCH_KIND, type SearchKind } from "./types";
  * BE shape → UI 계약 (§Mock 격리막 — **shape을 흡수하는 곳은 여기 하나다**).
  *
  * ⚠️ 컴포넌트는 이 파일을 모른다. BE가 모양을 바꾸면 여기만 고친다.
- * ⚠️ API 스펙 전달받음(2026-08-11) — **BE 실코드 미대조**(§연동 검증).
+ * ⚠️ [확인] `search/presentation/api/{SearchController,response/SearchResponse}.java`와
+ *    `search/application/service/SearchService.java` 실코드 대조(2026-08-13).
+ * ⚠️ **`GET /api/v1/search/overview`를 읽던 매퍼(`BeSearchOverview`·`toRecentViewItems`·
+ *    `toPersonBrowseItem`)는 걷어냈다** — BE에 그 매핑이 없다(#422). 없는 응답의 모양을
+ *    붙들고 있으면 다음 사람이 그걸 근거로 또 부른다. 생기면 그때 다시 세운다.
  */
-
-export interface BeSearchOverview {
-  recentQueries: string[];
-  recentItems: { type: string; id: number; title: string; meta: string | null }[];
-  projects: { id: number; tag: string; name: string; meetingCount: number }[];
-  people: { id: number; name: string; role: string | null }[];
-}
 
 const VALID_SEARCH_KINDS = Object.values(SEARCH_KIND) as string[];
 
@@ -33,34 +33,17 @@ function toSearchKind(type: string): SearchKind | null {
   return VALID_SEARCH_KINDS.includes(type) ? (type as SearchKind) : null;
 }
 
-/** 종류를 못 알아본 항목은 뺀다 */
-export function toRecentViewItems(items: BeSearchOverview["recentItems"]): SearchRecentViewItem[] {
-  return items.flatMap((item) => {
-    const kind = toSearchKind(item.type);
-    if (!kind) return [];
-    return [{ kind, id: item.id, title: item.title, meta: item.meta }];
-  });
-}
-
-export function toProjectBrowseItem(
-  project: BeSearchOverview["projects"][number],
-): ProjectBrowseItem {
-  return {
-    id: project.id,
-    name: project.name,
-    tag: project.tag,
-    meetingCount: project.meetingCount,
-  };
-}
-
-/** 모르는 권한 문자열은 가장 낮은 권한으로 떨어뜨린다(manage-mapper.ts와 같은 규칙, §권한) */
-function toAuthority(role: string | null): Authority {
-  const values = Object.values(AUTHORITY) as string[];
-  return role !== null && values.includes(role) ? (role as Authority) : AUTHORITY.MEMBER;
-}
-
-export function toPersonBrowseItem(person: BeSearchOverview["people"][number]): PersonBrowseItem {
-  return { id: person.id, name: person.name, authority: toAuthority(person.role) };
+/**
+ * 프로젝트 목록 응답 → 검색 화면의 프로젝트 한 줄(필터 옵션·둘러보기 공용).
+ *
+ * ⚠️ **프로젝트 도메인의 BE shape을 그대로 쓴다**(`BeProjectSummary`). 검색 전용 프로젝트
+ *    조회는 BE에 없어서 `GET /api/projects`를 나눠 쓰는데, 여기서 shape을 또 정의하면 같은
+ *    응답을 두 벌로 들고 있게 된다 — 바뀔 때 한쪽만 고쳐지고 조용히 어긋난다(§연동 검증).
+ * ⚠️ 화면에 나가는 건 **이름과 태그**뿐이다. 상태·진행률처럼 목록 카드용 값은 안 옮긴다 —
+ *    필터 드롭다운이 못 쓰는 값을 실어 나를 이유가 없다.
+ */
+export function toProjectFilterOption(be: BeProjectSummary): ProjectBrowseItem {
+  return { id: be.id, name: be.name, tag: be.tag, meetingCount: be.meetingCount };
 }
 
 /**
@@ -86,9 +69,8 @@ export interface BeSearchResponse {
 }
 
 /**
- * 모르는 권한 문자열은 **빈 값으로** 둔다 — `toAuthority`(overview의 사람 목록)와 다른 규칙이다.
- * 거긴 "이 사람의 권한은 늘 있다"는 전제라 최저 권한으로 떨어뜨리지만, 검색 결과의 `role`은
- * 요구사항대로 "안 오면 빈 값" — 모르는 문자열도 잘못된 권한 배지를 다는 것보다 안 다는 게 낫다.
+ * 모르는 권한 문자열은 **빈 값으로** 둔다. 검색 결과의 `role`은 요구사항대로 "안 오면 빈 값"이라 —
+ * 모르는 문자열도 잘못된 권한 배지를 다는 것보다 안 다는 게 낫다.
  */
 function toAuthorityOrNull(role: string | null): Authority | null {
   if (role === null) return null;
@@ -96,9 +78,42 @@ function toAuthorityOrNull(role: string | null): Authority | null {
   return values.includes(role) ? (role as Authority) : null;
 }
 
-/** BE 정렬 순서를 그대로 지킨다 — 여기서 다시 정렬하지 않는다 */
-export function toSearchResults(be: BeSearchResponse): SearchResults {
-  const items = be.results.flatMap((hit): SearchResultItem[] => {
+/**
+ * 서버가 `tags`(프로젝트)·`from`/`to`(기간)를 **실제로 걸러 주는가** — 지금은 아니다.
+ *
+ * ⚠️ **SR-2가 붙는 날 이 한 줄만 `true`로 바꾼다.** 그러면 화면의 "필터가 아직 반영되지
+ *    않습니다" 안내가 저절로 사라진다(§Mock 격리막 — 컴포넌트는 안 고친다).
+ *    근거: BE `SearchService`의 SR-1 주석 + `SearchJdbcQueryAdapter`에 태그·기간 WHERE 부재.
+ */
+const SERVER_APPLIES_FILTERS = false;
+
+/**
+ * 지금 탭에서 **몇 건 중 몇 건을 보고 있는지** — 다 받았으면 `null`.
+ *
+ * ⚠️ 세는 자리가 다르다: `total`은 서버가 상한과 무관하게 센 값이고 `shown`은 실제로 받은
+ *    줄 수다. 서버 상한(`limit`)에 걸려 잘렸거나, 매퍼가 모르는 종류를 걸러냈으면 벌어진다 —
+ *    어느 쪽이든 **화면이 전부를 보여주고 있지 않다**는 사실은 같으므로 같은 값으로 알린다.
+ * ⚠️ `all` 탭의 `total`은 4종 합계이고, 상한은 **종류마다** 걸리므로 한 종류만 잘려도 벌어진다.
+ */
+export function toResultCap(
+  counts: SearchCategoryCounts,
+  category: SearchCategory,
+  shown: number,
+): SearchResultCap | null {
+  const total = category === "all" ? counts.total : counts[category];
+  return shown < total ? { total, shown } : null;
+}
+
+/**
+ * BE 정렬 순서를 그대로 지킨다 — 여기서 다시 정렬하지 않는다.
+ *
+ * ⚠️ **탭 거르기를 여기서 한다.** 서버에 `type`을 실어 좁히지 않고 늘 `ALL`로 받아 오기
+ *    때문이다(이유는 `server.ts`의 호출부 주석 — `type`을 좁히면 다른 탭 숫자가 전부 0으로
+ *    내려와 "결과가 없다"는 거짓말이 된다). 종류별 상한은 서버가 종류마다 따로 걸어 주므로,
+ *    좁혀 받든 걸러 쓰든 **그 탭에 보이는 줄은 같다**.
+ */
+export function toSearchResults(be: BeSearchResponse, category: SearchCategory): SearchResults {
+  const all = be.results.flatMap((hit): SearchResultItem[] => {
     const kind = toSearchKind(hit.type);
     if (!kind) return [];
     return [
@@ -114,15 +129,20 @@ export function toSearchResults(be: BeSearchResponse): SearchResults {
     ];
   });
 
+  const counts: SearchCategoryCounts = {
+    total: be.counts.all,
+    meeting: be.counts.meeting,
+    action: be.counts.action,
+    project: be.counts.project,
+    person: be.counts.person,
+  };
+  const items = category === "all" ? all : all.filter((item) => categoryOf(item) === category);
+
   return {
     keyword: be.query,
-    counts: {
-      total: be.counts.all,
-      meeting: be.counts.meeting,
-      action: be.counts.action,
-      project: be.counts.project,
-      person: be.counts.person,
-    },
+    counts,
     items,
+    cap: toResultCap(counts, category, items.length),
+    filtersApplied: SERVER_APPLIES_FILTERS,
   };
 }

--- a/src/features/search/server.test.ts
+++ b/src/features/search/server.test.ts
@@ -1,0 +1,54 @@
+// server.ts는 "server-only"를 import한다 — jest(기본 조건)에선 그 모듈이 던지므로 비운다.
+jest.mock("server-only", () => ({}));
+
+import { getSearchHome, getSearchResults } from "./server";
+import { SEARCH_CATEGORY, SEARCH_PERIOD } from "./types";
+
+/** 목 분기만 여기서 확인한다(`isMock` 기본값 = 켜짐). 실서버 분기는 매퍼 테스트가 맡는다. */
+describe("검색 결과 — 목 분기", () => {
+  it("목은 픽스처 전체를 직접 거른다 — 잘릴 일이 없다", async () => {
+    const results = await getSearchResults({
+      keyword: "로드맵",
+      category: SEARCH_CATEGORY.ALL,
+      projectTag: null,
+      period: SEARCH_PERIOD.ALL,
+    });
+
+    expect(results.items.length).toBeGreaterThan(0);
+    expect(results.cap).toBeNull();
+  });
+
+  it("목은 프로젝트·기간을 직접 거른다 — '반영 안 됨' 안내를 띄우지 않는다", async () => {
+    const results = await getSearchResults({
+      keyword: "로드맵",
+      category: SEARCH_CATEGORY.ALL,
+      projectTag: null,
+      period: SEARCH_PERIOD.ALL,
+    });
+
+    expect(results.filtersApplied).toBe(true);
+  });
+
+  it("검색어가 없으면 아무것도 안 묻는다 — 잘림·필터 안내도 없다", async () => {
+    const results = await getSearchResults({
+      keyword: "   ",
+      category: SEARCH_CATEGORY.ALL,
+      projectTag: null,
+      period: SEARCH_PERIOD.ALL,
+    });
+
+    expect(results.items).toEqual([]);
+    expect(results.cap).toBeNull();
+    expect(results.filtersApplied).toBe(true);
+  });
+});
+
+describe("검색 랜딩 — 목 분기", () => {
+  it("목은 네 칸을 다 채우므로 '서버가 안 준다'고 말하지 않는다", async () => {
+    const home = await getSearchHome();
+
+    expect(home.unavailable).toEqual([]);
+    expect(home.projects.length).toBeGreaterThan(0);
+    expect(home.people.length).toBeGreaterThan(0);
+  });
+});

--- a/src/features/search/server.ts
+++ b/src/features/search/server.ts
@@ -1,19 +1,15 @@
 import "server-only";
 
 import { requireAccessToken } from "@/features/auth/session";
+import type { BePageResponse, BeProjectSummary } from "@/features/project/mapper";
 import { serverApi } from "@/lib/api";
 import { todayIso } from "@/lib/date";
 import { ep } from "@/lib/endpoints";
 import { isMock } from "@/mocks/config";
 
 import { categoryOf, textIncludes } from "./lib";
-import type { BeSearchOverview, BeSearchResponse } from "./mapper";
-import {
-  toPersonBrowseItem,
-  toProjectBrowseItem,
-  toRecentViewItems,
-  toSearchResults,
-} from "./mapper";
+import type { BeSearchResponse } from "./mapper";
+import { toProjectFilterOption, toSearchResults } from "./mapper";
 import {
   SEARCH_MOCK_ACTIONS,
   SEARCH_MOCK_MEETINGS,
@@ -25,12 +21,13 @@ import { listMockRecentSearches } from "./mock/recent-searches";
 import type {
   MockSearchRecord,
   ProjectBrowseItem,
-  SearchCategory,
   SearchHome,
+  SearchHomeSection,
   SearchQuery,
   SearchResultItem,
   SearchResults,
 } from "./types";
+import { SEARCH_HOME_SECTION } from "./types";
 
 /** 검색 — 격리막(CLAUDE.md). 연동할 때 고칠 곳은 이 파일과 매퍼뿐이고 컴포넌트는 건드리지 않는다. */
 
@@ -43,7 +40,38 @@ function mapProjectsForBrowse(): ProjectBrowseItem[] {
   }));
 }
 
-/** 검색어가 없을 때(랜딩)의 화면 — 최근 검색어·최근 본 항목·둘러보기 목록 */
+/**
+ * 프로젝트 목록을 한 번에 받는 크기.
+ *
+ * ⚠️ **드롭다운·둘러보기는 전부를 놓고 골라야 한다** — 잘라 받으면 뒤쪽 프로젝트가 목록에
+ *    아예 안 떠서 "그 프로젝트로는 못 좁힌다"가 된다. 다른 화면(`project/server.ts`·
+ *    `board/server.ts`)이 이미 쓰는 방식과 같다(BE에 "전체" 파라미터가 없다).
+ */
+const PROJECT_PAGE_SIZE = 9999;
+
+/**
+ * 랜딩·필터가 함께 쓰는 프로젝트 목록 — `GET /api/projects`(전 구성원 공개, `PageResponse` 봉투).
+ * [확인] `project/presentation/api/ProjectController.list` (2026-08-13 실코드 대조).
+ */
+async function fetchProjectOptions(accessToken: string): Promise<ProjectBrowseItem[]> {
+  const page = await serverApi<BePageResponse<BeProjectSummary>>(
+    ep.projects({ size: PROJECT_PAGE_SIZE }),
+    { accessToken },
+  );
+  return page.content.map(toProjectFilterOption);
+}
+
+/**
+ * 검색어가 없을 때(랜딩)의 화면 — 최근 검색어·최근 본 항목·둘러보기 목록.
+ *
+ * ⚠️ **실서버에서 채울 수 있는 칸은 프로젝트뿐이다**(2026-08-13, #422).
+ *    - 최근 검색어·최근 본 항목: `GET /api/v1/search/overview`가 **BE에 없다** — 예전엔 그걸
+ *      불러서 랜딩이 **404로 통째로 죽었다.** 검색어를 치기도 전에 에러 화면이었다.
+ *    - 사람: 회사 명부(`GET /api/members`)는 **OWNER·ADMIN 전용**이라(§권한 ①축) 사원·팀장이
+ *      부르면 403이다. 권한 없는 사람의 화면을 살리려고 부를 수 있는 API가 아니다.
+ *    못 채우는 칸은 **빈 배열이 아니라 `unavailable`로 알린다** — 빈 화면은 "본 게 없다"는
+ *    뜻이 되어 버려 사용자가 자기 탓으로 읽는다(§정직성).
+ */
 export async function getSearchHome(): Promise<SearchHome> {
   if (isMock) {
     return {
@@ -55,36 +83,35 @@ export async function getSearchHome(): Promise<SearchHome> {
         name: person.name,
         authority: person.authority,
       })),
+      unavailable: [],
     };
   }
 
-  /*
-    [스펙 전달, BE 실코드 미대조] `GET /api/v1/search/overview` — 최근 검색어·최근 본 항목·
-    둘러보기용 프로젝트·사람 목록을 한 번에 준다. 회사·사람은 토큰 기준으로 서버가 정한다.
-  */
   const accessToken = await requireAccessToken();
-  const overview = await serverApi<BeSearchOverview>(ep.searchOverview(), { accessToken });
+  const projects = await fetchProjectOptions(accessToken);
 
-  return {
-    recentSearches: overview.recentQueries,
-    recentlyViewed: toRecentViewItems(overview.recentItems),
-    projects: overview.projects.map(toProjectBrowseItem),
-    people: overview.people.map(toPersonBrowseItem),
-  };
+  const unavailable: SearchHomeSection[] = [
+    SEARCH_HOME_SECTION.RECENT_SEARCHES,
+    SEARCH_HOME_SECTION.RECENTLY_VIEWED,
+    SEARCH_HOME_SECTION.PEOPLE,
+  ];
+
+  return { recentSearches: [], recentlyViewed: [], projects, people: [], unavailable };
 }
 
 /**
  * 결과 화면의 프로젝트 필터 목록.
  *
- * ⚠️ **`getSearchHome()`을 대신 쓰지 않는다.** 그건 최근 검색어·최근 본 항목까지 같이 불러오는
- *    랜딩 전용 조회라, 검색어가 있는 화면(결과 목록)에서 그걸 불러오면 랜딩 쪽 API가 실패했을 때
- *    결과 화면까지 같이 죽는다 — 결과 화면이 실제로 필요한 건 필터용 프로젝트 목록뿐이다.
+ * ⚠️ **`getSearchHome()`을 대신 쓰지 않는다.** 그건 랜딩이 쓰는 칸까지 같이 들고 오는 조회라,
+ *    거기가 실패하면 결과 화면까지 같이 죽는다 — 결과 화면이 필요한 건 필터 목록뿐이다.
+ * ⚠️ 검색 전용 프로젝트 API는 없다. **회의·액션이 매달린 그 프로젝트 목록 그대로**를 쓴다 —
+ *    필터가 실제 데이터와 다른 목록을 보여주면 고른 값에 걸리는 결과가 없다(#422).
  */
 export async function getSearchProjects(): Promise<ProjectBrowseItem[]> {
   if (isMock) return mapProjectsForBrowse();
 
-  // ⚠️ 미구현 — API 스펙 확정 후 프로젝트 목록 경로로 fetch하고 매퍼로 UI 계약에 맞춘다.
-  throw new Error("검색 필터용 프로젝트 목록 API가 아직 연결되지 않았습니다.");
+  const accessToken = await requireAccessToken();
+  return fetchProjectOptions(accessToken);
 }
 
 /**
@@ -239,13 +266,11 @@ function toSearchResultItem(record: MockSearchRecord): SearchResultItem {
   }
 }
 
-const BE_SEARCH_TYPE: Record<SearchCategory, string> = {
-  all: "ALL",
-  meeting: "MEETING",
-  action: "ACTION",
-  project: "PROJECT",
-  person: "PERSON",
-};
+/*
+  ⚠️ 탭 → BE `type` 매핑표(`meeting`→`MEETING` …)는 걷어냈다(2026-08-13, #422). 지금은 늘
+     `type=ALL`로 부르고 탭은 매퍼가 거른다 — 이유는 `getSearchResults`의 호출부 주석에 있다.
+     표만 남겨 두면 다음 사람이 "쓰라고 있는 값"으로 읽고 되돌린다.
+*/
 
 /** 오늘 기준 `days`일 전 — `Date.UTC`로만 셈해 시간대에 안 흔들린다(`lib/date.ts`와 같은 방식) */
 function isoDaysBefore(to: string, days: number): string {
@@ -264,6 +289,18 @@ function toDateRange(period: SearchQuery["period"]): { from: string | null; to: 
   return { from: isoDaysBefore(to, days), to };
 }
 
+/**
+ * 한 번에 받아 오는 상한 — **BE가 허용하는 최대치**다(`SearchService.MAX_LIMIT`, 1~50).
+ *
+ * ⚠️ **51 이상을 보내면 결과가 아니라 400이 온다.** 더 받고 싶으면 BE부터 고쳐야 한다 —
+ *    안 보내면 서버 기본값 20이라, 그동안 21건째부터는 볼 방법이 아예 없었다(#422).
+ * ⚠️ 이 상한은 **종류마다** 걸린다(`type=ALL`이면 회의·액션·프로젝트·사람 각각 50까지).
+ * ⚠️ 넓혔을 뿐 **없앤 게 아니다.** `GET /api/v1/search`에는 page 파라미터가 없어서 스크롤로
+ *    이어 붙이는 방식(§목록·페이지네이션)을 못 붙인다 — 없는 페이지네이션을 지어내는 대신
+ *    **잘렸으면 잘렸다고 화면이 말한다**(`SearchResults.cap`, §정직성).
+ */
+const SEARCH_RESULT_LIMIT = 50;
+
 /** 검색 결과 — 카테고리 탭 숫자는 키워드·프로젝트·기간까지 반영해 센다(탭을 눌러도 숫자가 안 흔들리게). */
 export async function getSearchResults(query: SearchQuery): Promise<SearchResults> {
   const keyword = query.keyword.trim();
@@ -273,6 +310,9 @@ export async function getSearchResults(query: SearchQuery): Promise<SearchResult
       keyword,
       counts: { total: 0, meeting: 0, action: 0, project: 0, person: 0 },
       items: [],
+      cap: null,
+      /* 아무것도 안 물어봤으니 필터도 걸 일이 없다 — 안내를 띄울 자리가 아니다 */
+      filtersApplied: true,
     };
   }
 
@@ -300,21 +340,33 @@ export async function getSearchResults(query: SearchQuery): Promise<SearchResult
         : matched.filter((item) => categoryOf(item) === query.category)
     ).map(toSearchResultItem);
 
-    return { keyword, counts, items };
+    /* 목은 전체 픽스처를 직접 거른다 — 잘릴 일도, 서버가 안 걸러 줄 일도 없다 */
+    return { keyword, counts, items, cap: null, filtersApplied: true };
   }
 
   /*
-    [스펙 전달, BE 실코드 미대조] `GET /api/v1/search` — 탭 숫자(`counts`)는 카테고리(`type`)만
-    빼고 지금 건 프로젝트·기간 필터를 반영해 서버가 센다(우리 mock과 같은 규칙). 정렬도
-    서버가 정한 순서를 그대로 쓴다 — 여기서 다시 정렬하지 않는다.
+    [확인] `GET /api/v1/search` — BE 실코드 대조(2026-08-13): `SearchController`·`SearchService`.
+    정렬은 서버가 정한 순서(점수→날짜→id)를 그대로 쓴다 — 여기서 다시 정렬하지 않는다.
+
+    ⚠️ **탭(`type`)을 실어 좁히지 않고 늘 `ALL`로 부른다.** `type`을 좁히면 서버가 **나머지
+       종류의 `counts`를 0으로 내려보낸다**(`SearchService.countIfRequested`) — 회의 탭을 누른
+       순간 액션·프로젝트·사람 숫자가 전부 0이 되어 **"다른 데는 결과가 없다"는 거짓말**이 된다.
+       우리 계약은 "탭을 눌러도 숫자는 안 흔들린다"이므로(types.ts `SearchResults.counts`)
+       전부 받아 매퍼가 탭으로 거른다. 상한이 종류마다 걸리는 덕에 **그 탭에 보이는 줄은 같다.**
+    ⚠️ `tags`·`from`·`to`는 **서버가 아직 안 거른다**(SR-1). 그래도 계속 보내는 건 SR-2가
+       붙는 날 호출부를 다시 안 고치려는 것이고, 안 걸린다는 사실은 화면이 밝힌다(`filtersApplied`).
   */
   const accessToken = await requireAccessToken();
   const { from, to } = toDateRange(query.period);
-  const params = new URLSearchParams({ q: keyword, type: BE_SEARCH_TYPE[query.category] });
+  const params = new URLSearchParams({
+    q: keyword,
+    type: "ALL",
+    limit: String(SEARCH_RESULT_LIMIT),
+  });
   if (query.projectTag) params.append("tags", query.projectTag);
   if (from) params.set("from", from);
   if (to) params.set("to", to);
 
   const response = await serverApi<BeSearchResponse>(`${ep.search()}?${params}`, { accessToken });
-  return toSearchResults(response);
+  return toSearchResults(response, query.category);
 }

--- a/src/features/search/types.ts
+++ b/src/features/search/types.ts
@@ -100,6 +100,22 @@ export interface SearchCategoryCounts {
   person: number;
 }
 
+/**
+ * 결과가 **잘려서 왔다**는 사실 — 안 잘렸으면 `null`이다.
+ *
+ * ⚠️ **조용히 자르지 않으려고 값으로 들고 다닌다**(§정직성). 실서버 `GET /api/v1/search`는
+ *    `limit`(최대 50)까지만 주고 **page 파라미터가 없다** — 21건째, 51건째를 볼 방법이 서버에
+ *    없으므로 화면은 "여기까지가 전부"인 척하는 대신 **얼마 중 얼마인지**를 밝힌다.
+ * ⚠️ 무한 스크롤(§목록·페이지네이션)은 **못 만든다.** 이어 붙일 다음 페이지를 서버가 못 준다 —
+ *    없는 페이지네이션을 지어내면 [다시 시도]만 도는 화면이 된다.
+ */
+export interface SearchResultCap {
+  /** 이 조건에 실제로 있는 건수 — 서버가 상한과 무관하게 센 값(`counts`) */
+  total: number;
+  /** 그중 화면이 실제로 받은 건수 */
+  shown: number;
+}
+
 /** 검색 결과 화면이 한 번에 받는 것 */
 export interface SearchResults {
   keyword: string;
@@ -110,6 +126,18 @@ export interface SearchResults {
   counts: SearchCategoryCounts;
   /** 지금 고른 탭·필터로 걸러진 목록 */
   items: SearchResultItem[];
+  /** 서버가 상한까지만 줘서 잘린 상태 — 다 받았으면 `null` */
+  cap: SearchResultCap | null;
+  /**
+   * 프로젝트·기간 필터를 **서버가 실제로 걸렀는가**.
+   *
+   * ⚠️ 실서버는 지금 `tags`·`from`·`to`를 **받기만 하고 안 건다**(SR-1 — [확인] BE
+   *    `SearchService` 주석과 `SearchJdbcQueryAdapter`의 WHERE 절, 2026-08-13 실코드 대조).
+   *    그러면 필터를 골라도 결과가 그대로인데, 화면이 아무 말도 안 하면 **필터가 고장 난 것처럼
+   *    보인다** — 값으로 받아 화면이 "아직 반영되지 않는다"고 밝힌다(§정직성).
+   * ⚠️ 목은 직접 거르므로 항상 `true`다. SR-2가 붙으면 `mapper.ts`의 상수 한 줄만 바꾼다.
+   */
+  filtersApplied: boolean;
 }
 
 export interface ProjectBrowseItem {
@@ -137,6 +165,23 @@ export interface SearchRecentViewItem {
   meta: string | null;
 }
 
+/**
+ * 랜딩의 칸 — **비어 있는 것과 못 받은 것을 가르려고** 이름을 붙여 둔다.
+ * (`features/meeting/view-types.ts`의 `MeetingContentPending`과 같은 결: 왜 비었는지를 값으로 준다)
+ */
+export const SEARCH_HOME_SECTION = {
+  RECENT_SEARCHES: "RECENT_SEARCHES",
+  RECENTLY_VIEWED: "RECENTLY_VIEWED",
+  PEOPLE: "PEOPLE",
+} as const;
+export type SearchHomeSection = (typeof SEARCH_HOME_SECTION)[keyof typeof SEARCH_HOME_SECTION];
+
+export const SEARCH_HOME_SECTION_LABEL: Record<SearchHomeSection, string> = {
+  RECENT_SEARCHES: "최근 검색어",
+  RECENTLY_VIEWED: "최근 본 항목",
+  PEOPLE: "사람으로 찾기",
+};
+
 /** 검색어가 없을 때(랜딩) 보여줄 것 */
 export interface SearchHome {
   /** 최신순 — 최대 10개 */
@@ -144,6 +189,14 @@ export interface SearchHome {
   recentlyViewed: SearchRecentViewItem[];
   projects: ProjectBrowseItem[];
   people: PersonBrowseItem[];
+  /**
+   * **서버가 아직 못 채우는 칸** — 목에서는 늘 빈 배열이다.
+   *
+   * ⚠️ 빈 배열과 뜻이 다르다: `recentlyViewed: []`는 "본 게 없다"이고, 여기에
+   *    `RECENTLY_VIEWED`가 들어 있으면 "물어볼 API가 없다"다. 둘을 같은 빈 화면으로 보여주면
+   *    사용자는 자기가 아무것도 안 본 줄 안다(§정직성 — 조용히 안 되는 척 금지).
+   */
+  unavailable: SearchHomeSection[];
 }
 
 export const SEARCH_CATEGORY = {

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -270,11 +270,27 @@ export const ep = {
   notice: (noticeId: number) => `/api/notices/${noticeId}`,
   subscription: () => "/api/subscription",
 
-  /**
-   * 검색 — API 스펙 전달받음(2026-08-11), **BE 실코드 미대조**(§연동 검증: 문서와 코드가
-   * 다르면 코드가 맞다 — 구현 붙일 때 컨트롤러로 재확인한다).
+  /*
+   * 검색 — [확인] `search/presentation/api/SearchController.java` 실코드 대조(2026-08-13).
+   *
+   * ⚠️ **컨트롤러에 있는 건 `GET /api/v1/search` 하나뿐이다.** 아래 셋(overview·recent-queries·
+   *    recent-views)은 2026-08-11에 스펙만 받아 적어 둔 **FE 제안 경로**이고 BE에 매핑이 없다 —
+   *    부르면 404다. 지우지 않고 남기는 건 "합의는 있었고 구현이 없다"는 사실까지 잃지 않으려는
+   *    것이고, **생기기 전까지 호출하지 않는다**(§환각 API 방지). 호출부는 이 주석을 근거로
+   *    비워 뒀다(`features/search/{server,actions}.ts`).
+   * ⚠️ `/api/v1/` 접두사는 회의·캡처에서는 폐기됐지만 **검색은 아직 v1이 맞다**
+   *    (`@RequestMapping("/api/v1/search")`). 다른 도메인을 따라 떼면 404다.
    */
   searchOverview: () => "/api/v1/search/overview",
+  /**
+   * 통합 검색(SR-1) — `q`(필수) · `type`(ALL·MEETING·ACTION·PROJECT·PERSON) · `tags` · `from` ·
+   * `to` · `limit`. **page는 없다** — 21건째부터 보는 수단이 아직 서버에 없다.
+   *
+   * ⚠️ **`limit`은 1~50이고 벗어나면 400**(`SearchService.MAX_LIMIT`) — 크게 부르면 결과가
+   *    아니라 에러가 온다. 그리고 그 상한은 **종류마다** 걸린다(`type=ALL`이면 4종 × limit).
+   * ⚠️ **`tags`·`from`·`to`는 받기만 하고 WHERE에 안 건다**(SR-1 — `SearchJdbcQueryAdapter`에
+   *    태그·기간 조건이 아예 없다). 보내도 결과가 안 좁혀진다, SR-2 대기(§연동 검증).
+   */
   search: () => "/api/v1/search",
   searchRecentQueries: () => "/api/v1/search/recent-queries",
   searchRecentViews: () => "/api/v1/search/recent-views",


### PR DESCRIPTION
## 📋 PR 타입

> 해당하는 타입을 선택해 주세요 (복수 선택 가능)

- [ ] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- **프로젝트 필터를 `GET /api/projects`로 이었다** — `search/server.ts`가 던지던 "아직 연결되지 않았습니다"가 실연동에서 결과 화면 전체를 죽였다. `PageResponse` 봉투를 벗겨 `toProjectFilterOption` 매퍼로 UI 계약에 맞춘다(프로젝트 도메인의 `BeProjectSummary`를 그대로 재사용 — shape을 두 벌로 들면 조용히 어긋난다).
- **결과 상한을 20 → 50(BE 최대치)으로 올리고, 잘렸으면 잘렸다고 말한다** — `limit`은 1~50이고 벗어나면 400이다(`SearchService.MAX_LIMIT`). **BE에 page 파라미터가 없어 스크롤 무한로딩(§목록·페이지네이션)을 못 붙인다** — 없는 페이지네이션을 지어내는 대신 `SearchResults.cap`(전체 N건 중 M건)을 값으로 내려 화면이 "서버가 상위 M건까지만 돌려줍니다 · 검색어를 좁혀 주세요"라고 밝힌다(§정직성: 조용한 절삭 금지).
- **랜딩(검색어 없을 때)이 404로 죽던 것을 고쳤다** — `GET /api/v1/search/overview`는 **BE에 매핑 자체가 없다**(`SearchController`엔 `GET /api/v1/search` 하나뿐). 검색어를 치기도 전에 에러 화면이었다. 채울 수 있는 칸(프로젝트 둘러보기)만 실제로 채우고, 못 채우는 칸은 **빈 배열이 아니라 `SearchHome.unavailable`로** 알린다("최근 검색어 · 최근 본 항목 · 사람으로 찾기는 아직 서버가 제공하지 않습니다"). 빈 화면으로 두면 "내가 안 봐서 비었다"로 읽힌다.
- **탭 숫자가 0으로 내려가던 문제** — `type`을 좁혀 보내면 BE가 나머지 종류의 `counts`를 0으로 준다(`countIfRequested`). 회의 탭을 누른 순간 액션·프로젝트·사람이 전부 0이 되어 "다른 데는 결과가 없다"는 거짓말이 됐다. 늘 `type=ALL`로 받아 **매퍼가 탭으로 거른다**(상한이 종류마다 걸려 그 탭에 보이는 줄은 동일).
- **프로젝트·기간 필터가 서버에서 무시된다는 사실을 화면이 밝힌다** — BE SR-1은 `tags`·`from`·`to`를 시그니처로만 받고 WHERE에 안 건다(`SearchJdbcQueryAdapter`에 조건 부재). 파라미터는 계속 보내되(SR-2가 붙으면 매퍼 상수 한 줄만 `true`), "프로젝트·기간 필터는 아직 검색 결과에 반영되지 않습니다"를 결과 위에 한 줄로 띄운다.
- **없는 API를 부르던 기록 액션 2종을 멈췄다** — `POST .../recent-queries`·`.../recent-views`도 BE에 없다. 매번 404를 내고 조용히 삼키면 "기록되고 있다"는 착각만 남아서 호출을 걷어내고 이유를 주석으로 남겼다(경로·호출 지점은 그대로 둬 되살릴 때 안쪽만 채운다).
- 테스트: `search/mapper.test.ts`(탭 거르기·cap 계산·모르는 종류 제거·BE 정렬 유지·필터 옵션 매핑), `search/server.test.ts`(목 분기는 잘림·필터 안내가 안 뜬다).

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**(회의 담당자 등), 그리고 **서버(Server Action/BFF)에서 재검사** — 조회 전용이고 스코프는 토큰으로 서버가 정한다. 랜딩에서 회사 명부(`GET /api/members`, OWNER·ADMIN 전용)를 **부르지 않는 것**도 이 축 때문이다(사원·팀장이면 403).
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse` — 이 도메인은 아직 수동 매퍼다(기존과 동일, 별도 이슈).
- [x] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시 (조용히 "되는 척" 금지) — 이 PR의 본체다(상한·필터 미반영·랜딩 미제공 3종을 화면에 명시).
- [x] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨 — 안내 문구는 `text-muted-foreground`뿐, 새 색 없음.

**품질**

- [x] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그) — 서버 컴포넌트 유지, 클라이언트 번들 증가 없음.
- [x] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로 — 안내는 `<p>` 텍스트, 아이콘은 `aria-hidden`(정보는 글로 전달).
- [x] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인) — `EmptyState`·`lib/korean`(조사)·프로젝트 도메인 매퍼 재사용, 새 공용 컴포넌트 없음.
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 기존 `loading.tsx`·`error.tsx` 그대로, empty는 "안 받아온 것"과 구분해 문구를 나눴다.
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음 — 해당 없음.

---

## 🔗 연관 이슈

Closes #422

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
| 실연동 시 결과 화면 = 필터 조회 throw로 에러, 랜딩 = overview 404로 에러 | 필터가 실 프로젝트로 채워지고, 잘리면 "전체 128건 중 50건"과 안내 한 줄 |

---

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

- **상한 처리 방식에 동의하시는지**(핵심). BE에 page가 없어 §목록·페이지네이션의 스크롤 트리거를 못 씁니다. "50까지 받고 잘렸다고 말한다"가 지금 할 수 있는 정직한 최선이라 봤는데, 문구(`서버가 상위 N건까지만 돌려줍니다. 나머지를 보려면 검색어를 좁히거나 탭으로 종류를 골라 주세요`) 톤을 봐 주세요.
- **늘 `type=ALL`로 부르는 결정** — 탭 숫자를 지키려는 맞바꿈입니다(BE가 탭별 조회에서 나머지 counts를 0으로 준다). 대신 탭을 눌러도 서버는 4종을 다 훑습니다. 비용이 문제면 "탭 숫자는 첫 조회 값 유지" 같은 대안으로 바꿀 수 있습니다.
- **필터 미반영 안내를 화면에 노출하는 것** — 사용자에게 BE 사정을 알리는 문구라 호불호가 갈릴 수 있습니다. 다만 아무 말이 없으면 필터가 고장 난 것으로 읽힙니다. SR-2가 붙으면 `mapper.ts`의 `SERVER_APPLIES_FILTERS` 한 줄로 사라집니다.
- **기록 액션 2종을 호출하지 않게 한 것** — 404를 조용히 삼키는 기존 동작보다 낫다고 봤습니다. 되살릴 때 함수 안만 채우면 되게 경로·호출 지점은 남겼습니다.

---

## 📝 추가 메모

**BE에 요청할 것(요청 문서용, 전부 실코드 대조 2026-08-13)**

1. `GET /api/v1/search`에 **페이지네이션**(`page`/`size` + `PageResponse`) — 지금은 `limit` 최대 50이고 그 위는 볼 방법이 없습니다. 다른 목록 3종과 같은 봉투면 FE는 스크롤 트리거만 붙이면 됩니다.
2. **SR-2: `tags`·`from`·`to`를 WHERE에 연결** — 지금은 받기만 하고 안 걸러 프로젝트·기간 필터가 무동작입니다.
3. **탭별 조회에서도 전체 `counts`를 유지** — `type`을 좁히면 나머지 종류가 0으로 내려옵니다(`SearchService.countIfRequested`). 유지되면 FE가 `type=ALL` 우회를 걷어냅니다.
4. **최근 검색어·최근 본 항목 API**(`GET/POST /api/v1/search/recent-queries`·`recent-views`, `GET /api/v1/search/overview`) — 스펙만 있고 컨트롤러에 매핑이 없습니다. 랜딩의 두 칸이 이것 때문에 비어 있습니다.
5. **전 구성원이 부를 수 있는 사람 목록** — `GET /api/members`는 OWNER·ADMIN 전용이라 랜딩의 "사람으로 찾기"를 채울 수 없습니다(`/app/people`도 같은 제약).
