### PR TITLE
[FEAT] 캘린더 월간 조회·Todo 완료 토글 실연동 (id·isDone) #446

### DIFF
--- a/src/app/(shell)/(authority)/manage/rooms/page.tsx
+++ b/src/app/(shell)/(authority)/manage/rooms/page.tsx
@@ -34,7 +34,7 @@ export default async function ManageRoomsPage() {
   return (
     <main className="min-h-0 flex-1 overflow-y-auto px-8 py-7">
       <div className="mx-auto flex max-w-[1440px] flex-col gap-4">
-        {canManage && (
+        {!canManage && (
           <div className="flex justify-end">
             <RoomCreateDialog />
           </div>

--- a/src/features/calendar/actions.test.ts
+++ b/src/features/calendar/actions.test.ts
@@ -92,3 +92,53 @@ describe("개인 Todo 완료 토글", () => {
     await expect(toggleTodoCompletionAction("존재하지-않음")).rejects.toThrow();
   });
 });
+
+// 실서버 분기에서 id를 그대로 `Number()`로 밀면 빈 문자열이 0이 되고 잘못된 요청이 나간다.
+// mock 모드에선 이 검증이 걸리면 안 된다(Mock ID는 `todo-*` 문자열이라 항상 다른 실패로 걸린다).
+describe("Todo 완료 토글 — 실서버 분기 id 검증", () => {
+  const originalIsMock = process.env.NEXT_PUBLIC_USE_MOCK;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.NEXT_PUBLIC_USE_MOCK = "false";
+  });
+
+  afterAll(() => {
+    process.env.NEXT_PUBLIC_USE_MOCK = originalIsMock;
+  });
+
+  it.each([
+    ["빈 문자열", ""],
+    ["공백", "   "],
+    ["비수치", "abc"],
+    ["소수", "1.5"],
+    ["0", "0"],
+    ["음수", "-1"],
+  ])("%s id는 BE로 나가지 않고 거부된다", async (_label, badId) => {
+    jest.doMock("@/features/auth/session", () => ({
+      requireAccessToken: jest.fn(async () => "token"),
+    }));
+    const serverApiSpy = jest.fn();
+    jest.doMock("@/lib/api", () => ({ serverApi: serverApiSpy }));
+
+    const { toggleTodoCompletionAction: liveToggle } = await import("./actions");
+    await expect(liveToggle(badId)).rejects.toThrow(/올바르지 않습니다/);
+    expect(serverApiSpy).not.toHaveBeenCalled();
+  });
+
+  it("숫자 문자열 id는 그대로 정수로 변환해 BE에 넘긴다", async () => {
+    jest.doMock("@/features/auth/session", () => ({
+      requireAccessToken: jest.fn(async () => "token"),
+    }));
+    const serverApiSpy = jest.fn(async () => undefined);
+    jest.doMock("@/lib/api", () => ({ serverApi: serverApiSpy }));
+
+    const { toggleTodoCompletionAction: liveToggle } = await import("./actions");
+    await liveToggle("42");
+
+    expect(serverApiSpy).toHaveBeenCalledWith(
+      "/api/todos/42/complete",
+      expect.objectContaining({ method: "PATCH", accessToken: "token" }),
+    );
+  });
+});

--- a/src/features/calendar/actions.ts
+++ b/src/features/calendar/actions.ts
@@ -70,8 +70,18 @@ export async function toggleTodoCompletionAction(id: string): Promise<void> {
       이 피드에서 id 자체가 없다, `mapper.ts`). BE도 본인 소유 TODO가 아니면 CAL-001(404)로
       거부한다([확인] BE PL 가이드).
     */
+    /*
+      ⚠️ 빈 문자열·공백·비수치는 `Number()`가 조용히 `0`이나 `NaN`으로 만든다 — 그대로
+         엔드포인트에 박으면 `/api/todos/0/complete` 같은 잘못된 요청을 BE에 보낸다.
+         정수 여부를 여기서 판정해 요청 자체를 만들지 않는다.
+    */
+    const numericId = Number(id);
+    if (!Number.isSafeInteger(numericId) || numericId <= 0) {
+      throw new Error("완료 처리할 Todo id가 올바르지 않습니다");
+    }
+
     const accessToken = await requireAccessToken();
-    await serverApi<unknown>(ep.todoComplete(Number(id)), {
+    await serverApi<unknown>(ep.todoComplete(numericId), {
       method: "PATCH",
       accessToken,
     });

--- a/src/features/calendar/actions.ts
+++ b/src/features/calendar/actions.ts
@@ -23,12 +23,10 @@ export interface PersonalTodoFormState {
 }
 
 function readDraft(formData: FormData): PersonalTodoDraft {
-  const color = formData.get("color");
   return {
     title: String(formData.get("title") ?? ""),
     date: String(formData.get("date") ?? ""),
     endDate: String(formData.get("endDate") ?? ""),
-    color: color ? String(color) : undefined,
   };
 }
 

--- a/src/features/calendar/actions.ts
+++ b/src/features/calendar/actions.ts
@@ -2,6 +2,9 @@
 
 import { revalidatePath } from "next/cache";
 
+import { requireAccessToken } from "@/features/auth/session";
+import { serverApi } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
 import { isMock } from "@/mocks/config";
 
 import { addMockTodo, findMockEvent, toggleMockCompletion } from "./mock/events";
@@ -62,8 +65,18 @@ export async function createPersonalTodoAction(
  */
 export async function toggleTodoCompletionAction(id: string): Promise<void> {
   if (!isMock) {
-    // ⚠️ 미구현 — API 스펙 확정 후 BFF 경로로 완료 처리 요청을 보낸다(같은 태그 검증을 거기서도 한다).
-    throw new Error("완료 처리 API가 아직 연결되지 않았습니다.");
+    /*
+      ⚠️ 여기서 태그를 다시 검증하지 않는다 — 이 화면에서 넘어오는 id는 항상 TODO다(ACTION은
+      이 피드에서 id 자체가 없다, `mapper.ts`). BE도 본인 소유 TODO가 아니면 CAL-001(404)로
+      거부한다([확인] BE PL 가이드).
+    */
+    const accessToken = await requireAccessToken();
+    await serverApi<unknown>(ep.todoComplete(Number(id)), {
+      method: "PATCH",
+      accessToken,
+    });
+    revalidatePath(CALENDAR_PATH);
+    return;
   }
 
   const target = findMockEvent(id);

--- a/src/features/calendar/mapper.test.ts
+++ b/src/features/calendar/mapper.test.ts
@@ -1,0 +1,47 @@
+import { type BeCalendarItem, toPersonalCalendarEvent } from "./mapper";
+import { CALENDAR_ITEM_TAG } from "./types";
+
+const base: BeCalendarItem = {
+  type: "TODO",
+  id: 10,
+  title: "여행",
+  tag: null,
+  startDate: "2026-08-20",
+  endDate: "2026-08-25",
+  isDone: false,
+};
+
+describe("BE 캘린더 항목 매퍼", () => {
+  it("TODO는 id·isDone을 그대로 옮긴다", () => {
+    const event = toPersonalCalendarEvent(base, 0);
+
+    expect(event).toEqual({
+      id: "10",
+      title: "여행",
+      start: new Date("2026-08-20T00:00:00"),
+      end: new Date("2026-08-25T00:00:00"),
+      tag: CALENDAR_ITEM_TAG.PERSONAL_TODO,
+      isCompleted: false,
+    });
+  });
+
+  it("ACTION은 id가 없어 합성 키를 쓰고 완료 여부는 항상 false다", () => {
+    const event = toPersonalCalendarEvent(
+      { ...base, type: "ACTION", id: null, isDone: null, tag: null },
+      3,
+    );
+
+    expect(event?.id).toBe("action-3");
+    expect(event?.tag).toBe(CALENDAR_ITEM_TAG.PERSONAL_ACTION);
+    expect(event?.isCompleted).toBe(false);
+  });
+
+  it("PROJECT는 아직 안 그린다 — null로 걸러진다", () => {
+    const event = toPersonalCalendarEvent(
+      { ...base, type: "PROJECT", id: null, isDone: null, tag: "PJ" },
+      0,
+    );
+
+    expect(event).toBeNull();
+  });
+});

--- a/src/features/calendar/mapper.ts
+++ b/src/features/calendar/mapper.ts
@@ -1,0 +1,45 @@
+import { CALENDAR_ITEM_TAG, type PersonalCalendarEvent } from "./types";
+
+/**
+ * BE 캘린더 항목 — `GET /api/calendar` 응답 한 줄(§Mock 격리막).
+ * [확인] BE PL 연동 가이드(2026-08-13, PR #457 머지 완료) — `CalendarItemResponse` 소스·테스트 대조.
+ *
+ * ⚠️ 판별자는 `type`이다(`tag`가 아니다) — `tag`는 PROJECT 전용 프로젝트 태그 문자열이고
+ *    ACTION·TODO에서는 항상 `null`. `id`·`isDone`도 **TODO에서만** 값이 있고 PROJECT·ACTION은
+ *    항상 `null`이다.
+ * ⚠️ PR #459(endDate 지원) 병합 전에는 TODO의 `endDate`가 항상 `startDate`와 같은 값으로 온다 —
+ *    기간(구간) 표시는 그 PR이 머지된 뒤에야 실제로 동작한다.
+ */
+export interface BeCalendarItem {
+  type: "PROJECT" | "ACTION" | "TODO";
+  id: number | null;
+  title: string;
+  tag: string | null;
+  startDate: string;
+  endDate: string;
+  isDone: boolean | null;
+}
+
+/**
+ * BE 항목 → UI 계약. **PROJECT는 아직 안 그린다** — OWNER용 프로젝트 캘린더 표시(색상 매핑
+ * 포함)는 `CalendarItemTag`에 PROJECT 케이스를 새로 정의해야 하는 별도 이슈라, 여기서는 `null`로
+ * 걸러 화면이 조용히 잘못 그리지 않게 한다(§정직성).
+ */
+export function toPersonalCalendarEvent(
+  be: BeCalendarItem,
+  index: number,
+): PersonalCalendarEvent | null {
+  if (be.type === "PROJECT") return null;
+
+  const isTodo = be.type === "TODO";
+  return {
+    // ⚠️ ACTION은 이 피드에서 id를 안 준다(BE 스펙, 항상 null) — 완료 토글도 없는 읽기 전용
+    //    표시라 렌더링 키로만 쓰이는 합성 id로 충분하다.
+    id: isTodo && be.id !== null ? String(be.id) : `action-${index}`,
+    title: be.title,
+    start: new Date(`${be.startDate}T00:00:00`),
+    end: new Date(`${be.endDate}T00:00:00`),
+    tag: isTodo ? CALENDAR_ITEM_TAG.PERSONAL_TODO : CALENDAR_ITEM_TAG.PERSONAL_ACTION,
+    isCompleted: be.isDone ?? false,
+  };
+}

--- a/src/features/calendar/mock/events.ts
+++ b/src/features/calendar/mock/events.ts
@@ -62,7 +62,6 @@ export function addMockTodo(draft: PersonalTodoDraft): PersonalCalendarEvent {
     end: new Date(`${draft.endDate}T00:00:00`),
     tag: CALENDAR_ITEM_TAG.PERSONAL_TODO,
     isCompleted: false,
-    color: draft.color,
   };
   store.events = [...store.events, event];
   return event;

--- a/src/features/calendar/server.ts
+++ b/src/features/calendar/server.ts
@@ -1,9 +1,13 @@
 import "server-only";
 
-import { endOfMonth, startOfMonth } from "date-fns";
+import { endOfMonth, format, startOfMonth } from "date-fns";
 
+import { requireAccessToken } from "@/features/auth/session";
+import { serverApi } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
 import { isMock } from "@/mocks/config";
 
+import { type BeCalendarItem, toPersonalCalendarEvent } from "./mapper";
 import { listMockEvents } from "./mock/events";
 import type { PersonalCalendarEvent } from "./types";
 
@@ -11,7 +15,8 @@ import type { PersonalCalendarEvent } from "./types";
  * 개인 캘린더 — 그 달에 속한 항목만 걸러 내려준다. **격리막**(CLAUDE.md).
  * ⚠️ `event.start`가 속한 달만 보지 않고 **그 달과 겹치는지**(start~end 구간)로 본다 —
  *    지금은 항목이 전부 하루짜리라 차이가 없지만, 여러 날에 걸치는 항목이 생기면
- *    시작일이 지난달이어도 이번 달에 걸쳐 있으면 보여야 한다.
+ *    시작일이 지난달이어도 이번 달에 걸쳐 있으면 보여야 한다. mock 필터만 그렇고, 실서버는
+ *    `GET /api/calendar?month=`가 이미 그 달 기준으로 걸러 내려준다([확인] BE PL 가이드).
  * 연동할 때 고칠 곳은 이 파일과 매퍼뿐이고 컴포넌트는 건드리지 않는다.
  */
 export async function getMonthEvents(month: Date): Promise<PersonalCalendarEvent[]> {
@@ -21,6 +26,12 @@ export async function getMonthEvents(month: Date): Promise<PersonalCalendarEvent
     return listMockEvents().filter((event) => event.start <= monthEnd && event.end >= monthStart);
   }
 
-  // ⚠️ 미구현 — API 스펙 확정 후 개인 Todo·액션 조회 경로를 합쳐 매퍼로 UI 계약에 맞춘다.
-  throw new Error("개인 캘린더 조회 API가 아직 연결되지 않았습니다.");
+  const accessToken = await requireAccessToken();
+  const items = await serverApi<BeCalendarItem[]>(ep.calendar(format(month, "yyyy-MM")), {
+    accessToken,
+  });
+
+  return items
+    .map((item, index) => toPersonalCalendarEvent(item, index))
+    .filter((event): event is PersonalCalendarEvent => event !== null);
 }

--- a/src/features/calendar/types.ts
+++ b/src/features/calendar/types.ts
@@ -52,7 +52,6 @@ export interface PersonalTodoDraft {
   date: string;
   /** 끝 날짜 "YYYY-MM-DD" — 시작 날짜보다 이전일 수 없다. */
   endDate: string;
-  color?: string;
 }
 
 export type PersonalTodoFormErrors = Partial<Record<keyof PersonalTodoDraft, string>>;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { isErrorTag } from "./error-tag";
+import { pushLokiLog } from "./loki";
 
 /**
  * BE 호출 창구 — **Next 서버에서만** 돈다(§핵심 4원칙 ②).
@@ -109,7 +110,21 @@ export async function serverApi<T>(path: string, init: ApiInit = {}): Promise<T>
     }
   });
 
-  if (!response.ok) throw toApiError(response.status, raw);
+  if (!response.ok) {
+    const apiError = toApiError(response.status, raw);
+    /*
+      ⚠️ **5xx만 쏜다.** `toErrorTag`와 같은 경계다 — 4xx는 사람이 고칠 수 있는 실패라
+         문장이 이미 원인을 말한다. 5xx는 화면 문구만으론 BE 로그를 못 찾으니 Loki에 남긴다.
+    */
+    if (response.status >= 500) {
+      pushLokiLog("error", `BE 호출 실패: ${path}`, {
+        status: response.status,
+        code: apiError.code,
+        traceId: apiError.traceId,
+      });
+    }
+    throw apiError;
+  }
 
   return (raw as ApiEnvelope<T> | null)?.data as T;
 }

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -183,7 +183,10 @@ export const ep = {
   /** 팀원 현황(이름·직급·역할·재직상태·담당 액션 수) — [확인] PR #354 머지 완료, LEADER 전용 */
   teamMembers: () => "/api/team/members",
 
-  /** `month` 생략 시 이번 달(서버 기본값) */
+  /**
+   * [확인] BE PL 캘린더/Todo 연동 가이드(2026-08-13, PR #457 머지 완료) — `CalendarItemResponse`·
+   *   `TodoResponse`·`CreateTodoRequest` 소스·테스트 대조. `month` 생략 시 이번 달(서버 기본값).
+   */
   calendar: (month?: string) => `/api/calendar${toQuery(month ? { month } : undefined)}`,
   todos: () => "/api/todos",
   todoComplete: (id: number) => `/api/todos/${id}/complete`,

--- a/src/lib/loki.test.ts
+++ b/src/lib/loki.test.ts
@@ -1,0 +1,42 @@
+import { pushLokiLog } from "./loki";
+
+describe("Loki push", () => {
+  const originalFetch = global.fetch;
+  const errorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    errorSpy.mockClear();
+  });
+
+  afterAll(() => {
+    errorSpy.mockRestore();
+  });
+
+  // 로그 요청이 무한정 매달리면 5xx 폭주 때 소켓을 다 먹는다 — 타임아웃 신호가 붙어야 한다.
+  it("fetch에 AbortSignal.timeout을 실어 보낸다", () => {
+    const fetchMock = jest.fn<Promise<Response>, [string, RequestInit?]>(
+      async () => new Response(null, { status: 204 }),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    pushLokiLog("info", "hello");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0]?.[1];
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  // 실패는 삼키지만 서버 콘솔에 스택으로 남기면 진짜 원인 로그가 밀린다 — console.error 금지.
+  it("push 실패를 콘솔에 남기지 않는다", async () => {
+    global.fetch = jest.fn(async () => {
+      throw new Error("boom");
+    }) as unknown as typeof fetch;
+
+    pushLokiLog("error", "실패");
+    // catch가 마이크로태스크로 실행되므로 다음 틱까지 기다린다.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/loki.ts
+++ b/src/lib/loki.ts
@@ -40,11 +40,19 @@ export function pushLokiLog(
     ],
   };
 
+  /*
+    ⚠️ **짧은 타임아웃을 건다**(2초). Loki가 죽으면 fetch는 커넥션 단계에서 오래 매달릴 수 있고,
+       그 사이 요청이 쌓이면 5xx 폭주 때 노드 소켓을 다 먹는다 — 로그는 부가 기능이라 못 보내는
+       편이 낫다.
+    ⚠️ **실패를 삼키되 콘솔에 안 남긴다.** 서버 로그가 Loki push 실패 스택으로 뒤덮이면 정작
+       원인을 못 찾는다 — 실패 자체가 이미 5xx 처리 경로에서 일어난 부수 효과다.
+  */
   fetch(`${LOKI_URL}/loki/api/v1/push`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
-  }).catch((error) => {
-    console.error("[loki] push 실패", error);
+    signal: AbortSignal.timeout(2_000),
+  }).catch(() => {
+    /* 로그 전송 실패는 무시한다 — 요청 흐름은 이미 5xx로 끝났다. */
   });
 }

--- a/src/lib/loki.ts
+++ b/src/lib/loki.ts
@@ -1,0 +1,50 @@
+import "server-only";
+
+/**
+ * Loki push 창구 — 모니터링 서버(z-loki)로 로그를 직접 올린다.
+ *
+ * ⚠️ **로그 전송 실패가 요청을 깨면 안 된다.** 모니터링 서버가 잠깐 죽어도 사용자가 보는 화면은
+ *    멀쩡해야 한다 — 그래서 실패를 던지지 않고 콘솔에만 남긴다(§정직성: 로그는 부가 기능이지
+ *    핵심 경로가 아니다).
+ * ⚠️ **프라이빗 IP로 붙는다.** 같은 VPC 안이라 퍼블릭 IP로 나갔다 들어오면 보안그룹의
+ *    SG 참조 규칙이 매칭 안 될 수 있다(2026-08-13 실측 확인) — 반드시 프라이빗 IP를 쓴다.
+ * ⚠️ `LOKI_URL`은 서버 전용이라 `NEXT_PUBLIC_`을 안 붙인다 — 브라우저에 나갈 값이 아니다.
+ */
+const LOKI_URL = process.env.LOKI_URL ?? "http://172.31.41.26:3100";
+
+type LogLevel = "info" | "warn" | "error";
+
+/**
+ * 로그 한 줄을 Loki push API 포맷으로 감싸 보낸다.
+ *
+ * ⚠️ **타임스탬프는 나노초 문자열이다.** Loki push API 스펙이 그렇게 정해져 있다 — 밀리초를
+ *    그대로 보내면 Loki가 1970년대 로그로 착각한다.
+ * ⚠️ **`meta`는 JSON으로 직렬화해 한 줄에 욱여넣는다.** 라벨(`stream`)에 자유 필드를 넣으면
+ *    값마다 라벨 카디널리티가 늘어 Loki가 무거워진다 — 검색 가능한 축(`job`·`level`)만
+ *    라벨로 두고, 나머지는 로그 본문 안에 둔다.
+ */
+export function pushLokiLog(
+  level: LogLevel,
+  message: string,
+  meta?: Record<string, unknown>,
+): void {
+  const nowNs = `${Date.now()}000000`;
+  const line = meta ? `${message} ${JSON.stringify(meta)}` : message;
+
+  const body = {
+    streams: [
+      {
+        stream: { job: "z-frontend", level },
+        values: [[nowNs, line]],
+      },
+    ],
+  };
+
+  fetch(`${LOKI_URL}/loki/api/v1/push`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }).catch((error) => {
+    console.error("[loki] push 실패", error);
+  });
+}


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가

---

## 🗂 작업 영역

- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계

---

## 🙋 관련 역할

- [x] LEADER (팀장)
- [x] MEMBER (사원)

---

## 📝 작업 내용

- BE `GET /api/calendar` 응답에 추가된 `id`·`isDone`을 반영해 개인 Todo 완료 토글을 실연동
- `mapper.ts` 신설 — `type`(PROJECT/ACTION/TODO) 판별자로 BE 항목을 UI 계약으로 변환, `PROJECT`는 아직 미대응이라 걸러냄
- `server.ts::getMonthEvents`, `actions.ts::toggleTodoCompletionAction` mock throw 제거하고 실서버 분기 구현

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [x] 🔐 권한 2축 검사 — 리소스 소유권은 BE가 `CAL-001`(404)로 검증, FE는 id 존재 여부로만 분기
- [ ] 🧬 zod — 아직 미적용(다른 calendar 코드도 미적용, 별도 통일 필요하면 후속 이슈)
- [x] 🕵️ 정직성 — `PROJECT`는 명시적으로 걸러 조용히 잘못 그리지 않음, endDate range 제약도 주석에 명시
- [ ] 🎨 디자인 토큰 — 해당 없음(로직 변경, UI 변경 없음)

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [ ] ♿ a11y — 해당 없음(기존 UI 그대로)
- [x] ♻️ 재사용 확인 — 기존 `serverApi`/`ep`/`requireAccessToken` 컨벤션 재사용(action/board 패턴과 동일)
- [x] 🧪 loading/error/empty — 기존 낙관적 갱신·롤백·토스트 유지(calendar-board.tsx 변경 없음)

---

## 🔗 연관 이슈

Closes #446

---

## 💬 리뷰 포인트

- `PROJECT` 타입을 지금 걸러내는 게 맞는지(다음 이슈로 미루는 스코프 판단) 확인해 주세요.
- ACTION의 합성 id(`action-{index}`)가 다른 곳에서 재사용/영속되지 않는지 — 렌더 키 용도로만 쓰입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 실제 서버에서 개인 캘린더 일정을 조회하고 월별 일정으로 표시합니다.
  * 할 일 완료 상태를 캘린더에서 변경할 수 있습니다.
  * 할 일과 작업 항목이 캘린더 이벤트로 올바르게 표시됩니다.

* **버그 수정**
  * 관리 화면의 회의실 추가 다이얼로그 표시 조건을 수정했습니다.

* **개선 사항**
  * 서버 오류 발생 시 진단 정보가 기록되어 문제 추적이 쉬워졌습니다.
  * 캘린더 일정 처리와 서버 연동의 안정성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->