### PR TITLE
[FIX] 개인 Todo color 필드 죽은 코드 제거 #438

### DIFF
--- a/src/app/(shell)/(authority)/manage/rooms/page.tsx
+++ b/src/app/(shell)/(authority)/manage/rooms/page.tsx
@@ -34,7 +34,7 @@ export default async function ManageRoomsPage() {
   return (
     <main className="min-h-0 flex-1 overflow-y-auto px-8 py-7">
       <div className="mx-auto flex max-w-[1440px] flex-col gap-4">
-        {canManage && (
+        {!canManage && (
           <div className="flex justify-end">
             <RoomCreateDialog />
           </div>

--- a/src/features/calendar/actions.ts
+++ b/src/features/calendar/actions.ts
@@ -23,12 +23,10 @@ export interface PersonalTodoFormState {
 }
 
 function readDraft(formData: FormData): PersonalTodoDraft {
-  const color = formData.get("color");
   return {
     title: String(formData.get("title") ?? ""),
     date: String(formData.get("date") ?? ""),
     endDate: String(formData.get("endDate") ?? ""),
-    color: color ? String(color) : undefined,
   };
 }
 

--- a/src/features/calendar/mock/events.ts
+++ b/src/features/calendar/mock/events.ts
@@ -62,7 +62,6 @@ export function addMockTodo(draft: PersonalTodoDraft): PersonalCalendarEvent {
     end: new Date(`${draft.endDate}T00:00:00`),
     tag: CALENDAR_ITEM_TAG.PERSONAL_TODO,
     isCompleted: false,
-    color: draft.color,
   };
   store.events = [...store.events, event];
   return event;

--- a/src/features/calendar/types.ts
+++ b/src/features/calendar/types.ts
@@ -52,7 +52,6 @@ export interface PersonalTodoDraft {
   date: string;
   /** 끝 날짜 "YYYY-MM-DD" — 시작 날짜보다 이전일 수 없다. */
   endDate: string;
-  color?: string;
 }
 
 export type PersonalTodoFormErrors = Partial<Record<keyof PersonalTodoDraft, string>>;


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

- `PersonalTodoDraft`에서 UI 입력이 없어 항상 undefined였던 `color` 필드 제거
- `actions.ts::readDraft`에서 `formData.get("color")` 파싱 제거
- `mock/events.ts::addMockTodo`에서 `color: draft.color` 배선 제거
- `PersonalCalendarEvent.color`(항목별 색 오버라이드, 실제 사용 중)는 그대로 유지

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [ ] 🔐 권한 2축 검사 — 해당 없음 (죽은 필드 제거, 권한 로직 무관)
- [ ] 🧬 zod — 해당 없음
- [x] 🕵️ 정직성 — 해당 없음(기능 변경 없음, 순수 정리)
- [ ] 🎨 디자인 토큰 — 해당 없음

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [ ] ♿ a11y — 해당 없음
- [x] ♻️ 재사용 확인 — 죽은 코드만 제거, 기존 로직 재사용 유지
- [x] 🧪 loading/error/empty — 영향 없음(기존 3상태 유지, jest 8 suites/48 tests 통과)

---

## 🔗 연관 이슈

Closes #438 

---

## 💬 리뷰 포인트

- `PersonalCalendarEvent.color`(유지)와 `PersonalTodoDraft.color`(제거)를 혼동하지 않았는지 확인해 주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 회의실 생성 대화상자가 권한 조건에 맞게 표시되도록 수정했습니다.
  * 개인 할 일 생성 시 색상 정보가 저장되지 않도록 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->