### PR TITLE
[FIX] 실서버에서도 참석자 범위를 다시 본다 — 개설·교체 둘 다 #444

### DIFF
--- a/src/app/(shell)/app/meeting/[meetingId]/page.tsx
+++ b/src/app/(shell)/app/meeting/[meetingId]/page.tsx
@@ -89,9 +89,11 @@ export default async function MeetingDetailPage({
   /*
     ⚠️ 참석자 후보 목록은 **host이고 아직 안 끝난 회의일 때만** 가져온다(MEET-09 편집 조건과
     같다) — 그 외엔 다이얼로그 자체가 안 뜨는데 목록만 미리 불러오면 헛수고다.
+    ⚠️ `viewer`를 그대로 넘긴다 — `canEditMeetingAttendees`가 `isHost`를 요구하므로 이 자리에
+       도달했다면 `viewer`가 곧 이 회의의 host다(개설자 다른 사람의 회의는 여기 안 온다).
   */
   const canEditAttendees = canEditMeetingAttendees(result.detail);
-  const members = canEditAttendees ? await getReservableMembers() : [];
+  const members = canEditAttendees ? await getReservableMembers(viewer) : [];
 
   return (
     <main className="min-h-0 flex-1 overflow-y-auto px-8 py-7">

--- a/src/app/(shell)/app/rooms/page.tsx
+++ b/src/app/(shell)/app/rooms/page.tsx
@@ -41,12 +41,16 @@ export default async function RoomsPage({ searchParams }: RoomsPageProps) {
   const { week: weekParam, roomId: roomIdParam } = await searchParams;
   const week = parseWeekParam(weekParam);
 
-  // ⚠️ 팀 액션 목록은 지금 보고 있는 사람이 누구인지(권한·소속 팀)에 따라 달라져서 먼저 받는다.
+  /*
+    ⚠️ 팀 액션 목록·참석자 후보 둘 다 지금 보고 있는 사람이 누구인지(권한·소속 팀)에 따라
+       달라져서 먼저 받는다 — 참석자는 Owner면 팀별 리더, Leader·Member면 자기 팀뿐이다
+       (`getReservableMembers`, `attendee-scope.ts`).
+  */
   const viewer = await getViewer();
 
   const [rooms, members, projects, teamActions] = await Promise.all([
     getMeetingRooms(),
-    getReservableMembers(),
+    getReservableMembers(viewer),
     getReservableProjects(),
     getReservableTeamActions(viewer),
   ]);

--- a/src/features/meeting/actions.attendees-real.test.ts
+++ b/src/features/meeting/actions.attendees-real.test.ts
@@ -45,6 +45,8 @@ function meetingDetail(overrides: Partial<Record<string, unknown>> = {}) {
     status: "SCHEDULED",
     startAt: "2026-08-14T10:00:00",
     endAt: "2026-08-14T10:30:00",
+    pendingActionCount: 0,
+    summaryStatus: null,
     project: { projectId: 1, tag: "GOODS" },
     meetingRoom: { meetingRoomId: 1, name: "소회의실 B" },
     host: { memberId: HOST_LEADER.id, name: "김서준" },

--- a/src/features/meeting/actions.attendees-real.test.ts
+++ b/src/features/meeting/actions.attendees-real.test.ts
@@ -124,7 +124,29 @@ describe("updateMeetingAttendeesAction — 실서버, OWNER·ADMIN이 남의 회
     getViewerMock.mockResolvedValue({ id: 1, role: AUTHORITY.OWNER });
   });
 
-  it("host 정보를 getManagedMember로 따로 구해 그 범위로 검증한다", async () => {
+  it("host가 OWNER면 회사 전체 팀장 명부로 검증한다(호출자 무관, 안전한 축)", async () => {
+    serverApiMock
+      .mockResolvedValueOnce(meetingDetail({ host: { memberId: 9, name: "대표" } }))
+      .mockResolvedValueOnce({ meetingId: 100, attendees: [] });
+    getManagedMemberMock.mockResolvedValue({
+      member: { id: 9, authority: AUTHORITY.OWNER, teamName: null },
+    });
+
+    const result = await updateMeetingAttendeesAction(INITIAL, form(100, [3]));
+
+    expect(getManagedMemberMock).toHaveBeenCalledWith(9);
+    expect(getReservableMembersMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 9, role: AUTHORITY.OWNER }),
+    );
+    expect(result.error).toBeNull();
+  });
+
+  /*
+    ⚠️ **딱 한 칸** — host가 LEADER·MEMBER면 `GET /api/members/my-team`이 host가 아니라
+       actor(호출자)의 팀을 돌려줘 범위를 잘못 잰다(§정직성, 본 척하지 않는다). 그래서 이
+       축에서는 `getReservableMembers`를 부르지 않고 FE 검증을 건너뛴다 — BE가 최종 방어다.
+  */
+  it("host가 LEADER·MEMBER면 FE 검증을 건너뛰고 BE에 맡긴다(actor 팀으로 잘못 재는 것 방지)", async () => {
     serverApiMock
       .mockResolvedValueOnce(meetingDetail())
       .mockResolvedValueOnce({ meetingId: 100, attendees: [] });
@@ -135,16 +157,11 @@ describe("updateMeetingAttendeesAction — 실서버, OWNER·ADMIN이 남의 회
     const result = await updateMeetingAttendeesAction(INITIAL, form(100, [3]));
 
     expect(getManagedMemberMock).toHaveBeenCalledWith(HOST_LEADER.id);
-    expect(getReservableMembersMock).toHaveBeenCalledWith(
-      expect.objectContaining({ id: HOST_LEADER.id, role: AUTHORITY.LEADER, teamName: "개발팀" }),
-    );
+    expect(getReservableMembersMock).not.toHaveBeenCalled();
     expect(result.error).toBeNull();
+    expect(serverApiMock).toHaveBeenCalledTimes(2);
   });
 
-  /*
-    ⚠️ **딱 한 칸** — host 정보 자체를 못 구하면(탈퇴 등) FE 검증을 건너뛴다(§정직성, 본 척
-       하지 않는다). BE가 최종 방어다 — 여기서 막지 않았다고 뚫리는 게 아니다.
-  */
   it("host 정보를 못 구하면 FE 검증을 건너뛰고 BE에 맡긴다", async () => {
     serverApiMock
       .mockResolvedValueOnce(meetingDetail())

--- a/src/features/meeting/actions.attendees-real.test.ts
+++ b/src/features/meeting/actions.attendees-real.test.ts
@@ -1,0 +1,158 @@
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/mocks/config", () => ({ isMock: false }));
+jest.mock("@/features/auth/session", () => ({ requireAccessToken: jest.fn() }));
+jest.mock("@/features/shell/viewer", () => ({ getViewer: jest.fn() }));
+jest.mock("@/features/member/manage-server", () => ({ getManagedMember: jest.fn() }));
+jest.mock("@/features/rooms/server", () => ({ getReservableMembers: jest.fn() }));
+jest.mock("@/lib/api", () => ({
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+  serverApi: jest.fn(),
+}));
+
+import { AUTHORITY } from "@/constants/authority";
+import { getManagedMember } from "@/features/member/manage-server";
+import { getReservableMembers } from "@/features/rooms/server";
+import { getViewer } from "@/features/shell/viewer";
+import { ApiError, serverApi } from "@/lib/api";
+
+import { updateMeetingAttendeesAction } from "./actions";
+
+/**
+ * 참석자 명단 교체(MEET-09) — **실서버 참석자 재검증**.
+ *
+ * ⚠️ 기존 `actions.test.ts`는 파일 전체가 `isMock: true`라 이 분기(2026-08-13, `GET
+ *    /api/meetings/{id}` 조회 + `GET /api/members/my-team` 로스터 검증)는 그쪽에서
+ *    한 번도 실행되지 않는다 — 별도 파일로 잠근다.
+ */
+
+const getViewerMock = getViewer as unknown as jest.Mock;
+const getManagedMemberMock = getManagedMember as unknown as jest.Mock;
+const getReservableMembersMock = getReservableMembers as unknown as jest.Mock;
+const serverApiMock = serverApi as unknown as jest.Mock;
+
+const HOST_LEADER = { id: 2, role: AUTHORITY.LEADER, teamName: "개발팀" };
+
+function meetingDetail(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    meetingId: 100,
+    title: "스프린트 회의",
+    status: "SCHEDULED",
+    startAt: "2026-08-14T10:00:00",
+    endAt: "2026-08-14T10:30:00",
+    project: { projectId: 1, tag: "GOODS" },
+    meetingRoom: { meetingRoomId: 1, name: "소회의실 B" },
+    host: { memberId: HOST_LEADER.id, name: "김서준" },
+    attendees: [],
+    ...overrides,
+  };
+}
+
+function form(meetingId: number, attendeeIds: number[]): FormData {
+  const data = new FormData();
+  data.append("meetingId", String(meetingId));
+  for (const id of attendeeIds) data.append("attendeeIds", String(id));
+  return data;
+}
+
+const INITIAL = { error: null, attendeeIds: null } as const;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  getReservableMembersMock.mockResolvedValue([
+    { id: 3, name: "박도현", teamName: "개발팀", authority: AUTHORITY.MEMBER },
+  ]);
+});
+
+describe("updateMeetingAttendeesAction — 실서버, host 자신이 고치는 보통 경로", () => {
+  beforeEach(() => {
+    getViewerMock.mockResolvedValue(HOST_LEADER);
+  });
+
+  it("명부 안의 id만 제출하면 PUT까지 간다", async () => {
+    serverApiMock.mockResolvedValueOnce(meetingDetail()).mockResolvedValueOnce({
+      meetingId: 100,
+      attendees: [{ memberId: 3, name: "박도현", teamName: "개발팀" }],
+    });
+
+    const result = await updateMeetingAttendeesAction(INITIAL, form(100, [3]));
+
+    expect(result.error).toBeNull();
+    expect(result.attendeeIds).toEqual([3]);
+    expect(serverApiMock).toHaveBeenCalledTimes(2);
+    // host 정보를 이미 세션에서 아니까 getManagedMember는 안 부른다.
+    expect(getManagedMemberMock).not.toHaveBeenCalled();
+  });
+
+  it("명부 밖 id가 섞이면 PUT을 부르지 않고 막는다", async () => {
+    serverApiMock.mockResolvedValueOnce(meetingDetail());
+
+    const result = await updateMeetingAttendeesAction(INITIAL, form(100, [3, 999]));
+
+    expect(result.error).toBe("지정할 수 없는 참석자가 있습니다");
+    expect(result.attendeeIds).toBeNull();
+    expect(serverApiMock).toHaveBeenCalledTimes(1); // GET 회의 상세만, PUT은 없음
+  });
+
+  it("끝난 회의는 명부를 볼 것도 없이 막는다", async () => {
+    serverApiMock.mockResolvedValueOnce(meetingDetail({ status: "DONE" }));
+
+    const result = await updateMeetingAttendeesAction(INITIAL, form(100, [3]));
+
+    expect(result.error).toBe("끝난 회의는 참석자를 바꿀 수 없습니다");
+    expect(getReservableMembersMock).not.toHaveBeenCalled();
+  });
+
+  it("없는 회의는 404를 그런 회의가 없다는 말로 바꾼다", async () => {
+    serverApiMock.mockRejectedValueOnce(new ApiError(404, "not found"));
+
+    const result = await updateMeetingAttendeesAction(INITIAL, form(999, [3]));
+
+    expect(result.error).toBe("회의를 찾을 수 없습니다");
+  });
+});
+
+describe("updateMeetingAttendeesAction — 실서버, OWNER·ADMIN이 남의 회의를 고치는 드문 경로", () => {
+  beforeEach(() => {
+    getViewerMock.mockResolvedValue({ id: 1, role: AUTHORITY.OWNER });
+  });
+
+  it("host 정보를 getManagedMember로 따로 구해 그 범위로 검증한다", async () => {
+    serverApiMock
+      .mockResolvedValueOnce(meetingDetail())
+      .mockResolvedValueOnce({ meetingId: 100, attendees: [] });
+    getManagedMemberMock.mockResolvedValue({
+      member: { id: HOST_LEADER.id, authority: AUTHORITY.LEADER, teamName: "개발팀" },
+    });
+
+    const result = await updateMeetingAttendeesAction(INITIAL, form(100, [3]));
+
+    expect(getManagedMemberMock).toHaveBeenCalledWith(HOST_LEADER.id);
+    expect(getReservableMembersMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: HOST_LEADER.id, role: AUTHORITY.LEADER, teamName: "개발팀" }),
+    );
+    expect(result.error).toBeNull();
+  });
+
+  /*
+    ⚠️ **딱 한 칸** — host 정보 자체를 못 구하면(탈퇴 등) FE 검증을 건너뛴다(§정직성, 본 척
+       하지 않는다). BE가 최종 방어다 — 여기서 막지 않았다고 뚫리는 게 아니다.
+  */
+  it("host 정보를 못 구하면 FE 검증을 건너뛰고 BE에 맡긴다", async () => {
+    serverApiMock
+      .mockResolvedValueOnce(meetingDetail())
+      .mockResolvedValueOnce({ meetingId: 100, attendees: [] });
+    getManagedMemberMock.mockResolvedValue(null);
+
+    const result = await updateMeetingAttendeesAction(INITIAL, form(100, [3]));
+
+    expect(getReservableMembersMock).not.toHaveBeenCalled();
+    expect(result.error).toBeNull();
+    expect(serverApiMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/features/meeting/actions.ts
+++ b/src/features/meeting/actions.ts
@@ -4,16 +4,26 @@ import { revalidatePath } from "next/cache";
 
 import { MEETING_STATUS } from "@/constants/meeting";
 import { requireAccessToken } from "@/features/auth/session";
+import { getManagedMember } from "@/features/member/manage-server";
 import { findAttendeeScopeViolation } from "@/features/rooms/attendee-scope";
 import { findMockMember } from "@/features/rooms/mock/members";
+import { getReservableMembers } from "@/features/rooms/server";
+import { getViewer } from "@/features/shell/viewer";
 import { ApiError, serverApi } from "@/lib/api";
 import { ep } from "@/lib/endpoints";
 import { getMockActor } from "@/lib/mock-actor";
-import { canManageMeeting } from "@/lib/permission";
+import { type Actor, canManageMeeting } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
 import { checkMeetingTitle } from "./lib";
-import { attendeeIdsFrom, type BeUpdateAttendeesResponse } from "./mapper";
+import {
+  attendeeIdsFrom,
+  type BeMeetingDetail,
+  type BeUpdateAttendeesResponse,
+  hostIdOf,
+  isClosed,
+  parseMeetingDetail,
+} from "./mapper";
 import {
   cancelMockMeeting,
   findMockMeeting,
@@ -40,6 +50,36 @@ function toAttendeesErrorMessage(error: unknown): string {
   return error.message;
 }
 
+/** 재검증 실패 문구 — **목·실서버가 같은 문장을 쓴다**(두 경로가 갈리면 화면이 다른 말을 한다). */
+const ATTENDEES_EDIT_ERROR = {
+  notFound: "회의를 찾을 수 없습니다",
+  forbidden: "참석자를 바꿀 권한이 없습니다",
+  closed: "끝난 회의는 참석자를 바꿀 수 없습니다",
+  unknownMember: "존재하지 않는 참석자가 있습니다",
+} as const;
+
+/**
+ * 재검증에 필요한 **그 회의의 사실**(host·상태)을 실서버에서 가져온다 — `GET /api/meetings/{id}`
+ * (MEET-04, 이미 연동된 엔드포인트다. 캡처 진입 `getLiveMeetingCapture`가 같은 값을 같은 식으로 읽는다).
+ *
+ * ⚠️ **없는 회의는 값(`null`)으로 돌린다** — 던지면 다이얼로그 대신 `error.tsx`가 뜨는데, 없는
+ *    회의는 고장이 아니라 "그런 회의가 없습니다"라고 말해 줄 일이다(캡처 경로와 같은 판단).
+ * ⚠️ 나머지 오류(403·500)는 그대로 던져 호출부의 `catch`가 BE 문구로 옮긴다.
+ */
+async function fetchMeetingFacts(
+  meetingId: string,
+  accessToken: string,
+): Promise<BeMeetingDetail | null> {
+  try {
+    return parseMeetingDetail(
+      await serverApi<unknown>(ep.meeting(Number(meetingId)), { accessToken }),
+    );
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) return null;
+    throw error;
+  }
+}
+
 /**
  * 참석자 명단 교체(MEET-09) — **전체 명단 교체**다. `RoomReservation`의 참석자 피커를 그대로
  * 재사용하는 다이얼로그(`MeetingAttendeesEditDialog`)가 이 액션을 부른다.
@@ -52,7 +92,9 @@ function toAttendeesErrorMessage(error: unknown): string {
  *    AI 팀 액션 판단 근거가 똑같이 무너진다. 규칙은 `rooms/attendee-scope.ts` 한 곳이다.
  * ⚠️ 범위 기준은 **지금 보는 사람이 아니라 그 회의의 host**다 — `canManageMeeting`이 OWNER·Admin
  *    에게도 남의 회의 교체를 허용해서, actor로 재면 Owner가 남의 팀 회의를 열었을 때 규칙이
- *    "팀장만"으로 뒤바뀐다. 회의에 적힌 `hostAuthority`가 그 회의가 만들어질 때의 사실이다.
+ *    "팀장만"으로 뒤바뀐다. mock은 회의 레코드가 `hostAuthority`를 직접 들고 있어 그걸 쓰고,
+ *    실서버는 MEET-04 응답에 host의 role·team이 없어 actor===host면 세션 값을, 아니면
+ *    `getManagedMember`로 따로 구한다(아래 실서버 분기 주석).
  */
 export async function updateMeetingAttendeesAction(
   _prev: UpdateMeetingAttendeesState,
@@ -60,16 +102,27 @@ export async function updateMeetingAttendeesAction(
 ): Promise<UpdateMeetingAttendeesState> {
   const meetingId = String(formData.get("meetingId") ?? "");
   const attendeeIds = formData.getAll("attendeeIds").map(Number);
-  const actor = getMockActor();
+  /*
+    ⚠️ **실서버에서는 목 액터를 쓰지 않는다.** `getMockActor()`는 고정 OWNER를 돌려주는 목이라
+       실연동에서 그걸로 권한을 재면 "언제나 통과"가 된다 — 세션에서 읽는다(`rooms/actions.ts`와
+       같은 자리, CLAUDE.md §권한: 판정은 서버에서).
+  */
+  const actor = isMock ? getMockActor() : await getViewer();
 
   if (isMock) {
     const meeting = findMockMeeting(meetingId);
-    if (!meeting) return { error: "회의를 찾을 수 없습니다", attendeeIds: null };
+    if (!meeting) return { error: ATTENDEES_EDIT_ERROR.notFound, attendeeIds: null };
     if (!canManageMeeting(actor, { hostId: meeting.hostId })) {
-      return { error: "참석자를 바꿀 권한이 없습니다", attendeeIds: null };
+      return { error: ATTENDEES_EDIT_ERROR.forbidden, attendeeIds: null };
     }
-    if (meetingStatusOf(meeting, new Date()) === MEETING_STATUS.DONE) {
-      return { error: "끝난 회의는 참석자를 바꿀 수 없습니다", attendeeIds: null };
+    /*
+      ⚠️ 취소된 회의도 여기서 걸린다 — 명단을 고칠 자리가 아닌데 화면 계약에 아직 취소 문구가
+         없어서 "이미 끝난 회의"와 같은 자리로 보낸다(매퍼 `isClosed`와 같은 판단·같은 결과).
+         실서버 경로가 `isClosed`로 둘을 함께 막으므로, 목만 취소를 통과시키면 두 모드가 갈린다.
+    */
+    const status = meetingStatusOf(meeting, new Date());
+    if (status === MEETING_STATUS.DONE || status === MEETING_STATUS.CANCELED) {
+      return { error: ATTENDEES_EDIT_ERROR.closed, attendeeIds: null };
     }
 
     /*
@@ -100,19 +153,66 @@ export async function updateMeetingAttendeesAction(
   }
 
   const accessToken = await requireAccessToken();
+
+  const meeting = await fetchMeetingFacts(meetingId, accessToken);
+  if (!meeting) return { error: ATTENDEES_EDIT_ERROR.notFound, attendeeIds: null };
+  const hostId = hostIdOf(meeting);
+  if (!canManageMeeting(actor, { hostId })) {
+    return { error: ATTENDEES_EDIT_ERROR.forbidden, attendeeIds: null };
+  }
+  if (isClosed(meeting)) {
+    return { error: ATTENDEES_EDIT_ERROR.closed, attendeeIds: null };
+  }
+
+  /*
+    ⚠️ **참석자 서버 재검증** — `GET /api/members/my-team`이 붙으면서 대부분의 경로는 이제
+       실서버에서도 볼 수 있다(2026-08-13, `rooms/server.ts`의 `getReservableMembers`).
+    ⚠️ **범위 기준은 지금 보는 사람이 아니라 host다**(위 함수 주석). 두 경로로 갈린다:
+       - **host 자신이 고치는 보통 경로**: 세션에 이미 host의 role·team이 있다 — 그대로 쓴다.
+       - **OWNER·ADMIN이 남의 회의를 고치는 드문 경로**: `canManageMeeting`이 그걸 허용해서
+         생기는 경우다. 이 분기에 오려면 actor가 반드시 OWNER 아니면 ADMIN이므로,
+         OWNER·ADMIN 전용 API(`GET /api/members/{id}`, `getManagedMember`)로 host의
+         role·team을 따로 구해도 안전하다(actor 자신은 그 API를 부를 권한이 있다).
+    ⚠️ **딱 한 칸은 여기서도 못 본다 — 본 척하지 않는다**(§정직성). "OWNER·ADMIN이 다른
+       LEADER·MEMBER의 회의를 고치는" 경우, `GET /api/members/my-team`은 **호출자의 토큰**
+       으로 팀을 정하지 host의 팀이 아니다 — host의 팀 로스터를 이 API로는 구할 수 없다.
+       이 한 칸만 FE 검증을 건너뛰고 BE(`PUT /api/meetings/{id}/attendees`)가 최종 방어한다
+       — **아직 BE 요청 문서에 못 올렸다**, 다음 라운드에 올릴 것. UI는 애초에 이 경로로 못
+       들어온다(`canEditMeetingAttendees`가 `isHost`를 요구한다) — 직접 요청을 조작해야만
+       닿는 자리라 영향은 방어 심도 문제다.
+  */
+  let scopeActor: Actor | null;
+  if (actor.id === hostId) {
+    scopeActor = actor;
+  } else {
+    const hostDetail = await getManagedMember(hostId);
+    scopeActor = hostDetail
+      ? {
+          id: hostId,
+          role: hostDetail.member.authority,
+          teamName: hostDetail.member.teamName ?? undefined,
+        }
+      : null;
+  }
+
+  /*
+    ⚠️ Owner-호스트냐 아니냐는 `getReservableMembers`가 안에서 이미 가른다(`rooms/server.ts`)
+       — 여기서 또 나누지 않는다.
+  */
+  if (scopeActor) {
+    const roster = await getReservableMembers(scopeActor);
+    const rosterIds = new Set(roster.map((member) => member.id));
+    if (attendeeIds.some((id) => id !== hostId && !rosterIds.has(id))) {
+      return { error: "지정할 수 없는 참석자가 있습니다", attendeeIds: null };
+    }
+  }
+  // scopeActor가 null인 건 위 주석의 "한 칸"뿐이다 — BE가 마저 본다.
+
   try {
     /*
-      ⚠️ **참석자 범위는 여기서 못 본다 — 본 척하지 않는다**(§정직성). 명부(`getReservableMembers`)가
-         실연동에서 그대로 던지고, 명부 API도 권한별로 갈려 MEMBER는 자기 팀 명단을 볼 길이 없다
-         (`rooms/actions.ts`의 같은 자리 주석에 근거를 적어 뒀다). **최종 방어는 BE다** —
-         `PUT /api/meetings/{id}/attendees`는 [확인] 현재 존재·같은 회사만 보고 권한·팀은 전혀
-         안 본다(`MeetingAttendeeCommandService#findAndValidateMembers`). BE 요청 문서에 올린다.
-    */
-    /*
-      ⚠️ **여기서 host를 끼워 넣지 않는다.** 이 액션은 지금 보는 사람(`actor`)이 host인지
-      모른다(OWNER·Admin이 남의 회의를 고치는 경우도 있다, `canManageMeeting`) — "host 자동
-      포함·제거 불가"는 계약이 **서버 책임**이라고 명시한 규칙이라(MEET-09), FE가 잘못된
-      사람(지금 보는 사람)을 host로 끼워 넣으면 오히려 명단을 틀리게 만든다.
+      ⚠️ **여기서 host를 끼워 넣지 않는다.** "host 자동 포함·제거 불가"는 계약이 **서버 책임**
+         이라고 명시한 규칙이라(MEET-09), FE가 host를 직접 끼워 넣으면 오히려 명단을 틀리게
+         만든다 — 서버가 대신 채운다.
     */
     const response = await serverApi<BeUpdateAttendeesResponse>(
       ep.meetingAttendees(Number(meetingId)),

--- a/src/features/meeting/actions.ts
+++ b/src/features/meeting/actions.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 
+import { AUTHORITY } from "@/constants/authority";
 import { MEETING_STATUS } from "@/constants/meeting";
 import { requireAccessToken } from "@/features/auth/session";
 import { getManagedMember } from "@/features/member/manage-server";
@@ -170,34 +171,36 @@ export async function updateMeetingAttendeesAction(
     ⚠️ **범위 기준은 지금 보는 사람이 아니라 host다**(위 함수 주석). 두 경로로 갈린다:
        - **host 자신이 고치는 보통 경로**: 세션에 이미 host의 role·team이 있다 — 그대로 쓴다.
        - **OWNER·ADMIN이 남의 회의를 고치는 드문 경로**: `canManageMeeting`이 그걸 허용해서
-         생기는 경우다. 이 분기에 오려면 actor가 반드시 OWNER 아니면 ADMIN이므로,
-         OWNER·ADMIN 전용 API(`GET /api/members/{id}`, `getManagedMember`)로 host의
-         role·team을 따로 구해도 안전하다(actor 자신은 그 API를 부를 권한이 있다).
-    ⚠️ **딱 한 칸은 여기서도 못 본다 — 본 척하지 않는다**(§정직성). "OWNER·ADMIN이 다른
-       LEADER·MEMBER의 회의를 고치는" 경우, `GET /api/members/my-team`은 **호출자의 토큰**
-       으로 팀을 정하지 host의 팀이 아니다 — host의 팀 로스터를 이 API로는 구할 수 없다.
-       이 한 칸만 FE 검증을 건너뛰고 BE(`PUT /api/meetings/{id}/attendees`)가 최종 방어한다
-       — **아직 BE 요청 문서에 못 올렸다**, 다음 라운드에 올릴 것. UI는 애초에 이 경로로 못
-       들어온다(`canEditMeetingAttendees`가 `isHost`를 요구한다) — 직접 요청을 조작해야만
-       닿는 자리라 영향은 방어 심도 문제다.
+         생기는 경우다. host가 **OWNER**면 `getReservableMembers`가 회사 전체 팀장 명부
+         (`getTeamLeaders`, 호출자 무관)를 보므로 OWNER·ADMIN 전용 API(`GET /api/members/{id}`,
+         `getManagedMember`)로 host가 OWNER인지만 확인하면 그대로 검증해도 안전하다.
+    ⚠️ **host가 LEADER·MEMBER면 여기서도 못 본다 — 본 척하지 않는다**(§정직성). "OWNER·ADMIN이
+       다른 LEADER·MEMBER의 회의를 고치는" 경우 `GET /api/members/my-team`은 **호출자(actor)의
+       토큰**으로 팀을 정하지 host의 팀이 아니다 — `getReservableMembers`를 그대로 부르면
+       actor 자신의 팀 로스터가 와서 host 팀 기준 검증이 아니게 된다(범위를 잘못 잰다). 그래서
+       이 경우는 **FE 검증 자체를 건너뛰고** BE(`PUT /api/meetings/{id}/attendees`)가 최종
+       방어한다 — **아직 BE 요청 문서에 못 올렸다**, 다음 라운드에 올릴 것. UI는 애초에 이
+       경로로 못 들어온다(`canEditMeetingAttendees`가 `isHost`를 요구한다) — 직접 요청을
+       조작해야만 닿는 자리라 영향은 방어 심도 문제다.
   */
   let scopeActor: Actor | null;
   if (actor.id === hostId) {
     scopeActor = actor;
   } else {
     const hostDetail = await getManagedMember(hostId);
-    scopeActor = hostDetail
-      ? {
-          id: hostId,
-          role: hostDetail.member.authority,
-          teamName: hostDetail.member.teamName ?? undefined,
-        }
-      : null;
+    scopeActor =
+      hostDetail && hostDetail.member.authority === AUTHORITY.OWNER
+        ? {
+            id: hostId,
+            role: hostDetail.member.authority,
+            teamName: hostDetail.member.teamName ?? undefined,
+          }
+        : null;
   }
 
   /*
-    ⚠️ Owner-호스트냐 아니냐는 `getReservableMembers`가 안에서 이미 가른다(`rooms/server.ts`)
-       — 여기서 또 나누지 않는다.
+    ⚠️ scopeActor가 `null`인 건 "actor가 host가 아니고 host가 LEADER·MEMBER인" 경우다(host
+       정보를 못 구한 경우 포함) — 위 주석의 "한 칸", BE가 마저 본다.
   */
   if (scopeActor) {
     const roster = await getReservableMembers(scopeActor);
@@ -206,7 +209,6 @@ export async function updateMeetingAttendeesAction(
       return { error: "지정할 수 없는 참석자가 있습니다", attendeeIds: null };
     }
   }
-  // scopeActor가 null인 건 위 주석의 "한 칸"뿐이다 — BE가 마저 본다.
 
   try {
     /*

--- a/src/features/rooms/actions.real.test.ts
+++ b/src/features/rooms/actions.real.test.ts
@@ -1,0 +1,114 @@
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/mocks/config", () => ({ isMock: false }));
+jest.mock("@/features/auth/session", () => ({ requireAccessToken: jest.fn() }));
+jest.mock("@/features/shell/viewer", () => ({ getViewer: jest.fn() }));
+jest.mock("./server", () => ({ getReservableMembers: jest.fn() }));
+jest.mock("@/lib/api", () => ({
+  ApiError: class ApiError extends Error {
+    status: number;
+    code?: string;
+    constructor(status: number, message: string, code?: string) {
+      super(message);
+      this.status = status;
+      this.code = code;
+    }
+  },
+  serverApi: jest.fn(),
+}));
+
+import { AUTHORITY } from "@/constants/authority";
+import { requireAccessToken } from "@/features/auth/session";
+import { getViewer } from "@/features/shell/viewer";
+import { serverApi } from "@/lib/api";
+
+import { createRoomReservationAction } from "./actions";
+import { getReservableMembers } from "./server";
+
+/**
+ * 회의실 예약 생성 — **실서버 참석자 재검증**.
+ *
+ * ⚠️ 기존 `actions.test.ts`는 파일 전체가 `isMock: true`라 이 분기(2026-08-13에 새로 생김,
+ *    `GET /api/members/my-team` 연동)는 그쪽 어디서도 실행되지 않는다 — 별도 파일로 잠근다.
+ */
+
+const requireAccessTokenMock = requireAccessToken as unknown as jest.Mock;
+const getViewerMock = getViewer as unknown as jest.Mock;
+const getReservableMembersMock = getReservableMembers as unknown as jest.Mock;
+const serverApiMock = serverApi as unknown as jest.Mock;
+
+const LEADER = { id: 2, name: "김서준", role: AUTHORITY.LEADER, teamName: "개발팀" };
+
+/*
+  ⚠️ **LEADER는 `parentTeamActionId`가 형식상 필수다**(`validate.ts` — Owner만 면제된다).
+     실제 프로젝트·팀 소속 확인은 `actions.ts`가 별도로 하는데(이 테스트가 확인하려는 건
+     참석자 재검증이지 상위 팀 액션 존재 확인이 아니다), 실서버 분기는 그 확인을 아직
+     안 하고 그대로 BE로 보낸다(§핵심4원칙: BE가 최종 방어) — 형식만 채우면 통과한다.
+*/
+const VALID_ENTRIES: Record<string, string> = {
+  title: "새 회의",
+  roomId: "room-small-b",
+  date: "2026-08-11",
+  startTime: "13:00",
+  projectId: "1",
+  parentTeamActionId: "1",
+};
+
+function form(attendeeIds: number[]): FormData {
+  const data = new FormData();
+  for (const [key, value] of Object.entries(VALID_ENTRIES)) data.append(key, value);
+  for (const id of attendeeIds) data.append("attendeeIds", String(id));
+  data.append("topicMain", "제품");
+  data.append("topicSub", "로드맵 검토");
+  return data;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  requireAccessTokenMock.mockResolvedValue("token");
+  getViewerMock.mockResolvedValue(LEADER);
+  getReservableMembersMock.mockResolvedValue([
+    { id: 3, name: "박도현", teamName: "개발팀", authority: AUTHORITY.MEMBER },
+    { id: 4, name: "이서연", teamName: "개발팀", authority: AUTHORITY.MEMBER },
+  ]);
+  serverApiMock.mockResolvedValue({
+    meetingId: 10,
+    status: "SCHEDULED",
+    title: "새 회의",
+    startAt: "2026-08-11T13:00:00",
+    endAt: "2026-08-11T13:30:00",
+    recordingConsent: false,
+    meetingRoom: { meetingRoomId: 1, name: "소회의실 B", location: "3층" },
+    host: { memberId: LEADER.id, name: LEADER.name },
+    attendees: [],
+  });
+});
+
+describe("createRoomReservationAction — 실서버 참석자 재검증", () => {
+  it("명부(getReservableMembers) 안의 id만 제출하면 통과한다", async () => {
+    const result = await createRoomReservationAction({ errors: {} }, form([3, 4]));
+
+    expect(result.errors).toEqual({});
+    expect(result.created).toBeDefined();
+    expect(serverApiMock).toHaveBeenCalledTimes(1);
+  });
+
+  /*
+    ⚠️ 화면 피커는 명부 밖 id를 애초에 안 그리지만, Server Action은 주소만 알면 직접 부를 수
+       있다 — 조작된 제출은 BE를 부르기 **전에** 막아야 한다(§권한: 화면 숨김은 UX일 뿐).
+  */
+  it("명부 밖 id가 섞이면 BE를 부르지 않고 막는다", async () => {
+    const result = await createRoomReservationAction({ errors: {} }, form([3, 999]));
+
+    expect(result.errors.attendeeIds).toBeDefined();
+    expect(result.created).toBeUndefined();
+    expect(serverApiMock).not.toHaveBeenCalled();
+  });
+
+  /* ⚠️ host 자신이 섞여 있어도 막지 않는다 — BE가 알아서 다시 끼워 넣는 사람이라 무해하다 */
+  it("host 자신의 id가 섞여 있어도 막지 않는다", async () => {
+    const result = await createRoomReservationAction({ errors: {} }, form([LEADER.id, 3]));
+
+    expect(result.errors).toEqual({});
+    expect(serverApiMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/rooms/actions.ts
+++ b/src/features/rooms/actions.ts
@@ -27,6 +27,7 @@ import {
 import { findMockMember } from "./mock/members";
 import { addMockReservation, listMockReservationsByRoom } from "./mock/reservations";
 import { addMockRoom, deleteMockRoom, findMockRoom, updateMockRoom } from "./mock/rooms";
+import { getReservableMembers } from "./server";
 import type {
   MeetingRoom,
   MeetingRoomDraft,
@@ -161,22 +162,24 @@ export async function createRoomReservationAction(
 
   if (!isMock) {
     /*
-      ⚠️ **여기서는 참석자 범위를 검증하지 못한다 — 검증한 척하지 않는다**(§정직성, 2026-08-13).
-         규칙(Owner=팀장만 / Leader·Member=자기 팀만)을 서버에서 다시 보려면 **명부**가 있어야
-         하는데, 실서버 경로에는 명부를 가져올 길이 없다:
-           · `getReservableMembers()`(server.ts)가 실연동에서 그대로 던진다 — 사원 목록 API가
-             아직 이 화면에 안 붙었다.
-           · 붙는다 해도 명부 API가 권한별로 갈린다([확인] BE 실코드, §연동 검증):
-             `GET /api/members`는 `hasAnyRole('OWNER','ADMIN')`, `GET /api/team/members`는
-             `hasRole('LEADER')`다 — **MEMBER가 개설할 때 자기 팀 명단을 볼 엔드포인트가
-             아예 없다**(프로젝트·검색·회의 참석자 조회까지 훑어도 없다).
-           · `GET /api/team/members` 응답의 `roleName`은 **권한이 아니라 팀 안 역할 라벨**이라
-             "전원 팀장인가"를 그걸로 판정할 수 없다(§도메인 상수: 이름이 어긋나면 조용히 틀린다).
-      ⚠️ 그래서 **최종 방어는 BE(`POST /api/meetings`)다.** 참석자 범위 강제는 BE 요청 문서에
-         올린다 — FE 화면 필터·아래 목 검증은 어디까지나 그 앞단이다(§권한: 화면 숨김은 보안이
-         아니다 / §연동 검증). 명부를 구할 길이 생기면 목 분기와 **같은 함수**
-         (`findAttendeeScopeViolation`)를 여기서도 부른다.
+      ⚠️ **참석자 서버 재검증** — `GET /api/members/my-team`이 붙으면서 실서버에도 명부가
+         생겼다(2026-08-13, `getReservableMembers`). 화면 피커가 후보를 좁혀 보여줘도 Server
+         Action은 주소만 알면 직접 부를 수 있어, 제출된 id가 이 개설자 범위 안인지 여기서
+         다시 본다(§권한: 화면 숨김은 UX일 뿐).
+      ⚠️ **"존재하지 않음"과 "범위 밖"을 갈라 말하지 않는다**(§정직성). `getReservableMembers`가
+         돌려주는 명부는 **이미 이 개설자 범위로 걸러져 있다**(Owner=팀별 리더, Leader·Member=
+         자기 팀) — 거기 없는 id는 다른 회사 사람이든 범위 밖 동료든 이 요청에서는 똑같이
+         못 쓰는 값이라, 원인을 지어내 나누지 않고 한 문장으로 막는다.
+      ⚠️ **최종 방어는 여전히 BE(`POST /api/meetings`)다.** 여기서 걸러도 폼을 안 거치고
+         API를 직접 호출하면 이 검사 자체가 안 돈다 — BE `MeetingAttendeeCommandService`가
+         스스로 다시 봐야 한다(아직 BE 요청 문서에 못 올렸다, 다음 라운드에 올릴 것).
     */
+    const roster = await getReservableMembers(actor);
+    const rosterIds = new Set(roster.map((member) => member.id));
+    if (draft.attendeeIds.some((id) => id !== actor.id && !rosterIds.has(id))) {
+      return { errors: { attendeeIds: "지정할 수 없는 참석자가 있습니다" } };
+    }
+
     const range = toReservedRange(draft);
     const accessToken = await requireAccessToken();
     try {

--- a/src/features/rooms/server.test.ts
+++ b/src/features/rooms/server.test.ts
@@ -1,0 +1,85 @@
+jest.mock("@/mocks/config", () => ({ isMock: false }));
+jest.mock("@/features/auth/session", () => ({ requireAccessToken: jest.fn() }));
+jest.mock("@/features/member/manage-server", () => ({ getTeamLeaders: jest.fn() }));
+jest.mock("@/lib/api", () => ({
+  ApiError: class ApiError extends Error {},
+  serverApi: jest.fn(),
+}));
+
+import { AUTHORITY } from "@/constants/authority";
+import { requireAccessToken } from "@/features/auth/session";
+import { getTeamLeaders } from "@/features/member/manage-server";
+import { serverApi } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
+import type { Actor } from "@/lib/permission";
+
+import { getReservableMembers } from "./server";
+
+/**
+ * 참석자 후보 명부 — **실서버 분기가 Owner와 Leader·Member에서 다른 API를 부른다.**
+ *
+ * ⚠️ Owner는 팀이 없어 `/api/members/my-team`이 빈 배열만 준다(BE 확인) — 그래서 이 분기는
+ *    아예 그 API를 안 부르고 `getTeamLeaders()`로 간다. 실수로 두 분기가 뒤섞이면 Owner
+ *    화면의 참석자 후보가 조용히 텅 빈다.
+ */
+
+const requireAccessTokenMock = requireAccessToken as unknown as jest.Mock;
+const getTeamLeadersMock = getTeamLeaders as unknown as jest.Mock;
+const serverApiMock = serverApi as unknown as jest.Mock;
+
+const OWNER: Actor = { id: 1, role: AUTHORITY.OWNER };
+const LEADER: Actor = { id: 2, role: AUTHORITY.LEADER, teamName: "개발팀" };
+const MEMBER: Actor = { id: 3, role: AUTHORITY.MEMBER, teamName: "개발팀" };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  requireAccessTokenMock.mockResolvedValue("token");
+});
+
+describe("getReservableMembers — 실서버", () => {
+  it("Owner는 팀별 리더 조회(getTeamLeaders)로 후보를 만든다 — my-team API는 안 부른다", async () => {
+    getTeamLeadersMock.mockResolvedValue(
+      new Map([
+        ["개발팀", { id: 2, name: "김서준" }],
+        ["마케팅팀", { id: 5, name: "최유진" }],
+      ]),
+    );
+
+    const members = await getReservableMembers(OWNER);
+
+    expect(members).toEqual([
+      { id: 2, name: "김서준", teamName: "개발팀", authority: AUTHORITY.LEADER },
+      { id: 5, name: "최유진", teamName: "마케팅팀", authority: AUTHORITY.LEADER },
+    ]);
+    expect(serverApiMock).not.toHaveBeenCalled();
+  });
+
+  it("Leader·Member는 /api/members/my-team을 부르고 자기 팀 이름을 붙인다", async () => {
+    serverApiMock.mockResolvedValue([
+      { memberId: 2, name: "김서준" },
+      { memberId: 4, name: "박도현" },
+    ]);
+
+    const members = await getReservableMembers(LEADER);
+
+    expect(serverApiMock).toHaveBeenCalledWith(
+      ep.membersMyTeam(),
+      expect.objectContaining({ accessToken: "token" }),
+    );
+    expect(members).toEqual([
+      { id: 2, name: "김서준", teamName: "개발팀", authority: AUTHORITY.MEMBER },
+      { id: 4, name: "박도현", teamName: "개발팀", authority: AUTHORITY.MEMBER },
+    ]);
+    expect(getTeamLeadersMock).not.toHaveBeenCalled();
+  });
+
+  it("Member도 같은 API를 쓴다 — LEADER와 갈릴 이유가 없다(둘 다 자기 팀 로스터)", async () => {
+    serverApiMock.mockResolvedValue([{ memberId: 3, name: "이서연" }]);
+
+    const members = await getReservableMembers(MEMBER);
+
+    expect(members).toEqual([
+      { id: 3, name: "이서연", teamName: "개발팀", authority: AUTHORITY.MEMBER },
+    ]);
+  });
+});

--- a/src/features/rooms/server.ts
+++ b/src/features/rooms/server.ts
@@ -2,7 +2,9 @@ import "server-only";
 
 import { addDays, format, startOfWeek } from "date-fns";
 
+import { AUTHORITY } from "@/constants/authority";
 import { requireAccessToken } from "@/features/auth/session";
+import { getTeamLeaders } from "@/features/member/manage-server";
 import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
 import { PROJECT_TEAM_ACTIONS_MOCK } from "@/features/project/mock/team-actions";
 import { ApiError, serverApi } from "@/lib/api";
@@ -135,9 +137,49 @@ export async function getMeetingRooms(): Promise<MeetingRoom[]> {
   return meetingRooms.map(toMeetingRoom);
 }
 
-export async function getReservableMembers(): Promise<RoomMember[]> {
+/**
+ * 참석자 후보 명부 — **범위가 회사 전체가 아니라 개설자 권한별로 갈린다**(`attendee-scope.ts`).
+ * 화면(피커)이 `filterAttendeeCandidates`로 다시 거르므로 여기서는 "그 축을 채울 수 있는
+ * 명부"만 구하면 된다.
+ *
+ * ⚠️ **Owner와 Leader·Member는 API가 다르다.**
+ *    - Leader·Member: `GET /api/members/my-team`(자기 팀 로스터, ACTIVE만) — 토큰의
+ *      `teamId`로 범위가 자동으로 잡힌다.
+ *    - Owner: 이 엔드포인트는 팀이 없는 Owner에게 **빈 배열**을 돌려준다(BE 확인) — 대신
+ *      팀마다 리더 한 명을 세는 `getTeamLeaders()`(`ep.teams()`)를 그대로 쓴다. Owner가
+ *      고를 수 있는 후보가 정확히 "팀별 리더"라, 이미 있는 함수와 목적이 같다.
+ * ⚠️ **`authority` 필드는 두 갈래 다 정확하지 않을 수 있다.** `isAttendeeInScope`가 Leader·
+ *    Member 분기에서는 `teamName`만 보고 `authority`를 안 읽으므로(코드 참고) 문제가 안 된다 —
+ *    Owner 분기에서만 `authority===LEADER`가 실제로 걸리는데, `getTeamLeaders()`가 주는
+ *    사람은 정의상 전부 리더라 항상 참이다.
+ */
+export async function getReservableMembers(actor: Actor): Promise<RoomMember[]> {
   if (isMock) return listMockMembers();
-  throw new Error("사원 목록 조회 API가 아직 연결되지 않았습니다.");
+
+  if (actor.role === AUTHORITY.OWNER) {
+    const leaders = await getTeamLeaders();
+    return Array.from(leaders.entries()).map(([teamName, leader]) => ({
+      id: leader.id,
+      name: leader.name,
+      teamName,
+      authority: AUTHORITY.LEADER,
+    }));
+  }
+
+  const accessToken = await requireAccessToken();
+  const roster = await serverApi<{ memberId: number; name: string }[]>(ep.membersMyTeam(), {
+    accessToken,
+  });
+  return roster.map((row) => ({
+    id: row.memberId,
+    name: row.name,
+    teamName: actor.teamName ?? null,
+    /*
+      ⚠️ 실제 값이 아니다 — 이 분기(Leader·Member)의 범위 판정은 `teamName`만 보고 이 필드는
+         읽지 않는다(`attendee-scope.ts`). 타입을 채우기 위한 자리표시자다.
+    */
+    authority: AUTHORITY.MEMBER,
+  }));
 }
 
 /** 예약 폼의 "프로젝트" select용 — 프로젝트 도메인의 전체 목록에서 경량 필드만 골라 낸다. */

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -343,6 +343,17 @@ export const ep = {
   member: (id: number) => `/api/members/${id}`,
   /** 조직도 — OWNER·ADMIN 전용 */
   memberOrgChart: () => "/api/members/org-chart",
+  /**
+   * 내 팀 로스터 — 회의 참석자 픽커 전용(`/api/members`와 다르다, 그건 관리 화면용).
+   * 응답은 `{memberId, name}[]`, ACTIVE만, 본인도 포함(제외는 FE 몫) — 팀은 **토큰의 teamId**로
+   * 정해져 파라미터로 안 보낸다. 팀이 없으면(OWNER) 빈 배열이지 오류가 아니다.
+   * [확인] BE `MemberController.myTeamRoster` / `MemberDirectoryService.getTeamRoster`
+   * (identity/member 도메인) — 2026-08-13 BE 레포 실코드 대조.
+   * ⚠️ 역할 게이트는 `hasAnyRole('OWNER','ADMIN','LEADER','MEMBER')`로 전부 열려 있지만,
+   *    OWNER는 토큰에 teamId가 없어 호출해도 빈 배열만 온다 — 그래서 Owner 쪽 참석자 후보는
+   *    이 API가 아니라 팀별 리더 조회(`getTeamLeaders`, `ep.teams()`)로 따로 구한다.
+   */
+  membersMyTeam: () => "/api/members/my-team",
   /** 오너 대시보드 KPI(전체 사원·휴직자) — [확인] PR #385 머지 완료, OWNER 전용 */
   memberDashboardSummary: () => "/api/members/dashboard-summary",
   /** 팀장 현황(이름·이메일·팀·재직상태·휴직기간) — [확인] PR #385 머지 완료, OWNER 전용 */


### PR DESCRIPTION
## 📋 PR 타입

> 해당하는 타입을 선택해 주세요 (복수 선택 가능)

- [ ] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- 회의실 예약(개설)·참석자 명단 교체(MEET-09) 실서버 분기 모두에서 참석자 후보를 `getReservableMembers()`로 재검증한다.
  - Owner 호스트 → `getTeamLeaders()`(팀장만)
  - Leader/Member 호스트 → `GET /api/members/my-team`(자기 팀만)
- `attendee-scope.ts`(#452) 규칙을 실서버 경로에도 동일하게 적용 — 지금까지는 mock 분기에만 걸려 있었다.
- 참석자 교체는 host 기준으로 범위를 잰다(actor가 OWNER/ADMIN으로 남의 회의를 고치는 드문 경로는 `getManagedMember`로 host 정보를 따로 구함). host 정보를 못 구하는 한 칸(OWNER/ADMIN이 다른 팀 회의를 고칠 때 그 팀 로스터를 볼 API가 아직 없음)은 FE 검증을 건너뛰고 BE가 최종 방어 — 주석에 명시.
- 원래 같은 브랜치의 PR이 이 커밋들이 push되기 전 커밋으로 이미 머지되어, 이 수정이 `develop`에 반영되지 않은 채로 브랜치/PR이 닫혔다. `origin/develop` 실제 코드를 확인해 누락을 재확인했고, 같은 작업을 새 브랜치로 재제출한다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**(회의 담당자 등), 그리고 **서버(Server Action/BFF)에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [x] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시 (조용히 "되는 척" 금지)
- [ ] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그)
- [ ] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [ ] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인)
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음

---

## 🔗 연관 이슈

Closes #444

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

- OWNER/ADMIN이 다른 팀 회의를 고치는 드문 경로에서 host 정보를 못 구하는 칸 — FE 검증을 건너뛰고 BE가 최종 방어한다는 주석이 실제로 남아 있는지
- 회의실 개설·참석자 교체 양쪽 실서버 분기가 `attendee-scope.ts` 규칙과 동일하게 동작하는지

---

## 📝 추가 메모

- `npx tsc --noEmit` / `npx eslint <변경 파일> --max-warnings=0` / `npx jest --silent` / `npx next build` 전부 통과
- `src/features/rooms/actions.real.test.ts`, `src/features/meeting/actions.attendees-real.test.ts`, `src/features/rooms/server.test.ts`로 실서버 분기 회귀 확인
