### PR TITLE
[FIX] 사원 관리·기업 설정의 연동 결함 둘을 고친다 #453

### DIFF
--- a/src/features/auth/components/address-picker.tsx
+++ b/src/features/auth/components/address-picker.tsx
@@ -4,10 +4,11 @@ import { Check, MapPin, Search } from "lucide-react";
 import Script from "next/script";
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { EmptyState } from "@/components/common/empty-state";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 
-import type { PickedPlace } from "../register-draft";
+import { hasPinnedCoords, type PickedPlace } from "../register-draft";
 import { type KakaoPlace, readKakao } from "./kakao-sdk";
 
 /**
@@ -85,7 +86,8 @@ export function AddressPicker({
   const drawPin = useCallback(
     (container: HTMLDivElement | null) => {
       const kakao = readKakao();
-      if (!kakao || !container || !picked) return;
+      /* ⚠️ 좌표가 없으면(0,0) 그리지 않는다 — 아래에서 상자째 안 붙지만 판정은 여기도 둔다 */
+      if (!kakao || !container || !hasPinnedCoords(picked)) return;
 
       const center = new kakao.maps.LatLng(picked.lat, picked.lng);
       const map = new kakao.maps.Map(container, { center, level: 4 });
@@ -287,19 +289,42 @@ export function AddressPicker({
                `readKakao()`가 아직 `null`이다 — 그대로 두면 **빈 상자가 영영 남는다.**
                상태가 `ready`로 바뀌면 상자가 새로 붙으면서 콜백이 한 번 더 돈다.
           */}
-          <div
-            key={`${loadState}:${picked.lat},${picked.lng}`}
-            ref={drawPin}
-            /*
+          {/*
+            ⚠️ **좌표가 없으면 지도를 아예 안 그린다.** 지도를 못 쓴 채 저장된 회사는 주소만
+               있고 좌표가 `0,0`인데, 그대로 그리면 **맞는 주소 아래 기니만 앞바다에 핀**이
+               꽂혀 위치가 등록된 것처럼 읽힌다(§정직성 — 없는 걸 있는 것처럼 그리지 않는다).
+            ⚠️ 자리는 비워도 **높이는 지도와 같게** 둔다 — 안 그러면 좌표 유무에 따라 카드가
+               껑충 줄었다 늘어 옆 칸까지 밀린다.
+          */}
+          {!hasPinnedCoords(picked) ? (
+            <div
+              className={cn(
+                "border-border flex items-center justify-center overflow-hidden rounded-lg border",
+                mapClassName,
+              )}
+            >
+              <EmptyState
+                icon={MapPin}
+                title="지도 위치가 등록되지 않았습니다"
+                description="주소만 저장돼 있습니다. 위에서 다시 찾아 고르면 지도에 표시됩니다."
+                className="px-4 py-0"
+              />
+            </div>
+          ) : (
+            <div
+              key={`${loadState}:${picked.lat},${picked.lng}`}
+              ref={drawPin}
+              /*
               ⚠️ `aria-hidden`이 아니라 `inert`다. 지도 안에는 카카오 SDK가 만든 버튼·링크가
                  들어 있어서, `aria-hidden`만 걸면 **읽히지는 않는데 탭으로는 들어가진다** —
                  스크린리더 사용자가 이름 없는 것들 사이에 갇힌다. `inert`는 포커스까지 뺀다.
               ⚠️ 지도를 실제로 조작하게 둘 생각이면 반대로 `inert`를 떼고 이름을 줘야 한다.
                  지금은 **고른 곳을 눈으로 확인하는 그림**이라 빼는 게 맞다.
             */
-            inert
-            className={cn("border-border w-full overflow-hidden rounded-lg border", mapClassName)}
-          />
+              inert
+              className={cn("border-border w-full overflow-hidden rounded-lg border", mapClassName)}
+            />
+          )}
         </>
       )}
 

--- a/src/features/auth/register-draft.test.ts
+++ b/src/features/auth/register-draft.test.ts
@@ -1,4 +1,4 @@
-import { type RegisterDraft, validateRegister } from "./register-draft";
+import { hasPinnedCoords, type RegisterDraft, validateRegister } from "./register-draft";
 
 /**
  * 기업 등록 신청서 검증.
@@ -64,5 +64,28 @@ describe("validateRegister", () => {
   it("좌표가 없어도 주소만 있으면 통과한다", () => {
     const typed = { ...FILLED, place: { address: "서울 어딘가", lat: 0, lng: 0 } };
     expect(validateRegister(typed).place).toBeUndefined();
+  });
+});
+
+/*
+ * ⚠️ 저장(`company/mapper.ts`)과 그리는 쪽(`AddressPicker`)이 **같은 판정**을 써야 한다
+ *    (`hasPinnedCoords` 주석) — 저장에서만 0,0을 걸렀더니 화면은 기니만 앞바다에 핀을
+ *    그렸다. 판정 자체는 여기서 한 번만 검증하고, 두 호출부는 이 함수를 그대로 쓴다.
+ */
+describe("hasPinnedCoords — 0,0은 좌표가 아니라 '못 썼다'는 표기다", () => {
+  it("0,0이면 못 꽂은 것으로 본다", () => {
+    expect(hasPinnedCoords({ address: "서울 어딘가", lat: 0, lng: 0 })).toBe(false);
+  });
+
+  it("null이면 애초에 고른 적이 없다", () => {
+    expect(hasPinnedCoords(null)).toBe(false);
+  });
+
+  it("둘 중 하나만 0이어도 실제 좌표로 본다 — 기니만이 아닌 이상 우연히 0이 될 수 있다", () => {
+    expect(hasPinnedCoords({ address: "적도 어딘가", lat: 0, lng: 127 })).toBe(true);
+  });
+
+  it("실제 좌표는 꽂힌 것으로 본다", () => {
+    expect(hasPinnedCoords({ address: "서울 강남구", lat: 37.5, lng: 127 })).toBe(true);
   });
 });

--- a/src/features/auth/register-draft.ts
+++ b/src/features/auth/register-draft.ts
@@ -72,6 +72,18 @@ export type PickedPlace = z.infer<typeof placeSchema>;
 export type RegisterErrors = Partial<Record<keyof RegisterDraft, string>>;
 
 /**
+ * 지도에 꽂을 좌표가 실제로 있는지.
+ *
+ * ⚠️ **`0,0`은 좌표가 아니라 "지도를 못 썼다"는 표기다**(키 없음·SDK 차단 — 위 `placeSchema`
+ *    주석). 기니만 앞바다라 그대로 믿으면 **맞는 주소 아래에 틀린 핀**이 꽂힌다.
+ * ⚠️ **보내는 쪽과 그리는 쪽이 같은 판정을 쓴다.** 저장에서만 걸렀더니 좌표 없는 회사의
+ *    기업 설정 화면이 0,0에 핀을 꽂았다 — 없는 걸 있는 것처럼 그리지 않는다(§정직성).
+ */
+export function hasPinnedCoords(place: PickedPlace | null): place is PickedPlace {
+  return place !== null && (place.lat !== 0 || place.lng !== 0);
+}
+
+/**
  * 화면이 쓰는 모양(칸별 오류 한 줄)으로 옮긴다.
  *
  * ⚠️ `parse`가 아니라 `safeParse`다 — 검증 실패는 예외가 아니라 **정상적인 결과**다.

--- a/src/features/company/mapper.ts
+++ b/src/features/company/mapper.ts
@@ -1,3 +1,4 @@
+import { hasPinnedCoords } from "@/features/auth/register-draft";
 import type { AssignableRole } from "@/features/onboarding/types";
 
 import type { CompanyProfile, CompanyProfileDraft, DepartmentNode, Position } from "./types";
@@ -100,7 +101,8 @@ export interface BeCompanyUpdateBody {
  */
 export function toCompanyUpdateBody(draft: CompanyProfileDraft): BeCompanyUpdateBody {
   const place = draft.place?.address ? draft.place : null;
-  const hasPin = place !== null && (place.lat !== 0 || place.lng !== 0);
+  /* ⚠️ 판정은 `hasPinnedCoords` 한 곳이다 — 그리는 쪽(`AddressPicker`)과 같은 규칙을 써야 한다 */
+  const hasPin = hasPinnedCoords(place);
   return {
     name: draft.name,
     businessNumber: draft.businessNumber,

--- a/src/features/member/manage-actions.role-label.test.ts
+++ b/src/features/member/manage-actions.role-label.test.ts
@@ -1,0 +1,183 @@
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/mocks/config", () => ({ isMock: false }));
+jest.mock("@/features/shell/viewer", () => ({ getViewer: jest.fn() }));
+jest.mock("@/features/auth/session", () => ({ requireAccessToken: jest.fn() }));
+jest.mock("@/features/company/server", () => ({ getCompanyOrg: jest.fn() }));
+jest.mock("@/features/member/manage-server", () => ({ getManagedMember: jest.fn() }));
+jest.mock("@/lib/api", () => ({
+  serverApi: jest.fn().mockResolvedValue(undefined),
+  toUserMessage: jest.fn((error: unknown) => String(error)),
+}));
+
+import { AUTHORITY } from "@/constants/authority";
+import { requireAccessToken } from "@/features/auth/session";
+import { getCompanyOrg } from "@/features/company/server";
+import { getViewer } from "@/features/shell/viewer";
+import { serverApi } from "@/lib/api";
+
+import { changeMemberGradeAction } from "./manage-actions";
+import { getManagedMember } from "./manage-server";
+import type { ManagedMember } from "./manage-types";
+
+/**
+ * 실서버 분기(`isMock: false`)에서 `PATCH /api/members/{id}`로 나가는 요청 본문 — 특히
+ * `roleLabel`.
+ *
+ * ⚠️ **왜 따로 판다.** 기존 `manage-actions.test.ts`는 파일 전체가 `isMock: true`로
+ *    고정돼 있어(모듈 스코프 `jest.mock`), 실서버로 나가는 요청 본문은 그 파일 어디서도
+ *    실행되지 않는다 — `roleLabel`을 매번 실어 보내던 버그가 타입 에러 하나로만 드러났고
+ *    실행 경로로는 한 번도 검증되지 않았다.
+ * ⚠️ **바뀐 게 아니면 필드째 뺀다**(`manage-actions.ts` 주석). BE는 `null`(필드 없음)을
+ *    "안 바꾼다"로 읽고 빈 문자열은 400을 낸다 — 매 요청에 값을 실으면 직급만 고쳐도
+ *    역할이 함께 써진다(2026-08-13 재발 확인).
+ */
+
+const getViewerMock = getViewer as unknown as jest.Mock;
+const getCompanyOrgMock = getCompanyOrg as unknown as jest.Mock;
+const getManagedMemberMock = getManagedMember as unknown as jest.Mock;
+const requireAccessTokenMock = requireAccessToken as unknown as jest.Mock;
+const serverApiMock = serverApi as unknown as jest.Mock;
+
+const OWNER = { id: 1, name: "박대표", role: AUTHORITY.OWNER, isAdmin: false };
+
+function memberOf(overrides: Partial<ManagedMember>): ManagedMember {
+  return {
+    id: 4,
+    name: "박도현",
+    email: "dohyun@zgroup.co.kr",
+    /*
+      ⚠️ 팀은 있어야 `isRoleOfTeam`이 실제로 검사한다. `findTeamLeaderClash`는 권한이
+         안 바뀌면(이 테스트들은 authority를 그대로 둔다) `getTeamLeaders()`를 안 불러
+         팀이 있어도 추가 목 설정이 필요 없다.
+    */
+    teamName: "제품팀",
+    position: "사원",
+    authority: AUTHORITY.MEMBER,
+    isAdmin: false,
+    roleLabel: "프론트엔드",
+    status: "ACTIVE" as ManagedMember["status"],
+    joinedAt: "2026-01-01",
+    pendingHandoverType: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  getViewerMock.mockResolvedValue(OWNER);
+  getCompanyOrgMock.mockResolvedValue({
+    departments: [
+      {
+        id: "team-1",
+        name: "제품팀",
+        children: [
+          { id: "role-1", name: "프론트엔드", children: [] },
+          { id: "role-2", name: "백엔드", children: [] },
+        ],
+      },
+    ],
+    positions: [{ id: 10, name: "사원" }],
+  });
+  requireAccessTokenMock.mockResolvedValue("token");
+  serverApiMock.mockResolvedValue(undefined);
+});
+
+describe("changeMemberGradeAction — 실서버 요청 본문의 roleLabel", () => {
+  it("역할을 안 바꾸면 요청에 roleLabel 키 자체가 없다", async () => {
+    getManagedMemberMock.mockResolvedValue({
+      member: memberOf({ roleLabel: "프론트엔드" }),
+      actions: [],
+      pendingHandover: null,
+    });
+
+    const result = await changeMemberGradeAction(4, {
+      position: "사원",
+      authority: AUTHORITY.MEMBER,
+      isAdmin: false,
+      roleLabel: "프론트엔드",
+    });
+
+    expect(result.isSuccess).toBe(true);
+    const [, options] = serverApiMock.mock.calls[0]!;
+    expect(options.json).not.toHaveProperty("roleLabel");
+  });
+
+  it("roleLabel을 아예 안 넘겨도(직급만 고친 저장) 키가 없다", async () => {
+    getManagedMemberMock.mockResolvedValue({
+      member: memberOf({ roleLabel: "프론트엔드" }),
+      actions: [],
+      pendingHandover: null,
+    });
+
+    await changeMemberGradeAction(4, {
+      position: "사원",
+      authority: AUTHORITY.MEMBER,
+      isAdmin: false,
+    });
+
+    const [, options] = serverApiMock.mock.calls[0]!;
+    expect(options.json).not.toHaveProperty("roleLabel");
+  });
+
+  it("역할을 실제로 바꾸면 그 값을 싣는다", async () => {
+    getManagedMemberMock.mockResolvedValue({
+      member: memberOf({ roleLabel: "프론트엔드" }),
+      actions: [],
+      pendingHandover: null,
+    });
+
+    const result = await changeMemberGradeAction(4, {
+      position: "사원",
+      authority: AUTHORITY.MEMBER,
+      isAdmin: false,
+      roleLabel: "백엔드",
+    });
+
+    expect(result.isSuccess).toBe(true);
+    const [, options] = serverApiMock.mock.calls[0]!;
+    expect(options.json).toMatchObject({ roleLabel: "백엔드" });
+  });
+
+  /*
+    ⚠️ **비우기는 막지 않는다** — `team-roles.ts`의 `toBeRoleLabel`이 빈 값을 BE의 실제
+       시스템 행 `"없음"`으로 바꿔 보내는, 이미 해결된 길이다. 여기서 막으면 한 번 역할을
+       단 사람은 그 뒤로 영영 못 뗀다(2026-08-13 회귀 — 앞선 수정이 이 경로를 잘못 읽고
+       "비울 수 없습니다" 오류로 통째로 잠갔었다).
+  */
+  it("역할을 빈 값으로 바꾸면 '없음'을 실어 보낸다 — 비우기는 이미 되는 길이다", async () => {
+    getManagedMemberMock.mockResolvedValue({
+      member: memberOf({ roleLabel: "프론트엔드" }),
+      actions: [],
+      pendingHandover: null,
+    });
+
+    const result = await changeMemberGradeAction(4, {
+      position: "사원",
+      authority: AUTHORITY.MEMBER,
+      isAdmin: false,
+      roleLabel: "",
+    });
+
+    expect(result.isSuccess).toBe(true);
+    const [, options] = serverApiMock.mock.calls[0]!;
+    expect(options.json).toMatchObject({ roleLabel: "없음" });
+  });
+
+  it("이미 역할이 없는 사람에게 빈 값을 다시 보내면(안 바뀜) 키 자체를 안 싣는다", async () => {
+    getManagedMemberMock.mockResolvedValue({
+      member: memberOf({ roleLabel: null }),
+      actions: [],
+      pendingHandover: null,
+    });
+
+    await changeMemberGradeAction(4, {
+      position: "사원",
+      authority: AUTHORITY.MEMBER,
+      isAdmin: false,
+      roleLabel: "",
+    });
+
+    const [, options] = serverApiMock.mock.calls[0]!;
+    expect(options.json).not.toHaveProperty("roleLabel");
+  });
+});

--- a/src/features/member/manage-actions.role-label.test.ts
+++ b/src/features/member/manage-actions.role-label.test.ts
@@ -180,4 +180,29 @@ describe("changeMemberGradeAction — 실서버 요청 본문의 roleLabel", () 
     const [, options] = serverApiMock.mock.calls[0]!;
     expect(options.json).not.toHaveProperty("roleLabel");
   });
+
+  /*
+    ⚠️ 조회값이 `null`이 아니라 **문자열 `"없음"`으로 오는 경우**를 따로 검증한다 — 저장할 때
+       `toBeRoleLabel`이 빈 값을 `"없음"`으로 바꿔 보내므로, 이미 비워 둔 사람은 다음 조회에서
+       `roleLabel`이 `null`이 아니라 `"없음"` 문자열로 돌아온다(`manage-mapper.ts`는 빈 문자열만
+       `null`로 되돌리고 `"없음"`은 그대로 둔다). 요청 값 `""`과 비교할 때 이 정규화가 없으면
+       실제로는 안 바뀐 값을 바뀌었다고 오판해 불필요한 PATCH가 나간다(2026-08-14 회귀).
+  */
+  it("기존 값이 문자열 '없음'이고 빈 값을 다시 보내면(안 바뀜) 키 자체를 안 싣는다", async () => {
+    getManagedMemberMock.mockResolvedValue({
+      member: memberOf({ roleLabel: "없음" }),
+      actions: [],
+      pendingHandover: null,
+    });
+
+    await changeMemberGradeAction(4, {
+      position: "사원",
+      authority: AUTHORITY.MEMBER,
+      isAdmin: false,
+      roleLabel: "",
+    });
+
+    const [, options] = serverApiMock.mock.calls[0]!;
+    expect(options.json).not.toHaveProperty("roleLabel");
+  });
 });

--- a/src/features/member/manage-actions.test.ts
+++ b/src/features/member/manage-actions.test.ts
@@ -70,7 +70,6 @@ describe("권한 — 화면과 승인이 갈린다", () => {
         position: "선임",
         authority: AUTHORITY.MEMBER,
         isAdmin: false,
-        roleLabel: "",
       }),
     ).toEqual({ isSuccess: true });
 
@@ -86,7 +85,6 @@ describe("권한 — 화면과 승인이 갈린다", () => {
         position: "선임",
         authority: AUTHORITY.MEMBER,
         isAdmin: false,
-        roleLabel: "",
       }),
     ).toMatchObject({ isSuccess: false });
     expect(await issueAccountAction(DRAFT)).toMatchObject({ message: expect.any(String) });
@@ -113,7 +111,6 @@ describe("changeMemberGradeAction", () => {
       position: "사원",
       authority: AUTHORITY.OWNER,
       isAdmin: false,
-      roleLabel: "",
     });
 
     expect(result.isSuccess).toBe(false);
@@ -125,7 +122,6 @@ describe("changeMemberGradeAction", () => {
       position: "  ",
       authority: AUTHORITY.MEMBER,
       isAdmin: false,
-      roleLabel: "",
     });
 
     expect(result.isSuccess).toBe(false);
@@ -137,7 +133,6 @@ describe("changeMemberGradeAction", () => {
       position: "선임",
       authority: AUTHORITY.MEMBER,
       isAdmin: true,
-      roleLabel: "",
     });
 
     const after = findMockManagedMember(4)?.member;
@@ -157,7 +152,6 @@ describe("changeMemberGradeAction", () => {
       position: "팀장",
       authority: AUTHORITY.LEADER,
       isAdmin: true,
-      roleLabel: "",
     });
 
     expect(result.isSuccess).toBe(false);
@@ -174,7 +168,6 @@ describe("changeMemberGradeAction", () => {
       position: "사원",
       authority: AUTHORITY.MEMBER,
       isAdmin: false,
-      roleLabel: "",
     });
 
     expect(result.isSuccess).toBe(false);
@@ -193,7 +186,6 @@ describe("팀당 리더 한 명", () => {
       position: "팀장",
       authority: AUTHORITY.LEADER,
       isAdmin: false,
-      roleLabel: "",
     });
 
     expect(result.isSuccess).toBe(false);
@@ -205,7 +197,6 @@ describe("팀당 리더 한 명", () => {
       position: "선임",
       authority: AUTHORITY.MEMBER,
       isAdmin: false,
-      roleLabel: "",
     });
 
     expect(result.isSuccess).toBe(false);

--- a/src/features/member/manage-actions.ts
+++ b/src/features/member/manage-actions.ts
@@ -96,9 +96,23 @@ async function gate(
  */
 const PEOPLE_PATH = "/app/people";
 
+/**
+ * 직급·권한(·역할) 변경.
+ *
+ * ⚠️ **`roleLabel`은 안 보내면 "안 바꾼다"다**(부분 수정). 화면이 늘 값을 실어 보내던 때는
+ *    직급 하나만 고쳐도 역할이 함께 써졌다 — 게다가 라이브에서는 팀 역할 목록이 비어 있어
+ *    셀렉트가 잠기므로, 실어 보낼 수 있는 값이 **사용자가 건드린 적도 없는 빈 값** 하나였다.
+ *    사용자가 고르지 않은 값을 저장하지 않는다.
+ */
 export async function changeMemberGradeAction(
   id: number,
-  next: { position: string; authority: Authority; isAdmin: boolean; roleLabel: string },
+  next: {
+    position: string;
+    authority: Authority;
+    isAdmin: boolean;
+    /** 사용자가 **실제로 바꿨을 때만** 넘긴다. `undefined`면 요청에서 빠진다 */
+    roleLabel?: string;
+  },
 ): Promise<MemberActionResult> {
   const pass = await gate(canChangeMemberGrade, "사원 정보를 바꿀 권한이 없습니다");
   if ("denied" in pass) return { isSuccess: false, message: pass.denied };
@@ -147,13 +161,29 @@ export async function changeMemberGradeAction(
   if (lock) return { isSuccess: false, message: GRADE_LOCK_NOTE[lock] };
 
   /*
+    ⚠️ **바꾼 게 아니면 역할을 건드리지 않는다.** 화면이 안 넘겼거나(=안 고쳤다) 지금 값과
+       같으면 요청에서 빼서, 직급만 고친 저장이 역할을 덮어쓰지 않게 한다(부분 수정).
+    ⚠️ **비우는 건 막지 않는다.** `roleLabel`이 빈 값이어도 `isRoleOfTeam`은 통과시킨다
+       (`team-roles.ts` — "없음(빈 값)은 늘 통과한다"). BE로 나갈 때는 `toBeRoleLabel`이
+       빈 값을 시스템 행 `"없음"`으로 바꿔 보낸다(BE V2.3.9, 실제로 있는 값이다) — 비우기가
+       안 된다며 여기서 막으면, **이미 해결된 길을 다시 막는** 셈이다(2026-08-13 정정 —
+       이전 수정이 이 경로를 잘못 읽고 통째로 잠갔었다).
     ⚠️ 역할은 **그 사람 팀의 것만** 붙는다. 화면은 그 팀 역할만 주지만 Server Action은
        직접 부를 수 있다 — 남의 팀 역할이 붙으면 조직도가 거짓말을 한다.
     ⚠️ **대상을 읽은 뒤에 본다.** 기준이 그 사람이 지금 속한 팀이라, 조회 전에 두면
        무엇과 견줘야 할지 알 수 없다. 팀은 이 화면에서 안 바꾼다.
   */
-  const roleLabel = next.roleLabel.trim();
-  if (!isRoleOfTeam(buildTeamRoles(company.departments), target.member.teamName ?? "", roleLabel)) {
+  const roleLabel = next.roleLabel?.trim();
+  const currentRoleLabel = target.member.roleLabel?.trim() ?? "";
+  const changesRole = roleLabel !== undefined && roleLabel !== currentRoleLabel;
+  if (
+    changesRole &&
+    !isRoleOfTeam(
+      buildTeamRoles(company.departments),
+      target.member.teamName ?? "",
+      roleLabel ?? "",
+    )
+  ) {
     return { isSuccess: false, message: "그 팀에 없는 역할입니다" };
   }
 
@@ -173,10 +203,12 @@ export async function changeMemberGradeAction(
          관리자 토글만 **OWNER 전용** 경로로 떼어 둔 것이다.
       ⚠️ **직급은 이름이 아니라 id로 보낸다.** 화면은 이름을 다루므로 회사 목록에서 되찾는다 —
          못 찾으면 보내지 않는다(없는 직급으로 바뀌느니 실패가 낫다).
-      ⚠️ **`roleLabel`도 같이 보낸다**([확인] BE `UpdateMemberRoleRequest.roleLabel`
-         2026-08-13 develop `30952c10` — "보낼 곳이 없다"는 옛말이다). 단 **빈 문자열은 400**
-         (`@Pattern`)이고 `null`은 "안 바꾼다"라, 비우기는 `"없음"`으로 바꿔 보낸다
-         (`toBeRoleLabel`). 이 폼은 역할 칸을 늘 들고 있으므로 생략(null) 경로는 안 쓴다.
+      ⚠️ **`roleLabel`은 바뀔 때만 싣는다**([확인] BE `UpdateMemberRoleRequest.roleLabel`
+         2026-08-13 develop `30952c10` — 칸은 있다). 빈 문자열은 `@Pattern`이 400으로 거절하고
+         `null`(=필드 없음)은 "안 바꾼다"라, **안 고친 저장은 필드째 뺀다** — 늘 실어 보내면
+         직급만 고쳐도 역할이 함께 써진다.
+      ⚠️ 나가는 값은 **회사에 실제로 있는 역할 이름**뿐이다. 화면 라벨 상수(`ROLE_NONE_LABEL`)를
+         요청 값으로 쓰지 않는다 — 한글 라벨은 화면 것이고 BE로 나갈 값이 아니다(§도메인 상수).
     */
     const jobPosition = company.positions.find((item) => item.name === position);
     if (!jobPosition) return { isSuccess: false, message: "회사에 없는 직급입니다" };
@@ -196,10 +228,19 @@ export async function changeMemberGradeAction(
       await serverApi<unknown>(ep.member(id), {
         method: "PATCH",
         accessToken,
+        /*
+          ⚠️ **`roleLabel`은 바뀔 때만 키째 싣는다.** `changesRole`이 거짓이면 필드를 아예
+             안 넣는다 — BE는 `null`(=필드 없음)을 "안 바꾼다"로 읽는다. 매 요청에 값을 실으면
+             직급만 고쳐도 역할이 함께 써진다(위 §바꾼 게 아니면 역할을 건드리지 않는다).
+          ⚠️ **`roleLabel &&`가 아니라 `changesRole`만 본다.** 비우기(빈 문자열)도
+             `changesRole`이 참인 정당한 변경이다 — `roleLabel &&`를 같이 걸면 자바스크립트가
+             빈 문자열을 거짓으로 봐서, 역할을 지우려는 요청이 **조용히 빠진다**. `toBeRoleLabel`
+             이 빈 값을 알아서 `"없음"`으로 바꿔 보내므로 여기서 따로 거를 이유가 없다.
+        */
         json: {
           role: next.authority,
           jobPositionId: Number(jobPosition.id),
-          roleLabel: toBeRoleLabel(roleLabel),
+          ...(changesRole ? { roleLabel: toBeRoleLabel(roleLabel ?? "") } : {}),
         },
       });
 

--- a/src/features/member/manage-actions.ts
+++ b/src/features/member/manage-actions.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from "next/cache";
 
 import type { Authority } from "@/constants/authority";
 import { AUTHORITY, POSITION_AUTHORITIES } from "@/constants/authority";
-import { MEMBER_STATUS } from "@/constants/member";
+import { MEMBER_STATUS, ROLE_NONE_LABEL } from "@/constants/member";
 import { requireAccessToken } from "@/features/auth/session";
 import { getCompanyOrg } from "@/features/company/server";
 import { getViewer } from "@/features/shell/viewer";
@@ -173,8 +173,18 @@ export async function changeMemberGradeAction(
     ⚠️ **대상을 읽은 뒤에 본다.** 기준이 그 사람이 지금 속한 팀이라, 조회 전에 두면
        무엇과 견줘야 할지 알 수 없다. 팀은 이 화면에서 안 바꾼다.
   */
-  const roleLabel = next.roleLabel?.trim();
-  const currentRoleLabel = target.member.roleLabel?.trim() ?? "";
+  /*
+    ⚠️ **`ROLE_NONE_LABEL`("없음")도 빈 값과 같이 본다.** 저장할 때 `toBeRoleLabel`이 빈
+       문자열을 시스템 행 `"없음"`으로 바꿔 보내므로, 이미 "없음"인 사람의 값은 조회에서도
+       "없음" 그대로 돌아온다 — 이 정규화 없이 요청 값 `""`과 그대로 비교하면 실제로는 안
+       바뀐 값을 "바뀌었다"고 오판해 불필요한 PATCH가 나간다.
+  */
+  const normalizeRoleLabel = (label: string | null | undefined) => {
+    const trimmed = label?.trim() ?? "";
+    return trimmed === ROLE_NONE_LABEL ? "" : trimmed;
+  };
+  const roleLabel = next.roleLabel !== undefined ? normalizeRoleLabel(next.roleLabel) : undefined;
+  const currentRoleLabel = normalizeRoleLabel(target.member.roleLabel);
   const changesRole = roleLabel !== undefined && roleLabel !== currentRoleLabel;
   if (
     changesRole &&
@@ -207,8 +217,9 @@ export async function changeMemberGradeAction(
          2026-08-13 develop `30952c10` — 칸은 있다). 빈 문자열은 `@Pattern`이 400으로 거절하고
          `null`(=필드 없음)은 "안 바꾼다"라, **안 고친 저장은 필드째 뺀다** — 늘 실어 보내면
          직급만 고쳐도 역할이 함께 써진다.
-      ⚠️ 나가는 값은 **회사에 실제로 있는 역할 이름**뿐이다. 화면 라벨 상수(`ROLE_NONE_LABEL`)를
-         요청 값으로 쓰지 않는다 — 한글 라벨은 화면 것이고 BE로 나갈 값이 아니다(§도메인 상수).
+      ⚠️ 나가는 값은 **회사에 실제로 있는 역할 이름 또는 `ROLE_NONE_LABEL`**("없음")이다.
+         "없음"은 화면이 지어낸 라벨이 아니라 역할 미부여를 뜻하는 **BE 시스템 값**이다
+         (BE V2.3.9, `toBeRoleLabel` 참고) — 비우기 요청은 실제로 이 값을 그대로 실어 보낸다.
     */
     const jobPosition = company.positions.find((item) => item.name === position);
     if (!jobPosition) return { isSuccess: false, message: "회사에 없는 직급입니다" };


### PR DESCRIPTION
## 📋 PR 타입

> 해당하는 타입을 선택해 주세요 (복수 선택 가능)

- [ ] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- 0,0 좌표 핀 표시 버그 — 지도를 못 쓴 회사(주소 검색만 하고 좌표를 못 얻은 경우)가 실제로 0,0(기니만)에 핀을 찍고 있던 것을 `hasPinnedCoords()` 판정으로 고침. 저장(매퍼)·렌더링(AddressPicker) 둘 다 같은 판단을 쓴다.
- 역할(roleLabel) 부분 수정 버그 — 저장 시 역할을 안 건드렸는데도 기존 값이 덮어써지던 것, 그리고 역할을 비우는(팀 내 "없음") 조작이 통째로 막혀 있던 것을 고침. `changesRole` 판정을 도입해 "안 바뀜"·"빈 값으로 바꿈"을 정확히 구분한다.
- 원래 같은 브랜치의 PR이 이 커밋들이 push되기 전 커밋으로 이미 머지되어, 이 수정들이 `develop`에 반영되지 않은 채로 브랜치/PR이 닫혔다. `origin/develop` 실제 코드를 확인해 누락을 재확인했고, 같은 작업을 새 브랜치로 재제출한다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**(회의 담당자 등), 그리고 **서버(Server Action/BFF)에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [ ] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시 (조용히 "되는 척" 금지)
- [ ] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그)
- [ ] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [ ] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인)
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음

---

## 🔗 연관 이슈

Closes #453

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

- `hasPinnedCoords()` 판정이 저장(매퍼)과 렌더링(AddressPicker) 양쪽에서 동일하게 쓰이는지
- `changesRole` 판정이 "안 바뀜"과 "빈 값으로 바꿈"을 정확히 구분해 PATCH 본문을 구성하는지

---

## 📝 추가 메모

- `npx tsc --noEmit` / `npx eslint <변경 파일> --max-warnings=0` / `npx jest --silent` / `npx next build` 전부 통과
- `manage-actions.role-label.test.ts` 신규 6건으로 실서버 PATCH 본문 구성 회귀 확인, 기존 `manage-actions.test.ts`도 초록


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 주소 선택 시 유효한 좌표가 없으면 지도 대신 안내 상태를 표시합니다.
  * 유효한 위도·경도 좌표가 있을 때만 지도와 핀을 표시합니다.
  * 회원 역할을 변경하지 않으면 불필요한 역할 정보가 전송되지 않습니다.
  * 역할을 삭제하거나 미지정 상태로 변경할 때 변경 사항이 올바르게 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->