### PR TITLE
[FIX] 회의 참석자 범위를 역할별로 강제 — 전체 옵션 제거·서버 재검증 #444

### DIFF
--- a/src/app/(shell)/app/meeting/[meetingId]/page.tsx
+++ b/src/app/(shell)/app/meeting/[meetingId]/page.tsx
@@ -94,7 +94,9 @@ export default async function MeetingDetailPage({
       <MeetingDetailView
         detail={result.detail}
         members={members}
-        viewerTeamName={viewer.teamName ?? null}
+        /* ⚠️ 참석자 교체(MEET-09)도 개설과 **같은 범위 규칙**을 받는다(2026-08-13) — 개설만
+           막고 교체를 열어 두면 나중에 규칙을 깨서 넣을 수 있다(`attendee-scope.ts`). */
+        viewer={{ id: viewer.id, role: viewer.role, teamName: viewer.teamName ?? null }}
       />
     </main>
   );

--- a/src/app/(shell)/app/rooms/page.tsx
+++ b/src/app/(shell)/app/rooms/page.tsx
@@ -73,7 +73,9 @@ export default async function RoomsPage({ searchParams }: RoomsPageProps) {
           projects={projects}
           showParentTeamAction={requiresParentTeamAction(viewer)}
           teamActions={teamActions}
-          viewerTeamName={viewer.teamName ?? null}
+          /* ⚠️ 참석자 범위는 **권한이 정한다**(2026-08-13 확정) — 팀 이름만 넘겨 "팀이 없으면
+             Owner"로 읽던 간접 추론을 걷어냈다(CLAUDE.md §조직 계층: 권한은 직급에서 온다). */
+          viewer={{ id: viewer.id, role: viewer.role, teamName: viewer.teamName ?? null }}
           week={format(week, "yyyy-MM-dd")}
         />
       </div>

--- a/src/features/meeting/actions.test.ts
+++ b/src/features/meeting/actions.test.ts
@@ -1,0 +1,110 @@
+// 서버 액션은 next 런타임 함수를 부른다 — jsdom엔 없으니 목으로 대체하고 호출만 검증한다.
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+// isMock은 NEXT_PUBLIC_USE_MOCK 환경변수로 정해진다 — 테스트가 환경에 휘둘리지 않게 고정한다.
+jest.mock("@/mocks/config", () => ({ isMock: true }));
+// 기본은 실제 getMockActor()와 같은 값(OWNER, Admin 아님) — `canManageMeeting`이 OWNER를
+// 통과시키므로 host가 아닌 회의도 고칠 수 있다(MEET-09 계약: host·OWNER·ADMIN).
+jest.mock("@/lib/mock-actor", () => ({
+  getMockActor: jest.fn(() => ({ id: 1, role: "OWNER" })),
+}));
+
+import { updateMeetingAttendeesAction } from "./actions";
+import { addMockMeeting } from "./mock/meetings";
+import type { MeetingDraft } from "./types";
+
+const INITIAL = { error: null, attendeeIds: null } as const;
+
+/*
+  참석자 명부는 `features/rooms/mock/members.ts`다:
+    1 박대표(OWNER, 팀 없음) · 2 김서준(개발팀 LEADER) · 3 이하윤(개발팀 MEMBER)
+    5 최유진(마케팅팀 LEADER) · 7 강서연(디자인팀 LEADER)
+*/
+const BASE = {
+  title: "테스트 회의",
+  roomId: "room-small-b",
+  roomName: "소회의실 B",
+  projectId: 1,
+  projectTag: "GOODS",
+  topics: [{ main: "제품", sub: "로드맵 검토" }] as [{ main: string; sub: string }],
+  roomReservationId: "reservation-test",
+} as const;
+
+/** 아직 안 끝난(예정) 회의를 하나 만든다 — 끝난 회의는 교체 자체가 막힌다. */
+function seedMeeting(extra: Partial<MeetingDraft> & Pick<MeetingDraft, "hostAuthority">) {
+  const start = new Date(Date.now() + 60 * 60_000);
+  const end = new Date(start.getTime() + 30 * 60_000);
+  return addMockMeeting({
+    ...BASE,
+    start,
+    end,
+    hostId: 1,
+    attendeeIds: [1],
+    ...extra,
+  } as MeetingDraft);
+}
+
+const form = (meetingId: string, attendeeIds: number[]) => {
+  const data = new FormData();
+  data.append("meetingId", meetingId);
+  for (const id of attendeeIds) data.append("attendeeIds", String(id));
+  return data;
+};
+
+/*
+  ⚠️ 참석자 범위 강제(2026-08-13)는 **개설만이 아니라 교체(MEET-09)에도** 걸린다 — 개설만 막고
+     교체를 열어 두면 만든 뒤에 규칙을 깨서 넣을 수 있고, "Owner 개설 회의의 참석자는 전부
+     팀장"이라는 AI 팀 액션 판단 근거가 똑같이 무너진다.
+*/
+describe("참석자 교체(MEET-09) — 범위 재검증", () => {
+  it("Owner 개설 회의는 팀장만 받는다", async () => {
+    const meeting = seedMeeting({ hostAuthority: "OWNER" });
+
+    const result = await updateMeetingAttendeesAction(INITIAL, form(meeting.id, [2, 5]));
+
+    expect(result.error).toBeNull();
+    expect(result.attendeeIds).toEqual([2, 5, 1]);
+  });
+
+  it("Owner 개설 회의에 사원을 끼워 넣으면 막는다", async () => {
+    const meeting = seedMeeting({ hostAuthority: "OWNER" });
+
+    const result = await updateMeetingAttendeesAction(INITIAL, form(meeting.id, [2, 3]));
+
+    expect(result.error).toBe("Owner가 개설하는 회의에는 팀장만 참석자로 지정할 수 있습니다");
+    expect(result.attendeeIds).toBeNull();
+  });
+
+  it("범위 기준은 액터가 아니라 **그 회의의 host**다 — Owner가 팀 회의를 고쳐도 host의 팀으로 잰다", async () => {
+    // host = 김서준(id=2, 개발팀 LEADER). 액터는 OWNER지만 "팀장만"이 아니라 "개발팀만"이 걸린다.
+    const meeting = seedMeeting({
+      hostAuthority: "LEADER",
+      hostId: 2,
+      hostTeamId: 7,
+      parentTeamActionId: 1,
+      attendeeIds: [2],
+    });
+
+    const passed = await updateMeetingAttendeesAction(INITIAL, form(meeting.id, [3]));
+    expect(passed.error).toBeNull();
+
+    const blocked = await updateMeetingAttendeesAction(INITIAL, form(meeting.id, [5]));
+    expect(blocked.error).toBe("자기 팀 소속만 참석자로 지정할 수 있습니다");
+  });
+
+  it("현재 명단에 들어 있는 host는 위반으로 세지 않는다(화면을 열기만 해도 막히면 안 된다)", async () => {
+    const meeting = seedMeeting({ hostAuthority: "OWNER" });
+
+    // 다이얼로그는 현재 명단(host 포함)을 그대로 초기 선택으로 들고 연다.
+    const result = await updateMeetingAttendeesAction(INITIAL, form(meeting.id, [1, 2]));
+
+    expect(result.error).toBeNull();
+  });
+
+  it("존재하지 않는 참석자 id는 막는다(폼 조작 방어)", async () => {
+    const meeting = seedMeeting({ hostAuthority: "OWNER" });
+
+    const result = await updateMeetingAttendeesAction(INITIAL, form(meeting.id, [9999]));
+
+    expect(result.error).toBe("존재하지 않는 참석자가 있습니다");
+  });
+});

--- a/src/features/meeting/actions.ts
+++ b/src/features/meeting/actions.ts
@@ -4,6 +4,8 @@ import { revalidatePath } from "next/cache";
 
 import { MEETING_STATUS } from "@/constants/meeting";
 import { requireAccessToken } from "@/features/auth/session";
+import { findAttendeeScopeViolation } from "@/features/rooms/attendee-scope";
+import { findMockMember } from "@/features/rooms/mock/members";
 import { ApiError, serverApi } from "@/lib/api";
 import { ep } from "@/lib/endpoints";
 import { getMockActor } from "@/lib/mock-actor";
@@ -39,6 +41,12 @@ function toAttendeesErrorMessage(error: unknown): string {
  *    여기서 다시 확인한다(§권한).
  * ⚠️ **host는 자동 포함·제거 불가**다 — 이 액션이 직접 끼워 넣지는 않는다. mock 분기는
  *    `updateMockMeetingAttendees`가, 실연동은 서버(BE)가 그 규칙을 보장한다.
+ * ⚠️ **참석자 범위 규칙(2026-08-13 확정)이 여기에도 걸린다** — 개설(회의실 예약)만 막고 교체를
+ *    열어 두면 만든 뒤에 규칙을 깨서 넣을 수 있고, "Owner 개설 회의의 참석자는 전부 팀장"이라는
+ *    AI 팀 액션 판단 근거가 똑같이 무너진다. 규칙은 `rooms/attendee-scope.ts` 한 곳이다.
+ * ⚠️ 범위 기준은 **지금 보는 사람이 아니라 그 회의의 host**다 — `canManageMeeting`이 OWNER·Admin
+ *    에게도 남의 회의 교체를 허용해서, actor로 재면 Owner가 남의 팀 회의를 열었을 때 규칙이
+ *    "팀장만"으로 뒤바뀐다. 회의에 적힌 `hostAuthority`가 그 회의가 만들어질 때의 사실이다.
  */
 export async function updateMeetingAttendeesAction(
   _prev: UpdateMeetingAttendeesState,
@@ -58,6 +66,28 @@ export async function updateMeetingAttendeesAction(
       return { error: "끝난 회의는 참석자를 바꿀 수 없습니다", attendeeIds: null };
     }
 
+    /*
+      ⚠️ **참석자 서버 재검증**(§권한: 화면 숨김은 UX일 뿐 보안이 아니다). 다이얼로그가 후보를
+         좁혀 보여줘도 이 액션은 주소만 알면 직접 부를 수 있다.
+      ⚠️ host의 팀 이름은 **명부에서 찾는다** — 회의 레코드에는 `hostTeamId`(숫자)만 있고 범위
+         비교는 팀 **이름**으로 도는데(`RoomMember.teamName`), 팀 registry(id↔이름)가 아직
+         없어서다(`lib/permission.ts` `Actor.teamName` 주석과 같은 사정). host가 명부에 없으면
+         범위를 못 재므로 통과시키지 않는다(§정직성).
+    */
+    const attendees = attendeeIds.map(findMockMember);
+    if (attendees.some((member) => member === null)) {
+      return { error: "존재하지 않는 참석자가 있습니다", attendeeIds: null };
+    }
+    const scopeViolation = findAttendeeScopeViolation(
+      attendees.filter((member) => member !== null),
+      {
+        id: meeting.hostId,
+        role: meeting.hostAuthority,
+        teamName: findMockMember(meeting.hostId)?.teamName ?? null,
+      },
+    );
+    if (scopeViolation) return { error: scopeViolation, attendeeIds: null };
+
     const updated = updateMockMeetingAttendees(meetingId, attendeeIds);
     revalidatePath(`/app/meeting/${meetingId}`);
     return { error: null, attendeeIds: updated?.attendeeIds ?? null };
@@ -65,6 +95,13 @@ export async function updateMeetingAttendeesAction(
 
   const accessToken = await requireAccessToken();
   try {
+    /*
+      ⚠️ **참석자 범위는 여기서 못 본다 — 본 척하지 않는다**(§정직성). 명부(`getReservableMembers`)가
+         실연동에서 그대로 던지고, 명부 API도 권한별로 갈려 MEMBER는 자기 팀 명단을 볼 길이 없다
+         (`rooms/actions.ts`의 같은 자리 주석에 근거를 적어 뒀다). **최종 방어는 BE다** —
+         `PUT /api/meetings/{id}/attendees`는 [확인] 현재 존재·같은 회사만 보고 권한·팀은 전혀
+         안 본다(`MeetingAttendeeCommandService#findAndValidateMembers`). BE 요청 문서에 올린다.
+    */
     /*
       ⚠️ **여기서 host를 끼워 넣지 않는다.** 이 액션은 지금 보는 사람(`actor`)이 host인지
       모른다(OWNER·Admin이 남의 회의를 고치는 경우도 있다, `canManageMeeting`) — "host 자동

--- a/src/features/meeting/components/meeting-attendees-edit-dialog.test.tsx
+++ b/src/features/meeting/components/meeting-attendees-edit-dialog.test.tsx
@@ -1,0 +1,66 @@
+jest.mock("../actions", () => ({ updateMeetingAttendeesAction: jest.fn() }));
+jest.mock("sonner", () => ({ toast: { success: jest.fn() } }));
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { AUTHORITY } from "@/constants/authority";
+import type { AttendeeScopeViewer } from "@/features/rooms/attendee-scope";
+import type { RoomMember } from "@/features/rooms/types";
+
+import { MeetingAttendeesEditDialog } from "./meeting-attendees-edit-dialog";
+
+/**
+ * 참석자 교체(MEET-09) 다이얼로그 — **규칙 밖 기존 참석자를 어떻게 다루는가.**
+ *
+ * ⚠️ 규칙(`attendee-scope.ts`)이 생기기 전에 만든 회의에는 지금 규칙으로는 못 고르는 참석자가
+ *    그대로 남아 있다(예: Owner 회의에 일반 사원). 그 사람을 화면이 알리지 않으면 host가
+ *    아무것도 안 건드리고 [저장]만 눌러도 명단에서 사라진 채 성공 토스트가 뜬다(§정직성).
+ * ⚠️ 알리는 일 자체는 `RoomAttendeePicker`가 하지만, **현재 명단을 피커에 넘기는 건 이 다이얼로그**다
+ *    — 그 한 줄(`currentAttendeeIds`)이 빠지면 피커 테스트는 다 통과한 채 회귀가 되살아난다.
+ *    그래서 여기서 잠근다.
+ */
+
+const MEMBERS: RoomMember[] = [
+  { id: 1, name: "박대표", teamName: null, authority: AUTHORITY.OWNER },
+  { id: 2, name: "김서준", teamName: "개발팀", authority: AUTHORITY.LEADER },
+  { id: 3, name: "이하윤", teamName: "개발팀", authority: AUTHORITY.MEMBER },
+];
+
+/** 회의를 연 사람 = Owner(id 1) — 지정 가능한 참석자는 팀장뿐이다. */
+const OWNER_VIEWER: AttendeeScopeViewer = { id: 1, role: AUTHORITY.OWNER, teamName: null };
+
+async function openDialog(currentAttendeeIds: number[]) {
+  const user = userEvent.setup();
+  render(
+    <MeetingAttendeesEditDialog
+      meetingId="m1"
+      currentAttendeeIds={currentAttendeeIds}
+      members={MEMBERS}
+      viewer={OWNER_VIEWER}
+    />,
+  );
+  await user.click(screen.getByRole("button", { name: "참석자 수정" }));
+}
+
+it("규칙 밖 기존 참석자를 이름으로 알린다(현재 명단을 피커로 넘긴다)", async () => {
+  /* 3(사원 이하윤)은 예전엔 참석자였지만 지금 규칙(Owner=팀장만)으로는 못 고른다. */
+  await openDialog([1, 2, 3]);
+
+  const notice = screen.getByText(/저장하면 명단에서 빠집니다/);
+  expect(notice).toHaveTextContent("이하윤");
+});
+
+it("규칙 밖 기존 참석자는 선택 수에도 안 센다 — 세는 수와 저장되는 명단이 같다", async () => {
+  await openDialog([1, 2, 3]);
+
+  /* host(1)는 서버가 다시 끼워 넣고, 3은 규칙 밖이라 빠진다 → 남는 건 2 하나뿐이다. */
+  expect(screen.getByText("선택 1명")).toBeInTheDocument();
+  expect(screen.getByRole("checkbox", { name: /김서준/ })).toBeChecked();
+});
+
+it("전부 범위 안이면 안내가 뜨지 않는다 — 매번 뜨면 문구가 배경이 된다", async () => {
+  await openDialog([1, 2]);
+
+  expect(screen.queryByText(/저장하면 명단에서 빠집니다/)).not.toBeInTheDocument();
+});

--- a/src/features/meeting/components/meeting-attendees-edit-dialog.tsx
+++ b/src/features/meeting/components/meeting-attendees-edit-dialog.tsx
@@ -5,7 +5,7 @@ import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import type { AttendeeScopeViewer } from "@/features/rooms/attendee-scope";
+import { type AttendeeScopeViewer, isAttendeeInScope } from "@/features/rooms/attendee-scope";
 import { RoomAttendeePicker } from "@/features/rooms/components/room-attendee-picker";
 import type { RoomMember } from "@/features/rooms/types";
 
@@ -29,6 +29,24 @@ interface MeetingAttendeesEditDialogProps {
  * ⚠️ 트리거·노출 조건(host·SCHEDULED/IN_PROGRESS)은 `MeetingDetailView`가 정한다 — 이 컴포넌트는
  *    "지금 열렸는지"만 안다.
  */
+/**
+ * 저장될 명단으로 시작한다 — **규칙 밖 참석자는 빼고 연다.**
+ *
+ * ⚠️ 현재 명단을 그대로 초기값으로 두면 "선택 N명"이 저장되지도 않을 사람까지 세어 화면이
+ *    거짓말을 한다(§정직성). 규칙 밖인 사람은 서버가 어차피 거부하므로, 세는 수와 저장되는
+ *    명단을 처음부터 일치시킨다 — 누가 빠지는지는 피커가 이름으로 알린다.
+ */
+function toSelectableIds(
+  currentAttendeeIds: number[],
+  members: RoomMember[],
+  viewer: AttendeeScopeViewer,
+): number[] {
+  const inScope = new Set(
+    members.filter((member) => isAttendeeInScope(member, viewer)).map((member) => member.id),
+  );
+  return currentAttendeeIds.filter((id) => inScope.has(id));
+}
+
 export function MeetingAttendeesEditDialog({
   meetingId,
   currentAttendeeIds,
@@ -36,7 +54,9 @@ export function MeetingAttendeesEditDialog({
   viewer,
 }: MeetingAttendeesEditDialogProps) {
   const [open, setOpen] = useState(false);
-  const [selectedIds, setSelectedIds] = useState(currentAttendeeIds);
+  const [selectedIds, setSelectedIds] = useState(() =>
+    toSelectableIds(currentAttendeeIds, members, viewer),
+  );
   const [state, formAction, isPending] = useActionState(
     updateMeetingAttendeesAction,
     INITIAL_STATE,
@@ -56,7 +76,7 @@ export function MeetingAttendeesEditDialog({
       <button
         type="button"
         onClick={() => {
-          setSelectedIds(currentAttendeeIds);
+          setSelectedIds(toSelectableIds(currentAttendeeIds, members, viewer));
           setOpen(true);
         }}
         className="text-muted-foreground hover:text-foreground focus-visible:ring-ring rounded-md text-[12px] leading-4 underline underline-offset-2 transition-colors focus-visible:ring-2 focus-visible:outline-hidden"
@@ -85,6 +105,7 @@ export function MeetingAttendeesEditDialog({
                 selectedIds={selectedIds}
                 onChange={setSelectedIds}
                 viewer={viewer}
+                currentAttendeeIds={currentAttendeeIds}
               />
               {state.error && <p className="text-destructive pt-2 text-[12px]">{state.error}</p>}
             </div>

--- a/src/features/meeting/components/meeting-attendees-edit-dialog.tsx
+++ b/src/features/meeting/components/meeting-attendees-edit-dialog.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import type { AttendeeScopeViewer } from "@/features/rooms/attendee-scope";
 import { RoomAttendeePicker } from "@/features/rooms/components/room-attendee-picker";
 import type { RoomMember } from "@/features/rooms/types";
 
@@ -16,8 +17,9 @@ interface MeetingAttendeesEditDialogProps {
   meetingId: string;
   currentAttendeeIds: number[];
   members: RoomMember[];
-  /** "내 부서만"·"팀장급만" 필터 기준 — `RoomAttendeePicker`로 그대로 흘려보낸다. */
-  viewerTeamName: string | null;
+  /** 참석자 범위(Owner=팀장만 / Leader·Member=자기 팀만) 기준 — `RoomAttendeePicker`로
+   *  그대로 흘려보낸다(`attendee-scope.ts`, 2026-08-13 확정). */
+  viewer: AttendeeScopeViewer;
 }
 
 /**
@@ -31,7 +33,7 @@ export function MeetingAttendeesEditDialog({
   meetingId,
   currentAttendeeIds,
   members,
-  viewerTeamName,
+  viewer,
 }: MeetingAttendeesEditDialogProps) {
   const [open, setOpen] = useState(false);
   const [selectedIds, setSelectedIds] = useState(currentAttendeeIds);
@@ -82,7 +84,7 @@ export function MeetingAttendeesEditDialog({
                 members={members}
                 selectedIds={selectedIds}
                 onChange={setSelectedIds}
-                viewerTeamName={viewerTeamName}
+                viewer={viewer}
               />
               {state.error && <p className="text-destructive pt-2 text-[12px]">{state.error}</p>}
             </div>

--- a/src/features/meeting/components/meeting-detail-view.tsx
+++ b/src/features/meeting/components/meeting-detail-view.tsx
@@ -17,6 +17,7 @@ import { ProfileAvatar } from "@/components/common/profile-avatar";
 import { ProjectTag } from "@/components/common/project-tag";
 import { StatusDot } from "@/components/common/status-dot";
 import { ACTION_STATUS_LABEL } from "@/constants/action";
+import type { AttendeeScopeViewer } from "@/features/rooms/attendee-scope";
 import type { RoomMember } from "@/features/rooms/types";
 import { formatDate } from "@/lib/date";
 
@@ -198,11 +199,12 @@ interface MeetingDetailViewProps {
   detail: MeetingDetail;
   /** 참석자 명단 교체(MEET-09) 다이얼로그가 고를 전체 사원 목록. */
   members: RoomMember[];
-  /** "내 부서만"·"팀장급만" 필터 기준 — `RoomAttendeePicker`로 그대로 흘려보낸다. */
-  viewerTeamName: string | null;
+  /** 참석자 범위(Owner=팀장만 / Leader·Member=자기 팀만) 기준 — `RoomAttendeePicker`로
+   *  그대로 흘려보낸다(`attendee-scope.ts`, 2026-08-13 확정). */
+  viewer: AttendeeScopeViewer;
 }
 
-export function MeetingDetailView({ detail, members, viewerTeamName }: MeetingDetailViewProps) {
+export function MeetingDetailView({ detail, members, viewer }: MeetingDetailViewProps) {
   const actionsState = actionsSectionStateOf(detail);
   const canEditAttendees = canEditMeetingAttendees(detail);
   const canCancel = canCancelMeeting(detail);
@@ -280,7 +282,7 @@ export function MeetingDetailView({ detail, members, viewerTeamName }: MeetingDe
                   meetingId={detail.id}
                   currentAttendeeIds={detail.attendees.map((attendee) => attendee.id)}
                   members={members}
-                  viewerTeamName={viewerTeamName}
+                  viewer={viewer}
                 />
               )}
             </div>

--- a/src/features/rooms/actions.test.ts
+++ b/src/features/rooms/actions.test.ts
@@ -336,7 +336,8 @@ describe("회의실 예약 생성 (Owner 개설 = 프로젝트 회의)", () => {
     );
 
     expect(result.errors).toEqual({});
-    expect(result.created?.attendeeIds).toEqual([2, 5]);
+    // ⚠️ host(액터 id=1)는 피커가 후보로 안 내주는 대신 저장할 때 맨 앞에 자동으로 들어간다.
+    expect(result.created?.attendeeIds).toEqual([1, 2, 5]);
   });
 
   it("폼이 조작돼 참석자 값이 숫자가 아니면 막는다", async () => {
@@ -422,7 +423,8 @@ describe("회의실 예약 생성 (Leader 개설 = 팀 액션 회의)", () => {
     );
 
     expect(result.errors).toEqual({});
-    expect(result.created?.attendeeIds).toEqual([3]);
+    // host(액터 id=5)가 맨 앞에 자동으로 들어간다 — 개설자는 자기 회의 상세를 볼 수 있어야 한다.
+    expect(result.created?.attendeeIds).toEqual([5, 3]);
   });
 
   it("세션에 소속 팀이 없으면 통과시키지 않는다(범위를 잴 수 없다 — §정직성)", async () => {

--- a/src/features/rooms/actions.test.ts
+++ b/src/features/rooms/actions.test.ts
@@ -34,9 +34,14 @@ const VALID_ENTRIES: Record<string, string> = {
 
 const DEFAULT_TOPICS = [{ main: "제품", sub: "로드맵 검토" }];
 
+/*
+  ⚠️ 기본 참석자를 **김서준(id=2, 개발팀 LEADER)** 으로 둔다(2026-08-13). 전에는 박대표(id=1,
+     OWNER)였는데, 참석자 범위가 강제되면서 Owner 명단에 팀장 아닌 사람이 못 들어간다
+     (`attendee-scope.ts`) — 기본 액터(OWNER)와 아래 LEADER(개발팀) 둘 다에서 통과하는 값이다.
+*/
 const form = (
   entries: Record<string, string>,
-  attendeeIds: number[] = [1],
+  attendeeIds: number[] = [2],
   topics: { main: string; sub: string }[] = DEFAULT_TOPICS,
 ) => {
   const data = new FormData();
@@ -237,7 +242,7 @@ describe("회의실 예약 생성 (Owner 개설 = 프로젝트 회의)", () => {
       { errors: {} },
       form(
         { ...VALID_ENTRIES, date: "2026-08-14" },
-        [1],
+        [2],
         [
           { main: "제품", sub: "로드맵 검토" },
           { main: "마케팅", sub: "캠페인 리뷰" },
@@ -302,6 +307,38 @@ describe("회의실 예약 생성 (Owner 개설 = 프로젝트 회의)", () => {
     expect(result.created).toBeUndefined();
   });
 
+  it("Owner 명단에 팀장 아닌 사람이 섞이면 막는다(2026-08-13 범위 강제)", async () => {
+    // id=3 이하윤은 개발팀 MEMBER다 — 화면 피커엔 애초에 안 뜨지만 폼은 조작될 수 있다.
+    const result = await createRoomReservationAction({ errors: {} }, form(VALID_ENTRIES, [2, 3]));
+
+    expect(result.errors.attendeeIds).toBe(
+      "Owner가 개설하는 회의에는 팀장만 참석자로 지정할 수 있습니다",
+    );
+    expect(result.created).toBeUndefined();
+  });
+
+  it("host 자신(=액터)은 규칙에서 빠진다 — 명단에 끼어 있어도 통과한다", async () => {
+    // ⚠️ host는 고르는 사람이 아니라 서버가 명단에 넣는 사람이다(`attendee-scope.ts`).
+    const result = await createRoomReservationAction(
+      { errors: {} },
+      form({ ...VALID_ENTRIES, date: "2026-08-20" }, [1, 2]),
+    );
+
+    expect(result.errors).toEqual({});
+    expect(result.created).toBeDefined();
+  });
+
+  it("팀이 다른 팀장끼리는 함께 넣을 수 있다(Owner 회의는 전사 팀장 회의다)", async () => {
+    // id=2 김서준(개발팀 LEADER) · id=5 최유진(마케팅팀 LEADER)
+    const result = await createRoomReservationAction(
+      { errors: {} },
+      form({ ...VALID_ENTRIES, date: "2026-08-17" }, [2, 5]),
+    );
+
+    expect(result.errors).toEqual({});
+    expect(result.created?.attendeeIds).toEqual([2, 5]);
+  });
+
   it("폼이 조작돼 참석자 값이 숫자가 아니면 막는다", async () => {
     const data = new FormData();
     for (const [key, value] of Object.entries({ ...VALID_ENTRIES, date: "2026-08-15" })) {
@@ -363,6 +400,42 @@ describe("회의실 예약 생성 (Leader 개설 = 팀 액션 회의)", () => {
 
     expect(result.errors.parentTeamActionId).toBe("존재하지 않는 상위 팀 액션입니다");
     expect(result.created).toBeUndefined();
+  });
+
+  it("자기 팀이 아닌 사람을 참석자로 끼워 넣으면 막는다(2026-08-13 범위 강제)", async () => {
+    /* id=7 강서연은 디자인팀 LEADER다 — 개발팀 Leader의 회의엔 못 들어간다.
+       ⚠️ id=5는 안 쓴다 — 이 블록의 액터가 id=5라 host 예외에 걸려 검사에서 빠진다. */
+    const result = await createRoomReservationAction(
+      { errors: {} },
+      form({ ...VALID_ENTRIES, date: "2026-08-16", parentTeamActionId: "1" }, [2, 7]),
+    );
+
+    expect(result.errors.attendeeIds).toBe("자기 팀 소속만 참석자로 지정할 수 있습니다");
+    expect(result.created).toBeUndefined();
+  });
+
+  it("자기 팀 사원은 팀장이 아니어도 넣을 수 있다(Owner 규칙과 다른 축이다)", async () => {
+    // id=3 이하윤은 개발팀 MEMBER — 같은 팀이면 권한을 보지 않는다.
+    const result = await createRoomReservationAction(
+      { errors: {} },
+      form({ ...VALID_ENTRIES, date: "2026-08-18", parentTeamActionId: "1" }, [3]),
+    );
+
+    expect(result.errors).toEqual({});
+    expect(result.created?.attendeeIds).toEqual([3]);
+  });
+
+  it("세션에 소속 팀이 없으면 통과시키지 않는다(범위를 잴 수 없다 — §정직성)", async () => {
+    getMockActorMock.mockReturnValue({ id: 5, role: "LEADER", teamId: 7 });
+
+    const result = await createRoomReservationAction(
+      { errors: {} },
+      form({ ...VALID_ENTRIES, date: "2026-08-19", parentTeamActionId: "1" }, [2]),
+    );
+
+    // ⚠️ 팀 이름이 없으면 "상위 팀 액션"도 못 찾는다 — 둘 중 어느 칸에 걸리든 통과하면 안 된다.
+    expect(result.created).toBeUndefined();
+    expect(result.errors.attendeeIds ?? result.errors.parentTeamActionId).toBeDefined();
   });
 
   it("다른 프로젝트 소속 팀 액션 id를 끼워 넣으면 막는다", async () => {

--- a/src/features/rooms/actions.ts
+++ b/src/features/rooms/actions.ts
@@ -9,9 +9,10 @@ import { getViewer } from "@/features/shell/viewer";
 import { ApiError, serverApi } from "@/lib/api";
 import { ep } from "@/lib/endpoints";
 import { getMockActor } from "@/lib/mock-actor";
-import { canManageRooms, requiresParentTeamAction } from "@/lib/permission";
+import { type Actor, canManageRooms, requiresParentTeamAction } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
+import { type AttendeeScopeViewer, findAttendeeScopeViolation } from "./attendee-scope";
 import { RESERVATION_DURATION_MINUTES } from "./constants";
 import {
   type BeCreateMeetingResponse,
@@ -125,6 +126,15 @@ function readDraft(formData: FormData): RoomReservationDraft {
   };
 }
 
+/**
+ * 참석자 범위 판정에 필요한 최소 정보만 `Actor`에서 뽑는다(`attendee-scope.ts`).
+ * ⚠️ `Actor.teamName`은 "없음"을 `undefined`로 적고(`lib/permission.ts`), 규칙 쪽은 `null`로
+ *    적는다 — 옮기는 자리를 여기 하나로 두지 않으면 호출부마다 `?? null`이 흩어진다.
+ */
+function toAttendeeScopeViewer(actor: Actor): AttendeeScopeViewer {
+  return { id: actor.id, role: actor.role, teamName: actor.teamName ?? null };
+}
+
 function toReservedRange(draft: RoomReservationDraft): { start: Date; end: Date } {
   const start = new Date(`${draft.date}T${draft.startTime}:00`);
   const end = new Date(start.getTime() + RESERVATION_DURATION_MINUTES * 60_000);
@@ -150,6 +160,23 @@ export async function createRoomReservationAction(
   if (Object.keys(errors).length > 0) return { errors };
 
   if (!isMock) {
+    /*
+      ⚠️ **여기서는 참석자 범위를 검증하지 못한다 — 검증한 척하지 않는다**(§정직성, 2026-08-13).
+         규칙(Owner=팀장만 / Leader·Member=자기 팀만)을 서버에서 다시 보려면 **명부**가 있어야
+         하는데, 실서버 경로에는 명부를 가져올 길이 없다:
+           · `getReservableMembers()`(server.ts)가 실연동에서 그대로 던진다 — 사원 목록 API가
+             아직 이 화면에 안 붙었다.
+           · 붙는다 해도 명부 API가 권한별로 갈린다([확인] BE 실코드, §연동 검증):
+             `GET /api/members`는 `hasAnyRole('OWNER','ADMIN')`, `GET /api/team/members`는
+             `hasRole('LEADER')`다 — **MEMBER가 개설할 때 자기 팀 명단을 볼 엔드포인트가
+             아예 없다**(프로젝트·검색·회의 참석자 조회까지 훑어도 없다).
+           · `GET /api/team/members` 응답의 `roleName`은 **권한이 아니라 팀 안 역할 라벨**이라
+             "전원 팀장인가"를 그걸로 판정할 수 없다(§도메인 상수: 이름이 어긋나면 조용히 틀린다).
+      ⚠️ 그래서 **최종 방어는 BE(`POST /api/meetings`)다.** 참석자 범위 강제는 BE 요청 문서에
+         올린다 — FE 화면 필터·아래 목 검증은 어디까지나 그 앞단이다(§권한: 화면 숨김은 보안이
+         아니다 / §연동 검증). 명부를 구할 길이 생기면 목 분기와 **같은 함수**
+         (`findAttendeeScopeViolation`)를 여기서도 부른다.
+    */
     const range = toReservedRange(draft);
     const accessToken = await requireAccessToken();
     try {
@@ -177,9 +204,21 @@ export async function createRoomReservationAction(
   if (!project) {
     return { errors: { projectId: "존재하지 않는 프로젝트입니다" } };
   }
-  if (draft.attendeeIds.some((id) => !findMockMember(id))) {
+  /*
+    ⚠️ **참석자 서버 재검증**(2026-08-13 확정 — 2026-08-12의 "선택 토글"을 뒤집은 규칙).
+       화면 피커가 후보를 좁혀 보여줘도 Server Action은 주소만 알면 직접 부를 수 있어, 제출된
+       id가 **실존하는지**와 **범위 안인지**를 여기서 다시 본다(§권한: 화면 숨김은 UX일 뿐).
+       규칙 자체는 `attendee-scope.ts` 한 곳에 있다 — 화면과 서버가 갈리면 안 된다.
+  */
+  const attendees = draft.attendeeIds.map(findMockMember);
+  if (attendees.some((member) => member === null)) {
     return { errors: { attendeeIds: "존재하지 않는 참석자가 있습니다" } };
   }
+  const scopeViolation = findAttendeeScopeViolation(
+    attendees.filter((member) => member !== null),
+    toAttendeeScopeViewer(actor),
+  );
+  if (scopeViolation) return { errors: { attendeeIds: scopeViolation } };
   // ⚠️ Owner가 아니면 "상위 팀 액션"이 필수인데, 그 값이 진짜 이 프로젝트 소속이고 **자기
   //    팀**에 하달된 게 맞는지까지 다시 본다 — 화면이 이미 걸러 보여줘도, 폼은 조작될 수 있어서
   //    다른 팀의 팀 액션 id를 끼워 넣으면 그 팀 몫으로 회의가 잡히는 걸 여기서 막는다.

--- a/src/features/rooms/attendee-scope.test.ts
+++ b/src/features/rooms/attendee-scope.test.ts
@@ -6,6 +6,7 @@ import {
   type AttendeeScopeViewer,
   filterAttendeeCandidates,
   findAttendeeScopeViolation,
+  findAttendeesDroppedByScope,
 } from "./attendee-scope";
 import type { RoomMember } from "./types";
 
@@ -100,6 +101,34 @@ describe("findAttendeeScopeViolation (서버 재검증)", () => {
     expect(
       findAttendeeScopeViolation([DEV_MEMBER], { id: 3, role: AUTHORITY.MEMBER, teamName: null }),
     ).toBe(ATTENDEE_SCOPE_ERROR.unknownTeam);
+  });
+});
+
+describe("findAttendeesDroppedByScope — 규칙 밖이 된 기존 참석자", () => {
+  const MEMBERS = [OWNER, DEV_LEADER, DEV_MEMBER, MARKETING_LEADER];
+
+  /*
+    ⚠️ 이 함수는 참석자 교체(MEET-09) 화면 전용이다. 예약 화면(첫 개설)에는 "예전 명단"이 없다 —
+       호출부가 값을 안 넘기면 이 케이스 자체가 안 생긴다.
+  */
+  it("Owner 회의에 남아 있는 사원은 골라낸다(규칙 강제 이전 회의)", () => {
+    /* 초대 당시엔 규칙이 없어 팀원 이하윤이 참석자로 들어가 있었다. */
+    expect(findAttendeesDroppedByScope(MEMBERS, OWNER_VIEWER, [2, 3])).toEqual([DEV_MEMBER]);
+  });
+
+  it("전부 범위 안이면 빈 목록이다 — 안내 문구가 매번 뜨지 않도록", () => {
+    expect(findAttendeesDroppedByScope(MEMBERS, OWNER_VIEWER, [2])).toEqual([]);
+  });
+
+  it("host 본인은 빠지는 사람에 넣지 않는다 — 서버가 어차피 명단에 끼워 넣는다", () => {
+    expect(findAttendeesDroppedByScope(MEMBERS, OWNER_VIEWER, [1, 2])).toEqual([]);
+  });
+
+  /* ⚠️ Leader가 팀을 옮긴 사람과 같은 화면에서 회의를 열 때 — 다른 팀 참석자를 이름으로 알린다 */
+  it("Leader 회의에서 다른 팀 참석자도 골라낸다", () => {
+    expect(findAttendeesDroppedByScope(MEMBERS, DEV_LEADER_VIEWER, [3, 5])).toEqual([
+      MARKETING_LEADER,
+    ]);
   });
 });
 

--- a/src/features/rooms/attendee-scope.test.ts
+++ b/src/features/rooms/attendee-scope.test.ts
@@ -1,0 +1,105 @@
+import { AUTHORITY } from "@/constants/authority";
+
+import {
+  ATTENDEE_SCOPE_ERROR,
+  attendeeScopeGuideOf,
+  type AttendeeScopeViewer,
+  filterAttendeeCandidates,
+  findAttendeeScopeViolation,
+} from "./attendee-scope";
+import type { RoomMember } from "./types";
+
+const OWNER: RoomMember = { id: 1, name: "박대표", teamName: null, authority: AUTHORITY.OWNER };
+const DEV_LEADER: RoomMember = {
+  id: 2,
+  name: "김서준",
+  teamName: "개발팀",
+  authority: AUTHORITY.LEADER,
+};
+const DEV_MEMBER: RoomMember = {
+  id: 3,
+  name: "이하윤",
+  teamName: "개발팀",
+  authority: AUTHORITY.MEMBER,
+};
+const MARKETING_LEADER: RoomMember = {
+  id: 5,
+  name: "최유진",
+  teamName: "마케팅팀",
+  authority: AUTHORITY.LEADER,
+};
+
+const OWNER_VIEWER: AttendeeScopeViewer = { id: 1, role: AUTHORITY.OWNER, teamName: null };
+const DEV_LEADER_VIEWER: AttendeeScopeViewer = {
+  id: 2,
+  role: AUTHORITY.LEADER,
+  teamName: "개발팀",
+};
+const DEV_MEMBER_VIEWER: AttendeeScopeViewer = {
+  id: 3,
+  role: AUTHORITY.MEMBER,
+  teamName: "개발팀",
+};
+
+describe("filterAttendeeCandidates", () => {
+  const ALL = [OWNER, DEV_LEADER, DEV_MEMBER, MARKETING_LEADER];
+
+  it("Owner는 팀장만 고를 수 있다 — 자기 자신도 후보가 아니다", () => {
+    expect(filterAttendeeCandidates(ALL, OWNER_VIEWER)).toEqual([DEV_LEADER, MARKETING_LEADER]);
+  });
+
+  it("Leader는 자기 팀만 — 다른 팀 팀장은 빠진다", () => {
+    expect(filterAttendeeCandidates(ALL, DEV_LEADER_VIEWER)).toEqual([DEV_LEADER, DEV_MEMBER]);
+  });
+
+  it("Member도 Leader와 같은 범위다", () => {
+    expect(filterAttendeeCandidates(ALL, DEV_MEMBER_VIEWER)).toEqual([DEV_LEADER, DEV_MEMBER]);
+  });
+
+  it("팀을 모르는 Leader·Member에게는 아무도 안 열린다(조용히 전원 허용 금지)", () => {
+    expect(
+      filterAttendeeCandidates(ALL, { id: 3, role: AUTHORITY.MEMBER, teamName: null }),
+    ).toEqual([]);
+  });
+});
+
+describe("findAttendeeScopeViolation (서버 재검증)", () => {
+  it("Owner가 팀장만 냈으면 통과한다", () => {
+    expect(findAttendeeScopeViolation([DEV_LEADER, MARKETING_LEADER], OWNER_VIEWER)).toBeNull();
+  });
+
+  it("Owner 명단에 사원이 하나라도 섞이면 막는다(AI 팀 액션 판단 근거가 깨진다)", () => {
+    expect(findAttendeeScopeViolation([DEV_LEADER, DEV_MEMBER], OWNER_VIEWER)).toBe(
+      ATTENDEE_SCOPE_ERROR.owner,
+    );
+  });
+
+  it("host 자신은 규칙에서 빠진다 — 서버가 어차피 명단에 끼워 넣는다", () => {
+    /* Owner 개설 회의를 참석자 교체 화면에서 열면 현재 명단에 host(id=1)가 들어 있다 —
+       그걸 위반으로 세면 화면을 열기만 해도 저장이 막힌다. */
+    expect(findAttendeeScopeViolation([OWNER, DEV_LEADER], OWNER_VIEWER)).toBeNull();
+  });
+
+  it("Leader가 자기 팀만 냈으면 통과한다", () => {
+    expect(findAttendeeScopeViolation([DEV_LEADER, DEV_MEMBER], DEV_LEADER_VIEWER)).toBeNull();
+  });
+
+  it("Leader가 다른 팀 사람을 끼워 넣으면 막는다", () => {
+    expect(findAttendeeScopeViolation([DEV_MEMBER, MARKETING_LEADER], DEV_LEADER_VIEWER)).toBe(
+      ATTENDEE_SCOPE_ERROR.team,
+    );
+  });
+
+  it("팀을 모르는 Leader·Member는 통과시키지 않는다", () => {
+    expect(
+      findAttendeeScopeViolation([DEV_MEMBER], { id: 3, role: AUTHORITY.MEMBER, teamName: null }),
+    ).toBe(ATTENDEE_SCOPE_ERROR.unknownTeam);
+  });
+});
+
+describe("attendeeScopeGuideOf", () => {
+  it("왜 목록이 짧은지 권한별로 다른 말을 한다", () => {
+    expect(attendeeScopeGuideOf(OWNER_VIEWER)).toBe("팀장만 지정할 수 있습니다");
+    expect(attendeeScopeGuideOf(DEV_LEADER_VIEWER)).toBe("같은 팀 소속만 지정할 수 있습니다");
+  });
+});

--- a/src/features/rooms/attendee-scope.test.ts
+++ b/src/features/rooms/attendee-scope.test.ts
@@ -49,11 +49,17 @@ describe("filterAttendeeCandidates", () => {
   });
 
   it("Leader는 자기 팀만 — 다른 팀 팀장은 빠진다", () => {
-    expect(filterAttendeeCandidates(ALL, DEV_LEADER_VIEWER)).toEqual([DEV_LEADER, DEV_MEMBER]);
+    expect(filterAttendeeCandidates(ALL, DEV_LEADER_VIEWER)).toEqual([DEV_MEMBER]);
   });
 
   it("Member도 Leader와 같은 범위다", () => {
-    expect(filterAttendeeCandidates(ALL, DEV_MEMBER_VIEWER)).toEqual([DEV_LEADER, DEV_MEMBER]);
+    expect(filterAttendeeCandidates(ALL, DEV_MEMBER_VIEWER)).toEqual([DEV_LEADER]);
+  });
+
+  it("Leader·Member host도 자기 자신은 후보가 아니다(서버가 명단에 끼워 넣는다)", () => {
+    /* 체크를 풀어도 저장된 명단엔 host가 남는다 — 토글로 내주면 화면이 거짓말을 한다. */
+    expect(filterAttendeeCandidates(ALL, DEV_LEADER_VIEWER)).not.toContain(DEV_LEADER);
+    expect(filterAttendeeCandidates(ALL, DEV_MEMBER_VIEWER)).not.toContain(DEV_MEMBER);
   });
 
   it("팀을 모르는 Leader·Member에게는 아무도 안 열린다(조용히 전원 허용 금지)", () => {

--- a/src/features/rooms/attendee-scope.ts
+++ b/src/features/rooms/attendee-scope.ts
@@ -51,10 +51,15 @@ function isOwnerHost(viewer: AttendeeScopeViewer): boolean {
 
 /**
  * 이 사람을 참석자로 지정할 수 있는가.
+ * ⚠️ **host 자신은 후보가 아니다**(`AttendeeScopeViewer.id` 주석). host는 고르는 사람이 아니라
+ *    서버가 명단에 끼워 넣는 사람이라, 체크박스로 내주면 풀어도 저장된 명단엔 그대로 남아
+ *    화면이 거짓말을 한다(§정직성). Owner는 `authority` 조건에 이미 걸려 안 나왔지만
+ *    Leader·Member는 자기 팀 조건에 자기가 걸려 스스로를 토글할 수 있었다.
  * ⚠️ Leader·Member인데 팀 정보가 없으면 **아무도 못 고른다**(`false`). 조용히 전원 허용으로
  *    넘어가면 규칙이 있으나 마나가 된다 — 막고 화면에 알린다(§정직성).
  */
 export function isAttendeeInScope(member: RoomMember, viewer: AttendeeScopeViewer): boolean {
+  if (member.id === viewer.id) return false;
   if (isOwnerHost(viewer)) return member.authority === AUTHORITY.LEADER;
   return viewer.teamName !== null && member.teamName === viewer.teamName;
 }

--- a/src/features/rooms/attendee-scope.ts
+++ b/src/features/rooms/attendee-scope.ts
@@ -1,0 +1,118 @@
+/**
+ * 회의 참석자 **범위 규칙** — 화면(피커)과 서버(Server Action)가 이 파일 하나를 같이 본다.
+ *
+ * | 개설자 | 지정 가능한 참석자 |
+ * | --- | --- |
+ * | Owner | **LEADER만** |
+ * | Leader · Member | **자기 팀 소속만** |
+ *
+ * ⚠️ **2026-08-13 확정 — 2026-08-12의 "선택 가능한 토글"을 뒤집는다.** 전에는 "전체 · 팀장급만",
+ *    "전체 · 내 부서만"을 사람이 골랐지만 이제 **고정**이다. 미래의 읽는 사람에게: 이건 되돌린
+ *    게 아니라 **다음 결정**이다 — `ROOM_ATTENDEE_FILTER.ALL`이나 필터 토글을 "복원"하지 않는다.
+ * ⚠️ **왜 강제인가**: Owner 개설 회의의 참석자가 전부 팀장이면, 회의록에서 이름이 불린 사람이
+ *    곧 **그 팀의 대표**라는 게 확정된다 — BE가 AI로 뽑은 액션을 개인 액션이 아니라 **팀 액션**
+ *    으로 만드는 근거가 이것이다. 팀장 아닌 사람이 한 명이라도 섞이면 그 추론이 깨진다.
+ * ⚠️ **`server-only`를 끌어오지 않는다.** 이 규칙은 클라이언트 컴포넌트(`RoomAttendeePicker`)도
+ *    써야 해서 `validate.ts`(→`lib/permission.ts` = `server-only`)에 둘 수 없다 — `constants.ts`가
+ *    같은 이유로 분리돼 있는 것과 같다.
+ * ⚠️ 그래도 **화면 필터는 UX일 뿐이다**(CLAUDE.md §권한: 화면 숨김은 보안이 아니다).
+ *    Server Action은 주소만 알면 직접 부를 수 있어 `findAttendeeScopeViolation`으로 다시 본다.
+ */
+
+import { AUTHORITY, type Authority } from "@/constants/authority";
+
+import type { RoomMember } from "./types";
+
+/**
+ * 참석자 범위를 정하는 **개설자 정보**.
+ * ⚠️ 예전엔 `viewerTeamName === null`(= 팀이 없으니 Owner겠지)로 **간접 추론**했는데, 그건
+ *    "팀 정보가 아직 안 내려온 Leader"와 Owner를 구분하지 못한다 — 그러면 팀장에게 전사
+ *    팀장 명단이 열린다. CLAUDE.md §조직 계층대로 **권한은 직급(=`role`)에서 온다**:
+ *    `Actor.role`을 그대로 받아 명시적으로 가른다.
+ */
+export interface AttendeeScopeViewer {
+  /**
+   * 개설자 본인의 id — **host는 이 규칙에서 빠진다.**
+   * ⚠️ host는 고르는 사람이 아니라 **명단에 자동으로 들어가는 사람**이다(MEET-09 "host 자동
+   *    포함·제거 불가", 목은 `updateMockMeetingAttendees`, BE는 `Meeting.create`가 앞에 끼운다.
+   *    BE `validateInvitedAttendees`도 host를 뺀 수만 센다). 빼지 않으면 Owner가 연 회의를
+   *    참석자 교체 화면에서 열기만 해도 **자기 자신 때문에** 규칙 위반이 된다.
+   */
+  id: number;
+  role: Authority;
+  /** 소속 팀 이름 — Owner는 팀이 없어 `null`(CLAUDE.md §조직 계층). */
+  teamName: string | null;
+}
+
+/** Owner가 여는 회의인가 — 규칙이 갈리는 유일한 축이라 한 곳에서만 판정한다. */
+function isOwnerHost(viewer: AttendeeScopeViewer): boolean {
+  return viewer.role === AUTHORITY.OWNER;
+}
+
+/**
+ * 이 사람을 참석자로 지정할 수 있는가.
+ * ⚠️ Leader·Member인데 팀 정보가 없으면 **아무도 못 고른다**(`false`). 조용히 전원 허용으로
+ *    넘어가면 규칙이 있으나 마나가 된다 — 막고 화면에 알린다(§정직성).
+ */
+export function isAttendeeInScope(member: RoomMember, viewer: AttendeeScopeViewer): boolean {
+  if (isOwnerHost(viewer)) return member.authority === AUTHORITY.LEADER;
+  return viewer.teamName !== null && member.teamName === viewer.teamName;
+}
+
+/** 피커에 보여줄 후보만 남긴다 — 검색 키워드는 호출부가 따로 건다. */
+export function filterAttendeeCandidates(
+  members: RoomMember[],
+  viewer: AttendeeScopeViewer,
+): RoomMember[] {
+  return members.filter((member) => isAttendeeInScope(member, viewer));
+}
+
+/**
+ * 화면에 왜 목록이 짧은지 알려 주는 한 줄 — 토글이 사라진 자리를 이 문구가 대신한다.
+ * ⚠️ 조용히 좁히면 사용자는 "사람이 안 나온다"고만 느낀다(§정직성). 라벨 하드코딩 금지
+ *    원칙대로 컴포넌트가 아니라 여기 둔다(§도메인 상수).
+ */
+export const ATTENDEE_SCOPE_GUIDE = {
+  owner: "팀장만 지정할 수 있습니다",
+  team: "같은 팀 소속만 지정할 수 있습니다",
+} as const;
+
+export function attendeeScopeGuideOf(viewer: AttendeeScopeViewer): string {
+  return isOwnerHost(viewer) ? ATTENDEE_SCOPE_GUIDE.owner : ATTENDEE_SCOPE_GUIDE.team;
+}
+
+/** 후보가 한 명도 없을 때의 안내 — "검색 결과가 없습니다"와 원인이 다르다(§정직성). */
+export const ATTENDEE_SCOPE_EMPTY = "지정할 수 있는 참석자가 없습니다";
+
+/** 서버 재검증 실패 문구 — 폼 오류 칸(`attendeeIds`)에 그대로 붙는다. */
+export const ATTENDEE_SCOPE_ERROR = {
+  owner: "Owner가 개설하는 회의에는 팀장만 참석자로 지정할 수 있습니다",
+  team: "자기 팀 소속만 참석자로 지정할 수 있습니다",
+  /** Leader·Member인데 세션에 팀이 없는 경우 — 범위를 계산할 수 없으니 통과시키지 않는다. */
+  unknownTeam: "소속 팀을 확인할 수 없어 참석자를 지정할 수 없습니다",
+} as const;
+
+/**
+ * **서버 재검증** — 제출된 참석자가 규칙을 지키는지 본다. 어기면 화면에 띄울 문구, 지키면 `null`.
+ *
+ * ⚠️ 인자로 **이미 명부에서 찾아낸 사원 객체**를 받는다(id가 아니다) — 명부를 어디서 구하는지는
+ *    호출부(목/실서버)마다 달라서다. **명부를 못 구하면 이 함수를 부를 수 없고, 그때는 검증한
+ *    척하지 않는다**(§정직성) — 호출부 주석을 본다.
+ */
+export function findAttendeeScopeViolation(
+  attendees: RoomMember[],
+  viewer: AttendeeScopeViewer,
+): string | null {
+  /* host는 명단에 자동으로 들어가는 사람이라 규칙 대상이 아니다(`AttendeeScopeViewer.id` 주석). */
+  const invited = attendees.filter((member) => member.id !== viewer.id);
+
+  if (isOwnerHost(viewer)) {
+    return invited.every((member) => member.authority === AUTHORITY.LEADER)
+      ? null
+      : ATTENDEE_SCOPE_ERROR.owner;
+  }
+  if (viewer.teamName === null) return ATTENDEE_SCOPE_ERROR.unknownTeam;
+  return invited.every((member) => member.teamName === viewer.teamName)
+    ? null
+    : ATTENDEE_SCOPE_ERROR.team;
+}

--- a/src/features/rooms/attendee-scope.ts
+++ b/src/features/rooms/attendee-scope.ts
@@ -89,6 +89,33 @@ export function attendeeScopeGuideOf(viewer: AttendeeScopeViewer): string {
 /** 후보가 한 명도 없을 때의 안내 — "검색 결과가 없습니다"와 원인이 다르다(§정직성). */
 export const ATTENDEE_SCOPE_EMPTY = "지정할 수 있는 참석자가 없습니다";
 
+/**
+ * **이미 명단에 있는데 지금 규칙으로는 못 고르는 사람**을 골라낸다(참석자 교체 화면 전용).
+ *
+ * ⚠️ 이런 사람이 생긴다: 규칙이 없던 때 만든 회의, 초대 뒤에 팀을 옮긴 사람, 팀장에서 내려온 사람.
+ * ⚠️ **살려 보낼 수도 없고 몰래 뺄 수도 없다.** 살려 보내면 서버 재검증
+ *    (`findAttendeeScopeViolation`)이 통째로 거부해 저장 자체가 막히고, 몰래 빼면 아무것도
+ *    안 건드린 host가 [저장]만 눌러도 그 사람들이 명단에서 사라진 채 성공 토스트가 뜬다
+ *    (2026-08-13 적대적 검증에서 잡혔다 — 이 PR이 만든 회귀다).
+ * ⚠️ 그래서 **이름으로 보여주고 저장하게 한다**(§정직성). 화면이 "이 사람들은 빠집니다"라고
+ *    먼저 말하면, 명단이 바뀌는 건 사고가 아니라 host가 내린 결정이 된다.
+ * ⚠️ host 자신은 여기 안 낀다 — 규칙 대상이 아니고 서버가 다시 끼워 넣는다.
+ */
+export function findAttendeesDroppedByScope(
+  members: RoomMember[],
+  viewer: AttendeeScopeViewer,
+  currentAttendeeIds: number[],
+): RoomMember[] {
+  const current = new Set(currentAttendeeIds);
+  return members.filter(
+    (member) =>
+      current.has(member.id) && member.id !== viewer.id && !isAttendeeInScope(member, viewer),
+  );
+}
+
+/** 빠질 사람을 알리는 머리말 — 명단은 화면이 이름으로 잇는다(라벨 하드코딩 금지). */
+export const ATTENDEE_SCOPE_DROPPED = "지금 규칙으로는 지정할 수 없어, 저장하면 명단에서 빠집니다";
+
 /** 서버 재검증 실패 문구 — 폼 오류 칸(`attendeeIds`)에 그대로 붙는다. */
 export const ATTENDEE_SCOPE_ERROR = {
   owner: "Owner가 개설하는 회의에는 팀장만 참석자로 지정할 수 있습니다",

--- a/src/features/rooms/components/room-attendee-picker.test.tsx
+++ b/src/features/rooms/components/room-attendee-picker.test.tsx
@@ -216,4 +216,38 @@ describe("RoomAttendeePicker — 범위 강제(2026-08-13)", () => {
 
     expect(submitted).toEqual(["2"]);
   });
+
+  /*
+    ⚠️ **참석자 교체(MEET-09) 회귀** — 2026-08-13 적대적 검증에서 잡혔다.
+       이 PR이 규칙을 강제하기 전에 만든 회의에는 지금 규칙으로는 못 고르는 참석자가 그대로
+       남아 있는데(예: Owner 회의에 일반 사원이 들어가 있음), 그 사람을 **화면에 알리지 않으면**
+       host가 아무것도 안 건드리고 [저장]만 눌러도 명단에서 사라진 채 성공 토스트가 뜬다.
+       빠질 사람을 이름으로 먼저 보여준다(§정직성).
+  */
+  it("교체 화면에서 규칙 밖 기존 참석자를 이름으로 알린다", () => {
+    renderPicker(OWNER_VIEWER, {
+      selectedIds: [2],
+      /* 3(사원 이하윤)은 예전 회의 때는 참석자였지만 지금 규칙(Owner=팀장만)으로는 못 고른다. */
+      currentAttendeeIds: [2, 3],
+    });
+
+    expect(screen.getByText("이하윤", { exact: false })).toBeInTheDocument();
+  });
+
+  /* ⚠️ 범위 안이면 안내가 뜨지 않아야 한다 — 매번 뜨면 문구가 배경이 된다 */
+  it("범위 안인 기존 참석자에는 안내가 뜨지 않는다", () => {
+    renderPicker(OWNER_VIEWER, { selectedIds: [2], currentAttendeeIds: [2] });
+
+    expect(screen.queryByText(/저장하면 명단에서 빠집니다/)).not.toBeInTheDocument();
+  });
+
+  /*
+    ⚠️ **예약 화면에는 안 뜬다.** `currentAttendeeIds`를 안 넘기면(기본값) 참석자 교체가 아니라
+       처음 만드는 화면이라, 알릴 "예전 명단"이 없다. 오탐을 막는다.
+  */
+  it("currentAttendeeIds를 안 넘기면(예약 화면) 안내가 뜨지 않는다", () => {
+    renderPicker(OWNER_VIEWER, { selectedIds: [2, 3] });
+
+    expect(screen.queryByText(/저장하면 명단에서 빠집니다/)).not.toBeInTheDocument();
+  });
 });

--- a/src/features/rooms/components/room-attendee-picker.test.tsx
+++ b/src/features/rooms/components/room-attendee-picker.test.tsx
@@ -3,59 +3,133 @@ import userEvent from "@testing-library/user-event";
 
 import { AUTHORITY } from "@/constants/authority";
 
+import type { AttendeeScopeViewer } from "../attendee-scope";
 import type { RoomMember } from "../types";
 import { RoomAttendeePicker } from "./room-attendee-picker";
 
+/*
+  ⚠️ 이 파일은 2026-08-13에 통째로 다시 썼다 — 전에는 "전체 · 팀장급만"/"전체 · 내 부서만"
+     **토글**을 검증했는데, 그 토글은 폐기됐다(범위가 개설자 권한으로 고정). 필터 라디오를
+     기대하는 케이스를 되살리지 않는다(`attendee-scope.ts` 머리말).
+*/
 const MEMBERS: RoomMember[] = [
   { id: 1, name: "박대표", teamName: null, authority: AUTHORITY.OWNER },
   { id: 2, name: "김서준", teamName: "개발팀", authority: AUTHORITY.LEADER },
   { id: 3, name: "이하윤", teamName: "개발팀", authority: AUTHORITY.MEMBER },
+  { id: 5, name: "최유진", teamName: "마케팅팀", authority: AUTHORITY.LEADER },
 ];
 
-describe("RoomAttendeePicker", () => {
-  it("검색 전에는 전체 목록을 보여준다", () => {
-    render(
+const OWNER_VIEWER: AttendeeScopeViewer = { id: 1, role: AUTHORITY.OWNER, teamName: null };
+const LEADER_VIEWER: AttendeeScopeViewer = { id: 2, role: AUTHORITY.LEADER, teamName: "개발팀" };
+const MEMBER_VIEWER: AttendeeScopeViewer = { id: 3, role: AUTHORITY.MEMBER, teamName: "개발팀" };
+
+function renderPicker(
+  viewer: AttendeeScopeViewer,
+  overrides: Partial<React.ComponentProps<typeof RoomAttendeePicker>> = {},
+) {
+  const onChange = jest.fn();
+  render(
+    <RoomAttendeePicker
+      members={MEMBERS}
+      selectedIds={[]}
+      onChange={onChange}
+      viewer={viewer}
+      {...overrides}
+    />,
+  );
+  return { onChange };
+}
+
+describe("RoomAttendeePicker — 범위 강제(2026-08-13)", () => {
+  it("필터 토글을 더 이상 그리지 않는다", () => {
+    renderPicker(OWNER_VIEWER);
+
+    expect(screen.queryByRole("radiogroup", { name: "참석자 필터" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("radio")).not.toBeInTheDocument();
+    expect(screen.queryByText("전체")).not.toBeInTheDocument();
+  });
+
+  it("Owner가 열면 팀장만 보인다(Owner 본인·사원은 후보가 아니다)", () => {
+    renderPicker(OWNER_VIEWER);
+
+    expect(screen.getByText("김서준")).toBeInTheDocument();
+    expect(screen.getByText("최유진")).toBeInTheDocument();
+    expect(screen.queryByText("박대표")).not.toBeInTheDocument();
+    expect(screen.queryByText("이하윤")).not.toBeInTheDocument();
+  });
+
+  it("Leader가 열면 자기 팀만 보인다(다른 팀 팀장도 안 보인다)", () => {
+    renderPicker(LEADER_VIEWER);
+
+    expect(screen.getByText("김서준")).toBeInTheDocument();
+    expect(screen.getByText("이하윤")).toBeInTheDocument();
+    expect(screen.queryByText("최유진")).not.toBeInTheDocument();
+    expect(screen.queryByText("박대표")).not.toBeInTheDocument();
+  });
+
+  it("Member가 열어도 Leader와 같은 범위(자기 팀)다", () => {
+    renderPicker(MEMBER_VIEWER);
+
+    expect(screen.getByText("김서준")).toBeInTheDocument();
+    expect(screen.getByText("이하윤")).toBeInTheDocument();
+    expect(screen.queryByText("최유진")).not.toBeInTheDocument();
+  });
+
+  it("왜 목록이 짧은지 한 줄로 알린다(§정직성)", () => {
+    const { unmount } = render(
       <RoomAttendeePicker
         members={MEMBERS}
         selectedIds={[]}
         onChange={jest.fn()}
-        viewerTeamName="개발팀"
+        viewer={OWNER_VIEWER}
       />,
     );
+    expect(screen.getByText("팀장만 지정할 수 있습니다")).toBeInTheDocument();
+    unmount();
 
-    expect(screen.getByText("박대표")).toBeInTheDocument();
-    expect(screen.getByText("김서준")).toBeInTheDocument();
-    expect(screen.getByText("이하윤")).toBeInTheDocument();
+    renderPicker(LEADER_VIEWER);
+    expect(screen.getByText("같은 팀 소속만 지정할 수 있습니다")).toBeInTheDocument();
+  });
+
+  it("소속 팀을 모르는 Leader·Member에게는 아무도 안 열린다(조용히 전원 허용 금지)", () => {
+    renderPicker({ id: 3, role: AUTHORITY.MEMBER, teamName: null });
+
+    expect(screen.getByText("지정할 수 있는 참석자가 없습니다")).toBeInTheDocument();
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+  });
+
+  it("후보가 없는 것과 검색이 안 걸리는 것을 다른 문구로 가른다", async () => {
+    const user = userEvent.setup();
+    renderPicker(OWNER_VIEWER);
+
+    await user.type(screen.getByRole("textbox", { name: "참석자 검색" }), "존재하지않는이름");
+
+    expect(screen.getByText("검색 결과가 없습니다")).toBeInTheDocument();
+  });
+
+  it("검색은 범위 안에서만 걸린다 — 범위 밖 사람은 이름을 쳐도 안 나온다", async () => {
+    const user = userEvent.setup();
+    renderPicker(LEADER_VIEWER);
+
+    await user.type(screen.getByRole("textbox", { name: "참석자 검색" }), "최유진");
+
+    expect(screen.queryByText("최유진")).not.toBeInTheDocument();
+    expect(screen.getByText("검색 결과가 없습니다")).toBeInTheDocument();
   });
 
   it("이름을 검색하면 그 이름만 남는다", async () => {
     const user = userEvent.setup();
-    render(
-      <RoomAttendeePicker
-        members={MEMBERS}
-        selectedIds={[]}
-        onChange={jest.fn()}
-        viewerTeamName="개발팀"
-      />,
-    );
+    renderPicker(LEADER_VIEWER);
 
     await user.type(screen.getByRole("textbox", { name: "참석자 검색" }), "김");
 
     expect(screen.getByText("김서준")).toBeInTheDocument();
-    expect(screen.queryByText("박대표")).not.toBeInTheDocument();
+    expect(screen.queryByText("이하윤")).not.toBeInTheDocument();
   });
 
   it("체크하면 onChange에 추가된 id를 실어 보낸다", async () => {
     const user = userEvent.setup();
-    const onChange = jest.fn();
-    render(
-      <RoomAttendeePicker
-        members={MEMBERS}
-        selectedIds={[]}
-        onChange={onChange}
-        viewerTeamName="개발팀"
-      />,
-    );
+    const { onChange } = renderPicker(OWNER_VIEWER);
 
     await user.click(screen.getByRole("checkbox", { name: "김서준" }));
 
@@ -64,108 +138,16 @@ describe("RoomAttendeePicker", () => {
 
   it("이미 선택된 사람의 체크를 풀면 목록에서 뺀다", async () => {
     const user = userEvent.setup();
-    const onChange = jest.fn();
-    render(
-      <RoomAttendeePicker
-        members={MEMBERS}
-        selectedIds={[1, 2]}
-        onChange={onChange}
-        viewerTeamName="개발팀"
-      />,
-    );
+    const { onChange } = renderPicker(OWNER_VIEWER, { selectedIds: [2, 5] });
 
     await user.click(screen.getByRole("checkbox", { name: "김서준" }));
 
-    expect(onChange).toHaveBeenCalledWith([1]);
+    expect(onChange).toHaveBeenCalledWith([5]);
   });
 
   it("선택 인원 수를 보여준다", () => {
-    render(
-      <RoomAttendeePicker
-        members={MEMBERS}
-        selectedIds={[1, 2]}
-        onChange={jest.fn()}
-        viewerTeamName="개발팀"
-      />,
-    );
+    renderPicker(OWNER_VIEWER, { selectedIds: [2, 5] });
 
     expect(screen.getByText("선택 2명")).toBeInTheDocument();
-  });
-
-  it("검색 결과가 없으면 안내 문구를 보여준다", async () => {
-    const user = userEvent.setup();
-    render(
-      <RoomAttendeePicker
-        members={MEMBERS}
-        selectedIds={[]}
-        onChange={jest.fn()}
-        viewerTeamName="개발팀"
-      />,
-    );
-
-    await user.type(screen.getByRole("textbox", { name: "참석자 검색" }), "존재하지않는이름");
-
-    expect(screen.getByText("검색 결과가 없습니다")).toBeInTheDocument();
-  });
-
-  it("Owner(팀 없음)가 열면 '전체·팀장급만'만 뜨고, 고르면 LEADER만 남는다", async () => {
-    const user = userEvent.setup();
-    render(
-      <RoomAttendeePicker
-        members={MEMBERS}
-        selectedIds={[]}
-        onChange={jest.fn()}
-        viewerTeamName={null}
-      />,
-    );
-
-    expect(screen.getByRole("radio", { name: "팀장급만" })).toBeInTheDocument();
-    expect(screen.queryByRole("radio", { name: "내 부서만" })).not.toBeInTheDocument();
-
-    await user.click(screen.getByRole("radio", { name: "팀장급만" }));
-
-    expect(screen.getByText("김서준")).toBeInTheDocument();
-    expect(screen.queryByText("박대표")).not.toBeInTheDocument();
-    expect(screen.queryByText("이하윤")).not.toBeInTheDocument();
-  });
-
-  it("Leader/Member(소속 팀 있음)가 열면 '전체·내 부서만'만 뜨고, 고르면 같은 부서만 남는다", async () => {
-    const user = userEvent.setup();
-    render(
-      <RoomAttendeePicker
-        members={MEMBERS}
-        selectedIds={[]}
-        onChange={jest.fn()}
-        viewerTeamName="개발팀"
-      />,
-    );
-
-    expect(screen.getByRole("radio", { name: "내 부서만" })).toBeInTheDocument();
-    expect(screen.queryByRole("radio", { name: "팀장급만" })).not.toBeInTheDocument();
-
-    await user.click(screen.getByRole("radio", { name: "내 부서만" }));
-
-    expect(screen.getByText("김서준")).toBeInTheDocument();
-    expect(screen.getByText("이하윤")).toBeInTheDocument();
-    expect(screen.queryByText("박대표")).not.toBeInTheDocument();
-  });
-
-  it("방향키로 필터 라디오를 옮기면 그 필터가 바로 적용된다", async () => {
-    const user = userEvent.setup();
-    render(
-      <RoomAttendeePicker
-        members={MEMBERS}
-        selectedIds={[]}
-        onChange={jest.fn()}
-        viewerTeamName={null}
-      />,
-    );
-
-    await user.click(screen.getByRole("radio", { name: "전체" }));
-    await user.keyboard("{ArrowRight}");
-
-    expect(screen.getByRole("radio", { name: "팀장급만" })).toBeChecked();
-    expect(screen.getByText("김서준")).toBeInTheDocument();
-    expect(screen.queryByText("박대표")).not.toBeInTheDocument();
   });
 });

--- a/src/features/rooms/components/room-attendee-picker.test.tsx
+++ b/src/features/rooms/components/room-attendee-picker.test.tsx
@@ -159,4 +159,61 @@ describe("RoomAttendeePicker — 범위 강제(2026-08-13)", () => {
 
     expect(screen.getByText("선택 2명")).toBeInTheDocument();
   });
+
+  it("검색어를 남긴 채 제출해도 가려진 선택이 빠지지 않는다(§정직성)", async () => {
+    const user = userEvent.setup();
+    const submitted: string[] = [];
+    render(
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          submitted.push(
+            ...new FormData(event.currentTarget).getAll("attendeeIds").map((id) => String(id)),
+          );
+        }}
+      >
+        <RoomAttendeePicker
+          members={MEMBERS}
+          selectedIds={[2, 5]}
+          onChange={jest.fn()}
+          viewer={OWNER_VIEWER}
+        />
+        <button type="submit">예약</button>
+      </form>,
+    );
+
+    /* "김"으로 좁히면 최유진 줄이 사라진다 — 체크박스가 DOM에서 빠져도 제출값엔 남아야 한다. */
+    await user.type(screen.getByRole("textbox", { name: "참석자 검색" }), "김");
+    await user.click(screen.getByRole("button", { name: "예약" }));
+
+    expect(submitted.sort()).toEqual(["2", "5"]);
+  });
+
+  it("범위 밖 사람은 선택돼 있어도 제출값에 안 넣는다(규칙이 뺀 사람이다)", async () => {
+    const user = userEvent.setup();
+    const submitted: string[] = [];
+    render(
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          submitted.push(
+            ...new FormData(event.currentTarget).getAll("attendeeIds").map((id) => String(id)),
+          );
+        }}
+      >
+        {/* 3(사원)·1(host 본인)은 Owner 범위 밖이다. */}
+        <RoomAttendeePicker
+          members={MEMBERS}
+          selectedIds={[1, 2, 3]}
+          onChange={jest.fn()}
+          viewer={OWNER_VIEWER}
+        />
+        <button type="submit">저장</button>
+      </form>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "저장" }));
+
+    expect(submitted).toEqual(["2"]);
+  });
 });

--- a/src/features/rooms/components/room-attendee-picker.test.tsx
+++ b/src/features/rooms/components/room-attendee-picker.test.tsx
@@ -58,11 +58,11 @@ describe("RoomAttendeePicker — 범위 강제(2026-08-13)", () => {
     expect(screen.queryByText("이하윤")).not.toBeInTheDocument();
   });
 
-  it("Leader가 열면 자기 팀만 보인다(다른 팀 팀장도 안 보인다)", () => {
+  it("Leader가 열면 자기 팀만 보인다(다른 팀 팀장도, 본인도 안 보인다)", () => {
     renderPicker(LEADER_VIEWER);
 
-    expect(screen.getByText("김서준")).toBeInTheDocument();
     expect(screen.getByText("이하윤")).toBeInTheDocument();
+    expect(screen.queryByText("김서준")).not.toBeInTheDocument();
     expect(screen.queryByText("최유진")).not.toBeInTheDocument();
     expect(screen.queryByText("박대표")).not.toBeInTheDocument();
   });
@@ -71,8 +71,15 @@ describe("RoomAttendeePicker — 범위 강제(2026-08-13)", () => {
     renderPicker(MEMBER_VIEWER);
 
     expect(screen.getByText("김서준")).toBeInTheDocument();
-    expect(screen.getByText("이하윤")).toBeInTheDocument();
+    expect(screen.queryByText("이하윤")).not.toBeInTheDocument();
     expect(screen.queryByText("최유진")).not.toBeInTheDocument();
+  });
+
+  it("host 본인은 체크박스로 안 내준다 — 풀어도 서버가 다시 넣는다(§정직성)", () => {
+    renderPicker(LEADER_VIEWER, { selectedIds: [2, 3] });
+
+    expect(screen.queryByRole("checkbox", { name: "김서준" })).not.toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: "이하윤" })).toBeChecked();
   });
 
   it("왜 목록이 짧은지 한 줄로 알린다(§정직성)", () => {
@@ -119,7 +126,9 @@ describe("RoomAttendeePicker — 범위 강제(2026-08-13)", () => {
 
   it("이름을 검색하면 그 이름만 남는다", async () => {
     const user = userEvent.setup();
-    renderPicker(LEADER_VIEWER);
+    /* ⚠️ 개발팀 Member(이하윤) 시점이다 — Leader(김서준) 시점으로 "김"을 치면 host 본인이라
+       애초에 후보가 아니라서, 검색이 되는지가 아니라 범위가 좁은지를 재게 된다. */
+    renderPicker(MEMBER_VIEWER);
 
     await user.type(screen.getByRole("textbox", { name: "참석자 검색" }), "김");
 

--- a/src/features/rooms/components/room-attendee-picker.tsx
+++ b/src/features/rooms/components/room-attendee-picker.tsx
@@ -77,18 +77,30 @@ export function RoomAttendeePicker({
 }: RoomAttendeePickerProps) {
   const [keyword, setKeyword] = useState("");
 
+  const candidates = useMemo(() => filterAttendeeCandidates(members, viewer), [members, viewer]);
+
   const visible = useMemo(() => {
     const query = keyword.trim().toLowerCase();
-    return filterAttendeeCandidates(members, viewer).filter(
-      (member) => !query || member.name.toLowerCase().includes(query),
-    );
-  }, [members, keyword, viewer]);
+    return candidates.filter((member) => !query || member.name.toLowerCase().includes(query));
+  }, [candidates, keyword]);
 
   /* 후보가 아예 없는 것과 검색어에 안 걸리는 것은 원인이 달라 문구를 가른다(§정직성). */
-  const hasCandidate = useMemo(
-    () => filterAttendeeCandidates(members, viewer).length > 0,
-    [members, viewer],
-  );
+  const hasCandidate = candidates.length > 0;
+
+  /*
+    ⚠️ **검색으로 가려진 선택은 hidden input으로 같이 보낸다.** 제출값은 지금 그려진 체크박스가
+       만드는데, 검색어를 남긴 채 [예약]·[저장]을 누르면 걸러진 줄의 체크박스가 DOM에 없어
+       **골라 둔 사람이 조용히 빠진 채** 저장된다 — 바로 아래 "선택 N명"은 그대로라 화면이
+       거짓말을 한다(§정직성).
+    ⚠️ 범위 밖(`filterAttendeeCandidates`가 걸러 낸) 사람은 여기 안 넣는다 — 그건 규칙이 일부러
+       뺀 사람이고, host는 서버가 명단에 다시 끼워 넣는다(`attendee-scope.ts`).
+  */
+  const hiddenSelectedIds = useMemo(() => {
+    const shown = new Set(visible.map((member) => member.id));
+    return candidates
+      .filter((member) => selectedIds.includes(member.id) && !shown.has(member.id))
+      .map((member) => member.id);
+  }, [candidates, visible, selectedIds]);
 
   function toggle(id: number) {
     onChange(
@@ -133,6 +145,10 @@ export function RoomAttendeePicker({
           ))
         )}
       </div>
+
+      {hiddenSelectedIds.map((id) => (
+        <input key={id} type="hidden" name="attendeeIds" value={id} />
+      ))}
 
       <p className="text-muted-foreground text-[11px]">선택 {selectedIds.length}명</p>
     </div>

--- a/src/features/rooms/components/room-attendee-picker.tsx
+++ b/src/features/rooms/components/room-attendee-picker.tsx
@@ -5,74 +5,27 @@ import { useMemo, useState } from "react";
 
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { AUTHORITY } from "@/constants/authority";
 import { useProfileAvatar } from "@/hooks/use-profile-avatar";
-import { cn } from "@/lib/utils";
 
 import {
-  ROOM_ATTENDEE_FILTER,
-  ROOM_ATTENDEE_FILTER_LABEL,
-  type RoomAttendeeFilter,
-} from "../constants";
+  ATTENDEE_SCOPE_EMPTY,
+  attendeeScopeGuideOf,
+  type AttendeeScopeViewer,
+  filterAttendeeCandidates,
+} from "../attendee-scope";
 import type { RoomMember } from "../types";
 
 interface RoomAttendeePickerProps {
   members: RoomMember[];
   selectedIds: number[];
   onChange: (ids: number[]) => void;
-  /** 지금 보고 있는 사람의 부서 — "내 부서만" 필터 기준(`null`이면 Owner처럼 부서가 없는 사람). */
-  viewerTeamName: string | null;
-}
-
-interface AttendeeFilterGroupProps {
-  options: readonly RoomAttendeeFilter[];
-  value: RoomAttendeeFilter;
-  onChange: (value: RoomAttendeeFilter) => void;
-}
-
-/**
- * 참석자 필터 2종 — 서로 배타적이라 체크박스 모양이어도 동작은 라디오다(`RoomPickerList`와 같은 패턴).
- * ⚠️ 네이티브 `<input type="radio">`로 짠다(2026-08-10 정리) — 같은 `name`을 공유하는 라디오는
- *    브라우저·jsdom 모두 방향키로 이동·선택을 공짜로 지원한다(roving tabindex를 직접 짜지 않아도 된다).
- *    입력은 `sr-only`로 시각적으로만 숨기고 라벨이 모양을 그린다 — `peer-focus-visible`로 포커스
- *    링을 라벨에 얹어서, 숨긴 입력에 포커스가 가도 키보드 사용자에게는 그대로 보인다.
- * ⚠️ **옵션은 호출부가 정한다**(2026-08-12 사용자 확정) — Owner가 개설하면 "전체·팀장급만",
- *    Leader/Member가 개설하면 "전체·내 부서만"이다. Owner는 팀이 없어 "내 부서만"이 뜻이 없고,
- *    Leader/Member에게는 "팀장급만"이 굳이 필요한 필터가 아니다.
- */
-function AttendeeFilterGroup({ options, value, onChange }: AttendeeFilterGroupProps) {
-  return (
-    <div className="flex items-center gap-1" role="radiogroup" aria-label="참석자 필터">
-      {options.map((option) => {
-        const selected = option === value;
-        const inputId = `attendee-filter-${option}`;
-        return (
-          <label
-            key={option}
-            htmlFor={inputId}
-            className={cn(
-              "cursor-pointer rounded-full border px-2.5 py-1 text-[11px] transition-colors",
-              "peer-focus-visible:ring-ring peer-focus-visible:ring-2 peer-focus-visible:ring-offset-1",
-              selected
-                ? "border-foreground bg-foreground/5 font-medium"
-                : "border-input text-muted-foreground hover:bg-muted",
-            )}
-          >
-            <input
-              id={inputId}
-              type="radio"
-              name="attendee-filter"
-              value={option}
-              checked={selected}
-              onChange={() => onChange(option)}
-              className="peer sr-only"
-            />
-            {ROOM_ATTENDEE_FILTER_LABEL[option]}
-          </label>
-        );
-      })}
-    </div>
-  );
+  /**
+   * 개설자 — 참석자 범위를 **이 값이 강제로** 정한다(`attendee-scope.ts`).
+   * ⚠️ 예전 `viewerTeamName: string | null` 하나를 대체한다(2026-08-13). 팀 이름만으로
+   *    "팀이 없으니 Owner"라고 **간접 추론**하던 자리인데, 그건 팀 정보가 비어 온 Leader를
+   *    Owner로 읽는다 — 권한은 직급(`role`)에서 온다(CLAUDE.md §조직 계층).
+   */
+  viewer: AttendeeScopeViewer;
 }
 
 const AVATAR_SIZE = 20;
@@ -106,39 +59,36 @@ function AttendeeRow({
 }
 
 /**
- * 회의실 예약 "참석자" 선택 — 검색으로 좁히되, 결과는 **전체 목록을 체크박스로** 보여준다
- * (디자인 반영). 검색 전에는 전체가 다 보이고, 검색하면 이름이 걸리는 사람만 남는다.
+ * 회의실 예약·참석자 교체의 "참석자" 선택 — 검색으로 좁히되, 결과는 **후보 전체를 체크박스로**
+ * 보여준다(디자인 반영). 검색 전에는 후보가 다 보이고, 검색하면 이름이 걸리는 사람만 남는다.
+ *
+ * ⚠️ **필터 토글(`AttendeeFilterGroup`)이 없다**(2026-08-13 확정 — 2026-08-12의 "전체 · 팀장급만"
+ *    /"전체 · 내 부서만" 라디오를 걷어냈다). 범위가 개설자의 권한으로 **고정**돼 고를 것이 남지
+ *    않는다: Owner면 팀장만, Leader·Member면 자기 팀만. 근거는 `attendee-scope.ts` 머리말 —
+ *    **되살리지 않는다.**
+ * ⚠️ 목록을 조용히 좁히지 않는다 — 왜 짧은지 라벨 옆 한 줄로 알린다(§정직성).
+ * ⚠️ 여기서 좁히는 건 **UX일 뿐**이다. 제출값은 Server Action이 다시 본다(§권한).
  */
 export function RoomAttendeePicker({
   members,
   selectedIds,
   onChange,
-  viewerTeamName,
+  viewer,
 }: RoomAttendeePickerProps) {
   const [keyword, setKeyword] = useState("");
-  const [filter, setFilter] = useState<RoomAttendeeFilter>(ROOM_ATTENDEE_FILTER.ALL);
-
-  /*
-    ⚠️ Owner는 팀이 없다(`viewerTeamName === null`, CLAUDE.md §조직 계층) — 그 경우 "내 부서만"
-    대신 "팀장급만"을 준다. Leader/Member는 반대다(2026-08-12 사용자 확정).
-  */
-  const filterOptions =
-    viewerTeamName === null
-      ? [ROOM_ATTENDEE_FILTER.ALL, ROOM_ATTENDEE_FILTER.LEADER]
-      : [ROOM_ATTENDEE_FILTER.ALL, ROOM_ATTENDEE_FILTER.MY_TEAM];
 
   const visible = useMemo(() => {
     const query = keyword.trim().toLowerCase();
-    return members
-      .filter((member) => {
-        if (filter === ROOM_ATTENDEE_FILTER.LEADER) return member.authority === AUTHORITY.LEADER;
-        if (filter === ROOM_ATTENDEE_FILTER.MY_TEAM) {
-          return viewerTeamName !== null && member.teamName === viewerTeamName;
-        }
-        return true;
-      })
-      .filter((member) => !query || member.name.toLowerCase().includes(query));
-  }, [members, keyword, filter, viewerTeamName]);
+    return filterAttendeeCandidates(members, viewer).filter(
+      (member) => !query || member.name.toLowerCase().includes(query),
+    );
+  }, [members, keyword, viewer]);
+
+  /* 후보가 아예 없는 것과 검색어에 안 걸리는 것은 원인이 달라 문구를 가른다(§정직성). */
+  const hasCandidate = useMemo(
+    () => filterAttendeeCandidates(members, viewer).length > 0,
+    [members, viewer],
+  );
 
   function toggle(id: number) {
     onChange(
@@ -148,9 +98,9 @@ export function RoomAttendeePicker({
 
   return (
     <div className="flex h-full flex-col gap-2">
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-2">
         <Label>참석자</Label>
-        <AttendeeFilterGroup options={filterOptions} value={filter} onChange={setFilter} />
+        <span className="text-muted-foreground text-[11px]">{attendeeScopeGuideOf(viewer)}</span>
       </div>
 
       <div className="relative">
@@ -170,7 +120,7 @@ export function RoomAttendeePicker({
       <div className="border-border min-h-0 flex-1 overflow-y-auto rounded-lg border">
         {visible.length === 0 ? (
           <p className="text-muted-foreground px-3 py-3 text-[12px] leading-4">
-            검색 결과가 없습니다
+            {hasCandidate ? "검색 결과가 없습니다" : ATTENDEE_SCOPE_EMPTY}
           </p>
         ) : (
           visible.map((member) => (

--- a/src/features/rooms/components/room-attendee-picker.tsx
+++ b/src/features/rooms/components/room-attendee-picker.tsx
@@ -8,10 +8,12 @@ import { Label } from "@/components/ui/label";
 import { useProfileAvatar } from "@/hooks/use-profile-avatar";
 
 import {
+  ATTENDEE_SCOPE_DROPPED,
   ATTENDEE_SCOPE_EMPTY,
   attendeeScopeGuideOf,
   type AttendeeScopeViewer,
   filterAttendeeCandidates,
+  findAttendeesDroppedByScope,
 } from "../attendee-scope";
 import type { RoomMember } from "../types";
 
@@ -26,6 +28,12 @@ interface RoomAttendeePickerProps {
    *    Owner로 읽는다 — 권한은 직급(`role`)에서 온다(CLAUDE.md §조직 계층).
    */
   viewer: AttendeeScopeViewer;
+  /**
+   * **이미 명단에 있던 사람들** — 참석자 교체(MEET-09)에서만 넘긴다(예약 화면은 명단이 없다).
+   * ⚠️ 이 값이 있어야 "규칙 밖이라 저장하면 빠질 사람"을 이름으로 알릴 수 있다
+   *    (`findAttendeesDroppedByScope`). 안 넘기면 예전처럼 조용히 사라진다.
+   */
+  currentAttendeeIds?: number[];
 }
 
 const AVATAR_SIZE = 20;
@@ -74,10 +82,22 @@ export function RoomAttendeePicker({
   selectedIds,
   onChange,
   viewer,
+  currentAttendeeIds,
 }: RoomAttendeePickerProps) {
   const [keyword, setKeyword] = useState("");
 
   const candidates = useMemo(() => filterAttendeeCandidates(members, viewer), [members, viewer]);
+
+  /*
+    ⚠️ **명단에 있는데 규칙 밖인 사람은 이름으로 알린다**(§정직성 — `attendee-scope.ts` 주석).
+       체크박스로 안 내주는 건 같지만, 안 내주기만 하면 host가 아무것도 안 건드리고 [저장]만
+       눌러도 그 사람들이 사라진 채 성공 토스트가 뜬다.
+  */
+  const droppedByScope = useMemo(
+    () =>
+      currentAttendeeIds ? findAttendeesDroppedByScope(members, viewer, currentAttendeeIds) : [],
+    [members, viewer, currentAttendeeIds],
+  );
 
   const visible = useMemo(() => {
     const query = keyword.trim().toLowerCase();
@@ -149,6 +169,15 @@ export function RoomAttendeePicker({
       {hiddenSelectedIds.map((id) => (
         <input key={id} type="hidden" name="attendeeIds" value={id} />
       ))}
+
+      {droppedByScope.length > 0 && (
+        <p className="text-muted-foreground text-[11px] leading-4">
+          <span className="text-destructive">
+            {droppedByScope.map((member) => member.name).join(" · ")}
+          </span>
+          {` — ${ATTENDEE_SCOPE_DROPPED}`}
+        </p>
+      )}
 
       <p className="text-muted-foreground text-[11px]">선택 {selectedIds.length}명</p>
     </div>

--- a/src/features/rooms/components/room-reservation-dialog.test.tsx
+++ b/src/features/rooms/components/room-reservation-dialog.test.tsx
@@ -20,13 +20,18 @@ const ROOMS: MeetingRoom[] = [
     closeTime: "18:00",
   },
 ];
+/* ⚠️ Owner가 여는 폼이라 후보는 **팀장뿐**이다(2026-08-13, `attendee-scope.ts`) — 예전의
+   박대표(OWNER)를 그대로 두면 피커에 아무도 안 떠서 이 파일의 다른 케이스가 같이 죽는다. */
 const MEMBERS: RoomMember[] = [
-  { id: 1, name: "박대표", teamName: null, authority: AUTHORITY.OWNER },
+  { id: 2, name: "김서준", teamName: "개발팀", authority: AUTHORITY.LEADER },
 ];
 const PROJECTS: RoomProjectOption[] = [{ id: "1", name: "굿즈 프로젝트", tag: "GOODS" }];
 const TEAM_ACTIONS: RoomTeamActionOption[] = [];
 
 const SLOT_START = new Date("2026-08-11T10:00:00");
+
+/** 개설자 = Owner(팀 없음) — 참석자 후보가 팀장으로 고정되는 쪽이다. */
+const OWNER_VIEWER = { id: 1, role: AUTHORITY.OWNER, teamName: null } as const;
 
 function renderDialog(overrides: Partial<React.ComponentProps<typeof RoomReservationDialog>> = {}) {
   const onOpenChange = jest.fn();
@@ -40,7 +45,7 @@ function renderDialog(overrides: Partial<React.ComponentProps<typeof RoomReserva
       projects={PROJECTS}
       showParentTeamAction={false}
       teamActions={TEAM_ACTIONS}
-      viewerTeamName={null}
+      viewer={OWNER_VIEWER}
       onCreated={onCreated}
       {...overrides}
     />,
@@ -59,7 +64,7 @@ describe("RoomReservationDialog", () => {
         projects={PROJECTS}
         showParentTeamAction={false}
         teamActions={TEAM_ACTIONS}
-        viewerTeamName={null}
+        viewer={OWNER_VIEWER}
         onCreated={jest.fn()}
       />,
     );

--- a/src/features/rooms/components/room-reservation-dialog.tsx
+++ b/src/features/rooms/components/room-reservation-dialog.tsx
@@ -12,6 +12,7 @@ import { FieldError } from "@/components/common/field-error";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 
+import type { AttendeeScopeViewer } from "../attendee-scope";
 import { RESERVATION_DURATION_MINUTES } from "../constants";
 import type {
   MeetingRoom,
@@ -37,8 +38,9 @@ interface RoomReservationDialogProps {
    *  직접 못 부른다. */
   showParentTeamAction: boolean;
   teamActions: RoomTeamActionOption[];
-  /** 참석자 "내 부서만" 필터 기준 — `RoomAttendeePicker`로 그대로 흘려보낸다. */
-  viewerTeamName: string | null;
+  /** 참석자 범위(Owner=팀장만 / Leader·Member=자기 팀만) 기준 — `RoomAttendeePicker`로
+   *  그대로 흘려보낸다(`attendee-scope.ts`, 2026-08-13 확정). */
+  viewer: AttendeeScopeViewer;
   /** 생성 성공 시 호출 — 재조회 없이 부모 화면에 바로 얹는다(§최적화: action 리턴값 그대로 반영). */
   onCreated: (created: RoomReservation) => void;
 }
@@ -134,7 +136,7 @@ export function RoomReservationDialog({
   projects,
   showParentTeamAction,
   teamActions,
-  viewerTeamName,
+  viewer,
   onCreated,
 }: RoomReservationDialogProps) {
   const { state, formAction, form, setForm, handleOpenChange } = useRoomReservationForm({
@@ -223,7 +225,7 @@ export function RoomReservationDialog({
                   members={members}
                   selectedIds={form.attendeeIds}
                   onChange={(attendeeIds) => setForm((prev) => ({ ...prev, attendeeIds }))}
-                  viewerTeamName={viewerTeamName}
+                  viewer={viewer}
                 />
                 <FieldError reserveSpace message={state.errors.attendeeIds} />
               </div>

--- a/src/features/rooms/components/rooms-board.test.tsx
+++ b/src/features/rooms/components/rooms-board.test.tsx
@@ -34,7 +34,7 @@ const ROOMS: MeetingRoom[] = [
     closeTime: "18:00",
   },
 ];
-const MEMBERS = [{ id: 1, name: "박대표", teamName: null, authority: AUTHORITY.OWNER }];
+const MEMBERS = [{ id: 2, name: "김서준", teamName: "개발팀", authority: AUTHORITY.LEADER }];
 const PROJECTS: RoomProjectOption[] = [{ id: "1", name: "굿즈 프로젝트", tag: "GOODS" }];
 const TEAM_ACTIONS: RoomTeamActionOption[] = [];
 
@@ -50,7 +50,7 @@ describe("RoomsBoard", () => {
         projects={PROJECTS}
         showParentTeamAction={false}
         teamActions={TEAM_ACTIONS}
-        viewerTeamName={null}
+        viewer={{ id: 1, role: AUTHORITY.OWNER, teamName: null }}
         week="2026-08-10"
       />,
     );

--- a/src/features/rooms/components/rooms-board.tsx
+++ b/src/features/rooms/components/rooms-board.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 
+import type { AttendeeScopeViewer } from "../attendee-scope";
 import { toCalendarEventFromReservation } from "../mapper";
 import { getNextAvailableSlot } from "../next-available-slot";
 import type {
@@ -27,8 +28,9 @@ interface RoomsBoardProps {
    *  못 부른다(여기·`RoomReservationDialog`가 전부 client). */
   showParentTeamAction: boolean;
   teamActions: RoomTeamActionOption[];
-  /** 참석자 "내 부서만" 필터 기준 — `RoomReservationDialog`로 그대로 흘려보낸다. */
-  viewerTeamName: string | null;
+  /** 참석자 범위(Owner=팀장만 / Leader·Member=자기 팀만) 기준 — `RoomReservationDialog`로
+   *  그대로 흘려보낸다(`attendee-scope.ts`, 2026-08-13 확정). */
+  viewer: AttendeeScopeViewer;
   /** "YYYY-MM-DD" — 이 주의 월요일. 서버 컴포넌트가 이 주 기준으로 `initialEvents`를 내려준다. */
   week: string;
 }
@@ -53,7 +55,7 @@ export function RoomsBoard({
   projects,
   showParentTeamAction,
   teamActions,
-  viewerTeamName,
+  viewer,
   week,
 }: RoomsBoardProps) {
   const [events, setEvents] = useState(initialEvents);
@@ -85,7 +87,7 @@ export function RoomsBoard({
         projects={projects}
         showParentTeamAction={showParentTeamAction}
         teamActions={teamActions}
-        viewerTeamName={viewerTeamName}
+        viewer={viewer}
         onCreated={(created) => {
           // ⚠️ 지금 보고 있는 회의실과 다른 회의실에 예약했으면 이 그리드엔 안 얹는다 — 다른
           //    회의실의 예약을 이 화면에 섞으면 그 그리드가 거짓말을 하게 된다(§정직성).

--- a/src/features/rooms/constants.ts
+++ b/src/features/rooms/constants.ts
@@ -15,22 +15,13 @@ export const RESERVATION_DURATION_MINUTES = 30;
 export const ROOM_OPERATING_START_MINUTES = 9 * 60;
 export const ROOM_OPERATING_END_MINUTES = 18 * 60;
 
-/**
- * 참석자 피커 필터 3종 — `RoomAttendeePicker`가 쓴다.
- * ⚠️ 세 값은 서로 배타적이라 라디오그룹으로 짠다(`role="radiogroup"`, `RoomPickerList`와 같은 패턴).
- */
-export const ROOM_ATTENDEE_FILTER = {
-  ALL: "all",
-  LEADER: "leader",
-  MY_TEAM: "myTeam",
-} as const;
-export type RoomAttendeeFilter = (typeof ROOM_ATTENDEE_FILTER)[keyof typeof ROOM_ATTENDEE_FILTER];
-
-export const ROOM_ATTENDEE_FILTER_LABEL: Record<RoomAttendeeFilter, string> = {
-  all: "전체",
-  leader: "팀장급만",
-  myTeam: "내 부서만",
-};
+/*
+  ⚠️ **참석자 피커 필터 상수(`ROOM_ATTENDEE_FILTER`·`ROOM_ATTENDEE_FILTER_LABEL`)는 지웠다**
+     (2026-08-13 — 2026-08-12에 넣었던 "전체 · 팀장급만"/"전체 · 내 부서만" 토글을 뒤집었다).
+     참석자 범위가 개설자의 권한으로 **고정**돼(Owner=팀장만, Leader·Member=자기 팀만) 고를
+     것이 남지 않았고, 규칙은 `attendee-scope.ts` 한 곳으로 옮겼다.
+     안 쓰는 값을 남겨 두면 나중에 누가 되살린다(§도메인 상수) — 그래서 여기 문장만 남긴다.
+*/
 
 /** 회의실 캘린더 툴바(`rooms-calendar-toolbar.tsx`)·회의실 목록(`room-list-panel.tsx`) 카피
  * — 라벨 하드코딩 금지 원칙에 맞춰 뺐다. */

--- a/src/features/rooms/mock/reservations.test.ts
+++ b/src/features/rooms/mock/reservations.test.ts
@@ -42,6 +42,14 @@ describe("회의실 예약 mock 스토어", () => {
     expect(findMockReservation(created.id)).toEqual(created);
   });
 
+  it("host는 제출값에 없어도 명단 맨 앞에 들어간다(중복은 한 번만)", () => {
+    // 피커가 host를 후보로 안 내주므로(`attendee-scope.ts`) 제출값엔 host가 없다.
+    expect(addMockReservation(DRAFT, LEADER).attendeeIds).toEqual([5, 1, 2]);
+    expect(addMockReservation({ ...DRAFT, attendeeIds: [3, 1] }, OWNER).attendeeIds).toEqual([
+      3, 1,
+    ]);
+  });
+
   it("예약과 같이 회의(Meeting)도 만들어진다(WORKFLOW.md §3-1: 예약=회의 개설)", () => {
     const before = listMockMeetings().length;
 

--- a/src/features/rooms/mock/reservations.test.ts
+++ b/src/features/rooms/mock/reservations.test.ts
@@ -44,7 +44,10 @@ describe("회의실 예약 mock 스토어", () => {
 
   it("host는 제출값에 없어도 명단 맨 앞에 들어간다(중복은 한 번만)", () => {
     // 피커가 host를 후보로 안 내주므로(`attendee-scope.ts`) 제출값엔 host가 없다.
-    expect(addMockReservation(DRAFT, LEADER).attendeeIds).toEqual([5, 1, 2]);
+    // ⚠️ LEADER는 `requiresParentTeamAction`이라 `parentTeamActionId`가 있어야 저장 시 undefined가 안 새어 나간다.
+    expect(addMockReservation({ ...DRAFT, parentTeamActionId: 1 }, LEADER).attendeeIds).toEqual([
+      5, 1, 2,
+    ]);
     expect(addMockReservation({ ...DRAFT, attendeeIds: [3, 1] }, OWNER).attendeeIds).toEqual([
       3, 1,
     ]);

--- a/src/features/rooms/mock/reservations.ts
+++ b/src/features/rooms/mock/reservations.ts
@@ -122,6 +122,10 @@ export function findMockReservation(id: string): RoomReservation | null {
  *    같은 이유).
  * ⚠️ 참조 무결성(roomId/projectId/attendeeIds/parentTeamActionId 존재 여부)은 여기서 다시
  *    안 본다 — 호출부(`actions.ts`)가 먼저 확인한 뒤에만 이 함수를 부른다.
+ * ⚠️ **host는 명단 맨 앞에 자동으로 들어간다** — 피커가 host를 후보로 안 내주므로
+ *    (`attendee-scope.ts`) 제출값에는 host가 없다. 안 넣으면 MEMBER가 개설한 회의를 개설자
+ *    본인이 못 연다(`canViewMeetingDetail`은 참석자 명단으로 판정한다). 교체(MEET-09)의
+ *    `updateMockMeetingAttendees`·시드 데이터와 같은 규칙이다.
  */
 export function addMockReservation(draft: RoomReservationDraft, actor: Actor): RoomReservation {
   const room = findMockRoom(draft.roomId);
@@ -139,7 +143,7 @@ export function addMockReservation(draft: RoomReservationDraft, actor: Actor): R
     projectId: draft.projectId,
     projectTag: project?.tag ?? "",
     topics: draft.topics.map((topic) => ({ main: topic.main.trim(), sub: topic.sub.trim() })),
-    attendeeIds: draft.attendeeIds,
+    attendeeIds: Array.from(new Set([actor.id, ...draft.attendeeIds])),
     ownerId: actor.id,
   };
   store.reservations = [...store.reservations, reservation];

--- a/src/features/shell/viewer.ts
+++ b/src/features/shell/viewer.ts
@@ -33,10 +33,17 @@ export interface Viewer extends Actor {
  *    팀 화면으로 옮기면 팀장이다 — 목에서 역할별 화면을 확인하려면 이 편이 맞다.
  * ⚠️ `/app/*`은 **전원이 쓰는 공용 워크벤치**라 여기서 가르지 않는다(기본은 대표).
  */
-const MOCK_PEOPLE: Record<Authority, { id: number; name: string }> = {
+/*
+  ⚠️ `teamName`은 **지어낸 값이 아니다** — 같은 id의 사원 목(`features/rooms/mock/members.ts`,
+     `features/member/mock/managed.ts`)과 같은 팀이다(§정직한 목업: 화면을 오가는 동안 같은
+     사람의 소속이 달라 보이면 안 된다). Owner·System은 팀이 없다(CLAUDE.md §조직 계층).
+  ⚠️ 비워 두면 **팀 범위로 도는 화면이 목에서 통째로 빈다**(2026-08-13 채움) — 참석자 피커의
+     "자기 팀만"과 예약 폼의 "상위 팀 액션" 목록이 둘 다 `teamName`으로 걸러서다.
+*/
+const MOCK_PEOPLE: Record<Authority, { id: number; name: string; teamName?: string }> = {
   [AUTHORITY.OWNER]: { id: 1, name: "대표 계정" },
-  [AUTHORITY.LEADER]: { id: 2, name: "김서준" },
-  [AUTHORITY.MEMBER]: { id: 3, name: "이하윤" },
+  [AUTHORITY.LEADER]: { id: 2, name: "김서준", teamName: "개발팀" },
+  [AUTHORITY.MEMBER]: { id: 3, name: "이하윤", teamName: "개발팀" },
   [AUTHORITY.SYSTEM]: { id: 0, name: "Z 운영자" },
 };
 
@@ -77,7 +84,7 @@ export async function getViewer(): Promise<Viewer> {
     const role = previewRoleFrom(search) ?? mockRoleFor(pathname);
     const person = MOCK_PEOPLE[role];
 
-    return { id: person.id, name: person.name, role, isAdmin: false };
+    return { id: person.id, name: person.name, role, isAdmin: false, teamName: person.teamName };
   }
 
   /*


### PR DESCRIPTION
## 📋 PR 타입

> 해당하는 타입을 선택해 주세요 (복수 선택 가능)

- [ ] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [x] OWNER (대표)
- [x] ADMIN (관리자)
- [x] LEADER (팀장)
- [x] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- **참석자 "전체" 옵션을 없애고 역할별 강제 조건으로 바꿨습니다**(2026-08-13 확정 — 2026-08-12의 "선택 가능한 토글"을 뒤집습니다). Owner 개설이면 **팀장(LEADER)만**, Leader·Member 개설이면 **자기 팀 소속만**입니다. 강제인 이유는 Owner 회의의 참석자가 전부 팀장이어야 회의록에서 호명된 사람이 곧 그 팀의 대표라는 게 확정되고, 그게 BE가 AI 액션을 개인 액션이 아니라 **팀 액션**으로 만드는 근거이기 때문입니다.
- 규칙을 `features/rooms/attendee-scope.ts` **한 곳**에 모았습니다. `server-only`를 안 끌어오도록 `validate.ts`가 아니라 별도 파일로 뒀고(`constants.ts`가 분리된 것과 같은 이유), 화면 피커와 Server Action이 같은 함수를 씁니다. 필터 토글(`AttendeeFilterGroup`)과 `ROOM_ATTENDEE_FILTER`·`ROOM_ATTENDEE_FILTER_LABEL` 상수는 지웠습니다 — 안 쓰는 값을 남기면 나중에 누가 되살립니다(§도메인 상수).
- **역할 판정을 `role`로 명시했습니다.** 기존에는 `viewerTeamName === null`(= 팀이 없으니 Owner겠지)로 간접 추론했는데, 그건 "팀 정보가 비어 온 Leader"를 Owner로 읽어 팀장에게 전사 팀장 명단을 열어 줍니다. 권한은 직급에서 옵니다(CLAUDE.md §조직 계층) — prop을 `viewerTeamName: string | null` → `viewer: AttendeeScopeViewer{ id, role, teamName }` 하나로 바꾸고 호출부 전부(회의실 페이지 · `RoomsBoard` · `RoomReservationDialog` / 회의 상세 페이지 · `MeetingDetailView` · `MeetingAttendeesEditDialog`)를 맞췄습니다.
- **회의 개설 Server Action에서 재검증**합니다(`rooms/actions.ts`). 화면 필터는 UX일 뿐이고 Server Action은 주소만 알면 직접 부를 수 있습니다. `host`는 서버가 명단에 자동으로 넣는 사람이라 규칙 대상에서 뺐습니다(BE `validateInvitedAttendees`도 host를 뺀 수만 셉니다) — 안 빼면 Owner가 연 회의를 참석자 교체 화면에서 **열기만 해도** 자기 자신 때문에 저장이 막힙니다.
- **참석자 교체(MEET-09)에도 같은 규칙을 걸었습니다**(`meeting/actions.ts`). 여기서는 범위 기준이 액터가 아니라 **그 회의의 host**입니다 — `canManageMeeting`이 OWNER·Admin에게도 남의 회의 교체를 허용해서, 액터로 재면 Owner가 남의 팀 회의를 열었을 때 규칙이 "팀장만"으로 뒤바뀝니다.
- 목 뷰어(`shell/viewer.ts`)의 LEADER·MEMBER에 `teamName`을 채웠습니다. 비어 있으면 팀 범위로 도는 화면(참석자 피커의 "자기 팀만", 예약 폼의 "상위 팀 액션")이 목에서 통째로 빕니다. 값은 지어내지 않고 같은 id의 사원 목과 맞췄습니다.
- 테스트: `room-attendee-picker.test.tsx`를 새 규칙으로 다시 썼고(토글 케이스 폐기), 규칙 자체(`attendee-scope.test.ts`)·개설 액션·교체 액션(`meeting/actions.test.ts` 신규) 재검증 케이스를 더했습니다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**(회의 담당자 등), 그리고 **서버(Server Action/BFF)에서 재검사** ⚠️ 실서버 분기는 명부가 없어 재검사 불가 — 아래 리뷰 포인트 참고
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse` (이 PR은 매퍼를 안 건드립니다)
- [x] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시 (조용히 "되는 척" 금지)
- [x] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [x] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그)
- [x] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [x] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인)
- [x] 🧪 `loading` / `error` / `empty` 3상태 (후보 없음 · 검색 결과 없음을 다른 문구로 가릅니다)
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음 (해당 없음)

---

## 🔗 연관 이슈

Closes #444

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
| 참석자 라벨 옆 라디오 2개(`전체` · `팀장급만`/`내 부서만`), 기본값 `전체`로 전 사원 노출 | 토글 없음. 라벨 옆에 `팀장만 지정할 수 있습니다` / `같은 팀 소속만 지정할 수 있습니다` 한 줄, 목록은 범위 안 사람만 |

---

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

- ⚠️ **참석자 교체(MEET-09)까지 손댄 것은 요청 범위를 넘은 추론입니다 — 필요하면 물러 주세요.** 요청 문서에는 **개설**만 적혀 있었습니다. 그런데 이 피커는 `meeting-attendees-edit-dialog.tsx`가 그대로 재사용하고, 개설만 막고 교체를 열어 두면 회의를 만든 뒤에 규칙을 깨서 넣을 수 있어 AI 팀 액션 판단 근거가 똑같이 무너집니다. 그래서 같이 걸었습니다. 교체는 별도 결정이라고 보시면 3번째 커밋(`9048262`)만 되돌리면 됩니다.
- ⚠️ **실서버 경로에서는 참석자 범위를 재검증하지 못합니다 — 검증한 척하지 않았습니다.** BE 실코드로 확인한 근거([확인] `MemberController` · `TeamMemberController`):
  - `getReservableMembers()`(rooms/server.ts)가 실연동에서 그대로 던집니다 — 사원 목록 API가 아직 이 화면에 안 붙었습니다.
  - 붙어도 명부 API가 권한별로 갈립니다. `GET /api/members`는 `hasAnyRole('OWNER','ADMIN')`, `GET /api/team/members`는 `hasRole('LEADER')`입니다 — **MEMBER가 개설할 때 자기 팀 명단을 볼 엔드포인트가 아예 없습니다**(프로젝트·검색·회의 참석자 조회까지 훑어도 없습니다. `/api/v1/search`의 PERSON은 키워드가 필수라 명부 열거가 안 됩니다).
  - `GET /api/team/members` 응답의 `roleName`은 **권한이 아니라 팀 안 역할 라벨**이라 "전원 팀장인가"를 그걸로 판정할 수 없습니다.
  - 그래서 지금 재검증이 실제로 도는 곳은 **목 분기**뿐입니다. 실서버 분기에는 왜 못 하는지 주석으로 남겼고, 명부를 구할 길이 생기면 같은 함수(`findAttendeeScopeViolation`)를 그 자리에서 부르면 됩니다.
- 🚨 **BE가 강제해 줘야 합니다(요청 문서에 올릴 항목).** 현재 `POST /api/meetings`(`MeetingService#validateAndIndexMembers`)와 `PUT /api/meetings/{id}/attendees`(`MeetingAttendeeCommandService#findAndValidateMembers`)는 **존재·같은 회사·미삭제만** 봅니다 — 참석자의 권한도 팀도 **전혀 보지 않습니다**. FE는 최종 방어가 아닙니다.
- 🚨 **BE의 팀 액션 추론이 참석자가 아니라 `meeting.team_id`(= host의 팀)에서 나옵니다.** `ActionDistributionService`가 `meeting.teamId() == null`이면 예외를 던지는데, Owner는 팀이 없어 Owner 개설 회의는 `team_id`가 NULL입니다 — BE 주석도 이걸 "알려진 계약 한계"로 적어 뒀습니다. 즉 이 이슈의 근거("참석자가 전부 팀장이면 팀 액션으로 만들 수 있다")가 **BE 현재 구현과 아직 안 맞습니다.** 이 PR은 FE 쪽 전제를 먼저 세워 두는 것이고, 실제로 성립하려면 BE 분배 계약에 팀 지정 경로가 생겨야 합니다 — 담당자와 맞춰야 할 지점입니다.
- 역할 판정 방식(`viewerTeamName === null` → `viewer: { id, role, teamName }`)이 적절한지 봐 주세요. prop을 늘리지 않고 객체 하나로 바꿔서, 범위를 정하는 값이 무엇인지 호출부에서 한눈에 보이게 했습니다.
- `host`를 규칙에서 빼는 판단(`attendee-scope.ts`의 `AttendeeScopeViewer.id` 주석)을 봐 주세요. 목·BE 둘 다 host를 명단에 자동으로 끼워 넣어서, 빼지 않으면 Owner 회의의 참석자 교체가 열자마자 막힙니다.

---

## 📝 추가 메모

- `shell/viewer.ts`는 다른 작업자와 겹칠 수 있어 **목 사람 정보에 `teamName` 두 줄만** 더했습니다(판정 로직은 안 건드렸습니다).
- 검증: `npx tsc --noEmit` · `npx eslint <changed>` · `npx jest`(95 suites / 1040 tests 통과) · `npx next build` 전부 통과했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 권한과 소속 팀에 따라 회의 참석자 선택 범위를 제한합니다.
  * 대표는 팀장만, 리더와 구성원은 자신의 팀원만 선택할 수 있습니다.
  * 선택 화면에 범위 안내와 검색 결과 상태를 표시합니다.
* **버그 수정**
  * 예약 및 참석자 변경 시 범위를 재검증해 부적절하거나 존재하지 않는 참석자 등록을 차단합니다.
  * 호스트가 참석자 목록에 자동으로 포함됩니다.
* **테스트**
  * 권한별 참석자 선택과 검증 동작을 보강했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->