### PR TITLE
[FEAT] 알림 SSE 첫 소비 — 상단 배너 + 요약 진행 지속형 카드 #442

### DIFF
--- a/src/app/(shell)/layout.tsx
+++ b/src/app/(shell)/layout.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 
 import { getUnreadNoticeCount } from "@/features/notice/server";
+import { NotificationBanner } from "@/features/notification/components/notification-banner";
+import { NotificationProvider } from "@/features/notification/notification-provider";
 import { guardWorkspaceEntry } from "@/features/onboarding/guard";
 import { RoleSidebar } from "@/features/shell/components/role-sidebar";
 import type { NavSection } from "@/features/shell/nav";
@@ -68,6 +70,15 @@ export default async function ShellLayout({ children }: { children: ReactNode })
 
   return (
     // ⚠️ `h-screen-z` — 화면 배율이 걸려도 셸이 아래에서 안 잘린다(DECISIONS §화면 배율)
+    /*
+      ⚠️ **알림은 셸이 쥔다**(#442). 회의를 끝내고 화면을 옮겨도 요약 진행 카드가 따라오려면
+         상태가 화면이 아니라 여기 있어야 한다 — 캡처 화면이 들고 있으면 목록으로 가는 순간
+         언마운트돼 사라져서, 몇 초 만에 사라지던 예전 토스트와 똑같아진다.
+      ⚠️ SSE 연결도 **여기 하나뿐**이다(`useNotificationStream`). 화면마다 열면 같은 알림이
+         배너에 여러 줄 뜬다 — BE가 회원당 emitter 전부에 복사해 보내기 때문이다.
+      ⚠️ 클라이언트 프로바이더가 **`children`을 감싼다**(§렌더링·데이터 — client가 server를
+         import하지 않고 `children`으로 받는다). 안쪽 화면은 그대로 서버 컴포넌트다.
+    */
     <div className="app-shell bg-background h-screen-z flex overflow-hidden">
       <RoleSidebar sections={sections} home={dashboardFor(viewer.role)} user={viewer} />
 
@@ -83,7 +94,13 @@ export default async function ShellLayout({ children }: { children: ReactNode })
            화면이 셋으로 조각나 보인다(DECISIONS §셸 표면에 적힌 첫 실패). 넷을 한 색으로
            두고, 나누는 건 **선 하나**(사이드바 오른쪽·상단바 아래)에 맡긴다.
       */}
-      <div className="bg-background flex min-w-0 flex-1 flex-col overflow-hidden">{children}</div>
+      <NotificationProvider>
+        <div className="bg-background flex min-w-0 flex-1 flex-col overflow-hidden">
+          {/* 회의 개설·리마인더·취소·공지 — 본문 맨 위 줄로 들어간다(떠 있는 판이 아니다) */}
+          <NotificationBanner />
+          {children}
+        </div>
+      </NotificationProvider>
     </div>
   );
 }

--- a/src/app/(shell)/layout.tsx
+++ b/src/app/(shell)/layout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 import { getUnreadNoticeCount } from "@/features/notice/server";
+import { AnalysisProgressCard } from "@/features/notification/components/analysis-progress-card";
 import { NotificationBanner } from "@/features/notification/components/notification-banner";
 import { NotificationProvider } from "@/features/notification/notification-provider";
 import { guardWorkspaceEntry } from "@/features/onboarding/guard";
@@ -100,6 +101,8 @@ export default async function ShellLayout({ children }: { children: ReactNode })
           <NotificationBanner />
           {children}
         </div>
+        {/* 요약 진행 — 우하단 고정이라 어느 화면에 있든 같은 자리에 남는다 */}
+        <AnalysisProgressCard />
       </NotificationProvider>
     </div>
   );

--- a/src/app/api/notifications/stream/route.ts
+++ b/src/app/api/notifications/stream/route.ts
@@ -32,9 +32,11 @@ export async function GET(request: NextRequest) {
   const accessToken = await getAccessToken();
   if (!accessToken) {
     /*
-      ⚠️ **401을 그대로 돌려준다.** `EventSource`는 열리자마자 `error`를 받고 재연결을 반복하는데,
-         훅이 그 신호를 보고 연결을 접는다(`use-notification-stream.ts`) — 로그인이 풀린 채로
-         초당 몇 번씩 두드리지 않게 하려는 것이다.
+      ⚠️ **401을 그대로 돌려준다.** 응답이 온 실패라 `EventSource`가 연결을 닫고, 훅은 그
+         신호를 보고 **간격을 2초→최대 60초로 늘려 가며** 다시 연다
+         (`use-notification-stream.ts`) — 로그인이 풀린 채로 초당 몇 번씩 두드리지 않게
+         하려는 것이다. 아주 멈추지는 않는다: 다시 로그인하면 그 자리에서 알림이 돌아와야
+         한다(멈춰 두면 사람은 조용한 화면을 정상으로 읽는다, §정직성).
     */
     return new Response("인증이 필요합니다.", { status: 401 });
   }
@@ -58,7 +60,14 @@ export async function GET(request: NextRequest) {
   }
 
   if (!upstream.ok || !upstream.body) {
-    return new Response("알림 스트림에 연결하지 못했습니다.", { status: upstream.status || 502 });
+    /*
+      ⚠️ **위쪽 상태를 그대로 되쓰지 않는다.** 204·205·304는 본문을 못 싣는 상태라
+         `new Response(문구, { status: 204 })`가 그 자리에서 터지고, 라우트는 500으로
+         끝난다 — 못 붙었다는 말조차 못 전한다. 성공 계열로 온 실패는 **중계 실패(502)**로
+         모은다(우리가 보기엔 스트림을 못 얻은 것이다).
+    */
+    const status = upstream.status >= 400 ? upstream.status : 502;
+    return new Response("알림 스트림에 연결하지 못했습니다.", { status });
   }
 
   return new Response(upstream.body, {

--- a/src/app/api/notifications/stream/route.ts
+++ b/src/app/api/notifications/stream/route.ts
@@ -1,0 +1,72 @@
+import type { NextRequest } from "next/server";
+
+import { getAccessToken } from "@/features/auth/session";
+import { ep } from "@/lib/endpoints";
+
+/**
+ * 개인 알림 SSE 중계 — **BFF**(CLAUDE.md §렌더링·데이터: "BFF가 스트림을 중계하고 토큰을 주입한다").
+ *
+ * 브라우저는 우리 주소(`/api/notifications/stream`)만 구독하고, BE와의 대화는 여기가 대신한다.
+ * 자막 중계(`api/meetings/[meetingId]/captions/stream`)와 **같은 뼈대**다 — 다른 점은 회의가
+ * 아니라 **사람 단위**라 경로에 식별자가 없다는 것뿐이다. 수신자는 BE가 토큰에서 꺼낸다
+ * (`NotificationController` — `@AuthenticationPrincipal(expression = "memberId")`).
+ *
+ * ⚠️ **토큰이 브라우저로 안 나간다**(§핵심 4원칙 ②). `EventSource`는 헤더를 못 붙여서,
+ *    브라우저가 BE를 직접 구독하려면 토큰을 쿼리스트링에 실어야 한다 — 그러면 주소창·프록시
+ *    로그·리퍼러에 액세스 토큰이 남는다. 중계하면 헤더로 붙일 수 있다.
+ * ⚠️ **누구의 스트림인지를 URL이 정하지 않는다.** `?memberId=` 같은 걸 받는 순간 남의 알림을
+ *    훔쳐보는 길이 열린다 — BE 주석이 같은 이유로 principal에서만 꺼낸다(§권한: 검증은 서버에서).
+ * ⚠️ **본문을 모으지 않고 그대로 흘려보낸다.** `await response.text()`로 받으면 스트림이 끝날
+ *    때까지 기다린다 — 알림은 그 순간에 떠야 뜻이 있으므로 영영 안 뜨는 것과 같다.
+ * ⚠️ **`no-store`·`no-transform`이 필요하다.** 중간 프록시가 버퍼링하면 알림이 뭉텅이로 몰려
+ *    온다. `X-Accel-Buffering: no`는 nginx에게 같은 말을 하는 것이다.
+ * ⚠️ **Node 런타임이어야 한다.** 배포가 정적일 수 없는 이유 중 하나다(CLAUDE.md §팀확정).
+ */
+export const runtime = "nodejs";
+/** 스트림이라 캐시가 있으면 안 된다 — 한 사람의 알림이 다른 사람에게 간다 */
+export const dynamic = "force-dynamic";
+
+const BASE_URL = process.env.BACKEND_API_URL ?? "http://localhost:8080";
+
+export async function GET(request: NextRequest) {
+  const accessToken = await getAccessToken();
+  if (!accessToken) {
+    /*
+      ⚠️ **401을 그대로 돌려준다.** `EventSource`는 열리자마자 `error`를 받고 재연결을 반복하는데,
+         훅이 그 신호를 보고 연결을 접는다(`use-notification-stream.ts`) — 로그인이 풀린 채로
+         초당 몇 번씩 두드리지 않게 하려는 것이다.
+    */
+    return new Response("인증이 필요합니다.", { status: 401 });
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(`${BASE_URL}${ep.notificationStream()}`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: "text/event-stream",
+      },
+      /*
+        ⚠️ 화면을 떠나면 **위쪽 구독도 끊는다.** 안 끊으면 BE의 `NotificationStreamRegistry`에
+           죽은 emitter가 쌓이고, 20초마다 하트비트를 계속 밀어 넣는다(BE 실코드 확인).
+      */
+      signal: request.signal,
+      cache: "no-store",
+    });
+  } catch {
+    return new Response("알림 스트림에 연결하지 못했습니다.", { status: 502 });
+  }
+
+  if (!upstream.ok || !upstream.body) {
+    return new Response("알림 스트림에 연결하지 못했습니다.", { status: upstream.status || 502 });
+  }
+
+  return new Response(upstream.body, {
+    headers: {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache, no-store, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}

--- a/src/constants/meeting.ts
+++ b/src/constants/meeting.ts
@@ -63,6 +63,33 @@ export const AI_SUMMARY_STATUS_LABEL: Record<AiSummaryStatus, string> = {
   FAILED: "실패",
 };
 
+/**
+ * AI 처리 상태(CAP-06 `GET /api/meetings/:id/processing-status`)의 `status`.
+ * [확인] BE 실코드 대조(2026-08-13) — `capture/application/result/ProcessingStatus.java`
+ * (`OverallStatus`) · 응답은 `ProcessingStatusResponse`가 `status().name()`으로 문자열화한다.
+ *
+ * ⚠️ **`AI_SUMMARY_STATUS`와 다른 값이다.** 저쪽은 회의 카드에 붙는 요약 진행 라벨이고,
+ *    이건 **계층 실행 상태를 회의 하나로 접은 값**이다. 이름이 비슷해 섞어 쓰기 쉬운데,
+ *    섞으면 매퍼에서 조용히 틀린다(§도메인 상수 — BE enum과 이름이 어긋나면 조용히 틀린다).
+ * ⚠️ **`NOT_STARTED`는 "안 한다"가 아니라 "아직 계층 기록이 없다"**는 뜻이다. 회의 종료
+ *    직후 서버가 큐에 걸기 전까지 이 값이 온다 — 완료로 읽으면 요약이 없는데 다 됐다고
+ *    말하게 된다(§정직성).
+ * ⚠️ **멈춘 RUNNING은 BE가 `FAILED`로 접어 준다**(BE #177 · `stalled`). 화면이 따로
+ *    계산하지 않아도 실패로 보인다 — 안 접으면 「요약 중」이 영원히 끝나지 않는다.
+ */
+export const PROCESSING_STATUS = {
+  NOT_STARTED: "NOT_STARTED",
+  RUNNING: "RUNNING",
+  DONE: "DONE",
+  FAILED: "FAILED",
+} as const;
+export type ProcessingStatus = (typeof PROCESSING_STATUS)[keyof typeof PROCESSING_STATUS];
+
+/** 스트림·응답으로 들어온 문자열이 우리가 아는 값인지(`isMeetingStatus`와 같은 패턴). */
+export function isProcessingStatus(value: string): value is ProcessingStatus {
+  return (Object.values(PROCESSING_STATUS) as string[]).includes(value);
+}
+
 /*
   ⚠️ **초대 수락·거절 상수는 두지 않는다**(2026-08-07 제거). `MEETING_INVITE_STATUS`
      (미응답·참석·불참)가 정의만 되고 아무 데서도 안 쓰이고 있었는데, WORKFLOW 어디에도

--- a/src/constants/notification.ts
+++ b/src/constants/notification.ts
@@ -1,0 +1,27 @@
+/**
+ * 알림 종류 — **BE `NotificationType` enum 그대로**다.
+ * [확인] BE 실코드 대조(2026-08-13) — `notification/domain/model/NotificationType.java`
+ *
+ * ⚠️ **지금 BE에 있는 건 이 4종이 전부다.** 「분석 완료」·「분석 실패」는 이야기만 됐고 아직
+ *    들어오지 않았다 — 이 목록에 미리 적어 두면 영영 안 오는 이벤트를 기다리는 화면이 생긴다
+ *    (§도메인 상수: 없는 걸 금지 문장으로만 두면 나중에 누가 만든다). 요약 진행 카드가
+ *    SSE가 아니라 CAP-06 폴링으로 도는 이유다(`features/notification/analysis.ts`).
+ * ⚠️ 화면에 나가는 문구는 **BE가 만들어 보낸 `payload.message`**를 그대로 쓴다
+ *    (`lib/api.ts` 주석과 같은 규칙 — 코드로 문장을 조립하지 않는다). 그래서 라벨맵이 없다.
+ */
+export const NOTIFICATION_TYPE = {
+  /** 회의 예약 커밋 뒤 참석자에게 */
+  MEETING_CREATED: "MEETING_CREATED",
+  /** 회의 시작 10분 전 */
+  MEETING_REMINDER: "MEETING_REMINDER",
+  /** 회의 취소 뒤 참석자에게 */
+  MEETING_CANCELED: "MEETING_CANCELED",
+  /** 공지 등록 뒤 회사 활성 회원 전체에게(저장 없이 실시간만) */
+  NOTICE_CREATED: "NOTICE_CREATED",
+} as const;
+export type NotificationType = (typeof NOTIFICATION_TYPE)[keyof typeof NOTIFICATION_TYPE];
+
+/** 스트림으로 들어온 문자열이 우리가 아는 종류인지 — 모르는 종류는 조용히 버린다. */
+export function isNotificationType(value: string): value is NotificationType {
+  return (Object.values(NOTIFICATION_TYPE) as string[]).includes(value);
+}

--- a/src/features/meeting/capture/capture-view.tsx
+++ b/src/features/meeting/capture/capture-view.tsx
@@ -10,6 +10,7 @@ import { LeaveGuard } from "@/components/common/leave-guard";
 import { ProfileAvatar } from "@/components/common/profile-avatar";
 import { Button } from "@/components/ui/button";
 import { CAPTURE_FAILURE_MESSAGE } from "@/constants/meeting";
+import { useNotificationCenter } from "@/features/notification/notification-provider";
 import { pickPaletteColor } from "@/lib/palette";
 import { cn } from "@/lib/utils";
 
@@ -101,6 +102,11 @@ export function CaptureView({
   }, [capture.chunks, remoteCaptions, meeting.attendees]);
   const router = useRouter();
   const [isConfirming, setIsConfirming] = useState(false);
+  /*
+    ⚠️ 요약 진행은 **셸이 쫓는다**(#442). 이 화면은 "이 회의를 쫓아 달라"고 넘기기만 한다 —
+       여기서 들고 있으면 목록으로 옮기는 순간 사라져서 카드를 만든 뜻이 없어진다.
+  */
+  const { trackAnalysis } = useNotificationCenter();
 
   const unsupported = !capture.support.stt || !capture.support.recording;
   const isRecording = capture.phase === CAPTURE_PHASE.RECORDING;
@@ -150,13 +156,14 @@ export function CaptureView({
        ⚠️ **바로 목록으로 돌려보낸다**(팀 확정). 요약 API는 응답이 오래 걸려서 서버가
        백그라운드로 돌린다 — 여기서 기다리게 두면 아무것도 못 하는 화면을 몇 분씩
        쳐다보게 된다. 창을 닫아도 안전한 일이라 붙잡을 이유가 없다(§3-3 4).
-       ⚠️ 토스트가 **"백그라운드"를 말한다**(팀 확정: 목록으로 보낸 뒤에 그렇게 전한다).
-       옮겨 간 화면에서 처음 보는 말이 이거라, 여기서 안 하면 왜 목록으로 튕겼는지
-       모른 채 요약을 기다리게 된다.
-       ⚠️ 한 줄(220px)이라 글자 자리가 **184px**뿐이다(DESIGN §7) — 이 문구는 153px다.
-       더 길게 쓰려면 잘린다.
+       ⚠️ **토스트를 지속형 카드로 바꿨다**(#442). 전에는 `toast.success("백그라운드에서
+       요약 중입니다")` 한 줄이 몇 초 뜨고 사라졌는데, 그 뒤로 요약이 끝났는지 깨졌는지
+       알 방법이 없어서 사람이 회의 상세를 새로고침하며 기다렸다 — 토스트는 놓쳐도 되는
+       말만 담는 자리다(DESIGN §7). 카드는 셸이 들고 있어(`NotificationProvider`)
+       목록으로 옮겨도 따라오고, **닫기 전까지 남아 자리에서 상태만 바뀐다.**
+       ⚠️ 제목을 같이 넘긴다 — 목록으로 튕긴 뒤 카드만 보고도 어느 회의인지 알아야 한다.
     */
-    toast.success("백그라운드에서 요약 중입니다");
+    trackAnalysis(Number(meeting.id), meeting.title);
     router.push("/app/meeting");
   };
 

--- a/src/features/meeting/capture/capture-view.tsx
+++ b/src/features/meeting/capture/capture-view.tsx
@@ -162,8 +162,10 @@ export function CaptureView({
        말만 담는 자리다(DESIGN §7). 카드는 셸이 들고 있어(`NotificationProvider`)
        목록으로 옮겨도 따라오고, **닫기 전까지 남아 자리에서 상태만 바뀐다.**
        ⚠️ 제목을 같이 넘긴다 — 목록으로 튕긴 뒤 카드만 보고도 어느 회의인지 알아야 한다.
+       ⚠️ **id는 문자열 그대로 넘긴다.** `Number()`로 바꾸면 목 id(`meeting-3`)가 `NaN`이 되고,
+       `NaN === NaN`이 거짓이라 프로바이더가 자기 카드를 못 알아봐 「요약 중」에서 멈춘다.
     */
-    trackAnalysis(Number(meeting.id), meeting.title);
+    trackAnalysis(meeting.id, meeting.title);
     router.push("/app/meeting");
   };
 

--- a/src/features/notification/actions.test.ts
+++ b/src/features/notification/actions.test.ts
@@ -12,19 +12,24 @@ import { ANALYSIS_CARD_STATE } from "./types";
 */
 describe("요약 진행 조회(목)", () => {
   it("첫 조회는 요약 중, 두 번째 조회에서 완료로 넘긴다", async () => {
-    await expect(fetchAnalysisStatusAction(7, 0)).resolves.toEqual({
+    await expect(fetchAnalysisStatusAction("meeting-7", 0)).resolves.toEqual({
       ok: true,
       status: PROCESSING_STATUS.RUNNING,
     });
-    await expect(fetchAnalysisStatusAction(7, 1)).resolves.toEqual({
+    await expect(fetchAnalysisStatusAction("meeting-7", 1)).resolves.toEqual({
       ok: true,
       status: PROCESSING_STATUS.DONE,
     });
   });
 
-  /* 호출자가 넘기는 `attempt`가 0부터 오른다는 전제를 상태 기계와 함께 못박는다 */
+  /*
+    호출자가 넘기는 `attempt`가 0부터 오른다는 전제를 상태 기계와 함께 못박는다.
+    ⚠️ 회의 id는 **목 모양(`meeting-7`)** 으로 둔다. 숫자로 들고 있던 시절에는 `Number()`가
+       `NaN`을 만들고 프로바이더의 `prev.meetingId === current.meetingId`가 언제나 거짓이라
+       카드가 「요약 중」에서 멈췄다 — 숫자 id로 테스트하면 그게 안 잡힌다.
+  */
   it("쫓기 시작한 카드는 두 번 물어보면 완료가 된다", async () => {
-    let tracking = startTracking(7, "주간 회의", 1_700_000_000_000);
+    let tracking = startTracking("meeting-7", "주간 회의", 1_700_000_000_000);
 
     tracking = advance(
       tracking,

--- a/src/features/notification/actions.test.ts
+++ b/src/features/notification/actions.test.ts
@@ -1,0 +1,42 @@
+import { PROCESSING_STATUS } from "@/constants/meeting";
+
+import { fetchAnalysisStatusAction } from "./actions";
+import { advance, startTracking } from "./analysis";
+import { ANALYSIS_CARD_STATE } from "./types";
+
+/*
+  목 시나리오만 지킨다(실서버 분기는 BE가 붙은 뒤 E2E 몫이다). 지키는 건 하나다 —
+  **두 번째 조회(5초 × 2 ≈ 10초)에서 카드가 완료로 넘어간다.** 이게 어긋나면 목으로 도는
+  데모에서 카드가 끝나는 걸 아무도 못 보거나(영원히 「요약 중」), 주석이 말한 시간과
+  화면이 다른 말을 한다.
+*/
+describe("요약 진행 조회(목)", () => {
+  it("첫 조회는 요약 중, 두 번째 조회에서 완료로 넘긴다", async () => {
+    await expect(fetchAnalysisStatusAction(7, 0)).resolves.toEqual({
+      ok: true,
+      status: PROCESSING_STATUS.RUNNING,
+    });
+    await expect(fetchAnalysisStatusAction(7, 1)).resolves.toEqual({
+      ok: true,
+      status: PROCESSING_STATUS.DONE,
+    });
+  });
+
+  /* 호출자가 넘기는 `attempt`가 0부터 오른다는 전제를 상태 기계와 함께 못박는다 */
+  it("쫓기 시작한 카드는 두 번 물어보면 완료가 된다", async () => {
+    let tracking = startTracking(7, "주간 회의", 1_700_000_000_000);
+
+    tracking = advance(
+      tracking,
+      await fetchAnalysisStatusAction(tracking.meetingId, tracking.attempt),
+    );
+    expect(tracking.state).toBe(ANALYSIS_CARD_STATE.RUNNING);
+    expect(tracking.attempt).toBe(1);
+
+    tracking = advance(
+      tracking,
+      await fetchAnalysisStatusAction(tracking.meetingId, tracking.attempt),
+    );
+    expect(tracking.state).toBe(ANALYSIS_CARD_STATE.DONE);
+  });
+});

--- a/src/features/notification/actions.ts
+++ b/src/features/notification/actions.ts
@@ -39,10 +39,13 @@ export async function fetchAnalysisStatusAction(
          그렇다고 「요약 중」에 굳혀 두면 목으로 도는 개발·데모에서 이 카드가 **끝나는 걸
          아무도 못 본다** — 회의를 끝내도 검토 화면으로 갈 길이 안 생긴다.
          그래서 두 번 물어본 뒤 완료로 넘긴다(5초 간격 × 2 ≈ 10초).
+      ⚠️ **`attempt`는 0부터 온다** — 첫 조회가 0, 두 번째가 1이다(`startTracking`이 0으로
+         시작하고 `advance`가 응답 뒤에 올린다). 그래서 두 번째를 완료로 만드는 조건은
+         `>= 1`이다. `>= 2`로 두면 세 번째(약 15초)라 위에 적은 시나리오와 어긋난다.
       ⚠️ 실패 카드는 목으로 못 본다 — 실패를 섞어 넣으면 데모 때마다 무작위로 깨진 것처럼
          보인다. 실패 모양은 테스트(`analysis.test.ts`)가 지킨다.
     */
-    return { ok: true, status: attempt >= 2 ? PROCESSING_STATUS.DONE : PROCESSING_STATUS.RUNNING };
+    return { ok: true, status: attempt >= 1 ? PROCESSING_STATUS.DONE : PROCESSING_STATUS.RUNNING };
   }
 
   try {

--- a/src/features/notification/actions.ts
+++ b/src/features/notification/actions.ts
@@ -26,11 +26,14 @@ interface ProcessingStatusApiResponse {
 }
 
 /**
+ * @param meetingId 화면이 쓰는 문자열 id(라우트 `[meetingId]`와 같은 값). **숫자로 바꾸는 건
+ *                  여기, BE 경로를 만들 때뿐이다** — 화면이 들고 다니는 값이 숫자면 목 id
+ *                  (`meeting-3`)가 `NaN`이 된다(`types.ts` 주석).
  * @param attempt 몇 번째 조회인지 — **목에서만** 쓴다(진행하는 척을 시간이 아니라 횟수로 만든다).
  *                실서버에서는 무시된다.
  */
 export async function fetchAnalysisStatusAction(
-  meetingId: number,
+  meetingId: string,
   attempt: number,
 ): Promise<AnalysisProbe> {
   if (isMock) {
@@ -50,9 +53,11 @@ export async function fetchAnalysisStatusAction(
 
   try {
     const accessToken = await requireAccessToken();
-    const response = await serverApi<ProcessingStatusApiResponse>(ep.processingStatus(meetingId), {
-      accessToken,
-    });
+    /* ⚠️ 경로에 들어갈 때만 숫자다 — `getLiveMeetingCapture`의 `ep.meeting(Number(id))`와 같다 */
+    const response = await serverApi<ProcessingStatusApiResponse>(
+      ep.processingStatus(Number(meetingId)),
+      { accessToken },
+    );
     /*
       ⚠️ **모르는 값은 실패로 본다.** BE가 새 상태를 늘렸는데 우리가 임의로 「요약 중」이나
          「완료」로 접으면 화면이 사실이 아닌 말을 한다 — 못 읽었다고 말하는 편이 낫다.

--- a/src/features/notification/actions.ts
+++ b/src/features/notification/actions.ts
@@ -1,0 +1,62 @@
+"use server";
+
+import { isProcessingStatus, PROCESSING_STATUS } from "@/constants/meeting";
+import { requireAccessToken } from "@/features/auth/session";
+import { serverApi } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
+import { isMock } from "@/mocks/config";
+
+import type { AnalysisProbe } from "./analysis";
+
+/**
+ * 요약 진행 조회 창구(CAP-06) — 격리막(§Mock → Live 격리막).
+ *
+ * ⚠️ **왜 조회를 액션으로 하나.** 조회는 서버 컴포넌트가 하는 게 원칙이지만(§핵심 4원칙 ①),
+ *    이건 **화면을 옮겨 다니는 동안 계속 물어보는 값**이라 그릴 화면이 없다. 라우트 핸들러를
+ *    하나 더 파는 대신 액션으로 둔다 — 토큰이 브라우저로 안 나가는 건 똑같다(§4원칙 ②).
+ * ⚠️ **BE 응답을 그대로 흘리지 않는다.** 카드가 쓰는 건 `status` 하나뿐이라, 계층·구멍·토큰
+ *    같은 나머지 칸은 여기서 버린다 — 컴포넌트가 BE shape을 알면 모양이 바뀔 때 화면을 고친다.
+ * ⚠️ **던지지 않는다.** 5초마다 부르는 호출이 예외를 던지면 훅이 그때마다 잡아야 하고,
+ *    한 번 실패한 것과 세 번 연속 실패한 것을 가릴 수 없다 — 실패도 값으로 돌려준다.
+ */
+
+/** [확인] BE `AnalysisController.getProcessingStatus` — `ProcessingStatusResponse` */
+interface ProcessingStatusApiResponse {
+  status: string;
+}
+
+/**
+ * @param attempt 몇 번째 조회인지 — **목에서만** 쓴다(진행하는 척을 시간이 아니라 횟수로 만든다).
+ *                실서버에서는 무시된다.
+ */
+export async function fetchAnalysisStatusAction(
+  meetingId: number,
+  attempt: number,
+): Promise<AnalysisProbe> {
+  if (isMock) {
+    /*
+      ⚠️ **목에서는 서버를 안 부른다**(스트림도 안 연다 — `use-notification-stream`).
+         그렇다고 「요약 중」에 굳혀 두면 목으로 도는 개발·데모에서 이 카드가 **끝나는 걸
+         아무도 못 본다** — 회의를 끝내도 검토 화면으로 갈 길이 안 생긴다.
+         그래서 두 번 물어본 뒤 완료로 넘긴다(5초 간격 × 2 ≈ 10초).
+      ⚠️ 실패 카드는 목으로 못 본다 — 실패를 섞어 넣으면 데모 때마다 무작위로 깨진 것처럼
+         보인다. 실패 모양은 테스트(`analysis.test.ts`)가 지킨다.
+    */
+    return { ok: true, status: attempt >= 2 ? PROCESSING_STATUS.DONE : PROCESSING_STATUS.RUNNING };
+  }
+
+  try {
+    const accessToken = await requireAccessToken();
+    const response = await serverApi<ProcessingStatusApiResponse>(ep.processingStatus(meetingId), {
+      accessToken,
+    });
+    /*
+      ⚠️ **모르는 값은 실패로 본다.** BE가 새 상태를 늘렸는데 우리가 임의로 「요약 중」이나
+         「완료」로 접으면 화면이 사실이 아닌 말을 한다 — 못 읽었다고 말하는 편이 낫다.
+    */
+    if (!isProcessingStatus(response.status)) return { ok: false };
+    return { ok: true, status: response.status };
+  } catch {
+    return { ok: false };
+  }
+}

--- a/src/features/notification/analysis.test.ts
+++ b/src/features/notification/analysis.test.ts
@@ -1,0 +1,122 @@
+import { PROCESSING_STATUS } from "@/constants/meeting";
+
+import {
+  advance,
+  ANALYSIS_MAX_FAILURES,
+  ANALYSIS_POLL_MAX_MS,
+  expire,
+  isExpired,
+  isSettled,
+  restart,
+  restoreTracking,
+  shouldPoll,
+  startTracking,
+  toAnalysisCardState,
+} from "./analysis";
+import { ANALYSIS_CARD_STATE, type AnalysisTracking } from "./types";
+
+const NOW = 1_700_000_000_000;
+
+function running(overrides: Partial<AnalysisTracking> = {}): AnalysisTracking {
+  return { ...startTracking(7, "주간 회의", NOW), ...overrides };
+}
+
+describe("CAP-06 상태 → 카드 상태", () => {
+  /*
+    회의를 막 끝내면 계층 기록이 없어 NOT_STARTED가 온다. 완료로 접으면 요약이 없는데
+    다 됐다고 말하게 되고, 실패로 접으면 멀쩡한 회의가 깨진 것으로 보인다.
+  */
+  it("아직 시작 전이어도 사람에게는 요약 중이다", () => {
+    expect(toAnalysisCardState(PROCESSING_STATUS.NOT_STARTED)).toBe(ANALYSIS_CARD_STATE.RUNNING);
+    expect(toAnalysisCardState(PROCESSING_STATUS.RUNNING)).toBe(ANALYSIS_CARD_STATE.RUNNING);
+  });
+
+  it("끝났거나 깨진 것은 그대로 옮긴다", () => {
+    expect(toAnalysisCardState(PROCESSING_STATUS.DONE)).toBe(ANALYSIS_CARD_STATE.DONE);
+    expect(toAnalysisCardState(PROCESSING_STATUS.FAILED)).toBe(ANALYSIS_CARD_STATE.FAILED);
+  });
+
+  it("요약 중일 때만 끝나지 않은 것으로 본다", () => {
+    expect(isSettled(ANALYSIS_CARD_STATE.RUNNING)).toBe(false);
+    expect(isSettled(ANALYSIS_CARD_STATE.DONE)).toBe(true);
+    expect(isSettled(ANALYSIS_CARD_STATE.FAILED)).toBe(true);
+    expect(isSettled(ANALYSIS_CARD_STATE.UNAVAILABLE)).toBe(true);
+  });
+});
+
+describe("카드 상태 기계", () => {
+  it("완료가 오면 스피너를 멈추고 완료로 바꾼다", () => {
+    const next = advance(running(), { ok: true, status: PROCESSING_STATUS.DONE });
+    expect(next.state).toBe(ANALYSIS_CARD_STATE.DONE);
+    expect(next.attempt).toBe(1);
+  });
+
+  /* 늦게 도착한 응답이 이미 본 완료를 「요약 중」으로 되돌리면 안 된다 */
+  it("끝난 카드는 다시 안 움직인다", () => {
+    const done = running({ state: ANALYSIS_CARD_STATE.DONE });
+    expect(advance(done, { ok: true, status: PROCESSING_STATUS.RUNNING })).toBe(done);
+  });
+
+  it("한두 번 실패는 계속 쫓고, 연속 세 번이면 확인 못 했다고 말한다", () => {
+    let tracking = running();
+    for (let i = 1; i < ANALYSIS_MAX_FAILURES; i += 1) {
+      tracking = advance(tracking, { ok: false });
+      expect(tracking.state).toBe(ANALYSIS_CARD_STATE.RUNNING);
+      expect(tracking.failures).toBe(i);
+    }
+    tracking = advance(tracking, { ok: false });
+    expect(tracking.state).toBe(ANALYSIS_CARD_STATE.UNAVAILABLE);
+  });
+
+  /* 드문드문 실패한 멀쩡한 회의가 「확인 못 함」으로 접히면 안 된다 */
+  it("한 번이라도 성공하면 실패 횟수를 되돌린다", () => {
+    const failedTwice = running({ failures: ANALYSIS_MAX_FAILURES - 1 });
+    const recovered = advance(failedTwice, { ok: true, status: PROCESSING_STATUS.RUNNING });
+    expect(recovered.failures).toBe(0);
+    expect(recovered.state).toBe(ANALYSIS_CARD_STATE.RUNNING);
+  });
+
+  it("[다시 시도]는 시계와 실패 횟수를 처음으로 되돌린다", () => {
+    const dead = running({ state: ANALYSIS_CARD_STATE.UNAVAILABLE, failures: 5, attempt: 12 });
+    const again = restart(dead, NOW + 60_000);
+    expect(again).toMatchObject({
+      state: ANALYSIS_CARD_STATE.RUNNING,
+      startedAt: NOW + 60_000,
+      attempt: 0,
+      failures: 0,
+      meetingId: 7,
+    });
+  });
+});
+
+describe("언제 물어보는가", () => {
+  it("끝났거나 탭이 숨어 있으면 안 물어본다", () => {
+    expect(shouldPoll(running(), NOW, false)).toBe(true);
+    expect(shouldPoll(running(), NOW, true)).toBe(false);
+    expect(shouldPoll(running({ state: ANALYSIS_CARD_STATE.DONE }), NOW, false)).toBe(false);
+    expect(shouldPoll(null, NOW, false)).toBe(false);
+  });
+
+  /* 스피너를 영원히 돌리는 건 「요약 중」이라는 거짓말이다 */
+  it("상한을 넘기면 그만 묻고 확인 못 했다고 접는다", () => {
+    const old = running();
+    const late = NOW + ANALYSIS_POLL_MAX_MS;
+    expect(isExpired(old, late)).toBe(true);
+    expect(shouldPoll(old, late, false)).toBe(false);
+    expect(expire(old).state).toBe(ANALYSIS_CARD_STATE.UNAVAILABLE);
+  });
+});
+
+describe("새로고침 뒤 되살리기", () => {
+  it("저장해 둔 값을 그대로 돌려준다", () => {
+    const saved = running({ attempt: 3 });
+    expect(restoreTracking(JSON.stringify(saved))).toEqual(saved);
+  });
+
+  /* 옛 버전이 남긴 값으로 카드가 이상한 상태에 갇히지 않게 한다 */
+  it("없거나 깨졌거나 모양이 어긋나면 버린다", () => {
+    expect(restoreTracking(null)).toBeNull();
+    expect(restoreTracking("{")).toBeNull();
+    expect(restoreTracking(JSON.stringify({ meetingId: 7, state: "WHATEVER" }))).toBeNull();
+  });
+});

--- a/src/features/notification/analysis.test.ts
+++ b/src/features/notification/analysis.test.ts
@@ -17,8 +17,14 @@ import { ANALYSIS_CARD_STATE, type AnalysisTracking } from "./types";
 
 const NOW = 1_700_000_000_000;
 
+/*
+  ⚠️ id는 **목 모양(`meeting-7`)** 이다. 숫자로 들면 `Number("meeting-7")`이 `NaN`이 되어
+     프로바이더의 회의 대조가 전부 빗나간다 — 숫자 id로만 테스트하면 그게 안 잡힌다.
+*/
+const MEETING_ID = "meeting-7";
+
 function running(overrides: Partial<AnalysisTracking> = {}): AnalysisTracking {
-  return { ...startTracking(7, "주간 회의", NOW), ...overrides };
+  return { ...startTracking(MEETING_ID, "주간 회의", NOW), ...overrides };
 }
 
 describe("CAP-06 상태 → 카드 상태", () => {
@@ -84,7 +90,7 @@ describe("카드 상태 기계", () => {
       startedAt: NOW + 60_000,
       attempt: 0,
       failures: 0,
-      meetingId: 7,
+      meetingId: MEETING_ID,
     });
   });
 });
@@ -111,6 +117,18 @@ describe("새로고침 뒤 되살리기", () => {
   it("저장해 둔 값을 그대로 돌려준다", () => {
     const saved = running({ attempt: 3 });
     expect(restoreTracking(JSON.stringify(saved))).toEqual(saved);
+  });
+
+  /*
+    ⚠️ **회의 id는 저장과 비교를 견뎌야 한다.** 숫자로 들고 있던 시절에는 목 id가 `NaN`이라
+       `JSON.stringify`가 `null`로 적어(새로고침하면 카드가 사라졌다) 되살리지도 못했고,
+       `NaN === NaN`이 거짓이라 폴링 응답이 자기 카드를 못 찾아 「요약 중」에서 멈췄다.
+  */
+  it("목 회의 id(meeting-7)도 그대로 되살아나고 자기 자신과 같다", () => {
+    const tracking = running();
+    const restored = restoreTracking(JSON.stringify(tracking));
+    expect(restored?.meetingId).toBe(MEETING_ID);
+    expect(restored?.meetingId === tracking.meetingId).toBe(true);
   });
 
   /* 옛 버전이 남긴 값으로 카드가 이상한 상태에 갇히지 않게 한다 */

--- a/src/features/notification/analysis.ts
+++ b/src/features/notification/analysis.ts
@@ -137,7 +137,7 @@ export function restart(tracking: AnalysisTracking, now: number): AnalysisTracki
 }
 
 /** 회의 하나를 새로 쫓기 시작한다(회의 종료 직후 캡처 화면이 부른다). */
-export function startTracking(meetingId: number, title: string, now: number): AnalysisTracking {
+export function startTracking(meetingId: string, title: string, now: number): AnalysisTracking {
   return {
     meetingId,
     title,
@@ -160,7 +160,8 @@ export function startTracking(meetingId: number, title: string, now: number): An
  *    `safeParse`로 본다(§zod).
  */
 const trackingSchema = z.object({
-  meetingId: z.number(),
+  /* ⚠️ **문자열이다** — 숫자로 들면 목 id(`meeting-3`)가 `NaN`이 된다(`types.ts` 주석) */
+  meetingId: z.string(),
   title: z.string(),
   state: z.enum([
     ANALYSIS_CARD_STATE.RUNNING,

--- a/src/features/notification/analysis.ts
+++ b/src/features/notification/analysis.ts
@@ -1,0 +1,186 @@
+import { z } from "zod";
+
+import { PROCESSING_STATUS, type ProcessingStatus } from "@/constants/meeting";
+
+import { ANALYSIS_CARD_STATE, type AnalysisCardState, type AnalysisTracking } from "./types";
+
+/**
+ * 요약 진행 카드의 **상태 기계** — 순수 함수만 둔다(그래서 테스트가 있다).
+ *
+ * ⚠️ **여기가 소스 교체의 이음매다.** 지금 카드를 움직이는 건 CAP-06 폴링이지만, 이 파일은
+ *    "무엇이 들어오면 카드가 어떻게 바뀌는가"만 안다 — 폴링이든 SSE든 `advance()`에 같은
+ *    `ProcessingStatus`를 넣으면 된다. BE `NotificationType`에 분석 이벤트가 들어오면
+ *    `event.ts`의 `toAnalysisSignal`이 그 값을 만들어 이 함수로 흘려보내고, **폴링만
+ *    빠진다** — 카드·배너 렌더는 한 줄도 안 바뀐다.
+ * ⚠️ **왜 폴링부터인가.** BE `NotificationType`은 지금 4종뿐이고 분석 완료·실패가 없다
+ *    (2026-08-13 실코드 확인). SSE에만 걸면 카드가 「요약 중」에서 영영 안 바뀐다 —
+ *    몇 초 만에 사라지는 지금 토스트보다 나쁘다(§정직성).
+ */
+
+/**
+ * 폴링 간격.
+ *
+ * ⚠️ 요약은 분 단위로 걸린다(BE가 큐로 돌린다). 1~2초로 두면 회의 하나에 수백 번을
+ *    두드리면서도 사람이 체감하는 건 똑같다 — 5초면 "누른 것 같지도 않은데 바뀌어 있다"에
+ *    충분하다.
+ */
+export const ANALYSIS_POLL_INTERVAL_MS = 5_000;
+
+/**
+ * 쫓기를 포기하는 상한(10분).
+ *
+ * ⚠️ **끝없이 돌리지 않는다.** BE가 큐를 잃거나 상태를 안 바꾸면 스피너가 영원히 돈다 —
+ *    그건 「요약 중」이라는 거짓말이다. 상한을 넘기면 `UNAVAILABLE`로 접고 사람에게
+ *    [다시 시도]를 준다.
+ */
+export const ANALYSIS_POLL_MAX_MS = 10 * 60 * 1_000;
+
+/**
+ * 연속 실패 허용 횟수.
+ * ⚠️ 한 번 실패는 흔하다(배포·네트워크 튐). 세 번 연속이면 그건 상태다 — 조용히 계속
+ *    두드리지 않고 화면에 말한다.
+ */
+export const ANALYSIS_MAX_FAILURES = 3;
+
+/**
+ * CAP-06의 `status`를 카드 상태로 접는다.
+ *
+ * ⚠️ **`NOT_STARTED`는 `RUNNING`이다.** 회의를 막 끝냈으면 계층 기록이 아직 없어 이 값이
+ *    온다(BE `ProcessingStatus.of` — layers가 비면 NOT_STARTED). 완료로 읽으면 요약이
+ *    없는데 다 됐다고 말하게 되고, 실패로 읽으면 멀쩡한 회의를 깨진 것으로 만든다.
+ */
+export function toAnalysisCardState(status: ProcessingStatus): AnalysisCardState {
+  switch (status) {
+    case PROCESSING_STATUS.DONE:
+      return ANALYSIS_CARD_STATE.DONE;
+    case PROCESSING_STATUS.FAILED:
+      return ANALYSIS_CARD_STATE.FAILED;
+    case PROCESSING_STATUS.NOT_STARTED:
+    case PROCESSING_STATUS.RUNNING:
+      return ANALYSIS_CARD_STATE.RUNNING;
+  }
+}
+
+/** 끝난 카드인가 — 끝났으면 더 두드리지 않는다. */
+export function isSettled(state: AnalysisCardState): boolean {
+  return state !== ANALYSIS_CARD_STATE.RUNNING;
+}
+
+/** 상한을 넘겼는가 — 넘겼으면 더 기다리는 척하지 않는다. */
+export function isExpired(tracking: AnalysisTracking, now: number): boolean {
+  return now - tracking.startedAt >= ANALYSIS_POLL_MAX_MS;
+}
+
+/** 상한을 넘긴 카드를 접는다 — 「요약 중」을 영원히 돌리지 않는다(§정직성). */
+export function expire(tracking: AnalysisTracking): AnalysisTracking {
+  return { ...tracking, state: ANALYSIS_CARD_STATE.UNAVAILABLE };
+}
+
+/**
+ * 지금 한 번 더 물어봐야 하는가.
+ *
+ * ⚠️ **탭이 숨어 있으면 쉰다.** 안 보는 화면을 5초마다 두드릴 이유가 없다 — 돌아오면
+ *    바로 한 번 물어보므로(훅의 `visibilitychange`) 사람이 잃는 건 없다.
+ */
+export function shouldPoll(
+  tracking: AnalysisTracking | null,
+  now: number,
+  isDocumentHidden: boolean,
+): boolean {
+  if (!tracking) return false;
+  if (isSettled(tracking.state)) return false;
+  if (isDocumentHidden) return false;
+  return !isExpired(tracking, now);
+}
+
+/** 한 번 물어본 결과 — 성공이면 BE가 준 상태가 실린다. */
+export type AnalysisProbe = { ok: true; status: ProcessingStatus } | { ok: false };
+
+/**
+ * 결과 하나를 받아 카드를 다음 상태로 옮긴다.
+ *
+ * ⚠️ **끝난 카드는 안 움직인다.** 마지막 응답이 늦게 도착해 완료를 다시 「요약 중」으로
+ *    되돌리는 일을 막는다 — 사람은 이미 완료를 봤다.
+ * ⚠️ **성공하면 실패 횟수를 0으로 되돌린다.** 누적으로 세면 10분 동안 드문드문 실패한
+ *    멀쩡한 회의가 「확인 못 함」으로 접힌다.
+ */
+export function advance(tracking: AnalysisTracking, probe: AnalysisProbe): AnalysisTracking {
+  if (isSettled(tracking.state)) return tracking;
+
+  const attempt = tracking.attempt + 1;
+
+  if (!probe.ok) {
+    const failures = tracking.failures + 1;
+    return {
+      ...tracking,
+      attempt,
+      failures,
+      state:
+        failures >= ANALYSIS_MAX_FAILURES
+          ? ANALYSIS_CARD_STATE.UNAVAILABLE
+          : ANALYSIS_CARD_STATE.RUNNING,
+    };
+  }
+
+  return { ...tracking, attempt, failures: 0, state: toAnalysisCardState(probe.status) };
+}
+
+/** [다시 시도] — 시계와 실패 횟수를 처음으로 되돌린다(회의는 그대로). */
+export function restart(tracking: AnalysisTracking, now: number): AnalysisTracking {
+  return {
+    ...tracking,
+    state: ANALYSIS_CARD_STATE.RUNNING,
+    startedAt: now,
+    attempt: 0,
+    failures: 0,
+  };
+}
+
+/** 회의 하나를 새로 쫓기 시작한다(회의 종료 직후 캡처 화면이 부른다). */
+export function startTracking(meetingId: number, title: string, now: number): AnalysisTracking {
+  return {
+    meetingId,
+    title,
+    state: ANALYSIS_CARD_STATE.RUNNING,
+    startedAt: now,
+    attempt: 0,
+    failures: 0,
+  };
+}
+
+/**
+ * 새로고침을 건너뛰기 위해 저장해 둔 값을 되살린다.
+ *
+ * ⚠️ **왜 저장하나.** 카드가 있는 이유가 "화면을 옮겨 다녀도 진행이 따라온다"인데,
+ *    새로고침 한 번에 사라지면 그 약속이 반만 지켜진다.
+ * ⚠️ **`sessionStorage`다.** 탭을 닫으면 같이 사라져야 한다 — 어제 끝난 회의 카드가
+ *    다음 날 아침에 떠 있으면 그건 알림이 아니라 쓰레기다. 토큰이 아니므로
+ *    `localStorage` 금지 규칙(§렌더링·데이터)과는 다른 얘기다.
+ * ⚠️ **모양이 어긋나면 버린다.** 옛 버전이 남긴 값으로 카드가 이상한 상태에 갇히지 않게
+ *    `safeParse`로 본다(§zod).
+ */
+const trackingSchema = z.object({
+  meetingId: z.number(),
+  title: z.string(),
+  state: z.enum([
+    ANALYSIS_CARD_STATE.RUNNING,
+    ANALYSIS_CARD_STATE.DONE,
+    ANALYSIS_CARD_STATE.FAILED,
+    ANALYSIS_CARD_STATE.UNAVAILABLE,
+  ]),
+  startedAt: z.number(),
+  attempt: z.number(),
+  failures: z.number(),
+});
+
+export function restoreTracking(raw: string | null): AnalysisTracking | null {
+  if (!raw) return null;
+  let json: unknown;
+  try {
+    json = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  const parsed = trackingSchema.safeParse(json);
+  return parsed.success ? parsed.data : null;
+}

--- a/src/features/notification/components/analysis-progress-card.tsx
+++ b/src/features/notification/components/analysis-progress-card.tsx
@@ -114,10 +114,13 @@ function CardBody({
          그림자가 없으면 화면 위에 떠 있는 것으로 안 읽힌다.
       ⚠️ 폭을 고정(288px)한다 — 회의 제목 길이에 따라 카드가 늘었다 줄면 자리가 흔들린다.
          제목은 `truncate`로 자른다.
+      ⚠️ 다만 **좁은 화면에서는 접힌다**(§디자인 토큰 — 고정 폭 대신 반응형 여지). 288 + 우측
+         여백 24는 336px보다 좁은 뷰포트에서 왼쪽으로 삐져나가 닫기 버튼만 남는다.
+         `max-w`로 양옆 24px을 남긴다.
       ⚠️ 모션은 **150ms**다(DESIGN — 100/150/250ms). 상태가 바뀔 때 카드를 다시 튀어나오게
          하지 않는다: 처음 뜰 때만 올라오고, 그 뒤로는 안쪽 내용만 바뀐다.
     */
-    <div className="border-border bg-card animate-in fade-in slide-in-from-bottom-2 fixed right-6 bottom-6 z-50 w-72 rounded-2xl border shadow-lg duration-150">
+    <div className="border-border bg-card animate-in fade-in slide-in-from-bottom-2 fixed right-6 bottom-6 z-50 w-72 max-w-[calc(100vw-3rem)] rounded-2xl border shadow-lg duration-150">
       {/*
         ⚠️ `role="status"` + `aria-live`로 **자리에서 바뀌는 것**을 읽게 한다. 카드가 이미
            떠 있는 채로 글자만 바뀌면 스크린리더는 아무 말도 하지 않는다 — 눈으로 보는

--- a/src/features/notification/components/analysis-progress-card.tsx
+++ b/src/features/notification/components/analysis-progress-card.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { Check, CircleAlert, Loader2, RotateCcw, X } from "lucide-react";
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import { Button } from "@/components/ui/button";
+
+import { useNotificationCenter } from "../notification-provider";
+import { ANALYSIS_CARD_STATE, type AnalysisCardState, type AnalysisTracking } from "../types";
+
+/**
+ * 우측 하단 **지속형 카드** — 회의 종료 뒤 요약이 어디까지 갔는지.
+ *
+ * ⚠️ **이건 토스트가 아니다.** 전에는 종료 직후 `toast.success("백그라운드에서 요약 중입니다")`
+ *    한 줄이 몇 초 뜨고 사라졌다 — 그 뒤로 끝났는지 깨졌는지 알 방법이 없어서, 사람이
+ *    회의 상세를 새로고침하며 기다렸다. 카드는 **닫기 전까지 남고 자리에서 상태만 바뀐다.**
+ * ⚠️ **자리를 바꿔 가며 알리지 않는다.** 스피너 → 완료 아이콘으로 같은 카드 안에서 바뀐다.
+ *    새 카드가 뜨면 눈이 다시 자리를 찾아야 한다.
+ * ⚠️ **토스트와 안 겹친다.** 토스트는 `top-center`(`components/ui/sonner.tsx`)이고 이건
+ *    우하단이다. 랜딩의 고객센터 위젯도 우하단이지만 그건 로그인 **전** 화면이라 만나지 않는다.
+ * ⚠️ **색을 안 쓴다**(DESIGN §5). 진행은 스피너, 완료는 체크 표식으로 가른다 —
+ *    색을 쓰는 자리는 **실패(에러)** 하나뿐이다.
+ */
+
+/** 상태 한 장의 내용 — 아이콘·제목·보조 문구가 한 벌로 바뀐다 */
+interface CardFace {
+  icon: ReactNode;
+  title: string;
+  detail: string;
+}
+
+function faceOf(state: AnalysisCardState): CardFace {
+  switch (state) {
+    case ANALYSIS_CARD_STATE.RUNNING:
+      return {
+        icon: <Loader2 className="text-muted-foreground size-4 animate-spin" aria-hidden />,
+        title: "요약 중입니다",
+        detail: "다른 작업을 하셔도 됩니다",
+      };
+    case ANALYSIS_CARD_STATE.DONE:
+      return {
+        icon: <Check className="size-4" aria-hidden />,
+        title: "요약이 끝났습니다",
+        detail: "검토 화면에서 액션을 확정해 주세요",
+      };
+    case ANALYSIS_CARD_STATE.FAILED:
+      return {
+        /* ⚠️ 여기만 색을 쓴다 — DESIGN §5가 색을 허용한 유일한 자리가 에러다 */
+        icon: <CircleAlert className="text-destructive size-4" aria-hidden />,
+        title: "요약에 실패했습니다",
+        detail: "회의 상세에서 다시 분석할 수 있습니다",
+      };
+    case ANALYSIS_CARD_STATE.UNAVAILABLE:
+      return {
+        icon: <CircleAlert className="text-muted-foreground size-4" aria-hidden />,
+        /*
+          ⚠️ **모르는 것을 실패라고 하지 않는다.** 조회가 안 된 것이지 요약이 깨진 게
+             아니다 — 둘을 같은 말로 덮으면 멀쩡한 요약을 다시 돌리게 만든다(§정직성).
+        */
+        title: "요약 상태를 확인하지 못했습니다",
+        detail: "요약은 서버에서 계속 돌고 있을 수 있습니다",
+      };
+  }
+}
+
+export function AnalysisProgressCard() {
+  const { tracking, dismissAnalysis, retryAnalysis } = useNotificationCenter();
+  if (!tracking) return null;
+
+  return (
+    <CardBody
+      tracking={tracking}
+      onClose={dismissAnalysis}
+      onRetry={retryAnalysis}
+      face={faceOf(tracking.state)}
+    />
+  );
+}
+
+function CardBody({
+  tracking,
+  face,
+  onClose,
+  onRetry,
+}: {
+  tracking: AnalysisTracking;
+  face: CardFace;
+  onClose: () => void;
+  onRetry: () => void;
+}) {
+  const isDone = tracking.state === ANALYSIS_CARD_STATE.DONE;
+
+  const body = (
+    <>
+      <span className="flex h-[18px] shrink-0 items-center">{face.icon}</span>
+      <span className="min-w-0 flex-1">
+        <span className="block text-[13px] leading-[18px] font-medium break-keep">
+          {face.title}
+        </span>
+        <span className="text-muted-foreground block truncate pt-0.5 text-[11px] leading-4">
+          {tracking.title}
+        </span>
+        <span className="text-muted-foreground block pt-1 text-[11px] leading-4 break-keep">
+          {face.detail}
+        </span>
+      </span>
+    </>
+  );
+
+  return (
+    /*
+      ⚠️ `--card` + 얕은 그림자다(DESIGN §5 표면). 라이트에서는 바탕과 카드가 둘 다 흰색이라
+         그림자가 없으면 화면 위에 떠 있는 것으로 안 읽힌다.
+      ⚠️ 폭을 고정(288px)한다 — 회의 제목 길이에 따라 카드가 늘었다 줄면 자리가 흔들린다.
+         제목은 `truncate`로 자른다.
+      ⚠️ 모션은 **150ms**다(DESIGN — 100/150/250ms). 상태가 바뀔 때 카드를 다시 튀어나오게
+         하지 않는다: 처음 뜰 때만 올라오고, 그 뒤로는 안쪽 내용만 바뀐다.
+    */
+    <div className="border-border bg-card animate-in fade-in slide-in-from-bottom-2 fixed right-6 bottom-6 z-50 w-72 rounded-2xl border shadow-lg duration-150">
+      {/*
+        ⚠️ `role="status"` + `aria-live`로 **자리에서 바뀌는 것**을 읽게 한다. 카드가 이미
+           떠 있는 채로 글자만 바뀌면 스크린리더는 아무 말도 하지 않는다 — 눈으로 보는
+           사람만 완료를 알게 된다.
+      */}
+      <div role="status" aria-live="polite" className="flex items-start gap-2.5 py-3.5 pr-9 pl-4">
+        {/*
+          ⚠️ **완료 카드는 통째로 링크다**(이슈 #442 — "완료 카드 클릭 → 검토 화면").
+             안쪽에 작은 [보기] 버튼을 두면 누를 자리를 찾아야 한다.
+          ⚠️ 완료가 아닐 때는 링크로 만들지 않는다 — 아직 없는 검토 화면으로 보내면
+             빈 화면을 보여 주게 된다.
+        */}
+        {isDone ? (
+          <Link
+            href={`/app/meeting/${tracking.meetingId}/review`}
+            onClick={onClose}
+            className="focus-visible:ring-ring flex flex-1 items-start gap-2.5 rounded-lg focus-visible:ring-2 focus-visible:outline-hidden"
+          >
+            {body}
+          </Link>
+        ) : (
+          body
+        )}
+      </div>
+
+      {tracking.state === ANALYSIS_CARD_STATE.UNAVAILABLE ? (
+        /* ⚠️ 조용히 멈추지 않는다 — 다시 물어볼 길을 준다(§목록 3상태와 같은 규칙) */
+        <div className="px-4 pb-3.5">
+          <Button variant="outline" size="sm" onClick={onRetry}>
+            <RotateCcw aria-hidden />
+            다시 시도
+          </Button>
+        </div>
+      ) : null}
+
+      <Button
+        variant="ghost"
+        size="icon-xs"
+        aria-label="요약 진행 알림 닫기"
+        onClick={onClose}
+        className="text-muted-foreground absolute top-2.5 right-2.5"
+      >
+        <X aria-hidden />
+      </Button>
+    </div>
+  );
+}

--- a/src/features/notification/components/notification-banner.tsx
+++ b/src/features/notification/components/notification-banner.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { Info, X } from "lucide-react";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+
+import { useNotificationCenter } from "../notification-provider";
+
+/**
+ * 상단 배너 — 회의 개설·리마인더·취소·공지(BE `NotificationType` 4종).
+ *
+ * ⚠️ **알림 화면은 없다**(CLAUDE.md §렌더링·데이터). 목록을 만들지 않고 오는 순간 위에 띄운다.
+ * ⚠️ **떠 있는 판이 아니라 본문 맨 위 줄이다.** `fixed`로 얹으면 토스트(`top-center`)와 같은
+ *    자리를 다투고, 상단바 제목을 가린다 — 흐름에 넣으면 아래 내용이 그만큼 내려갈 뿐이다.
+ * ⚠️ **색을 안 쓴다**(DESIGN §5 — 색으로 알리는 건 에러뿐). 취소 알림도 빨갛게 칠하지 않는다.
+ *    개설·취소·공지를 가르는 건 문장이고, 배너는 그 문장을 나르는 자리다.
+ * ⚠️ **문구를 조립하지 않는다.** BE가 만들어 보낸 `message`를 그대로 쓴다(`event.ts` 주석).
+ */
+export function NotificationBanner() {
+  const { banners, dismissBanner } = useNotificationCenter();
+
+  /* 없으면 자리도 안 만든다 — 빈 상자가 있으면 화면 위가 늘 한 칸 내려간다 */
+  if (banners.length === 0) return null;
+
+  return (
+    /*
+      ⚠️ `aria-live="polite"`다 — 새 알림이 와도 지금 하던 조작을 끊지 않는다.
+         `assertive`는 스크린리더가 읽던 문장을 잘라 먹는다.
+    */
+    <div role="status" aria-live="polite" className="flex shrink-0 flex-col gap-2 px-8 pt-4">
+      {banners.map((banner) => (
+        <div
+          key={banner.id}
+          className="border-border bg-secondary animate-in fade-in slide-in-from-top-1 flex items-start gap-2 rounded-lg border px-3.5 py-3 text-[12px] leading-[18px] duration-150"
+        >
+          {/* ⚠️ 아이콘은 첫 줄 높이 상자에 넣어 가운데 맞춘다(DESIGN §2 안내 배너) */}
+          <span className="flex h-[18px] shrink-0 items-center">
+            <Info className="text-muted-foreground size-3.5" aria-hidden />
+          </span>
+
+          {/*
+            ⚠️ **이동은 `<Link>`다**(CLAUDE.md §SEO — a11y 이유로 지킨다). `onClick`+`router.push`로
+               만들면 새 탭·가운데 클릭이 안 되고 스크린리더가 링크로 못 읽는다.
+            ⚠️ 갈 곳을 모르면(`href === null`) 문장만 남긴다 — 눌리지도 않는 링크를 만들지 않는다.
+          */}
+          <span className="min-w-0 flex-1 break-keep">
+            {banner.href ? (
+              <Link href={banner.href} className="hover:underline">
+                {banner.message}
+              </Link>
+            ) : (
+              banner.message
+            )}
+          </span>
+
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            aria-label="알림 닫기"
+            onClick={() => dismissBanner(banner.id)}
+            className="text-muted-foreground -my-0.5 shrink-0"
+          >
+            <X aria-hidden />
+          </Button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/features/notification/event.test.ts
+++ b/src/features/notification/event.test.ts
@@ -1,0 +1,106 @@
+import { PROCESSING_STATUS } from "@/constants/meeting";
+import { NOTIFICATION_TYPE } from "@/constants/notification";
+
+import {
+  ANALYSIS_EVENT_STATE,
+  parseNotificationEnvelope,
+  toAnalysisSignal,
+  toBannerNotification,
+} from "./event";
+
+/** BE `NotificationEvent` 레코드가 직렬화되는 모양 그대로 */
+function raw(type: string, payload: unknown): string {
+  return JSON.stringify({ type, payload });
+}
+
+describe("스트림 겉봉 읽기", () => {
+  it("BE가 보내는 { type, payload }를 읽는다", () => {
+    expect(parseNotificationEnvelope(raw("MEETING_CREATED", { meetingId: 1 }))).toEqual({
+      type: "MEETING_CREATED",
+      payload: { meetingId: 1 },
+    });
+  });
+
+  /* 한 줄이 깨졌다고 구독 전체를 잃으면 안 된다 */
+  it("깨진 줄은 버린다", () => {
+    expect(parseNotificationEnvelope("{")).toBeNull();
+    expect(parseNotificationEnvelope(JSON.stringify({ payload: {} }))).toBeNull();
+  });
+});
+
+describe("배너 매핑", () => {
+  it.each([
+    NOTIFICATION_TYPE.MEETING_CREATED,
+    NOTIFICATION_TYPE.MEETING_REMINDER,
+    NOTIFICATION_TYPE.MEETING_CANCELED,
+  ])("회의 알림(%s)은 회의 상세로 보낸다", (type) => {
+    const envelope = parseNotificationEnvelope(
+      raw(type, { meetingId: 42, message: "주간 회의가 개설되었습니다." }),
+    );
+    expect(toBannerNotification(envelope!)).toEqual({
+      id: `${type}:42`,
+      type,
+      message: "주간 회의가 개설되었습니다.",
+      href: "/app/meeting/42",
+    });
+  });
+
+  /* 취소 payload에는 title이 없다 — title을 쓰면 취소 배너만 빈다 */
+  it("제목이 없는 취소 알림도 문장을 그대로 띄운다", () => {
+    const envelope = parseNotificationEnvelope(
+      raw(NOTIFICATION_TYPE.MEETING_CANCELED, {
+        meetingId: 9,
+        message: "주간 회의가 취소되었습니다.",
+        startAt: "2026-08-14T10:00:00",
+        canceledAt: "2026-08-13T09:00:00",
+      }),
+    );
+    expect(toBannerNotification(envelope!)?.message).toBe("주간 회의가 취소되었습니다.");
+  });
+
+  it("공지 알림은 공지 상세로 보낸다", () => {
+    const envelope = parseNotificationEnvelope(
+      raw(NOTIFICATION_TYPE.NOTICE_CREATED, {
+        noticeId: 3,
+        title: "휴무",
+        message: "휴무 공지사항이 등록되었습니다.",
+      }),
+    );
+    expect(toBannerNotification(envelope!)?.href).toBe("/app/notice/3");
+  });
+
+  /* BE가 새 종류를 먼저 배포해도 화면이 안 터져야 한다 */
+  it("모르는 종류와 모양이 어긋난 payload는 버린다", () => {
+    expect(toBannerNotification({ type: "SOMETHING_NEW", payload: { meetingId: 1 } })).toBeNull();
+    expect(
+      toBannerNotification({ type: NOTIFICATION_TYPE.MEETING_CREATED, payload: { message: "" } }),
+    ).toBeNull();
+  });
+});
+
+describe("분석 이벤트 이음매", () => {
+  /*
+    ⚠️ BE `NotificationType`에 분석 이벤트가 아직 없다(2026-08-13 실코드 확인).
+       그래서 오늘 스트림으로 오는 건 전부 배너감이고, 카드는 CAP-06 폴링이 움직인다.
+  */
+  it("오늘 BE가 보내는 4종은 분석 신호가 아니다", () => {
+    expect(ANALYSIS_EVENT_STATE).toEqual({});
+    for (const type of Object.values(NOTIFICATION_TYPE)) {
+      expect(toAnalysisSignal({ type, payload: { meetingId: 1 } })).toBeNull();
+    }
+  });
+
+  /*
+    ⚠️ BE가 타입 이름을 확정하면 `ANALYSIS_EVENT_STATE`에 한 줄 적는 것만으로 스트림이
+       카드를 움직인다 — 여기서는 이름을 지어내지 않으려고 표를 주입해 그 길만 확인한다.
+  */
+  it("표에 이름이 적히는 순간 스트림이 카드를 움직인다", () => {
+    const table = { ANALYSIS_DONE: PROCESSING_STATUS.DONE } as const;
+    expect(toAnalysisSignal({ type: "ANALYSIS_DONE", payload: { meetingId: 11 } }, table)).toEqual({
+      meetingId: 11,
+      status: PROCESSING_STATUS.DONE,
+    });
+    /* 어느 회의인지 모르면 카드를 못 고른다 — 조용히 남의 카드를 바꾸지 않는다 */
+    expect(toAnalysisSignal({ type: "ANALYSIS_DONE", payload: {} }, table)).toBeNull();
+  });
+});

--- a/src/features/notification/event.test.ts
+++ b/src/features/notification/event.test.ts
@@ -96,8 +96,9 @@ describe("분석 이벤트 이음매", () => {
   */
   it("표에 이름이 적히는 순간 스트림이 카드를 움직인다", () => {
     const table = { ANALYSIS_DONE: PROCESSING_STATUS.DONE } as const;
+    /* ⚠️ BE는 숫자로 보내지만 카드가 쥔 id는 문자열이다 — 매퍼가 여기서 맞춰 준다 */
     expect(toAnalysisSignal({ type: "ANALYSIS_DONE", payload: { meetingId: 11 } }, table)).toEqual({
-      meetingId: 11,
+      meetingId: "11",
       status: PROCESSING_STATUS.DONE,
     });
     /* 어느 회의인지 모르면 카드를 못 고른다 — 조용히 남의 카드를 바꾸지 않는다 */

--- a/src/features/notification/event.ts
+++ b/src/features/notification/event.ts
@@ -118,7 +118,12 @@ export const ANALYSIS_EVENT_STATE: Readonly<Record<string, ProcessingStatus>> = 
 const analysisPayloadSchema = z.object({ meetingId: z.number() });
 
 export interface AnalysisSignal {
-  meetingId: number;
+  /**
+   * ⚠️ **문자열로 내보낸다.** BE payload는 숫자지만 카드가 들고 있는 id는 화면 쪽 문자열이라
+   *    (`AnalysisTracking.meetingId`), 여기서 안 맞추면 프로바이더의 "쫓던 회의가 맞나"
+   *    비교가 언제나 거짓이 되어 스트림이 카드를 못 움직인다.
+   */
+  meetingId: string;
   status: ProcessingStatus;
 }
 
@@ -138,5 +143,5 @@ export function toAnalysisSignal(
   const parsed = analysisPayloadSchema.safeParse(envelope.payload);
   if (!parsed.success) return null;
 
-  return { meetingId: parsed.data.meetingId, status };
+  return { meetingId: String(parsed.data.meetingId), status };
 }

--- a/src/features/notification/event.ts
+++ b/src/features/notification/event.ts
@@ -1,0 +1,142 @@
+import { z } from "zod";
+
+import { type ProcessingStatus } from "@/constants/meeting";
+import { isNotificationType, NOTIFICATION_TYPE } from "@/constants/notification";
+
+import type { BannerNotification } from "./types";
+
+/**
+ * 알림 SSE 매퍼 — **BE shape을 여기서 흡수한다**(§Mock → Live 격리막).
+ *
+ * BE 계약([확인] 실코드 대조 2026-08-13):
+ *   · 이벤트 이름은 `notification` · `heartbeat` 둘뿐이다(`NotificationStreamRegistry`)
+ *   · `notification`의 data = `NotificationEvent` 레코드 = `{ type, payload }`
+ *   · `type`은 `NotificationType` enum 이름 문자열 · `payload`는 종류마다 다른 객체
+ *
+ * ⚠️ **`safeParse`로 받는다**(PR 체크리스트 §zod). 스트림은 바깥에서 들어오는 값이라
+ *    모양이 어긋날 수 있는데, 한 줄이 깨졌다고 배너 전체를 잃으면 안 된다 — 못 읽은 줄은
+ *    버리고 다음 줄을 읽는다(`use-live-captions`의 `try/catch`와 같은 태도).
+ * ⚠️ **모르는 `type`은 조용히 버린다.** BE가 새 종류를 먼저 배포해도 화면이 안 터진다.
+ */
+
+/** `notification` 이벤트의 겉봉 — 속은 종류마다 다르므로 `unknown`으로 받는다. */
+const notificationEnvelopeSchema = z.object({
+  type: z.string(),
+  payload: z.unknown(),
+});
+
+export interface NotificationEnvelope {
+  type: string;
+  payload: unknown;
+}
+
+/**
+ * `event.data`(JSON 문자열) → 겉봉. 못 읽으면 `null`.
+ * ⚠️ `JSON.parse`는 던진다 — 스트림 한 줄 때문에 구독이 끊기지 않게 여기서 잡는다.
+ */
+export function parseNotificationEnvelope(raw: string): NotificationEnvelope | null {
+  let json: unknown;
+  try {
+    json = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  const parsed = notificationEnvelopeSchema.safeParse(json);
+  return parsed.success ? parsed.data : null;
+}
+
+/*
+  payload 스키마 — **화면이 실제로 쓰는 칸만** 적는다(zod는 남는 칸을 통과시킨다).
+
+  ⚠️ 종류마다 칸이 다르다(BE 실코드):
+     · MEETING_CREATED  { meetingId, title, message, startAt, endAt }
+     · MEETING_REMINDER { meetingId, title, message, startAt, endAt, meetingRoomId, meetingRoomName }
+     · MEETING_CANCELED { meetingId, message, startAt, canceledAt }   ← **title이 없다**
+     · NOTICE_CREATED   { noticeId, title, message }
+  ⚠️ 그래서 배너는 `title`을 안 쓴다 — 한 종류에만 없는 칸을 쓰면 취소 배너만 빈다.
+     `message`에 이미 제목이 들어 있다(BE가 `event.title() + " 회의가 개설되었습니다."`로 만든다).
+*/
+const meetingPayloadSchema = z.object({
+  meetingId: z.number(),
+  message: z.string().min(1),
+});
+
+const noticePayloadSchema = z.object({
+  noticeId: z.number(),
+  message: z.string().min(1),
+});
+
+/**
+ * 겉봉 → 상단 배너 한 줄. 배너로 띄울 종류가 아니거나 모양이 어긋나면 `null`.
+ *
+ * ⚠️ **가는 곳까지 여기서 정한다.** 컴포넌트가 `type`을 보고 주소를 조립하면 라우트가
+ *    바뀔 때 화면을 고쳐야 한다(§라우트 그룹 — 링크는 `<Link>`, 주소는 한 곳에서).
+ */
+export function toBannerNotification(envelope: NotificationEnvelope): BannerNotification | null {
+  if (!isNotificationType(envelope.type)) return null;
+
+  if (envelope.type === NOTIFICATION_TYPE.NOTICE_CREATED) {
+    const parsed = noticePayloadSchema.safeParse(envelope.payload);
+    if (!parsed.success) return null;
+    return {
+      id: `${envelope.type}:${parsed.data.noticeId}`,
+      type: envelope.type,
+      message: parsed.data.message,
+      href: `/app/notice/${parsed.data.noticeId}`,
+    };
+  }
+
+  const parsed = meetingPayloadSchema.safeParse(envelope.payload);
+  if (!parsed.success) return null;
+  return {
+    id: `${envelope.type}:${parsed.data.meetingId}`,
+    type: envelope.type,
+    message: parsed.data.message,
+    /*
+      ⚠️ **취소된 회의도 상세로 보낸다.** 소프트 취소라 화면이 남아 있고(`MEETING_STATUS.CANCELED`),
+         "왜 취소됐는지"를 볼 자리가 거기다 — 링크를 떼면 사람이 갈 곳이 없다.
+    */
+    href: `/app/meeting/${parsed.data.meetingId}`,
+  };
+}
+
+/* ─────────────────────── 분석 이벤트 이음매 (BE 미배포) ─────────────────────── */
+
+/**
+ * 분석 이벤트 `type` → CAP-06 상태값.
+ *
+ * ⚠️ **지금은 비어 있다.** BE `NotificationType`에 분석 이벤트가 없다(2026-08-13 실코드
+ *    확인 — `MEETING_CREATED`·`MEETING_REMINDER`·`MEETING_CANCELED`·`NOTICE_CREATED` 4종뿐).
+ *    이름을 미리 지어 넣으면 오지 않는 이벤트를 기다리는 코드가 된다(§연동 검증 — 추측 금지).
+ * ⚠️ **BE에 이름이 확정되면 여기 한 줄씩만 적으면 된다.** 예를 들어 `ANALYSIS_DONE: "DONE"`,
+ *    `ANALYSIS_FAILED: "FAILED"`를 넣는 순간 스트림이 카드를 직접 움직이고, 폴링은
+ *    `use-analysis-tracker`에서 보조로 내려간다 — **카드·배너 컴포넌트는 안 고친다.**
+ *    payload에서 `meetingId`를 꺼내는 규칙은 아래 `analysisPayloadSchema` 하나뿐이다.
+ */
+export const ANALYSIS_EVENT_STATE: Readonly<Record<string, ProcessingStatus>> = {};
+
+const analysisPayloadSchema = z.object({ meetingId: z.number() });
+
+export interface AnalysisSignal {
+  meetingId: number;
+  status: ProcessingStatus;
+}
+
+/**
+ * 겉봉 → 분석 신호. 분석 이벤트가 아니면 `null`(오늘은 **언제나 `null`**이다).
+ *
+ * ⚠️ 표를 인자로 받는 건 **테스트가 이름을 지어내지 않고도 이음매를 검사**하기 위해서다 —
+ *    BE가 이름을 확정하면 기본값(`ANALYSIS_EVENT_STATE`)에만 적으면 된다.
+ */
+export function toAnalysisSignal(
+  envelope: NotificationEnvelope,
+  eventStates: Readonly<Record<string, ProcessingStatus>> = ANALYSIS_EVENT_STATE,
+): AnalysisSignal | null {
+  const status = eventStates[envelope.type];
+  if (!status) return null;
+
+  const parsed = analysisPayloadSchema.safeParse(envelope.payload);
+  if (!parsed.success) return null;
+
+  return { meetingId: parsed.data.meetingId, status };
+}

--- a/src/features/notification/notification-provider.tsx
+++ b/src/features/notification/notification-provider.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { createContext, useCallback, useContext, useState } from "react";
+
+import { type NotificationEnvelope, toBannerNotification } from "./event";
+import type { BannerNotification } from "./types";
+import { useNotificationStream } from "./use-notification-stream";
+
+/**
+ * 알림 상태를 쥐고 있는 자리 — **셸에 한 번만** 마운트한다(`app/(shell)/layout.tsx`).
+ *
+ * ⚠️ **스트림은 여기 하나뿐이다.** 화면마다 열면 같은 알림이 배너에 여러 줄 뜬다
+ *    (BE는 회원당 emitter 리스트 전부에 복사해 보낸다).
+ */
+
+interface NotificationContextValue {
+  banners: BannerNotification[];
+  dismissBanner: (id: string) => void;
+}
+
+const NotificationContext = createContext<NotificationContextValue | null>(null);
+
+/**
+ * ⚠️ **없으면 던진다.** 셸 밖(랜딩·온보딩)에서 부르면 조용히 아무 일도 안 일어나는데,
+ *    그건 원인을 못 찾는 화면이다(§정직성).
+ */
+export function useNotificationCenter(): NotificationContextValue {
+  const value = useContext(NotificationContext);
+  if (!value) throw new Error("NotificationProvider 안에서만 쓸 수 있습니다.");
+  return value;
+}
+
+/** 배너를 쌓아 두는 최대 줄 수 — 넘으면 오래된 것부터 밀려난다 */
+const MAX_BANNERS = 3;
+
+export function NotificationProvider({ children }: { children: ReactNode }) {
+  const [banners, setBanners] = useState<BannerNotification[]>([]);
+
+  const handleEvent = useCallback((envelope: NotificationEnvelope) => {
+    const banner = toBannerNotification(envelope);
+    if (!banner) return;
+    setBanners((prev) => {
+      /* 재연결로 같은 알림이 다시 오면 한 줄로 접는다(§목록 — id로 중복을 거른다) */
+      if (prev.some((item) => item.id === banner.id)) return prev;
+      return [...prev, banner].slice(-MAX_BANNERS);
+    });
+  }, []);
+
+  useNotificationStream(handleEvent);
+
+  const dismissBanner = useCallback((id: string) => {
+    setBanners((prev) => prev.filter((banner) => banner.id !== id));
+  }, []);
+
+  return (
+    <NotificationContext.Provider value={{ banners, dismissBanner }}>
+      {children}
+    </NotificationContext.Provider>
+  );
+}

--- a/src/features/notification/notification-provider.tsx
+++ b/src/features/notification/notification-provider.tsx
@@ -33,8 +33,12 @@ interface NotificationContextValue {
   banners: BannerNotification[];
   dismissBanner: (id: string) => void;
   tracking: AnalysisTracking | null;
-  /** 회의 종료 직후 캡처 화면이 부른다 — 이 순간부터 카드가 뜬다 */
-  trackAnalysis: (meetingId: number, title: string) => void;
+  /**
+   * 회의 종료 직후 캡처 화면이 부른다 — 이 순간부터 카드가 뜬다.
+   * ⚠️ `meetingId`는 **화면이 쓰는 문자열 id 그대로** 넘긴다(`Number()`로 바꾸지 않는다 —
+   *    목 id가 `NaN`이 되어 카드가 멈춘다, `types.ts` 주석).
+   */
+  trackAnalysis: (meetingId: string, title: string) => void;
   dismissAnalysis: () => void;
   retryAnalysis: () => void;
 }
@@ -124,7 +128,7 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
     ⚠️ **한 번에 한 회의만 쫓는다.** 사람이 동시에 두 회의를 끝낼 수는 없고, 여러 장을
        쌓으면 화면 오른쪽 아래가 카드로 덮인다 — 새로 끝내면 앞 카드는 그 자리를 내준다.
   */
-  const trackAnalysis = useCallback((meetingId: number, title: string) => {
+  const trackAnalysis = useCallback((meetingId: string, title: string) => {
     setTracking(startTracking(meetingId, title, Date.now()));
   }, []);
 

--- a/src/features/notification/notification-provider.tsx
+++ b/src/features/notification/notification-provider.tsx
@@ -1,29 +1,49 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { createContext, useCallback, useContext, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
 
-import { type NotificationEnvelope, toBannerNotification } from "./event";
-import type { BannerNotification } from "./types";
+import { fetchAnalysisStatusAction } from "./actions";
+import {
+  advance,
+  ANALYSIS_POLL_INTERVAL_MS,
+  expire,
+  isExpired,
+  isSettled,
+  restart,
+  restoreTracking,
+  shouldPoll,
+  startTracking,
+} from "./analysis";
+import { type NotificationEnvelope, toAnalysisSignal, toBannerNotification } from "./event";
+import type { AnalysisTracking, BannerNotification } from "./types";
 import { useNotificationStream } from "./use-notification-stream";
 
 /**
  * 알림 상태를 쥐고 있는 자리 — **셸에 한 번만** 마운트한다(`app/(shell)/layout.tsx`).
  *
- * ⚠️ **스트림은 여기 하나뿐이다.** 화면마다 열면 같은 알림이 배너에 여러 줄 뜬다
+ * ⚠️ **왜 화면이 아니라 셸인가.** 카드의 존재 이유가 "회의를 끝내고 다른 일을 해도 진행이
+ *    따라온다"이다. 캡처 화면이 들고 있으면 목록으로 옮기는 순간 언마운트돼 사라진다 —
+ *    지금 토스트와 똑같아진다.
+ * ⚠️ **스트림도 여기 하나뿐이다.** 화면마다 열면 같은 알림이 배너에 여러 줄 뜬다
  *    (BE는 회원당 emitter 리스트 전부에 복사해 보낸다).
  */
 
 interface NotificationContextValue {
   banners: BannerNotification[];
   dismissBanner: (id: string) => void;
+  tracking: AnalysisTracking | null;
+  /** 회의 종료 직후 캡처 화면이 부른다 — 이 순간부터 카드가 뜬다 */
+  trackAnalysis: (meetingId: number, title: string) => void;
+  dismissAnalysis: () => void;
+  retryAnalysis: () => void;
 }
 
 const NotificationContext = createContext<NotificationContextValue | null>(null);
 
 /**
- * ⚠️ **없으면 던진다.** 셸 밖(랜딩·온보딩)에서 부르면 조용히 아무 일도 안 일어나는데,
- *    그건 원인을 못 찾는 화면이다(§정직성).
+ * ⚠️ **없으면 던진다.** 셸 밖(랜딩·온보딩)에서 부르면 카드가 조용히 안 뜨는데, 그건
+ *    "종료했는데 아무 일도 안 일어난 화면"이라 원인을 못 찾는다(§정직성).
  */
 export function useNotificationCenter(): NotificationContextValue {
   const value = useContext(NotificationContext);
@@ -34,10 +54,59 @@ export function useNotificationCenter(): NotificationContextValue {
 /** 배너를 쌓아 두는 최대 줄 수 — 넘으면 오래된 것부터 밀려난다 */
 const MAX_BANNERS = 3;
 
+/** ⚠️ 탭을 닫으면 같이 사라져야 한다 — `sessionStorage`인 이유는 `analysis.ts` 주석 참고 */
+const TRACKING_STORAGE_KEY = "z:analysis-tracking";
+
 export function NotificationProvider({ children }: { children: ReactNode }) {
   const [banners, setBanners] = useState<BannerNotification[]>([]);
+  const [tracking, setTracking] = useState<AnalysisTracking | null>(null);
+
+  /*
+    ⚠️ **먼저 되살리고, 되살린 뒤부터 저장한다**(`features/onboarding/use-draft-sync.ts`와
+       같은 순서). 반대로 하면 마운트 첫 렌더의 `null`이 보관함을 덮어써서, 새로고침할
+       때마다 쫓던 회의가 날아간다.
+    ⚠️ **마운트 뒤에 읽는다.** 렌더 중에 읽으면 서버가 그린 HTML과 어긋난다(hydration) —
+       서버는 브라우저 저장소를 모른다. 한 번만 일어나는 동기화라 규칙을 끈다.
+  */
+  const [isRestored, setIsRestored] = useState(false);
+
+  useEffect(() => {
+    const saved = restoreTracking(window.sessionStorage.getItem(TRACKING_STORAGE_KEY));
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setTracking(saved);
+
+    setIsRestored(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isRestored) return;
+    if (tracking) {
+      window.sessionStorage.setItem(TRACKING_STORAGE_KEY, JSON.stringify(tracking));
+    } else {
+      window.sessionStorage.removeItem(TRACKING_STORAGE_KEY);
+    }
+  }, [isRestored, tracking]);
+
+  /* ─────────────────────────────── 스트림 ─────────────────────────────── */
 
   const handleEvent = useCallback((envelope: NotificationEnvelope) => {
+    /*
+      ⚠️ **여기가 소스 교체의 이음매다.** 오늘 `toAnalysisSignal`은 언제나 `null`이다 —
+         BE `NotificationType`에 분석 이벤트가 없기 때문이다(2026-08-13 실코드 확인).
+         BE가 타입을 배포하고 `event.ts`의 `ANALYSIS_EVENT_STATE`에 이름만 적으면, 그
+         순간부터 스트림이 카드를 직접 움직이고 폴링은 늦게 도착하는 보조가 된다 —
+         **카드·배너 컴포넌트는 한 줄도 안 바뀐다.**
+    */
+    const signal = toAnalysisSignal(envelope);
+    if (signal) {
+      setTracking((prev) =>
+        prev && prev.meetingId === signal.meetingId
+          ? advance(prev, { ok: true, status: signal.status })
+          : prev,
+      );
+      return;
+    }
+
     const banner = toBannerNotification(envelope);
     if (!banner) return;
     setBanners((prev) => {
@@ -49,12 +118,103 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
 
   useNotificationStream(handleEvent);
 
+  /* ─────────────────────────── 요약 진행 폴링(CAP-06) ─────────────────────────── */
+
+  /*
+    ⚠️ **한 번에 한 회의만 쫓는다.** 사람이 동시에 두 회의를 끝낼 수는 없고, 여러 장을
+       쌓으면 화면 오른쪽 아래가 카드로 덮인다 — 새로 끝내면 앞 카드는 그 자리를 내준다.
+  */
+  const trackAnalysis = useCallback((meetingId: number, title: string) => {
+    setTracking(startTracking(meetingId, title, Date.now()));
+  }, []);
+
+  const dismissAnalysis = useCallback(() => setTracking(null), []);
+
+  const retryAnalysis = useCallback(() => {
+    setTracking((prev) => (prev ? restart(prev, Date.now()) : prev));
+  }, []);
+
+  /*
+    ⚠️ **의존성이 `tracking` 통째다.** 한 번 물어볼 때마다 `attempt`가 올라 새 객체가 되고,
+       그때마다 이 효과가 다시 돌며 다음 한 번을 예약한다 — `setInterval` 하나로 돌리면
+       응답이 늦을 때 요청이 겹쳐 쌓인다.
+  */
+  useEffect(() => {
+    const current = tracking;
+    if (!current || isSettled(current.state)) return;
+
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    /*
+      ⚠️ **화살표 함수로 둔다.** `function` 선언은 끌어올려져서 위의 `if (!current) return`
+         narrowing이 안쪽까지 안 따라온다(TS) — 타입을 느슨하게 푸는 대신 모양을 바꾼다.
+    */
+    const probe = async () => {
+      const result = await fetchAnalysisStatusAction(current.meetingId, current.attempt);
+      if (cancelled) return;
+      /* 쫓는 회의가 그 사이 바뀌었으면(다른 회의를 끝냈다) 늦게 온 답은 버린다 */
+      setTracking((prev) =>
+        prev && prev.meetingId === current.meetingId ? advance(prev, result) : prev,
+      );
+    };
+
+    /*
+      ⚠️ **상한 판정을 타이머 안에서 한다.** 효과 본문에서 바로 `setTracking`을 부르면
+         렌더가 연쇄로 한 번 더 돈다(`react-hooks/set-state-in-effect`) — 어차피 5초 뒤
+         이 타이머가 깨어나므로 그 자리에서 접으면 된다.
+      ⚠️ 접는 걸 빼먹으면 스피너가 영원히 돈다 — 그게 「요약 중」이라는 거짓말이다(§정직성).
+    */
+    const tick = () => {
+      const now = Date.now();
+      if (isExpired(current, now)) {
+        setTracking((prev) =>
+          prev && prev.meetingId === current.meetingId && !isSettled(prev.state)
+            ? expire(prev)
+            : prev,
+        );
+        return;
+      }
+      if (!shouldPoll(current, now, document.hidden)) return;
+      void probe();
+    };
+
+    timer = setTimeout(tick, ANALYSIS_POLL_INTERVAL_MS);
+
+    /*
+      ⚠️ 숨은 탭에서는 예약이 지나가도 아무것도 안 한다 — 돌아오는 순간 이 핸들러가
+         **기다리지 않고 바로** 한 번 물어본다. 안 그러면 화면을 다시 켰을 때 이미 끝난
+         요약이 몇 초 더 「요약 중」으로 남는다.
+    */
+    const wake = () => {
+      if (document.hidden) return;
+      if (timer) clearTimeout(timer);
+      tick();
+    };
+
+    document.addEventListener("visibilitychange", wake);
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      document.removeEventListener("visibilitychange", wake);
+    };
+  }, [tracking]);
+
   const dismissBanner = useCallback((id: string) => {
     setBanners((prev) => prev.filter((banner) => banner.id !== id));
   }, []);
 
   return (
-    <NotificationContext.Provider value={{ banners, dismissBanner }}>
+    <NotificationContext.Provider
+      value={{
+        banners,
+        dismissBanner,
+        tracking,
+        trackAnalysis,
+        dismissAnalysis,
+        retryAnalysis,
+      }}
+    >
       {children}
     </NotificationContext.Provider>
   );

--- a/src/features/notification/types.ts
+++ b/src/features/notification/types.ts
@@ -48,7 +48,15 @@ export type AnalysisCardState = (typeof ANALYSIS_CARD_STATE)[keyof typeof ANALYS
 
 /** 지금 쫓고 있는 회의 하나. 카드가 통째로 이 값을 그린다. */
 export interface AnalysisTracking {
-  meetingId: number;
+  /**
+   * 화면이 쓰는 회의 id — **문자열이다**(`MeetingCaptureInfo.id`·라우트 `[meetingId]`와 같은 값).
+   *
+   * ⚠️ **숫자로 바꿔 들고 있으면 안 된다.** 목 회의 id는 `meeting-3`이라 `Number()`가 `NaN`이
+   *    되는데, `NaN === NaN`은 거짓이라 프로바이더의 "쫓던 회의가 맞나" 비교가 전부 빗나가
+   *    카드가 「요약 중」에서 영영 안 바뀐다(§정직성). 숫자가 필요한 건 BE 경로 하나뿐이라
+   *    변환은 `actions.ts`(API 경계)에서 한다 — `server.ts`의 `ep.meeting(Number(id))`와 같다.
+   */
+  meetingId: string;
   /** 카드에 적을 회의 제목 — 목록으로 튕긴 뒤에도 무엇이 도는지 알아야 한다 */
   title: string;
   state: AnalysisCardState;

--- a/src/features/notification/types.ts
+++ b/src/features/notification/types.ts
@@ -1,0 +1,61 @@
+import type { NotificationType } from "@/constants/notification";
+
+/**
+ * 알림 UI 계약 — **화면은 이 모양만 안다**(§Mock → Live 격리막).
+ *
+ * BE가 실제로 무엇을 어떤 봉투에 담아 보내는지는 `event.ts`(매퍼)가 흡수한다. 스트림에
+ * 분석 이벤트가 생기든 폴링으로 알아내든, 카드가 보는 것은 아래 `AnalysisTracking` 하나다 —
+ * **소스가 바뀌어도 컴포넌트는 0줄 고친다.**
+ */
+
+/**
+ * 상단 배너 한 줄(회의 개설·리마인더·취소·공지).
+ *
+ * ⚠️ **문구를 코드로 조립하지 않는다.** `message`는 BE가 만들어 보낸 한국어 문장 그대로다
+ *    (`lib/api.ts` 주석과 같은 규칙) — 우리가 다시 쓰면 같은 사실을 두 곳이 말하게 된다.
+ */
+export interface BannerNotification {
+  /**
+   * 화면 목록 키.
+   * ⚠️ **BE payload에 알림 id가 없다**(실코드 확인 — 저장된 알림의 id는 스트림에 안 실린다).
+   *    그래서 `종류:대상id`로 만든다 — 재연결로 같은 알림이 다시 와도 한 줄로 접힌다
+   *    (§목록: 이어 붙일 때 id로 중복을 거른다와 같은 이유).
+   */
+  id: string;
+  type: NotificationType;
+  /** BE가 보낸 문장 그대로 */
+  message: string;
+  /** 눌렀을 때 갈 곳. 대상을 모르면 `null`이고 그러면 링크가 아니라 문장만 남는다 */
+  href: string | null;
+}
+
+/**
+ * 우측 하단 지속형 카드의 상태.
+ *
+ * ⚠️ **`NOT_STARTED`가 여기 없다.** BE의 CAP-06 값은 4개지만 사람이 봐야 하는 사실은
+ *    "아직인가 · 됐나 · 깨졌나 · 모르겠나" 넷이다. 종료 직후의 `NOT_STARTED`는 사람에게는
+ *    그냥 「요약 중」이다(§도메인 상수: 파생값은 상태 필드가 아니라 계산).
+ * ⚠️ **`UNAVAILABLE`을 없애지 않는다.** 폴링이 계속 실패하거나 상한을 넘겼을 때 스피너를
+ *    계속 돌리면 화면이 거짓말을 한다 — 못 알아냈다고 말하고 [다시 시도]를 준다(§정직성).
+ */
+export const ANALYSIS_CARD_STATE = {
+  RUNNING: "RUNNING",
+  DONE: "DONE",
+  FAILED: "FAILED",
+  UNAVAILABLE: "UNAVAILABLE",
+} as const;
+export type AnalysisCardState = (typeof ANALYSIS_CARD_STATE)[keyof typeof ANALYSIS_CARD_STATE];
+
+/** 지금 쫓고 있는 회의 하나. 카드가 통째로 이 값을 그린다. */
+export interface AnalysisTracking {
+  meetingId: number;
+  /** 카드에 적을 회의 제목 — 목록으로 튕긴 뒤에도 무엇이 도는지 알아야 한다 */
+  title: string;
+  state: AnalysisCardState;
+  /** 쫓기 시작한 시각(epoch ms). 상한(`ANALYSIS_POLL_MAX_MS`)을 재는 자리다 */
+  startedAt: number;
+  /** 몇 번째 조회인지. 목 진행과 로그에 쓴다 */
+  attempt: number;
+  /** 연속 실패 횟수. 성공하면 0으로 돌아간다 */
+  failures: number;
+}

--- a/src/features/notification/use-notification-stream.ts
+++ b/src/features/notification/use-notification-stream.ts
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import { isMock } from "@/mocks/config";
+
+import { type NotificationEnvelope, parseNotificationEnvelope } from "./event";
+
+/**
+ * 개인 알림 SSE 구독 — **앱 전체에 연결 하나**(셸에서 한 번만 마운트한다).
+ *
+ * 자막 구독(`features/meeting/capture/use-live-captions.ts`)과 **같은 뼈대**다. 다른 점만 적는다.
+ *
+ * ⚠️ **우리 주소를 구독한다**(`/api/notifications/stream`). `EventSource`는 헤더를 못 붙여서
+ *    BE를 직접 구독하려면 토큰을 쿼리스트링에 실어야 하는데, 그러면 주소창·프록시 로그에
+ *    액세스 토큰이 남는다 — BFF가 헤더로 붙여 준다(§핵심 4원칙 ②).
+ * ⚠️ **연결은 하나여야 한다.** 화면마다 열면 사람 하나가 탭 하나로 여러 emitter를 잡고
+ *    (BE는 회원당 리스트로 들고 전부에 복사해 보낸다), 같은 알림이 배너에 여러 줄 뜬다.
+ *    그래서 이 훅은 **셸의 `NotificationProvider` 한 곳에서만** 부른다.
+ * ⚠️ **목에서는 안 연다.** BE가 없으니 BFF가 502를 돌려주고, `EventSource`는 그걸 재연결
+ *    신호로 알아 계속 두드린다 — 개발 콘솔이 실패로 뒤덮인다(§Mock 격리막).
+ * ⚠️ **끊기면 스스로 붙지만, 거절당하면 안 붙는다.** 네트워크가 튀면 브라우저가 알아서
+ *    재연결한다(그건 우리가 안 짠다). 하지만 401·502처럼 **응답이 온 실패**는 브라우저가
+ *    연결을 닫고 끝낸다(`readyState === CLOSED`) — 그때만 우리가 물러서며 다시 연다.
+ *    간격을 안 늘리면 로그인이 풀린 채로 초당 몇 번씩 서버를 두드린다.
+ */
+
+/** 재연결 첫 대기(ms) — 배포 한 번으로 끊긴 정도는 이 안에 붙는다 */
+const RECONNECT_BASE_MS = 2_000;
+/** 물러설 수 있는 최대(ms) — 더 늘리면 사람이 돌아왔는데 한참 알림이 안 온다 */
+const RECONNECT_MAX_MS = 60_000;
+
+export function useNotificationStream(onEvent: (envelope: NotificationEnvelope) => void): void {
+  /*
+    ⚠️ 콜백을 **ref에 담는다.** 의존성에 그대로 넣으면 부모가 다시 그릴 때마다 연결을 끊고
+       새로 연다 — 그 사이에 온 알림이 사라진다.
+  */
+  const handlerRef = useRef(onEvent);
+  /* ⚠️ 갈아 끼우는 건 **효과 안**이다 — 렌더 중에 ref를 건드리면 안 된다(`react-hooks/refs`) */
+  useEffect(() => {
+    handlerRef.current = onEvent;
+  }, [onEvent]);
+
+  useEffect(() => {
+    /*
+      ⚠️ `EventSource`가 없는 환경(오래된 브라우저·테스트)에서 터지지 않게 먼저 묻는다.
+         알림을 못 받아도 나머지 화면은 그대로 돌아야 한다.
+    */
+    if (isMock) return;
+    if (typeof window === "undefined" || typeof EventSource === "undefined") return;
+
+    let source: EventSource | null = null;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    let retryDelay = RECONNECT_BASE_MS;
+    let closed = false;
+
+    function handleNotification(event: MessageEvent<string>) {
+      const envelope = parseNotificationEnvelope(event.data);
+      /* 한 줄이 깨졌다고 스트림 전체를 버리지 않는다 — 다음 줄은 멀쩡할 수 있다 */
+      if (envelope) handlerRef.current(envelope);
+    }
+
+    function open() {
+      if (closed) return;
+      const next = new EventSource("/api/notifications/stream");
+      source = next;
+
+      next.addEventListener("open", () => {
+        /* 한 번 붙으면 물러선 만큼을 되돌린다 — 안 되돌리면 다음 끊김에 1분을 기다린다 */
+        retryDelay = RECONNECT_BASE_MS;
+      });
+      next.addEventListener("notification", handleNotification as EventListener);
+      /*
+        ⚠️ `heartbeat`(20초)는 **듣지 않는다.** 연결이 살아 있게 하는 게 일이라 화면에
+           그릴 것이 없다 — 듣지 않는 것과 못 듣는 것은 다르니 적어 둔다.
+      */
+      next.addEventListener("error", () => {
+        /*
+          ⚠️ `CONNECTING`이면 브라우저가 이미 다시 붙는 중이다 — 여기서 손대면 그 재시도를
+             끊고 우리 타이머로 갈아타 오히려 늦어진다. **닫힌 것만** 우리가 다시 연다.
+        */
+        if (next.readyState !== EventSource.CLOSED) return;
+        next.close();
+        if (closed) return;
+        retryTimer = setTimeout(open, retryDelay);
+        retryDelay = Math.min(retryDelay * 2, RECONNECT_MAX_MS);
+      });
+    }
+
+    open();
+
+    return () => {
+      closed = true;
+      if (retryTimer) clearTimeout(retryTimer);
+      source?.removeEventListener("notification", handleNotification as EventListener);
+      source?.close();
+    };
+  }, []);
+}

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -263,7 +263,18 @@ export const ep = {
 
   /* 기타 */
   notifications: () => "/api/notifications",
-  /** SSE 스트림 — BFF가 중계하며 토큰을 주입한다 */
+  /**
+   * 개인 알림 실시간 구독(SSE) — BFF가 중계하며 토큰을 주입한다.
+   * [확인] BE 실코드 대조(2026-08-13) — `notification/presentation/api/NotificationController.java`
+   *
+   * ⚠️ **수신자를 URL로 안 보낸다.** BE가 토큰의 `memberId`로 스코프를 정한다
+   *    (`@AuthenticationPrincipal(expression = "memberId")`) — 쿼리로 받으면 남의 알림을 본다.
+   * ⚠️ 이벤트 두 종류: `notification` · `heartbeat`(20초, `{ t }`).
+   *    `notification`의 data는 `{ type, payload }`다(`NotificationEvent` 레코드).
+   * ⚠️ `type`은 지금 **4종뿐**이다 — `MEETING_CREATED`·`MEETING_REMINDER`·`MEETING_CANCELED`·
+   *    `NOTICE_CREATED`(`NotificationType.java`). **분석 완료·실패 이벤트는 아직 없다** —
+   *    그래서 요약 진행 카드는 CAP-06(`processingStatus`) 폴링으로 돈다.
+   */
   notificationStream: () => "/api/notifications/stream",
   notices: () => "/api/notices",
   /** 공지 상세(`GET`, NOTI-02)·수정(`PUT`, NOTI-04)·삭제(`DELETE`, NOTI-05)가 같은 경로를 쓴다. */


### PR DESCRIPTION
## 📋 PR 타입

> 해당하는 타입을 선택해 주세요 (복수 선택 가능)

- [x] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [x] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [x] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- **BFF 중계 라우트 `app/api/notifications/stream`** — httpOnly 쿠키의 토큰을 헤더로 붙여 BE SSE를 중계합니다. `EventSource`는 헤더를 못 붙여서, 브라우저가 BE를 직접 구독하면 액세스 토큰이 쿼리스트링·주소창·프록시 로그에 남습니다(CLAUDE.md §렌더링·데이터). 자막 중계(CAP-13)와 같은 뼈대이고, 다른 점은 **경로에 식별자가 없다**는 것뿐입니다 — 수신자는 BE가 토큰의 `memberId`로 정합니다.
- **알림 SSE 구독 훅** — `ep.notificationStream()`을 실제로 여는 **첫 코드**입니다(그동안 URL만 등록돼 있고 호출부가 0곳). 연결은 앱 전체에 하나(셸에서만 마운트), 목에서는 안 열고, 401·502처럼 거절당해 닫힌 경우만 2s→60s로 물러서며 다시 붙습니다.
- **상단 배너** — `MEETING_CREATED`·`MEETING_REMINDER`·`MEETING_CANCELED`·`NOTICE_CREATED`(BE `NotificationType` 실코드 4종). 본문 맨 위 줄로 들어갑니다 — `fixed`로 얹으면 토스트(`top-center`)와 자리를 다투고 상단바 제목을 가립니다.
- **우측 하단 지속형 카드** — 회의 종료 뒤 요약 진행. 스피너 → 완료·실패로 **자리에서** 바뀌고 닫기 전까지 남습니다. 완료 카드를 누르면 `/app/meeting/:id/review`로 갑니다.
- **`capture-view.tsx`의 일회성 토스트 제거** — `toast.success("백그라운드에서 요약 중입니다")`는 몇 초 뒤 사라져서, 그 뒤로 요약이 끝났는지 깨졌는지 알 방법이 없었습니다. 카드는 셸이 들고 있어 목록으로 옮겨도 따라옵니다.
- ⚠️ **카드는 SSE가 아니라 CAP-06 폴링으로 움직입니다.** BE `NotificationType`에 분석 이벤트가 아직 없어서(2026-08-13 실코드 확인), SSE에만 걸면 「요약 중」에서 **영영 안 바뀝니다** — 지금 토스트보다 나빠집니다(§정직성). `GET /api/meetings/{id}/processing-status`가 `NOT_STARTED·RUNNING·DONE·FAILED`를 주므로 완료·실패를 지금도 알 수 있습니다.
- **이음매를 남겨 뒀습니다** — `event.ts`의 `ANALYSIS_EVENT_STATE`가 지금은 빈 표입니다. BE가 타입 이름을 확정하면 **거기 한 줄씩 적는 것만으로** 스트림이 카드를 직접 움직이고 폴링이 빠집니다. 카드·배너 컴포넌트는 한 줄도 안 바뀝니다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**(회의 담당자 등), 그리고 **서버(Server Action/BFF)에서 재검사** — 스트림 스코프는 BE가 토큰 `memberId`로 정하고(`@AuthenticationPrincipal`), 우리는 수신자를 URL·쿼리로 **보내지 않습니다.** CAP-06도 `companyId`를 토큰에서만 읽습니다.
- [x] 🧬 **zod** — SSE 겉봉·payload·보관함 복원 전부 `safeParse`(`event.ts` · `analysis.ts`)
- [x] 🕵️ **정직성** — 목이면 스트림을 안 열고 폴링도 안 부릅니다(주석에 명시) · 못 알아냈을 때 스피너를 계속 돌리지 않고 「확인하지 못했습니다」 + [다시 시도] · BE에 분석 이벤트가 없다는 사실을 상수·매퍼·PR에 모두 적어 뒀습니다
- [x] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨 — 색은 **실패(에러)** 한 곳뿐(DESIGN §5), 진행은 스피너·명도로 가릅니다

**품질**

- [x] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그) — 스트림은 연결 하나, 폴링은 탭이 숨으면 쉽니다
- [x] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로 — 배너·카드 `role="status"` + `aria-live="polite"`, 닫기 버튼에 접근 이름, 이동은 `<Link>`
- [x] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인) — `Button`(ghost/icon-xs/outline) 재사용, 배너는 DESIGN §2 안내 배너 골격 그대로
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 카드의 진행·실패·확인 못 함이 그 셋에 해당하고, 배너는 없으면 자리도 안 만듭니다
- [x] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음 — `EventSource`가 없는 환경에서는 조용히 넘기고 나머지 화면은 그대로 돕니다(구독 실패가 화면을 죽이지 않습니다)

---

## 🔗 연관 이슈

Closes #442

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
| 종료 직후 `top-center` 토스트 한 줄이 몇 초 뜨고 사라짐 | 우하단 카드가 「요약 중입니다 · 다른 작업을 하셔도 됩니다」로 남았다가 「요약이 끝났습니다」로 바뀜 |

---

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

- **화면에서 카드 보는 법(목 기준, 지금 기본값)** — `/app/meeting/:id/capture`에서 [녹음 시작] → [회의 종료 및 제출] → 확인 창 확정. 회의 목록으로 튕긴 뒤 **우측 하단에 카드**가 뜹니다. 목에서는 서버를 안 부르고 두 번째 조회(약 10초) 뒤 완료로 넘어가며, **완료 카드를 누르면 `/app/meeting/:id/review`** 로 갑니다. 사이드바로 다른 화면(예: `/app/board`)에 가도 카드가 따라오는지, 새로고침해도 남는지(`sessionStorage`), 닫기 전까지 안 사라지는지 봐 주세요.
- **실서버(`NEXT_PUBLIC_USE_MOCK=false`)에서는** 카드가 CAP-06을 5초마다 물어봅니다. BE가 `DONE`을 주는 순간 카드가 바뀝니다. 상단 배너는 다른 사람이 회의를 예약·취소하거나 공지를 올리면 즉시 뜹니다.
- **가장 중요한 판단 — 왜 폴링부터인가.** `NotificationType`에 분석 이벤트가 없어서 SSE에만 걸면 카드가 「요약 중」에 영원히 갇힙니다. 이 선택과 이음매(`ANALYSIS_EVENT_STATE`) 위치가 맞는지 봐 주세요.
- **BFF 라우트** — 본문을 모으지 않고 흘려보내는지(`await res.text()` 없음), 클라이언트가 떠날 때 `request.signal`로 위쪽 구독까지 끊는지, 헤더(`no-store`·`no-transform`·`X-Accel-Buffering`)가 맞는지.
- **연결이 하나인지** — 훅을 셸에서만 부릅니다. 다른 화면에서 또 부르면 같은 알림이 여러 줄 뜹니다(BE가 회원당 emitter 전부에 복사해 보냅니다).
- **배너 자리** — 토스트가 `top-center`라 겹치지 않게 흐름 안의 줄로 뒀습니다. 상단바 위가 아니라 아래(본문 첫 줄)가 맞는지 봐 주세요.

---

## 📝 추가 메모

- ⚠️ **BE에 요청할 것** — 분석 이벤트 타입 이름 확정(`ANALYSIS_DONE`·`ANALYSIS_FAILED` 등)과 그 payload에 `meetingId`가 들어가는지. 이름만 오면 `event.ts`의 표에 적고 폴링을 내릴 수 있습니다.
- ⚠️ **CLAUDE.md 갱신 필요** — §렌더링·데이터에 "알림 화면은 없다 — 상단 배너로만 띄운다"라고 적혀 있는데, 이번에 **하단 카드가 추가**됐습니다. 문서는 손대기 전에 팀에 물어보려고 이 PR에는 안 넣었습니다.
- ⚠️ **회의 하나만 쫓습니다.** 사람이 동시에 두 회의를 끝낼 수 없고, 여러 장을 쌓으면 화면 오른쪽 아래가 카드로 덮입니다 — 새로 끝내면 앞 카드가 자리를 내줍니다.
- 검증: `npx tsc --noEmit` · `npx eslint` · `npx jest`(95 suites / 1037 tests) · `npx next build` 전부 통과.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 실시간 알림 배너를 화면 상단에서 확인하고 닫을 수 있습니다.
  * 회의 종료 후 AI 분석 진행 상태를 지속적으로 확인할 수 있습니다.
  * 분석 완료 시 회의 검토 화면으로 이동할 수 있습니다.
  * 분석 실패 또는 확인 불가 상태에서 재시도할 수 있습니다.
  * 알림과 분석 상태가 새로고침 후에도 복원됩니다.
  * 회의 생성·리마인더·취소·공지 알림을 지원합니다.

* **개선 사항**
  * 탭 상태와 연결 상황에 맞춰 알림 및 분석 상태를 안정적으로 갱신합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->