### PR TITLE
[FIX] 결제 확정에서 임시로 결제사를 안 부른다 #429

### DIFF
--- a/src/features/billing/actions.test.ts
+++ b/src/features/billing/actions.test.ts
@@ -1,0 +1,56 @@
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/mocks/config", () => ({ isMock: false }));
+jest.mock("@/features/shell/viewer", () => ({ getViewer: jest.fn() }));
+jest.mock("@/lib/api", () => ({ serverApi: jest.fn(), toUserMessage: jest.fn() }));
+
+import { revalidatePath } from "next/cache";
+
+import { AUTHORITY } from "@/constants/authority";
+import { getViewer } from "@/features/shell/viewer";
+import { serverApi } from "@/lib/api";
+
+import { confirmSubscriptionAction } from "./actions";
+
+/**
+ * `confirmSubscriptionAction` — **실서버에서도 결제사를 안 부르는 임시 조치**(2026-08-13,
+ * Toss 실연동 여부가 [팀확정] 미정이라 사용자 확정).
+ *
+ * ⚠️ 화면에 카드 정보를 받는 자리가 없다 — 이 임시 조치 없이 실서버로 나가면
+ *    `POST /api/companies/me/subscription/pay`가 `NO_PAYMENT_METHOD`로 영원히 실패해
+ *    온보딩이 못 끝난다. 이 테스트는 **그 실패가 되살아나지 않는지**를 잠근다 —
+ *    누군가 원래 구현으로 되돌리면서 이 회귀 방지 없이 그러면 여기서 잡힌다.
+ */
+
+const getViewerMock = getViewer as unknown as jest.Mock;
+const serverApiMock = serverApi as unknown as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  getViewerMock.mockResolvedValue({ id: 1, role: AUTHORITY.OWNER });
+});
+
+describe("confirmSubscriptionAction — 실서버", () => {
+  it("BE 결제 API를 부르지 않고 바로 성공을 돌려준다", async () => {
+    const result = await confirmSubscriptionAction();
+
+    expect(result).toEqual({ isSuccess: true });
+    expect(serverApiMock).not.toHaveBeenCalled();
+  });
+
+  it("구독을 읽는 화면 둘 다 갱신한다 — 결제 화면과 재개 화면이 같은 값을 본다", async () => {
+    await confirmSubscriptionAction();
+
+    expect(revalidatePath).toHaveBeenCalledWith("/manage/billing");
+    expect(revalidatePath).toHaveBeenCalledWith("/subscription");
+  });
+
+  /* ⚠️ 권한 문지기는 이 임시 조치와 무관하게 그대로 살아 있어야 한다 */
+  it("구독 관리 권한이 없으면 여전히 막는다", async () => {
+    getViewerMock.mockResolvedValue({ id: 4, role: AUTHORITY.MEMBER });
+
+    const result = await confirmSubscriptionAction();
+
+    expect(result.isSuccess).toBe(false);
+    expect(serverApiMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/billing/actions.ts
+++ b/src/features/billing/actions.ts
@@ -9,13 +9,7 @@ import { ep } from "@/lib/endpoints";
 import { canManageBilling } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
-import {
-  type BePaymentAction,
-  parsePaymentAction,
-  parsePaymentMethod,
-  toPaymentMethod,
-} from "./mapper";
-import { toFailureMessage } from "./payment";
+import { parsePaymentMethod, toPaymentMethod } from "./mapper";
 import type { CardAuthResult } from "./payment-method";
 import type { PaymentMethod } from "./subscription";
 
@@ -85,45 +79,22 @@ export async function confirmSubscriptionAction(): Promise<ActionResult> {
   }
 
   /*
-    [확인] `POST /api/companies/me/subscription/pay` — `BillingController.pay`, OWNER‖admin.
-    ⚠️ **봉투가 과도기다 — BE PR #461.** 지금 배포본은 `BillingPaymentActionResult` 맨몸이고,
-       #461부터 `ApiResponse<T>`로 온다. FE·BE가 어느 순서로 배포돼도 안전하도록
-       `isEnveloped: false`로 **원문을 받고**, 매퍼(`unwrapTransitionalEnvelope`)가 봉투
-       유무를 감지해 가른다 — 여기서 기본값으로 미리 바꾸면 BE 미배포 환경에서 맨몸 응답이
-       `undefined`로 벗겨져 **결제 실패가 성공으로 읽힌다**(§정직성). BE #461 배포가 전 환경에
-       확정되면 `isEnveloped` 기본값 경로로 되돌리고 감지를 걷어낸다.
-    ⚠️ **결제 전 구독 행이 없어도 된다** — #461의 `getOrCreateSubscription`이 `pay`에서
-       `UNPAID` 행을 만든다(옛 `BIL-001` 404 블로커 해소).
-    ⚠️ **실패도 HTTP 200이다.** 결제 실패는 예외가 아니라 값(`isSuccess:false`)으로 온다 —
-       `try/catch`만 두면 실패를 성공으로 넘긴다.
+    ⚠️⚠️ **임시 — Toss 실연동 여부가 [팀확정] 미정이라 결제사를 안 부른다**(2026-08-13,
+       사용자 확정). 화면 어디에도 카드 정보를 받는 자리가 없다(`CheckoutPanel`은 금액·동의
+       뿐, Toss SDK 위젯이 없다) — 그런데 이 자리는 원래 `POST /api/companies/me/subscription
+       /pay`를 실서버로 불렀다(`BillingController.pay`). BE는 등록된 결제수단이 있어야
+       통과시키는데(`NO_PAYMENT_METHOD`), 카드를 받을 길이 아예 없으니 실배포에서는 **이
+       버튼을 눌러도 영원히 실패**해 온보딩이 못 끝났다.
+    ⚠️ **그래서 목과 같은 값을 돌려준다 — BE 구독 상태는 그대로 `UNPAID`로 남는다.**
+       `/manage/billing`·`/subscription`이 이 회사를 다시 조회하면 여전히 결제 전으로
+       보인다(§정직성 — 여기서 감추지 않는다. 그 화면들의 상태 판정은 이 변경의 범위 밖이다).
+       middleware가 나중에 `canUseWorkspace`로 다시 막으면(`shell/entry.ts` 주석 — "지금은
+       미들웨어를 두지 않는다") **이 우회가 막힌다** — 그때는 BE에 카드 없이 활성화하는 길을
+       요청하거나 Toss를 실제로 붙여야 한다.
+    ⚠️ **Toss가 결정되면 이 블록을 지우고 실서버 호출로 되돌린다.** 원래 구현은 커밋 이력에
+       있다(`git log -p -- src/features/billing/actions.ts`에서 이 블록이 생긴 커밋의 부모를
+       본다) — 주석으로 코드를 남겨 두지 않는다(PR 체크리스트 §console·주석코드 금지).
   */
-  let result: BePaymentAction;
-  try {
-    const accessToken = await requireAccessToken();
-    result = parsePaymentAction(
-      await serverApi<unknown>(ep.subscriptionPay(), {
-        method: "POST",
-        accessToken,
-        isEnveloped: false,
-      }),
-    );
-  } catch (error) {
-    /*
-      ⚠️ **던지지 않고 값으로 돌려준다**(이 파일의 공통 규약). 부르는 쪽에 `try/catch`가 없어서
-         던지면 화면이 아무 반응 없이 멈춘다 — 통신 실패 문구는 `toUserMessage`가 고른다.
-    */
-    return { isSuccess: false, message: toUserMessage(error) };
-  }
-
-  if (!result.isSuccess) {
-    /*
-      ⚠️ 받는 건 **코드**다. 화면 문구는 `toFailureMessage`가 정한다 — BE 문자열을 그대로
-         뿌리면 `NO_PAYMENT_METHOD` 같은 게 화면에 뜬다.
-    */
-    return { isSuccess: false, message: toFailureMessage(result.failureCode ?? undefined) };
-  }
-
-  // 목 갈래와 **같은 곳을 갱신한다** — 결제로 바뀐 상태를 구독 재개 화면도 읽는다
   revalidatePath("/manage/billing");
   revalidatePath("/subscription");
   return { isSuccess: true };


### PR DESCRIPTION
## 📋 PR 타입

- [ ] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [x] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- `confirmSubscriptionAction()`의 실서버 분기가 `POST /api/companies/me/subscription/pay`(Toss)를 부르던 걸, 목 분기와 같은 즉시 성공으로 임시 대체한다.
- 원래 실연동 코드는 주석으로 남기지 않고 완전히 삭제 — 되돌릴 때는 git history를 본다.
- 더는 안 쓰는 `BePaymentAction`·`parsePaymentAction`·`toFailureMessage` import 정리.
- [팀확정] Toss 실연동 여부가 아직 미정인데, 결제 화면 어디에도 카드 정보를 받는 자리가 없다(`CheckoutPanel`은 금액·동의뿐, Toss SDK 위젯 없음). 실서버로 그대로 두면 BE가 `NO_PAYMENT_METHOD`로 항상 막아 온보딩이 못 끝난다 — 임시로 성공 처리해 흐름을 열어 둔다.
- 원래 같은 브랜치의 PR이 이 커밋이 push되기 전 커밋으로 이미 머지되어, 이 수정이 `develop`에 반영되지 않은 채로 브랜치/PR이 닫혔다. `origin/develop` 실제 코드를 확인해 누락을 재확인했고, 같은 작업을 새 브랜치로 재제출한다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**, 그리고 **서버에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [x] 🕵️ **정직성** — 결제사 임시 미호출을 주석·PR 본문에 명시(§정직한 목업)
- [ ] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화
- [ ] ♿ a11y
- [x] ♻️ 재사용 확인
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API 사용 시 안내

---

## 🔗 연관 이슈

Closes #429

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

- Toss 실연동 코드를 흔적 없이 삭제한 게 맞는 방향인지 (되돌릴 때는 git history)
- 임시 처리가 §요금제 정직성 원칙(무료·결제 없이라고 쓰지 않기)을 건드리지 않는지

---

## 📝 추가 메모

- 확인법: `npx tsc --noEmit` / `npx eslint <변경 파일> --max-warnings=0` / `npx jest --silent` / `npx next build` 전부 통과. `actions.test.ts` 3건 — BE 미호출, 두 `revalidatePath` 모두 호출, 권한 게이트가 여전히 비특권 뷰어를 막는지 확인.
