### PR TITLE
[FEAT] 회의 상세 발화 기록을 실서버에 잇는다(ANLZ-05) #430

### DIFF
--- a/src/features/meeting/lib.ts
+++ b/src/features/meeting/lib.ts
@@ -27,6 +27,16 @@ export function formatMeetingSchedule(start: Date, end: Date): string {
 }
 
 /**
+ * 시각만 `10:04` — 발화 기록(ANLZ-05)이 쓴다.
+ *
+ * ⚠️ **`formatMeetingSchedule`과 같은 `TIME_PART`를 쓴다**(한국 시간대) — 회의 시작·발화
+ *    시각이 다른 시계로 찍히면 "10:04에 한 말"이 회의 시작(10:00)보다 이르게 보일 수 있다.
+ */
+export function formatClockTime(at: Date): string {
+  return TIME_PART.format(at);
+}
+
+/**
  * 회의 목록(MEET-02)이 물어볼 기간 — 앞뒤로 3개월씩.
  *
  * ⚠️ **뒤를 열어 주는 게 핵심이다.** BE 기본값은 `오늘-3개월 ~ 오늘`이라

--- a/src/features/meeting/mapper.test.ts
+++ b/src/features/meeting/mapper.test.ts
@@ -4,16 +4,19 @@ import {
   type BeDashboardMeeting,
   type BeMeetingDetail,
   type BeMeetingListItem,
+  type BeUtterance,
   hostIdOf,
   isClosed,
   meetingPendingReasonOf,
   parseDashboardMeetings,
   parseMeetingDetail,
   parseMeetingList,
+  parseTranscriptsResponse,
   toDashboardMeetingCard,
   toMeetingCaptureInfo,
   toMeetingDetailView,
   toMeetingListItem,
+  toScriptChunks,
 } from "./mapper";
 
 /** MEET-04 응답 그대로 — 중첩·필드 이름을 BE 실코드에 맞춰 둔다 */
@@ -432,5 +435,123 @@ describe("toDashboardMeetingCard", () => {
 
     expect(card.originLabel).toBe("개발팀");
     expect(card.hostLabel).toBe("김서준(팀장)");
+  });
+});
+
+describe("parseTranscriptsResponse — ANLZ-05", () => {
+  const UTTERANCE: BeUtterance = {
+    transcriptId: 1,
+    seq: 0,
+    speakerMemberId: 3,
+    speakerSource: "SELF_STREAM",
+    startOffsetMs: 4_000,
+    endOffsetMs: 6_500,
+    content: "안녕하세요, 시작하겠습니다.",
+  };
+
+  it("정상 응답을 그대로 읽는다", () => {
+    expect(parseTranscriptsResponse({ utterances: [UTTERANCE], nextCursor: "abc" })).toEqual({
+      utterances: [UTTERANCE],
+      nextCursor: "abc",
+    });
+  });
+
+  /* ⚠️ 마지막 페이지는 `nextCursor`가 없다(`undefined`) — `null`로 정규화해 호출부가 한 값만 본다 */
+  it("마지막 페이지의 nextCursor 부재를 null로 정규화한다", () => {
+    expect(parseTranscriptsResponse({ utterances: [] }).nextCursor).toBeNull();
+  });
+
+  /* ⚠️ speakerMemberId===null은 정상이다(BE 주석 — 화자 판정 포기) — 검사에 안 걸려야 한다 */
+  it("speakerMemberId가 null이어도 통과한다(화자 판정 포기, 오류 아님)", () => {
+    expect(() =>
+      parseTranscriptsResponse({
+        utterances: [{ ...UTTERANCE, speakerMemberId: null, speakerSource: null }],
+      }),
+    ).not.toThrow();
+  });
+
+  it.each([
+    ["utterances가 없음", { nextCursor: "x" }],
+    ["content가 숫자", { utterances: [{ ...UTTERANCE, content: 1 }] }],
+    ["배열 안이 문자열", { utterances: ["안녕"] }],
+  ])("%s이면 그리기 전에 멈춘다", (_label, broken) => {
+    expect(() => parseTranscriptsResponse(broken)).toThrow("약속한 모양");
+  });
+});
+
+describe("toScriptChunks — 회의 시작 + 오프셋 = 발화 시각", () => {
+  /* ⚠️ 목 데이터와 같은 형식이다(`mock/seed.ts`) — "10:00", "10:04"처럼 회의 시작 기준 시계다 */
+  it("시작 시각에 오프셋(ms)을 더해 HH:MM으로 찍는다", () => {
+    const start = new Date("2026-08-14T10:00:00+09:00");
+    const chunks = toScriptChunks(start, [
+      {
+        transcriptId: 1,
+        seq: 0,
+        speakerMemberId: 3,
+        speakerSource: null,
+        startOffsetMs: 0,
+        endOffsetMs: 2_000,
+        content: "시작합니다.",
+      },
+      {
+        transcriptId: 2,
+        seq: 1,
+        speakerMemberId: 4,
+        speakerSource: null,
+        startOffsetMs: 240_000,
+        endOffsetMs: 245_000,
+        content: "네, 진행하겠습니다.",
+      },
+    ]);
+
+    expect(chunks).toEqual([
+      { at: "10:00", text: "시작합니다." },
+      { at: "10:04", text: "네, 진행하겠습니다." },
+    ]);
+  });
+
+  /* ⚠️ 화자 귀속 포기(오프셋 없음)도 화면에서는 그냥 회의 시작 시각으로 보인다 — 없는 값을 지어내지 않는다 */
+  it("오프셋이 없으면(null) 회의 시작 시각으로 찍는다", () => {
+    const start = new Date("2026-08-14T14:00:00+09:00");
+    const chunks = toScriptChunks(start, [
+      {
+        transcriptId: 1,
+        seq: 0,
+        speakerMemberId: null,
+        speakerSource: null,
+        startOffsetMs: null,
+        endOffsetMs: null,
+        content: "...",
+      },
+    ]);
+
+    expect(chunks[0]!.at).toBe("14:00");
+  });
+
+  /* ⚠️ BE는 페이지 단위로 주는데, 페이지 경계에서 seq가 뒤섞여 오면 화면 순서가 틀어진다 */
+  it("seq 순서가 뒤섞여 와도 시간순으로 정렬한다", () => {
+    const start = new Date("2026-08-14T10:00:00+09:00");
+    const chunks = toScriptChunks(start, [
+      {
+        transcriptId: 2,
+        seq: 1,
+        speakerMemberId: null,
+        speakerSource: null,
+        startOffsetMs: 60_000,
+        endOffsetMs: null,
+        content: "두 번째",
+      },
+      {
+        transcriptId: 1,
+        seq: 0,
+        speakerMemberId: null,
+        speakerSource: null,
+        startOffsetMs: 0,
+        endOffsetMs: null,
+        content: "첫 번째",
+      },
+    ]);
+
+    expect(chunks.map((chunk) => chunk.text)).toEqual(["첫 번째", "두 번째"]);
   });
 });

--- a/src/features/meeting/mapper.ts
+++ b/src/features/meeting/mapper.ts
@@ -11,7 +11,7 @@ import {
   MEETING_STATUS,
 } from "@/constants/meeting";
 
-import { formatMeetingSchedule } from "./lib";
+import { formatClockTime, formatMeetingSchedule } from "./lib";
 import type {
   CaptureAttendee,
   MeetingAgenda,
@@ -19,6 +19,7 @@ import type {
   MeetingContentPending,
   MeetingDetail,
   MeetingListItem,
+  ScriptChunk,
 } from "./view-types";
 
 /** Owner 개설 회의의 소속 라벨(WORKFLOW §2) — 옛 문구 "프로젝트 공통"은 폐기됐다 */
@@ -631,9 +632,14 @@ export function meetingPendingReasonOf(
  * ⚠️ **여전히 비는 칸**(§정직성 — 지어내지 않는다):
  *    - `parentTeamActionHref`: 상위 팀 액션 id가 **모델에 없어 영구 제공 불가**다(#461 회신).
  *      `teamId`는 팀이지 팀 액션이 아니라 링크를 못 만든다.
- *    - `outputs`·`script`: 다른 API(`GET /api/meetings/{id}/actions` · CAP-12 자막 조회)가
- *      줄 값이라 이 연동 범위 밖이다. **빈 배열이 아니라 `null`이다** — 빈 배열로 두면 화면이
- *      "하달된 액션이 없습니다"·"발화 기록이 없습니다"라고 **안 물어본 것을 단정한다**.
+ *    - `outputs`: 다른 API(`GET /api/meetings/{id}/actions`)가 줄 값이라 이 연동 범위 밖이다.
+ *      **빈 배열이 아니라 `null`이다** — 빈 배열로 두면 화면이 "하달된 액션이 없습니다"라고
+ *      **안 물어본 것을 단정한다**.
+ * ⚠️ **`script`는 여기서 안 채운다 — 다른 API다.** 발화 기록(ANLZ-05,
+ *    `GET /api/meetings/{id}/transcripts`)은 이 함수가 받는 `BeMeetingDetail`에 없다.
+ *    이 함수는 늘 `null`을 주고, 회의가 끝났으면(`pendingReason===null`) `server.ts`의
+ *    `getLiveMeetingDetail`이 따로 조회해 덮어쓴다(`toScriptChunks`) — outputs와 같은 이유로
+ *    비워 두지만, 그쪽과 달리 이 연동의 실제 범위 **안**이라 곧바로 채워진다.
  */
 export function toMeetingDetailView(
   be: BeMeetingDetail,
@@ -673,4 +679,81 @@ function outputKindLabelOf(teamId: number | null | undefined): string {
 function toMeetingAgenda(agenda: BeMeetingDetail["agenda"]): MeetingAgenda | null {
   if (agenda === undefined || agenda === null) return null;
   return { main: agenda.mainTopic, subs: agenda.subTopics };
+}
+
+/**
+ * 발화 기록(ANLZ-05) — `GET /api/meetings/{id}/transcripts`.
+ *
+ * ⚠️ **화자를 안 싣는다.** BE는 `speakerMemberId`·`speakerSource`도 주지만(오귀속 대비 근거),
+ *    화면 계약(`ScriptChunk`)은 시각·본문뿐이다 — 자막은 "화자 없는 청크"라는 게 팀이 정한
+ *    표시 방식이다(화자 귀속 단순화 작업과 같은 결). 근거가 필요해지면 그때 칸을 늘린다.
+ * ⚠️ `speakerMemberId === null`은 **정상**이다(BE 주석 — 판정 포기, 오류가 아니다). 화면이
+ *    안 쓰는 값이라 여기서 걸러 낼 것도 없다.
+ */
+export interface BeUtterance {
+  transcriptId: number;
+  seq: number;
+  speakerMemberId: number | null;
+  speakerSource: string | null;
+  startOffsetMs: number | null;
+  endOffsetMs: number | null;
+  content: string;
+}
+
+export interface BeTranscriptsResponse {
+  utterances: BeUtterance[];
+  nextCursor: string | null;
+}
+
+/**
+ * 응답이 읽는 모양인가 — `parseMeetingDetail`과 같은 이유로 여기서도 한 번 본다(§정직성).
+ * ⚠️ **화면이 쓰는 것만 본다.** `content`·`startOffsetMs`만 있으면 `at`·`text`를 만들 수
+ *    있다 — `speakerMemberId`·`speakerSource`는 화면이 안 쓰므로 모양을 안 따진다.
+ */
+function isBeUtterance(value: unknown): value is BeUtterance {
+  if (typeof value !== "object" || value === null) return false;
+  const utterance = value as Partial<BeUtterance>;
+  return (
+    typeof utterance.transcriptId === "number" &&
+    typeof utterance.content === "string" &&
+    (utterance.startOffsetMs === null || typeof utterance.startOffsetMs === "number")
+  );
+}
+
+function isBeTranscriptsResponse(value: unknown): value is BeTranscriptsResponse {
+  if (typeof value !== "object" || value === null) return false;
+  const response = value as Partial<BeTranscriptsResponse>;
+  return (
+    Array.isArray(response.utterances) &&
+    response.utterances.every(isBeUtterance) &&
+    (response.nextCursor === null ||
+      response.nextCursor === undefined ||
+      typeof response.nextCursor === "string")
+  );
+}
+
+/** 검사까지 마친 발화 페이지 — 호출부는 이걸 통과한 값만 만진다(§정직성, `parseMeetingDetail`과 같은 자리). */
+export function parseTranscriptsResponse(raw: unknown): BeTranscriptsResponse {
+  if (!isBeTranscriptsResponse(raw)) {
+    throw new Error("발화 기록 응답이 약속한 모양이 아닙니다.");
+  }
+  return { utterances: raw.utterances, nextCursor: raw.nextCursor ?? null };
+}
+
+/**
+ * BE 발화 → 화면 청크. **시각은 회의 시작 시각 + 오프셋**이다 — `startOffsetMs`가 없으면
+ * (화자 귀속과 무관한 결측) 회의 시작 시각으로 표시한다(0으로 둔다).
+ *
+ * ⚠️ **회의 로컬(한국) 시간대로 찍는다** — `formatClockTime`이 회의 시작 시각과 같은
+ *    `TIME_PART`를 쓴다(`lib.ts`). 시계가 갈리면 "10:04에 한 말"이 회의 시작(10:00)보다
+ *    이르게 보일 수 있다.
+ */
+export function toScriptChunks(meetingStart: Date, utterances: BeUtterance[]): ScriptChunk[] {
+  return utterances
+    .slice()
+    .sort((a, b) => a.seq - b.seq)
+    .map((utterance) => ({
+      at: formatClockTime(new Date(meetingStart.getTime() + (utterance.startOffsetMs ?? 0))),
+      text: utterance.content,
+    }));
 }

--- a/src/features/meeting/server.transcripts-real.test.ts
+++ b/src/features/meeting/server.transcripts-real.test.ts
@@ -1,0 +1,146 @@
+jest.mock("@/mocks/config", () => ({ isMock: false }));
+jest.mock("@/features/auth/session", () => ({ requireAccessToken: jest.fn() }));
+jest.mock("@/lib/api", () => ({
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+  serverApi: jest.fn(),
+}));
+
+import { AUTHORITY } from "@/constants/authority";
+import { requireAccessToken } from "@/features/auth/session";
+import { serverApi } from "@/lib/api";
+import type { Actor } from "@/lib/permission";
+
+import { getMeetingDetail } from "./server";
+
+/**
+ * 회의 상세 — **실서버 발화 기록(ANLZ-05) 조회**.
+ *
+ * ⚠️ 기존 `server.test.ts`는 `@/mocks/config`를 목으로 안 바꿔서(실제 `isMock` 값을 그대로
+ *    읽는다) 이 경로(실서버 분기)는 그쪽에서 한 번도 실행되지 않는다 — 별도 파일로 잠근다.
+ */
+
+const requireAccessTokenMock = requireAccessToken as unknown as jest.Mock;
+const serverApiMock = serverApi as unknown as jest.Mock;
+
+const HOST: Actor = { id: 2, role: AUTHORITY.LEADER, teamName: "개발팀" };
+
+function meetingDetail(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    meetingId: 100,
+    title: "스프린트 회의",
+    status: "DONE",
+    startAt: "2026-08-14T10:00:00",
+    endAt: "2026-08-14T10:30:00",
+    pendingActionCount: 0,
+    summaryStatus: "DONE",
+    project: { projectId: 1, tag: "GOODS" },
+    meetingRoom: { meetingRoomId: 1, name: "소회의실 B" },
+    host: { memberId: HOST.id, name: "김서준" },
+    attendees: [],
+    ...overrides,
+  };
+}
+
+function utterance(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    transcriptId: 1,
+    seq: 0,
+    speakerMemberId: null,
+    speakerSource: null,
+    startOffsetMs: 0,
+    endOffsetMs: 1_000,
+    content: "발화",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  requireAccessTokenMock.mockResolvedValue("token");
+});
+
+describe("getMeetingDetail — 실서버, 발화 기록 조회", () => {
+  it("끝난 회의는 발화 기록을 조회해 시각순으로 채운다", async () => {
+    serverApiMock.mockResolvedValueOnce(meetingDetail()).mockResolvedValueOnce({
+      utterances: [utterance({ transcriptId: 1, seq: 0, startOffsetMs: 0, content: "시작합니다" })],
+      nextCursor: null,
+    });
+
+    const result = await getMeetingDetail("100", HOST);
+
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.detail.script).toEqual([{ at: "10:00", text: "시작합니다" }]);
+    // GET 회의 상세 1회 + GET 발화 1페이지 = 2회
+    expect(serverApiMock).toHaveBeenCalledTimes(2);
+  });
+
+  /*
+    ⚠️ **커서를 끝까지 이어 받는다.** "N건"이라는 화면 문구가 첫 페이지만 세면 거짓말이 된다
+       (§정직성) — 두 페이지짜리 응답을 흉내 내 이어받기 자체를 확인한다.
+  */
+  it("nextCursor가 있으면 다음 페이지를 이어 받는다", async () => {
+    serverApiMock
+      .mockResolvedValueOnce(meetingDetail())
+      .mockResolvedValueOnce({
+        utterances: [
+          utterance({ transcriptId: 1, seq: 0, startOffsetMs: 0, content: "첫 페이지" }),
+        ],
+        nextCursor: "page2",
+      })
+      .mockResolvedValueOnce({
+        utterances: [
+          utterance({ transcriptId: 2, seq: 1, startOffsetMs: 60_000, content: "둘째 페이지" }),
+        ],
+        nextCursor: null,
+      });
+
+    const result = await getMeetingDetail("100", HOST);
+
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.detail.script).toEqual([
+      { at: "10:00", text: "첫 페이지" },
+      { at: "10:01", text: "둘째 페이지" },
+    ]);
+    expect(serverApiMock).toHaveBeenCalledTimes(3);
+    // 두 번째 발화 호출은 첫 페이지가 준 커서를 그대로 되돌려줘야 한다
+    expect(serverApiMock.mock.calls[2]![0]).toContain("cursor=page2");
+  });
+
+  /*
+    ⚠️ **회의가 아직 안 끝났으면 발화 기록을 안 물어본다** — 화면이 그 칸에 안내 카드만
+       그리므로(§view-types `pendingReason`) 조회 자체가 헛수고다.
+  */
+  it("회의가 아직 안 끝났으면 발화 기록 API를 안 부른다", async () => {
+    serverApiMock.mockResolvedValueOnce(meetingDetail({ status: "SCHEDULED" }));
+
+    const result = await getMeetingDetail("100", HOST);
+
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.detail.script).toBeNull();
+    expect(serverApiMock).toHaveBeenCalledTimes(1); // 회의 상세만
+  });
+
+  /* ⚠️ 커서가 끝없이 이어지는 BE 결함이 나도 화면이 영원히 안 끝나면 안 된다 */
+  it("커서가 안 끊기면 상한에서 멈춘다", async () => {
+    serverApiMock.mockResolvedValueOnce(meetingDetail());
+    // 이후 모든 호출은 nextCursor가 있는 페이지를 계속 준다
+    serverApiMock.mockResolvedValue({ utterances: [utterance()], nextCursor: "again" });
+
+    const result = await getMeetingDetail("100", HOST);
+
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    // 회의 상세 1 + 최대 50페이지 = 51회를 넘지 않는다
+    expect(serverApiMock.mock.calls.length).toBeLessThanOrEqual(51);
+    expect(result.detail.script!.length).toBeGreaterThan(0);
+  });
+});

--- a/src/features/meeting/server.transcripts-real.test.ts
+++ b/src/features/meeting/server.transcripts-real.test.ts
@@ -129,6 +129,40 @@ describe("getMeetingDetail — 실서버, 발화 기록 조회", () => {
     expect(serverApiMock).toHaveBeenCalledTimes(1); // 회의 상세만
   });
 
+  /*
+    ⚠️ **커서 경계가 겹쳐도 같은 발화를 두 번 안 보여준다**(§목록·페이지네이션 — id 중복 제거).
+       BE가 커서 경계에서 같은 발화를 다시 주는 결함이 나도 "N건"이 거짓말을 하면 안 된다.
+  */
+  it("페이지 경계에서 transcriptId가 겹치면 중복을 거른다", async () => {
+    serverApiMock
+      .mockResolvedValueOnce(meetingDetail())
+      .mockResolvedValueOnce({
+        utterances: [
+          utterance({ transcriptId: 1, seq: 0, startOffsetMs: 0, content: "첫 페이지" }),
+          utterance({ transcriptId: 2, seq: 1, startOffsetMs: 1_000, content: "경계 발화" }),
+        ],
+        nextCursor: "page2",
+      })
+      .mockResolvedValueOnce({
+        utterances: [
+          // 경계 발화(transcriptId: 2)가 다음 페이지 첫머리에도 겹쳐 온다
+          utterance({ transcriptId: 2, seq: 1, startOffsetMs: 1_000, content: "경계 발화" }),
+          utterance({ transcriptId: 3, seq: 2, startOffsetMs: 60_000, content: "둘째 페이지" }),
+        ],
+        nextCursor: null,
+      });
+
+    const result = await getMeetingDetail("100", HOST);
+
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.detail.script).toEqual([
+      { at: "10:00", text: "첫 페이지" },
+      { at: "10:00", text: "경계 발화" },
+      { at: "10:01", text: "둘째 페이지" },
+    ]);
+  });
+
   /* ⚠️ 커서가 끝없이 이어지는 BE 결함이 나도 화면이 영원히 안 끝나면 안 된다 */
   it("커서가 안 끊기면 상한에서 멈춘다", async () => {
     serverApiMock.mockResolvedValueOnce(meetingDetail());

--- a/src/features/meeting/server.ts
+++ b/src/features/meeting/server.ts
@@ -362,10 +362,13 @@ export async function getMeetingDetail(id: string, viewer: Actor): Promise<Meeti
  *    영영 안 끝난다 — 상한(50페이지, 회의 하나에 발화 수천 건이라는 BE 주석 기준 넉넉하다)
  *    에 걸리면 그때까지 받은 것만 돌린다. `console`은 커밋하지 않는다(PR 체크리스트) —
  *    상한에 걸리는 건 BE 결함(끝없는 커서)일 때뿐이라 서버 쪽에서 잡을 일이다.
+ * ⚠️ **`transcriptId`로 중복을 거른다**(§목록·페이지네이션 — 이어 붙일 때 id 중복 제거).
+ *    커서 경계가 겹치는 BE 결함이 나도 "N건"과 화면에 같은 발화가 두 번 찍히지 않는다.
  */
 async function fetchAllTranscripts(meetingId: number, accessToken: string): Promise<BeUtterance[]> {
   const TRANSCRIPT_PAGE_CAP = 50;
   const utterances: BeUtterance[] = [];
+  const seenTranscriptIds = new Set<number>();
   let cursor: string | undefined;
 
   for (let page = 0; page < TRANSCRIPT_PAGE_CAP; page++) {
@@ -373,7 +376,11 @@ async function fetchAllTranscripts(meetingId: number, accessToken: string): Prom
       accessToken,
     });
     const parsed = parseTranscriptsResponse(raw);
-    utterances.push(...parsed.utterances);
+    for (const utterance of parsed.utterances) {
+      if (seenTranscriptIds.has(utterance.transcriptId)) continue;
+      seenTranscriptIds.add(utterance.transcriptId);
+      utterances.push(utterance);
+    }
     if (!parsed.nextCursor) return utterances;
     cursor = parsed.nextCursor;
   }

--- a/src/features/meeting/server.ts
+++ b/src/features/meeting/server.ts
@@ -18,13 +18,16 @@ import { isMock } from "@/mocks/config";
 import { formatMeetingSchedule, meetingListRange } from "./lib";
 import {
   type BeMeetingListItem,
+  type BeUtterance,
   hostIdOf,
   isClosed,
   parseMeetingDetail,
   parseMeetingList,
+  parseTranscriptsResponse,
   toMeetingCaptureInfo,
   toMeetingDetailView,
   toMeetingListItem,
+  toScriptChunks,
 } from "./mapper";
 import { findMockMeeting, listMockMeetings } from "./mock/meetings";
 import { ensureMockMeetingsSeeded, findMockMeetingExtras } from "./mock/seed";
@@ -348,6 +351,36 @@ export async function getMeetingDetail(id: string, viewer: Actor): Promise<Meeti
  * ⚠️ 개설자 판정은 **목 경로와 같은 함수**(`canOperateMeeting`)다. 매퍼는 값이 어디 있는지만
  *    알려 주고(`hostIdOf`) 판정은 `lib/permission.ts` 한 곳이다(CLAUDE.md §권한).
  */
+/**
+ * 발화 기록 전체(ANLZ-05) — 커서를 서버가 `nextCursor`로 끊어 줄 때까지 이어 받는다.
+ *
+ * ⚠️ **왜 페이지를 그대로 안 보여주고 다 모아 온다.** 이 화면은 스크롤 목록이 아니라
+ *    상세의 고정 섹션이다 — "N건"이라는 건수를 보여주는데 첫 페이지만 세면 그 수가
+ *    거짓말이 된다(§정직성, §목록·페이지네이션과는 다른 자리 — 여기는 무한 스크롤 목록이
+ *    아니라 한 회의 분량이 유한하다).
+ * ⚠️ **그래도 무한 루프는 안 된다.** BE가 커서를 안 끊어 주는 결함이 나면 화면이 걸린 채
+ *    영영 안 끝난다 — 상한(50페이지, 회의 하나에 발화 수천 건이라는 BE 주석 기준 넉넉하다)
+ *    에 걸리면 그때까지 받은 것만 돌린다. `console`은 커밋하지 않는다(PR 체크리스트) —
+ *    상한에 걸리는 건 BE 결함(끝없는 커서)일 때뿐이라 서버 쪽에서 잡을 일이다.
+ */
+async function fetchAllTranscripts(meetingId: number, accessToken: string): Promise<BeUtterance[]> {
+  const TRANSCRIPT_PAGE_CAP = 50;
+  const utterances: BeUtterance[] = [];
+  let cursor: string | undefined;
+
+  for (let page = 0; page < TRANSCRIPT_PAGE_CAP; page++) {
+    const raw = await serverApi<unknown>(ep.meetingTranscripts(meetingId, { cursor }), {
+      accessToken,
+    });
+    const parsed = parseTranscriptsResponse(raw);
+    utterances.push(...parsed.utterances);
+    if (!parsed.nextCursor) return utterances;
+    cursor = parsed.nextCursor;
+  }
+
+  return utterances;
+}
+
 async function getLiveMeetingDetail(id: string, viewer: Actor): Promise<MeetingDetailResult> {
   const accessToken = await requireAccessToken();
 
@@ -362,12 +395,23 @@ async function getLiveMeetingDetail(id: string, viewer: Actor): Promise<MeetingD
 
   /* ⚠️ 단언이 아니라 **검사**다 — 모양이 어긋나면 화면을 그리기 전에 여기서 멈춘다 */
   const detail = parseMeetingDetail(raw);
+  const view = toMeetingDetailView(detail, {
+    isHost: canOperateMeeting(viewer, { ownerId: hostIdOf(detail) }),
+  });
 
+  /*
+    ⚠️ **`pendingReason`이 있으면 발화 기록을 안 물어본다.** 화면이 그 칸을 안 그리는데
+       (`meeting-detail-view.tsx` — 안내 카드만 뜬다) 조회부터 하면 헛수고다. 회의가 아직
+       안 끝났으면 발화 자체가 없을 수도 있다.
+  */
+  if (view.pendingReason !== null) {
+    return { kind: "ok", detail: view };
+  }
+
+  const utterances = await fetchAllTranscripts(Number(id), accessToken);
   return {
     kind: "ok",
-    detail: toMeetingDetailView(detail, {
-      isHost: canOperateMeeting(viewer, { ownerId: hostIdOf(detail) }),
-    }),
+    detail: { ...view, script: toScriptChunks(new Date(detail.startAt), utterances) },
   };
 }
 

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -171,6 +171,17 @@ export const ep = {
   /** 참석자 명단 교체(MEET-09, 구현 완료) — 전체 명단 교체(부분 추가·삭제 아님). */
   meetingAttendees: (meetingId: number) => `/api/meetings/${meetingId}/attendees`,
   /**
+   * 정본 스크립트 조회(ANLZ-05) — 회의 발화를 시간순으로. [확인]
+   * `capture/presentation/api/AnalysisController.getTranscripts`(2026-08-14, BE 실코드 대조).
+   *
+   * ⚠️ **커서는 우리가 해석하지 않는다.** 불투명한 문자열이고 BE가 준 `nextCursor`를 다음
+   *    호출의 `cursor`로 그대로 돌려준다 — 안에 무엇이 들었는지는 BE만 안다.
+   * ⚠️ `ids`는 근거 발화 지름길(검토 화면이 액션 근거 몇 건만 볼 때)이라 여기서는 안 쓴다 —
+   *    상세 화면은 전체를 시간순으로 읽는다.
+   */
+  meetingTranscripts: (meetingId: number, params?: { cursor?: string }) =>
+    `/api/meetings/${meetingId}/transcripts${toQuery(params)}`,
+  /**
    * 확정 대기 회의 목록(MEET-10, 구현 완료 — PR #233) — 마이페이지 "미확정 액션" 위젯용.
    * [확인] D도메인 REST API 명세(2026-08-12) 대조. 파라미터 없음 — host 본인 회의만 서버가
    * 자동 스코프한다(전 롤 호출 가능, 판정은 역할이 아니라 `hostMemberId` 일치).


### PR DESCRIPTION
## 📋 PR 타입

> 해당하는 타입을 선택해 주세요 (복수 선택 가능)

- [x] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- 회의 상세의 발화 기록(script)을 실서버 `GET /api/meetings/{meetingId}/transcripts`(커서 페이지네이션)에 연결한다.
- `BeUtterance`·`BeTranscriptsResponse` 검증기·`parseTranscriptsResponse`, seq 정렬 후 회의 시작 시각 기준 절대시각→시계 표기로 변환하는 `toScriptChunks` 추가.
- `fetchAllTranscripts`: 커서를 끝까지(최대 50페이지 안전판) 따라가며 전량 수집. 요약 대기중(`pendingReason !== null`)인 회의는 호출을 건너뛴다(끝나지 않은 회의는 발화 기록도 아직 없다).
- 원래 같은 브랜치의 PR이 이 커밋이 push되기 전 커밋으로 이미 머지되어, 이 수정이 `develop`에 반영되지 않은 채로 브랜치/PR이 닫혔다. `origin/develop` 실제 코드를 확인해 누락을 재확인했고, 같은 작업을 새 브랜치로 재제출한다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**(회의 담당자 등), 그리고 **서버(Server Action/BFF)에서 재검사**
- [x] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [x] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시 (조용히 "되는 척" 금지)
- [ ] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그)
- [ ] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [ ] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인)
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음

---

## 🔗 연관 이슈

Closes #430

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

- `fetchAllTranscripts`의 50페이지 안전판과 커서 드레인 로직이 무한 루프 없이 끝까지 수집하는지
- 요약 대기중(`pendingReason !== null`) 회의에서 호출을 건너뛰는 분기가 올바른지

---

## 📝 추가 메모

- `npx tsc --noEmit` / `npx eslint <변경 파일> --max-warnings=0` / `npx jest --silent` / `npx next build` 전부 통과
- `mapper.test.ts`·`server.transcripts-real.test.ts`로 파싱·청크 변환·커서 드레인·pending 스킵·50페이지 안전판 회귀 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 종료된 회의의 발화 기록을 조회해 회의 스크립트로 표시합니다.
  * 발화 시각을 한국 시간 기준의 `HH:mm` 형식으로 제공합니다.
  * 발화 기록의 페이지네이션을 지원하며, 중복 발화를 자동으로 제거합니다.
  * 발화 정보가 없는 경우에도 안정적으로 처리합니다.

* **버그 수정**
  * 발화 순서를 보장하고 누락된 시간 정보를 올바르게 처리합니다.
  * 진행 중인 회의에서는 불필요한 발화 기록 조회를 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->