### PR TITLE
[FEAT] 비대면 회의 만들기 기능 추가(mock 전용) #473

### DIFF
--- a/src/app/(shell)/app/meeting/page.tsx
+++ b/src/app/(shell)/app/meeting/page.tsx
@@ -6,7 +6,13 @@ import {
   type MeetingTab,
 } from "@/features/meeting/components/meeting-list-view";
 import { getMeetingDirectory } from "@/features/meeting/server";
+import {
+  getReservableMembers,
+  getReservableProjects,
+  getReservableTeamActions,
+} from "@/features/rooms/server";
 import { getViewer } from "@/features/shell/viewer";
+import { requiresParentTeamAction } from "@/lib/permission";
 
 /*
   ⚠️ 정적으로 굳히지 않는다 — 예약이 회의를 만들고 상태가 시각으로 변하는 화면이라
@@ -27,7 +33,10 @@ function parseTab(value: string | string[] | undefined): MeetingTab {
  * 회의 목록(WORKFLOW §3-2) — 조회뿐이라 Server Component 하나로 끝난다.
  *
  * ⚠️ **목록은 전 구성원 공개**다(§3-2-1) — 권한 가드가 없다. 막는 건 상세다.
- * ⚠️ "새 회의 만들기" 버튼이 없다 — 생성 진입점은 `/app/rooms` 예약 모달 하나뿐이다(§3-1).
+ * ⚠️ **대면 회의 생성 진입점은 여전히 `/app/rooms` 예약 모달 하나뿐이다**(§3-1) — 회의실
+ *    예약이 곧 회의 개설이라 이 화면에 따로 만들지 않는다. 다만 **비대면 회의는 회의실·시간이
+ *    없어 예약이 필요 없다**(이슈 #473) — 그래서 이 목록 화면에 자기 진입점(비대면 회의
+ *    다이얼로그)을 하나 더 둔다.
  */
 export default async function AppMeetingPage({
   searchParams,
@@ -36,12 +45,25 @@ export default async function AppMeetingPage({
 }) {
   const tab = parseTab((await searchParams).tab);
   const viewer = await getViewer();
-  const directory = await getMeetingDirectory(viewer.id);
+  const [directory, members, projects, teamActions] = await Promise.all([
+    getMeetingDirectory(viewer.id),
+    getReservableMembers(),
+    getReservableProjects(),
+    getReservableTeamActions(viewer),
+  ]);
 
   return (
     <main className="min-h-0 flex-1 overflow-y-auto px-8 py-7">
       <div className="mx-auto w-full max-w-[1440px]">
-        <MeetingListView directory={directory} tab={tab} />
+        <MeetingListView
+          directory={directory}
+          tab={tab}
+          members={members}
+          projects={projects}
+          showParentTeamAction={requiresParentTeamAction(viewer)}
+          teamActions={teamActions}
+          viewer={{ id: viewer.id, role: viewer.role, teamName: viewer.teamName ?? null }}
+        />
       </div>
     </main>
   );

--- a/src/features/meeting/actions.online-real.test.ts
+++ b/src/features/meeting/actions.online-real.test.ts
@@ -1,0 +1,53 @@
+// 서버 액션은 next 런타임 함수를 부른다 — jsdom엔 없으니 목으로 대체하고 호출만 검증한다.
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+// 이 파일만 실서버 분기를 본다(`actions.attendees-real.test.ts`와 같은 패턴).
+jest.mock("@/mocks/config", () => ({ isMock: false }));
+jest.mock("@/features/shell/viewer", () => ({
+  getViewer: jest.fn(() => Promise.resolve({ id: 1, role: "OWNER" })),
+}));
+jest.mock("@/lib/api", () => ({
+  ApiError: class ApiError extends Error {},
+  serverApi: jest.fn(),
+}));
+
+import { serverApi } from "@/lib/api";
+
+import { createOnlineMeetingAction } from "./actions";
+
+const serverApiMock = serverApi as unknown as jest.Mock;
+
+const VALID_FORM = () => {
+  const data = new FormData();
+  data.append("title", "비대면 주간 싱크");
+  data.append("projectId", "1");
+  data.append("attendeeIds", "2");
+  data.append("topicMain", "제품");
+  data.append("topicSub", "로드맵 검토");
+  return data;
+};
+
+/*
+  ⚠️ BE API가 아직 안 정해졌다(1안/2안 논의 중, 이슈 #473) — 추측 요청을 보내지 않는다
+     (CLAUDE.md §연동 검증: Swagger·구두 추측 금지). 확정되기 전까지 실서버 분기는 정직하게
+     "아직 준비 중"이라고만 말하고, `serverApi`를 절대 부르지 않아야 한다.
+*/
+describe("비대면 회의 만들기(이슈 #473) — 실서버 분기(!isMock)", () => {
+  beforeEach(() => {
+    serverApiMock.mockClear();
+  });
+
+  it("아직 준비 중이라는 오류를 돌려주고 serverApi를 부르지 않는다", async () => {
+    const result = await createOnlineMeetingAction({ errors: {} }, VALID_FORM());
+
+    expect(result.errors.title).toBe("비대면 회의는 아직 준비 중입니다 — 곧 지원됩니다");
+    expect(result.created).toBeUndefined();
+    expect(serverApiMock).not.toHaveBeenCalled();
+  });
+
+  it("폼 자체가 비어 있으면 그 검증 오류가 먼저 온다(실서버 안내보다 앞선다)", async () => {
+    const result = await createOnlineMeetingAction({ errors: {} }, new FormData());
+
+    expect(result.errors.title).toBe("회의 제목을 입력해 주세요");
+    expect(serverApiMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/meeting/actions.test.ts
+++ b/src/features/meeting/actions.test.ts
@@ -8,7 +8,7 @@ jest.mock("@/lib/mock-actor", () => ({
   getMockActor: jest.fn(() => ({ id: 1, role: "OWNER" })),
 }));
 
-import { updateMeetingAttendeesAction } from "./actions";
+import { createOnlineMeetingAction, updateMeetingAttendeesAction } from "./actions";
 import { addMockMeeting } from "./mock/meetings";
 import type { MeetingDraft } from "./types";
 
@@ -106,5 +106,74 @@ describe("참석자 교체(MEET-09) — 범위 재검증", () => {
     const result = await updateMeetingAttendeesAction(INITIAL, form(meeting.id, [9999]));
 
     expect(result.error).toBe("존재하지 않는 참석자가 있습니다");
+  });
+});
+
+/*
+  ⚠️ 비대면 회의 만들기(이슈 #473) — **이 파일은 mock 전용이다**(파일 머리 `isMock: true`
+     고정). `!isMock` 분기("아직 준비 중")는 별도 파일(`actions.online-real.test.ts`)이 본다.
+*/
+const onlineForm = (entries: {
+  title?: string;
+  projectId?: string;
+  attendeeIds?: number[];
+  topics?: { main: string; sub: string }[];
+  parentTeamActionId?: number;
+}) => {
+  const data = new FormData();
+  data.append("title", entries.title ?? "비대면 주간 싱크");
+  data.append("projectId", entries.projectId ?? "1");
+  for (const id of entries.attendeeIds ?? [2]) data.append("attendeeIds", String(id));
+  for (const topic of entries.topics ?? [{ main: "제품", sub: "로드맵 검토" }]) {
+    data.append("topicMain", topic.main);
+    data.append("topicSub", topic.sub);
+  }
+  if (entries.parentTeamActionId !== undefined) {
+    data.append("parentTeamActionId", String(entries.parentTeamActionId));
+  }
+  return data;
+};
+
+const ONLINE_INITIAL = { errors: {} } as const;
+
+describe("비대면 회의 만들기(이슈 #473) — mock 분기", () => {
+  it("성공하면 즉시 완료 처리된 회의를 만들고 id를 돌려준다", async () => {
+    const result = await createOnlineMeetingAction(ONLINE_INITIAL, onlineForm({}));
+
+    expect(result.errors).toEqual({});
+    expect(result.created?.id).toMatch(/^meeting-\d+$/);
+  });
+
+  it("존재하지 않는 프로젝트면 막는다(폼 조작 방어)", async () => {
+    const result = await createOnlineMeetingAction(
+      ONLINE_INITIAL,
+      onlineForm({ projectId: "999" }),
+    );
+
+    expect(result.errors.projectId).toBe("존재하지 않는 프로젝트입니다");
+    expect(result.created).toBeUndefined();
+  });
+
+  it("Owner 개설인데 팀장이 아닌 참석자를 넣으면 막는다(참석자 범위)", async () => {
+    // 3 = 이하윤(개발팀 MEMBER) — Owner가 여는 회의엔 팀장만 지정할 수 있다.
+    const result = await createOnlineMeetingAction(
+      ONLINE_INITIAL,
+      onlineForm({ attendeeIds: [3] }),
+    );
+
+    expect(result.errors.attendeeIds).toBe(
+      "Owner가 개설하는 회의에는 팀장만 참석자로 지정할 수 있습니다",
+    );
+    expect(result.created).toBeUndefined();
+  });
+
+  it("존재하지 않는 참석자 id는 막는다(폼 조작 방어)", async () => {
+    const result = await createOnlineMeetingAction(
+      ONLINE_INITIAL,
+      onlineForm({ attendeeIds: [9999] }),
+    );
+
+    expect(result.errors.attendeeIds).toBe("존재하지 않는 참석자가 있습니다");
+    expect(result.created).toBeUndefined();
   });
 });

--- a/src/features/meeting/actions.ts
+++ b/src/features/meeting/actions.ts
@@ -2,25 +2,40 @@
 
 import { revalidatePath } from "next/cache";
 
+import { AUTHORITY, type Authority } from "@/constants/authority";
 import { MEETING_STATUS } from "@/constants/meeting";
 import { requireAccessToken } from "@/features/auth/session";
-import { findAttendeeScopeViolation } from "@/features/rooms/attendee-scope";
+import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
+import { PROJECT_TEAM_ACTIONS_MOCK } from "@/features/project/mock/team-actions";
+import {
+  type AttendeeScopeViewer,
+  findAttendeeScopeViolation,
+} from "@/features/rooms/attendee-scope";
 import { findMockMember } from "@/features/rooms/mock/members";
+import { getViewer } from "@/features/shell/viewer";
 import { ApiError, serverApi } from "@/lib/api";
 import { ep } from "@/lib/endpoints";
 import { getMockActor } from "@/lib/mock-actor";
-import { canManageMeeting } from "@/lib/permission";
+import { type Actor, canManageMeeting, requiresParentTeamAction } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
 import { checkMeetingTitle } from "./lib";
 import { attendeeIdsFrom, type BeUpdateAttendeesResponse } from "./mapper";
 import {
+  addMockOnlineMeeting,
   cancelMockMeeting,
   findMockMeeting,
   updateMockMeeting,
   updateMockMeetingAttendees,
 } from "./mock/meetings";
 import { meetingStatusOf } from "./status";
+import type {
+  MeetingDraft,
+  MeetingTopic,
+  OnlineMeetingDraft,
+  OnlineMeetingFormErrors,
+} from "./types";
+import { validateOnlineMeetingDraft } from "./validate";
 
 const MEETING_LIST_PATH = "/app/meeting";
 
@@ -259,4 +274,144 @@ export async function updateMeetingAction(
   } catch (error) {
     return { error: toUpdateErrorMessage(error), saved: null };
   }
+}
+
+/**
+ * 참석자 범위 판정에 필요한 최소 정보만 `Actor`에서 뽑는다(`attendee-scope.ts`).
+ * ⚠️ `rooms/actions.ts`에 같은 이름의 헬퍼가 있지만 export되지 않아 여기서 다시 만든다 —
+ *    로직은 한 줄이라 두 벌이어도 어긋날 여지가 없다(`updateMeetingAttendeesAction`도 같은
+ *    모양을 인라인으로 쓴다).
+ */
+function toAttendeeScopeViewer(actor: Actor): AttendeeScopeViewer {
+  return { id: actor.id, role: actor.role, teamName: actor.teamName ?? null };
+}
+
+/** 비대면 회의 만들기 폼 결과 — `useActionState`가 그대로 들고 있는 모양. */
+export interface OnlineMeetingFormState {
+  errors: OnlineMeetingFormErrors;
+  /** 성공 시 방금 만든 회의 id — 다이얼로그가 이 값으로 상세로 이동한다(재조회 없이). */
+  created?: { id: string };
+}
+
+function readOnlineMeetingDraft(formData: FormData): OnlineMeetingDraft {
+  const parentTeamActionId = formData.get("parentTeamActionId");
+  const recordingFileName = formData.get("recordingFileName");
+  const mains = formData.getAll("topicMain");
+  const subs = formData.getAll("topicSub");
+
+  return {
+    title: String(formData.get("title") ?? ""),
+    projectId: String(formData.get("projectId") ?? ""),
+    topics: mains.map((main, index) => ({ main: String(main), sub: String(subs[index] ?? "") })),
+    attendeeIds: formData.getAll("attendeeIds").map(Number),
+    parentTeamActionId: parentTeamActionId ? Number(parentTeamActionId) : undefined,
+    recordingFileName: recordingFileName ? String(recordingFileName) : null,
+  };
+}
+
+/**
+ * 비대면 회의 만들기(이슈 #473) — `/app/meeting` 목록의 [비대면 회의] 버튼이 부른다.
+ *
+ * ⚠️ **BE API가 아직 안 정해졌다**(1안/2안 논의 중, 팀원 회신 — 이슈 #473). 추측 요청을 보내지
+ *    않는다(CLAUDE.md §연동 검증: Swagger·구두 추측 금지) — 실서버 분기는 확정될 때까지
+ *    "아직 준비 중"이라고 정직하게 말한다(§정직성). 확정되면 이 분기만 실서버 호출로 바꾼다
+ *    (§Mock 격리막).
+ * ⚠️ **제출하면 그 자리에서 완료 처리된다** — 회의실 예약(`createRoomReservationAction`)과
+ *    달리 캡처 화면으로 안 넘어간다(팀 명세). 그래서 회의실·시간을 아예 안 받는다.
+ * ⚠️ mock 분기의 검증 순서는 `createRoomReservationAction`과 맞춘다(프로젝트 → 참석자 범위 →
+ *    상위 팀 액션) — 같은 도메인의 두 생성 경로가 다른 순서로 막히면 같은 실수가 화면마다
+ *    다른 첫 오류로 보인다.
+ */
+export async function createOnlineMeetingAction(
+  _prev: OnlineMeetingFormState,
+  formData: FormData,
+): Promise<OnlineMeetingFormState> {
+  const draft = readOnlineMeetingDraft(formData);
+  const actor = isMock ? getMockActor() : await getViewer();
+  const errors = validateOnlineMeetingDraft(draft, { role: actor.role });
+  if (Object.keys(errors).length > 0) return { errors };
+
+  if (!isMock) {
+    // ⚠️ BE API가 아직 안 정해졌다(1안/2안 논의 중, 이슈 #473) — 추측 요청을 보내지 않는다
+    //    (CLAUDE.md §연동 검증: Swagger·구두 추측 금지). 확정되면 이 분기를 실서버 호출로 바꾼다.
+    return { errors: { title: "비대면 회의는 아직 준비 중입니다 — 곧 지원됩니다" } };
+  }
+
+  // ⚠️ 화면 select·피커가 이미 실제 목록에서만 고르게 해도, 폼은 조작될 수 있다
+  //    (§권한: 화면 숨김은 UX일 뿐 보안이 아니다) — 참조값이 실제로 존재하는지 서버에서 다시 본다.
+  const project = TOP_LEVEL_PROJECTS.find((item) => String(item.id) === draft.projectId);
+  if (!project) {
+    return { errors: { projectId: "존재하지 않는 프로젝트입니다" } };
+  }
+
+  /*
+    ⚠️ **참석자 서버 재검증**(`createRoomReservationAction`과 같은 규칙, 2026-08-13 확정).
+       화면 피커가 후보를 좁혀 보여줘도 Server Action은 주소만 알면 직접 부를 수 있어, 제출된
+       id가 **실존하는지**와 **범위 안인지**를 여기서 다시 본다. 규칙 자체는 `attendee-scope.ts`
+       한 곳이다 — 화면과 서버가 갈리면 안 된다.
+  */
+  const attendees = draft.attendeeIds.map(findMockMember);
+  if (attendees.some((member) => member === null)) {
+    return { errors: { attendeeIds: "존재하지 않는 참석자가 있습니다" } };
+  }
+  const scopeViolation = findAttendeeScopeViolation(
+    attendees.filter((member) => member !== null),
+    toAttendeeScopeViewer(actor),
+  );
+  if (scopeViolation) return { errors: { attendeeIds: scopeViolation } };
+
+  // ⚠️ Owner가 아니면 "상위 팀 액션"이 필수인데, 그 값이 진짜 이 프로젝트 소속이고 **자기
+  //    팀**에 하달된 게 맞는지까지 다시 본다 — `createRoomReservationAction`과 같은 검사다.
+  if (requiresParentTeamAction(actor) && draft.parentTeamActionId !== undefined) {
+    const teamAction = PROJECT_TEAM_ACTIONS_MOCK[project.tag]?.find(
+      (item) => item.id === draft.parentTeamActionId,
+    );
+    if (!teamAction || teamAction.team !== actor.teamName) {
+      return { errors: { parentTeamActionId: "존재하지 않는 상위 팀 액션입니다" } };
+    }
+  }
+
+  // ⚠️ `Meeting.topics`는 최소 1개짜리 튜플 타입이다 — 위 검증이 이미 최소 1쌍을 보장했다
+  //    (`rooms/mock/reservations.ts`의 `addMockReservation`과 같은 처리).
+  const trimmedTopics = draft.topics.map((topic) => ({
+    main: topic.main.trim(),
+    sub: topic.sub.trim(),
+  }));
+  const [firstTopic, ...restTopics] = trimmedTopics;
+  const topics: [MeetingTopic, ...MeetingTopic[]] = [firstTopic!, ...restTopics];
+  const attendeeIds = Array.from(new Set([actor.id, ...draft.attendeeIds]));
+
+  const meetingCommon = {
+    title: draft.title.trim(),
+    // ⚠️ 비대면 회의는 회의실·시간이 없다(이슈 #473) — mock 스토어(`addMockOnlineMeeting`)가
+    //    저장 직전에 실제 시각(제출 시각)을 채운다. 여기서는 판별식 유니언 조립에 필요한
+    //    최소값만 넣는다.
+    start: new Date(0),
+    end: new Date(0),
+    roomId: null,
+    roomName: null,
+    roomReservationId: null,
+    isOnline: true,
+    recordingFileName: draft.recordingFileName,
+    projectId: project.id,
+    projectTag: project.tag,
+    topics,
+    attendeeIds,
+    hostId: actor.id,
+  };
+
+  // ⚠️ `Meeting`은 Owner 개설/팀 액션 개설을 판별식 유니언으로 나눠 둔다 — 같은 분기를
+  //    `rooms/mock/reservations.ts`의 `addMockReservation`이 쓴다(같은 규칙, 다른 생성 경로).
+  const meetingDraft: MeetingDraft = requiresParentTeamAction(actor)
+    ? {
+        ...meetingCommon,
+        hostAuthority: actor.role as Extract<Authority, "LEADER" | "MEMBER">,
+        hostTeamId: actor.teamId!,
+        parentTeamActionId: draft.parentTeamActionId!,
+      }
+    : { ...meetingCommon, hostAuthority: AUTHORITY.OWNER };
+
+  const meeting = addMockOnlineMeeting(meetingDraft);
+  revalidatePath(MEETING_LIST_PATH);
+  return { errors: {}, created: { id: meeting.id } };
 }

--- a/src/features/meeting/components/meeting-card.test.tsx
+++ b/src/features/meeting/components/meeting-card.test.tsx
@@ -17,6 +17,7 @@ const BASE: MeetingListItem = {
   attendeeCount: 4,
   isHost: true,
   aiSummaryStatus: null,
+  isOnline: false,
 };
 
 function renderCard(patch: Partial<MeetingListItem> = {}) {
@@ -66,6 +67,30 @@ describe("MeetingCard — 발치 버튼", () => {
       "href",
       "/app/meeting/meeting-3/review",
     );
+  });
+});
+
+/** 비대면 회의(이슈 #473) — 발치의 일시·장소 자리가 안내 한 줄로 바뀐다. 인원수는 그대로다. */
+describe("MeetingCard — 비대면 회의(isOnline)", () => {
+  it("대면 회의는 일시·장소를 그대로 보여준다", () => {
+    renderCard({ isOnline: false });
+
+    expect(screen.getByText("8월 14일(금) 10:00 – 10:30")).toBeInTheDocument();
+    expect(screen.getByText("대회의실")).toBeInTheDocument();
+    expect(screen.queryByText("온라인으로 진행된 회의입니다")).not.toBeInTheDocument();
+  });
+
+  it("비대면 회의는 일시·장소 대신 안내 한 줄을 보여준다", () => {
+    renderCard({ isOnline: true, schedule: "", roomName: "" });
+
+    expect(screen.getByText("온라인으로 진행된 회의입니다")).toBeInTheDocument();
+    expect(screen.queryByText("대회의실")).not.toBeInTheDocument();
+  });
+
+  it("비대면 회의도 참석자 인원수는 그대로 보여준다", () => {
+    renderCard({ isOnline: true, schedule: "", roomName: "" });
+
+    expect(screen.getByText("4명")).toBeInTheDocument();
   });
 });
 

--- a/src/features/meeting/components/meeting-card.tsx
+++ b/src/features/meeting/components/meeting-card.tsx
@@ -1,4 +1,4 @@
-import { CalendarClock, ChevronRight, MapPin, Mic, Sparkles, Users } from "lucide-react";
+import { CalendarClock, ChevronRight, MapPin, Mic, Sparkles, Users, Video } from "lucide-react";
 import Link from "next/link";
 
 import { ProjectTag } from "@/components/common/project-tag";
@@ -166,16 +166,30 @@ function CardFooter({
            서로 다른 데서 끝났다(§오와 열) — 좁으면 접는 대신 **회의실 이름을 자른다.**
       */}
       <div className="flex min-w-0 flex-nowrap items-center gap-x-3">
-        <span className="flex shrink-0 items-center gap-1.5 text-[13px] leading-5 font-medium">
-          <CalendarClock className="text-muted-foreground size-4 shrink-0" aria-hidden />
-          <span className="tabular-nums">{meeting.schedule}</span>
-        </span>
+        {/*
+          ⚠️ **비대면 회의는 일시·장소 대신 안내 한 줄이다**(이슈 #473). 회의실·시간이 없어서
+             (`meeting.schedule`·`meeting.roomName`이 서버에서부터 빈 문자열로 온다) 그 칸을
+             그대로 그리면 빈 채로 보인다 — `isOnline`을 먼저 보고 아예 다른 것을 그린다.
+        */}
+        {meeting.isOnline ? (
+          <span className="flex shrink-0 items-center gap-1.5 text-[13px] leading-5 font-medium">
+            <Video className="text-muted-foreground size-4 shrink-0" aria-hidden />
+            <span>온라인으로 진행된 회의입니다</span>
+          </span>
+        ) : (
+          <span className="flex shrink-0 items-center gap-1.5 text-[13px] leading-5 font-medium">
+            <CalendarClock className="text-muted-foreground size-4 shrink-0" aria-hidden />
+            <span className="tabular-nums">{meeting.schedule}</span>
+          </span>
+        )}
         <span className="bg-border h-3 w-px shrink-0" aria-hidden />
         <span className="text-muted-foreground flex min-w-0 items-center gap-x-3 text-[12px] leading-4">
-          <span className="flex min-w-0 items-center gap-1.5">
-            <MapPin className="size-3.5 shrink-0" aria-hidden />
-            <span className="truncate">{meeting.roomName}</span>
-          </span>
+          {!meeting.isOnline && (
+            <span className="flex min-w-0 items-center gap-1.5">
+              <MapPin className="size-3.5 shrink-0" aria-hidden />
+              <span className="truncate">{meeting.roomName}</span>
+            </span>
+          )}
           <span className="flex shrink-0 items-center gap-1.5">
             <Users className="size-3.5 shrink-0" aria-hidden />
             <span className="tabular-nums">{meeting.attendeeCount}명</span>

--- a/src/features/meeting/components/meeting-detail-view.test.tsx
+++ b/src/features/meeting/components/meeting-detail-view.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, within } from "@testing-library/react";
+
+import { AUTHORITY } from "@/constants/authority";
+import type { AttendeeScopeViewer } from "@/features/rooms/attendee-scope";
+import type { RoomMember } from "@/features/rooms/types";
+
+import type { MeetingDetail } from "../view-types";
+import { MeetingDetailView } from "./meeting-detail-view";
+
+/**
+ * 비대면 회의(이슈 #473) — 발치 레일과 발화 기록 칸이 `isOnline`으로 갈리는지 본다.
+ * ⚠️ `pendingReason: null`(요약까지 끝난 상태)로 고정한다 — 그래야 [회의 수정]·[회의 취소]·
+ *    [참석자 수정] 다이얼로그(`canEditMeeting` 등이 전부 `pendingReason === "SCHEDULED"`
+ *    일 때만 연다)가 안 뜨고, 이 화면이 순수하게 데이터만 읽는 형태로 렌더된다.
+ */
+const MEMBERS: RoomMember[] = [
+  { id: 1, name: "박대표", teamName: null, authority: AUTHORITY.OWNER },
+];
+const VIEWER: AttendeeScopeViewer = { id: 1, role: AUTHORITY.OWNER, teamName: null };
+
+const BASE: MeetingDetail = {
+  id: "meeting-1",
+  title: "굿즈 앱 킥오프",
+  projectId: 1,
+  projectTag: "GOODS",
+  originLabel: "Owner 개설",
+  parentTeamActionHref: null,
+  agenda: { main: "프로젝트", subs: ["킥오프"] },
+  schedule: "8월 14일(금) 10:00 – 10:30",
+  roomName: "대회의실",
+  attendees: [{ id: 1, name: "박대표" }],
+  outputKindLabel: "팀 액션",
+  outputs: [],
+  script: [],
+  pendingReason: null,
+  pendingActionCount: 0,
+  isStalled: false,
+  isHost: true,
+  isOnline: false,
+};
+
+function renderDetail(patch: Partial<MeetingDetail> = {}) {
+  render(<MeetingDetailView detail={{ ...BASE, ...patch }} members={MEMBERS} viewer={VIEWER} />);
+}
+
+describe("MeetingDetailView — 비대면 회의(isOnline)", () => {
+  it("대면 회의는 발치 레일에 일시·장소를 그대로 보여준다", () => {
+    renderDetail({ isOnline: false });
+
+    expect(screen.getByText("8월 14일(금) 10:00 – 10:30")).toBeInTheDocument();
+    expect(screen.getByText("대회의실")).toBeInTheDocument();
+    expect(screen.queryByText("온라인으로 진행된 회의입니다")).not.toBeInTheDocument();
+  });
+
+  it("비대면 회의는 발치 레일의 일시·장소 대신 안내 한 줄을 보여준다", () => {
+    renderDetail({ isOnline: true, schedule: "", roomName: "" });
+
+    expect(screen.getByText("온라인으로 진행된 회의입니다")).toBeInTheDocument();
+    expect(screen.queryByText("대회의실")).not.toBeInTheDocument();
+  });
+
+  it("비대면 회의는 발화 기록 칸에 항상 안내만 뜬다 — 스크립트가 있어도 안 보여준다", () => {
+    renderDetail({
+      isOnline: true,
+      schedule: "",
+      roomName: "",
+      script: [{ at: "10:00", text: "이 텍스트는 화면에 뜨면 안 된다" }],
+    });
+
+    expect(screen.getByText("온라인으로 진행된 회의입니다.")).toBeInTheDocument();
+    expect(screen.getByText("비대면 회의는 발화 기록을 남기지 않습니다.")).toBeInTheDocument();
+    expect(screen.queryByText("이 텍스트는 화면에 뜨면 안 된다")).not.toBeInTheDocument();
+  });
+
+  it("비대면 회의는 pendingReason이 있어도 발화 기록 칸은 안내가 우선한다", () => {
+    renderDetail({
+      isOnline: true,
+      schedule: "",
+      roomName: "",
+      pendingReason: "SUMMARIZING",
+      script: null,
+    });
+
+    // ⚠️ "요약 중" 문구 자체는 산출물(하달된 액션) 칸에도 그대로 뜬다 — 그 칸은 이 이슈의
+    //    범위 밖이라 손대지 않는다(WORKFLOW: "AI 분배는 온라인 회의 전용 분기 없음"). 그래서
+    //    페이지 전체가 아니라 **발화 기록 섹션 안**만 좁혀서 본다.
+    const scriptHeading = screen.getByRole("heading", { name: "발화 기록" });
+    const scriptSection = scriptHeading.closest("section");
+    expect(scriptSection).not.toBeNull();
+
+    expect(
+      within(scriptSection!).getByText("비대면 회의는 발화 기록을 남기지 않습니다."),
+    ).toBeInTheDocument();
+    expect(
+      within(scriptSection!).queryByText("회의 내용을 요약하고 있습니다."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("대면 회의는 발화 기록이 없으면 미연동 안내를 보여준다(회귀 방지)", () => {
+    renderDetail({ isOnline: false, script: null });
+
+    expect(screen.getByText("발화 기록을 아직 표시할 수 없습니다.")).toBeInTheDocument();
+  });
+});

--- a/src/features/meeting/components/meeting-detail-view.tsx
+++ b/src/features/meeting/components/meeting-detail-view.tsx
@@ -9,6 +9,7 @@ import {
   MessageSquareOff,
   Radio,
   Sparkles,
+  Video,
 } from "lucide-react";
 import Link from "next/link";
 
@@ -344,15 +345,29 @@ export function MeetingDetailView({ detail, members, viewer }: MeetingDetailView
             ⚠️ 띠 색은 표 머리와 같은 것(`bg-secondary/50`)이다. 새 회색을 만들지 않는다.
           */}
           <div className="border-border bg-secondary/50 -mx-7 mt-6 -mb-7 flex flex-wrap items-center gap-x-3 gap-y-1 border-t px-7 py-4">
-            <span className="flex shrink-0 items-center gap-1.5 text-[13px] leading-5 font-medium">
-              <CalendarClock className="text-muted-foreground size-4 shrink-0" aria-hidden />
-              <span className="tabular-nums">{detail.schedule}</span>
-            </span>
-            <span className="bg-border h-3 w-px shrink-0" aria-hidden />
-            <span className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-[12px] leading-4">
-              <MapPin className="size-3.5 shrink-0" aria-hidden />
-              <span className="truncate">{detail.roomName}</span>
-            </span>
+            {/*
+              ⚠️ **비대면 회의는 일시·장소가 없다**(이슈 #473) — `schedule`·`roomName`이 서버에서
+                 빈 문자열로 온다. `isOnline`을 먼저 보고 안내 한 줄로 대신한다(목록 카드와
+                 같은 규칙, `meeting-card.tsx`).
+            */}
+            {detail.isOnline ? (
+              <span className="flex shrink-0 items-center gap-1.5 text-[13px] leading-5 font-medium">
+                <Video className="text-muted-foreground size-4 shrink-0" aria-hidden />
+                <span>온라인으로 진행된 회의입니다</span>
+              </span>
+            ) : (
+              <>
+                <span className="flex shrink-0 items-center gap-1.5 text-[13px] leading-5 font-medium">
+                  <CalendarClock className="text-muted-foreground size-4 shrink-0" aria-hidden />
+                  <span className="tabular-nums">{detail.schedule}</span>
+                </span>
+                <span className="bg-border h-3 w-px shrink-0" aria-hidden />
+                <span className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-[12px] leading-4">
+                  <MapPin className="size-3.5 shrink-0" aria-hidden />
+                  <span className="truncate">{detail.roomName}</span>
+                </span>
+              </>
+            )}
           </div>
         </section>
 
@@ -447,14 +462,26 @@ export function MeetingDetailView({ detail, members, viewer }: MeetingDetailView
         <section className="border-border bg-card rounded-2xl border">
           <div className="flex items-baseline justify-between gap-3 px-7 pt-6 pb-3">
             <h2 className="text-[17px] leading-7 font-semibold tracking-[-0.3px]">발화 기록</h2>
-            {!detail.pendingReason && detail.script !== null && (
+            {!detail.isOnline && !detail.pendingReason && detail.script !== null && (
               <p className="text-muted-foreground text-[12px] leading-4 tabular-nums">
                 {detail.script.length}건
               </p>
             )}
           </div>
 
-          {detail.pendingReason ? (
+          {/*
+            ⚠️ **비대면 회의는 발화 기록을 절대 안 남긴다**(이슈 #473, 팀 명세). 캡처(STT)를
+               거치지 않아서다 — 요약 상태·자막 조회 미연동 같은 다른 이유보다 **앞서** 이 사실을
+               말해야 한다. `pendingReason`이 "요약 중"이라고 말해도 온라인 회의는 어차피
+               발화 기록이 생기지 않으므로 그 안내는 거짓말이 된다.
+          */}
+          {detail.isOnline ? (
+            <EmptyState
+              icon={Video}
+              title="온라인으로 진행된 회의입니다."
+              description="비대면 회의는 발화 기록을 남기지 않습니다."
+            />
+          ) : detail.pendingReason ? (
             <SectionNotice reason={detail.pendingReason} />
           ) : detail.script === null ? (
             /* ⚠️ 산출물 칸의 `notLoaded`와 같은 자리다 — 자막 조회(CAP-12) 미연동이라 안 물어봤다 */

--- a/src/features/meeting/components/meeting-list-view.tsx
+++ b/src/features/meeting/components/meeting-list-view.tsx
@@ -2,16 +2,20 @@ import { Video } from "lucide-react";
 import Link from "next/link";
 
 import { EmptyState } from "@/components/common/empty-state";
+import type { AttendeeScopeViewer } from "@/features/rooms/attendee-scope";
+import type { RoomMember, RoomProjectOption, RoomTeamActionOption } from "@/features/rooms/types";
 import { cn } from "@/lib/utils";
 
 import type { MeetingDirectory, MeetingListItem } from "../view-types";
 import { MeetingCard } from "./meeting-card";
+import { OnlineMeetingDialog } from "./online-meeting-dialog";
 
 /**
- * 회의 목록 — 탭 두 개가 전부다(WORKFLOW §3-2).
+ * 회의 목록 — 탭 두 개 + 비대면 회의 진입점(WORKFLOW §3-2, 이슈 #473).
  *
- * ⚠️ **"새 회의 만들기" 버튼이 없다.** 회의 생성 진입점은 `/app/rooms` 예약 모달 하나뿐이다
- *    (§3-1) — 여기 버튼을 두면 진입점이 두 개가 된다.
+ * ⚠️ **대면 회의는 여기 만드는 버튼이 없다.** 생성 진입점은 `/app/rooms` 예약 모달 하나뿐이다
+ *    (§3-1) — 여기 또 두면 진입점이 두 개가 된다. 다만 **비대면 회의는 회의실·시간이 없어
+ *    예약이 필요 없다**(이슈 #473)라 이 목록 화면이 그 하나뿐인 진입점이다.
  * ⚠️ 탭은 **주소로** 오간다(`?tab=`). 화면 상태로 두면 새로고침·뒤로 가기에서 탭이 날아간다.
  *    서버 컴포넌트라 클릭은 `Link`다 — 프로젝트 목록의 `?status=`와 같은 패턴.
  */
@@ -76,28 +80,57 @@ function MeetingEmptyState({ tab }: { tab: MeetingTab }) {
   );
 }
 
+interface MeetingListViewProps {
+  directory: MeetingDirectory;
+  tab: MeetingTab;
+  /** 비대면 회의 다이얼로그로 그대로 흘려보낸다(`/app/rooms/page.tsx`와 같은 데이터 원천). */
+  members: RoomMember[];
+  projects: RoomProjectOption[];
+  showParentTeamAction: boolean;
+  teamActions: RoomTeamActionOption[];
+  viewer: AttendeeScopeViewer;
+}
+
 export function MeetingListView({
   directory,
   tab,
-}: {
-  directory: MeetingDirectory;
-  tab: MeetingTab;
-}) {
+  members,
+  projects,
+  showParentTeamAction,
+  teamActions,
+  viewer,
+}: MeetingListViewProps) {
   const items: MeetingListItem[] =
     tab === MEETING_TAB.HOSTED ? directory.hosted : directory.invited;
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="border-border flex gap-1 border-b" role="group" aria-label="회의 거르기">
-        <TabLink
-          tab={MEETING_TAB.HOSTED}
-          isActive={tab === MEETING_TAB.HOSTED}
-          count={directory.hosted.length}
-        />
-        <TabLink
-          tab={MEETING_TAB.INVITED}
-          isActive={tab === MEETING_TAB.INVITED}
-          count={directory.invited.length}
+      {/*
+        ⚠️ 선(`border-b`)을 **이 바깥 줄**에 건다(2026-08-14, 비대면 회의 버튼을 더하며 옮김).
+           탭 두 개만 있을 때는 탭 상자에 걸어도 됐지만, 오른쪽에 버튼을 나란히 두면 탭 상자
+           너비만큼만 선이 그어져 버튼 아래는 선이 끊긴다 — 줄 전체 폭으로 선을 그어야
+           헤더 한 줄로 읽힌다. `TabLink`의 `-mb-px`는 가장 가까운 `border-b` 조상을 기준으로
+           겹치므로 옮겨도 밑줄 탭 모양은 그대로다.
+      */}
+      <div className="border-border flex items-center justify-between gap-3 border-b">
+        <div className="flex gap-1" role="group" aria-label="회의 거르기">
+          <TabLink
+            tab={MEETING_TAB.HOSTED}
+            isActive={tab === MEETING_TAB.HOSTED}
+            count={directory.hosted.length}
+          />
+          <TabLink
+            tab={MEETING_TAB.INVITED}
+            isActive={tab === MEETING_TAB.INVITED}
+            count={directory.invited.length}
+          />
+        </div>
+        <OnlineMeetingDialog
+          members={members}
+          projects={projects}
+          showParentTeamAction={showParentTeamAction}
+          teamActions={teamActions}
+          viewer={viewer}
         />
       </div>
 

--- a/src/features/meeting/components/online-meeting-dialog.test.tsx
+++ b/src/features/meeting/components/online-meeting-dialog.test.tsx
@@ -1,0 +1,132 @@
+const pushMock = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/lib/mock-actor", () => ({
+  getMockActor: jest.fn(() => ({ id: 1, role: "OWNER" })),
+}));
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { AUTHORITY } from "@/constants/authority";
+import type { RoomMember, RoomProjectOption, RoomTeamActionOption } from "@/features/rooms/types";
+
+import { OnlineMeetingDialog } from "./online-meeting-dialog";
+
+/*
+  ⚠️ 이 파일은 `RoomReservationDialog`의 테스트(`room-reservation-dialog.test.tsx`)와 같은
+     전제다 — `isMock`을 따로 목하지 않는다(`NEXT_PUBLIC_USE_MOCK`이 없으면 기본이 `true`라
+     mock 분기가 실제로 돈다). Owner가 여는 폼이라 참석자 후보는 팀장뿐이다(2026-08-13,
+     `attendee-scope.ts`).
+*/
+const MEMBERS: RoomMember[] = [
+  { id: 2, name: "김서준", teamName: "개발팀", authority: AUTHORITY.LEADER },
+];
+const PROJECTS: RoomProjectOption[] = [{ id: "1", name: "굿즈 프로젝트", tag: "GOODS" }];
+const TEAM_ACTIONS: RoomTeamActionOption[] = [];
+const OWNER_VIEWER = { id: 1, role: AUTHORITY.OWNER, teamName: null } as const;
+
+function renderDialog() {
+  render(
+    <OnlineMeetingDialog
+      members={MEMBERS}
+      projects={PROJECTS}
+      showParentTeamAction={false}
+      teamActions={TEAM_ACTIONS}
+      viewer={OWNER_VIEWER}
+    />,
+  );
+}
+
+describe("OnlineMeetingDialog", () => {
+  it("트리거를 누르기 전에는 모달 제목이 없다", () => {
+    renderDialog();
+
+    expect(screen.queryByText("비대면 회의 만들기")).not.toBeInTheDocument();
+  });
+
+  it("[비대면 회의]를 누르면 회의실·시간 필드 없이 모달이 열린다", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(screen.getByRole("button", { name: "비대면 회의" }));
+
+    expect(screen.getByRole("dialog", { name: "비대면 회의 만들기" })).toBeInTheDocument();
+    expect(screen.queryByLabelText("회의실")).not.toBeInTheDocument();
+    expect(screen.queryByText(/시작 시간/)).not.toBeInTheDocument();
+    expect(screen.getByText("녹음 파일 첨부 (선택)")).toBeInTheDocument();
+  });
+
+  it("등록을 누르면 바로 등록하지 않고 확인 모달을 먼저 띄운다", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(screen.getByRole("button", { name: "비대면 회의" }));
+    await user.click(screen.getByRole("button", { name: "등록" }));
+
+    expect(screen.getByRole("dialog", { name: "이대로 등록하시겠습니까?" })).toBeInTheDocument();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it("제목 입력 중 Enter로 암시적 제출이 걸려도 확인 모달을 연다", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(screen.getByRole("button", { name: "비대면 회의" }));
+    await user.type(screen.getByLabelText("회의 제목"), "새 비대면 회의{Enter}");
+
+    const form = screen.getByLabelText("회의 제목").closest("form");
+    expect(form).not.toBeNull();
+    fireEvent.submit(form!);
+
+    expect(screen.getByRole("dialog", { name: "이대로 등록하시겠습니까?" })).toBeInTheDocument();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it("필수값을 안 채우고 확인 모달에서 등록을 누르면 필드별 오류를 보여준다", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(screen.getByRole("button", { name: "비대면 회의" }));
+    await user.click(screen.getByRole("button", { name: "등록" }));
+    await user.click(screen.getByRole("button", { name: "등록" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          (_content, element) =>
+            element?.tagName === "P" && element.textContent === "회의 제목을 입력해 주세요",
+        ),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(
+        (_content, element) =>
+          element?.tagName === "P" && element.textContent === "프로젝트를 선택해 주세요",
+      ),
+    ).toBeInTheDocument();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it("성공하면 회의 상세로 이동한다", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(screen.getByRole("button", { name: "비대면 회의" }));
+    await user.type(screen.getByLabelText("회의 제목"), "새 비대면 회의");
+    await user.click(screen.getByRole("combobox", { name: "프로젝트" }));
+    await user.click(await screen.findByRole("option", { name: "굿즈 프로젝트" }));
+    await user.type(screen.getByLabelText("안건 1 대주제"), "제품");
+    await user.type(screen.getByLabelText("안건 1 소주제"), "점검");
+    await user.click(screen.getByRole("checkbox", { name: /김서준/ }));
+
+    await user.click(screen.getByRole("button", { name: "등록" }));
+    await user.click(screen.getByRole("button", { name: "등록" }));
+
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith(expect.stringMatching(/^\/app\/meeting\/meeting-/));
+    });
+  });
+});

--- a/src/features/meeting/components/online-meeting-dialog.tsx
+++ b/src/features/meeting/components/online-meeting-dialog.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { Paperclip, Video, X } from "lucide-react";
+import type { ChangeEvent, FormEvent } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useFormStatus } from "react-dom";
+
+import { ConfirmDialog } from "@/components/common/confirm-dialog";
+import { FieldError } from "@/components/common/field-error";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import type { AttendeeScopeViewer } from "@/features/rooms/attendee-scope";
+import { RoomAttendeePicker } from "@/features/rooms/components/room-attendee-picker";
+import type { RoomMember, RoomProjectOption, RoomTeamActionOption } from "@/features/rooms/types";
+
+import { OnlineMeetingFields } from "./online-meeting-fields";
+import { useOnlineMeetingForm } from "./use-online-meeting-form";
+
+interface OnlineMeetingDialogProps {
+  members: RoomMember[];
+  projects: RoomProjectOption[];
+  showParentTeamAction: boolean;
+  teamActions: RoomTeamActionOption[];
+  viewer: AttendeeScopeViewer;
+}
+
+/** 취소·제출 버튼 — `useFormStatus`는 `<form>`의 자손에서만 읽을 수 있다(`RoomReservationDialog`와 같은 이유). */
+function DialogActions({
+  onCancel,
+  onRequestSubmit,
+}: {
+  onCancel: () => void;
+  onRequestSubmit: () => void;
+}) {
+  const { pending } = useFormStatus();
+
+  return (
+    <div className="flex shrink-0 gap-2">
+      <Button type="button" variant="outline" disabled={pending} onClick={onCancel}>
+        취소
+      </Button>
+      <Button type="button" variant="ink" disabled={pending} onClick={onRequestSubmit}>
+        {pending ? "등록 중" : "등록"}
+      </Button>
+    </div>
+  );
+}
+
+/** 제출 중인지를 창에 올려 보낸다 — `RoomReservationDialog`의 `PendingReporter`와 같다. */
+function PendingReporter({ onChange }: { onChange: (pending: boolean) => void }) {
+  const { pending } = useFormStatus();
+
+  useEffect(() => {
+    onChange(pending);
+  }, [pending, onChange]);
+
+  return null;
+}
+
+/**
+ * 비대면 회의 만들기 — `/app/meeting` 목록의 진입점(이슈 #473). `RoomReservationDialog`와
+ * 같은 뼈대(`ConfirmDialog`를 안 쓰는 이유·확인 2단계 제출도 그대로)를 쓰되 **회의실·시간이
+ * 없다.** 대신 녹음 파일 첨부 필드가 하나 더 있다.
+ * ⚠️ **첨부는 실제 업로드가 아니다**(§정직한 목업). BE에 파일을 받을 자리가 없어(이슈 #473)
+ *    파일 이름만 hidden input(`recordingFileName`)으로 실어 보낸다 — 바이트는 어디에도
+ *    안 올라간다.
+ */
+export function OnlineMeetingDialog({
+  members,
+  projects,
+  showParentTeamAction,
+  teamActions,
+  viewer,
+}: OnlineMeetingDialogProps) {
+  const [open, setOpen] = useState(false);
+  const { state, formAction, form, setForm, handleOpenChange } = useOnlineMeetingForm({
+    onOpenChange: setOpen,
+  });
+
+  const [isPending, setIsPending] = useState(false);
+  const handlePendingChange = useCallback((next: boolean) => setIsPending(next), []);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const formRef = useRef<HTMLFormElement>(null);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const confirmedSubmitRef = useRef(false);
+
+  function handleFormSubmit(event: FormEvent<HTMLFormElement>) {
+    if (confirmedSubmitRef.current) {
+      confirmedSubmitRef.current = false;
+      return;
+    }
+    event.preventDefault();
+    setShowConfirm(true);
+  }
+
+  function handleFileChange(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0] ?? null;
+    setForm((prev) => ({ ...prev, recordingFileName: file?.name ?? null }));
+  }
+
+  function clearFile() {
+    setForm((prev) => ({ ...prev, recordingFileName: null }));
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        // ⚠️ 제출 중엔 Esc·바깥 클릭 전부 막는다 — 요청은 계속 가는데 창만 사라지면 결과를
+        //    못 본다(`RoomReservationDialog`와 같은 이유).
+        if (!next && isPending) return;
+        // `handleOpenChange`가 폼 리셋 + `setOpen`까지 한 번에 한다(훅 안에서 `onOpenChange`로 위임).
+        handleOpenChange(next);
+      }}
+    >
+      <DialogTrigger render={<Button type="button" variant="outline" />}>
+        <Video aria-hidden />
+        비대면 회의
+      </DialogTrigger>
+
+      <DialogContent className="gap-0 p-0 sm:max-w-[720px]">
+        <DialogHeader className="border-border border-b px-6 py-4">
+          <DialogTitle>비대면 회의 만들기</DialogTitle>
+        </DialogHeader>
+
+        <form ref={formRef} action={formAction} onSubmit={handleFormSubmit}>
+          <PendingReporter onChange={handlePendingChange} />
+          <input type="hidden" name="projectId" value={form.projectId} />
+          <input type="hidden" name="parentTeamActionId" value={form.parentTeamActionId} />
+          <input type="hidden" name="recordingFileName" value={form.recordingFileName ?? ""} />
+
+          <div className="flex max-h-[70vh] flex-col gap-4 overflow-y-auto px-6 py-4">
+            <div className="grid grid-cols-1 gap-6 sm:grid-cols-[1fr_260px]">
+              <OnlineMeetingFields
+                form={form}
+                setForm={setForm}
+                errors={state.errors}
+                projects={projects}
+                showParentTeamAction={showParentTeamAction}
+                teamActions={teamActions}
+              />
+
+              <div className="flex flex-col gap-4">
+                <RoomAttendeePicker
+                  members={members}
+                  selectedIds={form.attendeeIds}
+                  onChange={(attendeeIds) => setForm((prev) => ({ ...prev, attendeeIds }))}
+                  viewer={viewer}
+                />
+                <FieldError reserveSpace message={state.errors.attendeeIds} />
+
+                <div className="flex flex-col gap-1.5">
+                  <span
+                    id="online-meeting-recording-label"
+                    className="text-[13px] leading-5 font-medium"
+                  >
+                    녹음 파일 첨부 (선택)
+                  </span>
+                  {/* ⚠️ 바이너리는 안 보낸다 — 파일명만 읽어 hidden input으로 싣는다(위 주석). */}
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    className="hidden"
+                    onChange={handleFileChange}
+                  />
+                  <div className="flex items-center gap-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="w-full min-w-0 justify-start"
+                      aria-labelledby="online-meeting-recording-label"
+                      onClick={() => fileInputRef.current?.click()}
+                    >
+                      <Paperclip aria-hidden />
+                      <span className="truncate">
+                        {form.recordingFileName ?? "파일 첨부 (선택)"}
+                      </span>
+                    </Button>
+                    {form.recordingFileName && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-sm"
+                        aria-label="녹음 파일 선택 해제"
+                        onClick={clearFile}
+                      >
+                        <X aria-hidden />
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="border-border flex items-center justify-end gap-4 border-t px-6 py-4">
+            <DialogActions
+              onCancel={() => handleOpenChange(false)}
+              onRequestSubmit={() => setShowConfirm(true)}
+            />
+          </div>
+        </form>
+      </DialogContent>
+
+      <ConfirmDialog
+        isOpen={showConfirm}
+        onOpenChange={setShowConfirm}
+        title="이대로 등록하시겠습니까?"
+        description="등록하면 곧바로 회의가 완료 처리되고 AI 요약이 시작됩니다."
+        confirmLabel="등록"
+        onConfirm={() => {
+          setShowConfirm(false);
+          confirmedSubmitRef.current = true;
+          formRef.current?.requestSubmit();
+        }}
+      />
+    </Dialog>
+  );
+}

--- a/src/features/meeting/components/online-meeting-fields.tsx
+++ b/src/features/meeting/components/online-meeting-fields.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import type { Dispatch, SetStateAction } from "react";
+import { useMemo } from "react";
+
+import { FieldError } from "@/components/common/field-error";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { MeetingTopicList } from "@/features/rooms/components/meeting-topic-list";
+import type { RoomProjectOption, RoomTeamActionOption } from "@/features/rooms/types";
+
+import type { OnlineMeetingFormErrors } from "../types";
+import type { OnlineMeetingFormValues } from "./use-online-meeting-form";
+
+interface OnlineMeetingFieldsProps {
+  form: OnlineMeetingFormValues;
+  setForm: Dispatch<SetStateAction<OnlineMeetingFormValues>>;
+  errors: OnlineMeetingFormErrors;
+  projects: RoomProjectOption[];
+  /** "상위 팀 액션" 필드를 보여줄지 — `RoomReservationFields`와 같은 판정(`requiresParentTeamAction`). */
+  showParentTeamAction: boolean;
+  teamActions: RoomTeamActionOption[];
+}
+
+/**
+ * 비대면 회의 만들기 모달 왼쪽 열(이슈 #473) — `RoomReservationFields`와 같은 필드를 쓰되
+ * **회의실이 없다.** 회의실 예약 폼과 같은 select·안건 위젯을 그대로 재사용한다.
+ */
+export function OnlineMeetingFields({
+  form,
+  setForm,
+  errors,
+  projects,
+  showParentTeamAction,
+  teamActions,
+}: OnlineMeetingFieldsProps) {
+  const selectedProjectTag = projects.find((project) => project.id === form.projectId)?.tag;
+
+  // ⚠️ `useMemo`로 참조를 고정한다 — `RoomReservationFields`와 같은 이유(base-ui `Select`
+  //    내부 이펙트가 매 렌더 새 참조를 물면 "Maximum update depth exceeded"로 이어진다).
+  const availableTeamActions = useMemo(
+    () => teamActions.filter((teamAction) => teamAction.projectTag === selectedProjectTag),
+    [teamActions, selectedProjectTag],
+  );
+  const projectItems = useMemo(
+    () => Object.fromEntries(projects.map((project) => [project.id, project.name])),
+    [projects],
+  );
+  const teamActionItems = useMemo(
+    () =>
+      Object.fromEntries(
+        availableTeamActions.map((teamAction) => [String(teamAction.id), teamAction.name]),
+      ),
+    [availableTeamActions],
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="online-meeting-title">회의 제목</Label>
+        <Input
+          id="online-meeting-title"
+          name="title"
+          value={form.title}
+          onChange={(event) => setForm((prev) => ({ ...prev, title: event.target.value }))}
+          placeholder="회의 제목을 입력하세요"
+          aria-invalid={Boolean(errors.title)}
+        />
+        <FieldError reserveSpace message={errors.title} />
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="online-meeting-project">프로젝트</Label>
+        <Select
+          items={projectItems}
+          value={form.projectId}
+          onValueChange={(value) =>
+            setForm((prev) => ({ ...prev, projectId: value ?? "", parentTeamActionId: "" }))
+          }
+        >
+          <SelectTrigger
+            id="online-meeting-project"
+            aria-invalid={Boolean(errors.projectId)}
+            className="w-full"
+          >
+            <SelectValue placeholder="프로젝트 선택" />
+          </SelectTrigger>
+          <SelectContent>
+            {projects.map((project) => (
+              <SelectItem key={project.id} value={project.id}>
+                {project.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <FieldError reserveSpace message={errors.projectId} />
+      </div>
+
+      {showParentTeamAction && (
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="online-meeting-parent-team-action">상위 팀 액션</Label>
+          <Select
+            items={teamActionItems}
+            value={form.parentTeamActionId}
+            onValueChange={(value) =>
+              setForm((prev) => ({ ...prev, parentTeamActionId: value ?? "" }))
+            }
+            disabled={!form.projectId}
+          >
+            <SelectTrigger
+              id="online-meeting-parent-team-action"
+              aria-invalid={Boolean(errors.parentTeamActionId)}
+              className="w-full"
+            >
+              <SelectValue
+                placeholder={form.projectId ? "상위 팀 액션 선택" : "프로젝트를 먼저 선택해 주세요"}
+              />
+            </SelectTrigger>
+            <SelectContent>
+              {availableTeamActions.map((teamAction) => (
+                <SelectItem key={teamAction.id} value={String(teamAction.id)}>
+                  {teamAction.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <FieldError reserveSpace message={errors.parentTeamActionId} />
+        </div>
+      )}
+
+      <MeetingTopicList
+        topics={form.topics}
+        onChange={(topics) => setForm((prev) => ({ ...prev, topics }))}
+        error={errors.topics}
+      />
+    </div>
+  );
+}

--- a/src/features/meeting/components/use-online-meeting-form.ts
+++ b/src/features/meeting/components/use-online-meeting-form.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useActionState, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+
+import type { MeetingTopicInput } from "@/features/rooms/types";
+
+import { createOnlineMeetingAction, type OnlineMeetingFormState } from "../actions";
+
+const INITIAL_STATE: OnlineMeetingFormState = { errors: {} };
+
+const EMPTY_TOPIC: MeetingTopicInput = { main: "", sub: "" };
+
+const EMPTY_FORM = {
+  title: "",
+  projectId: "",
+  topics: [EMPTY_TOPIC] as MeetingTopicInput[],
+  attendeeIds: [] as number[],
+  /** Select 값은 문자열이라 여기서도 문자열로 든다 — `useRoomReservationForm`과 같은 관례. */
+  parentTeamActionId: "",
+  /** 첨부한 녹음 파일 이름 — 바이트는 안 든다(§정직한 목업, `Meeting.recordingFileName`). */
+  recordingFileName: null as string | null,
+};
+
+export type OnlineMeetingFormValues = typeof EMPTY_FORM;
+
+interface UseOnlineMeetingFormOptions {
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * 비대면 회의 만들기 모달의 폼 상태·제출 흐름(이슈 #473) — `useRoomReservationForm`과 같은
+ * 골격이다(CLAUDE.md §폴더·네이밍: 로직=커스텀훅).
+ * ⚠️ **성공 후 흐름이 회의실 예약과 다르다.** 예약은 같은 화면(캘린더)에 비관적으로 반영하지만,
+ *    이 다이얼로그는 목록 화면 어디에도 그릴 자리가 없다 — 만들자마자 완료 처리되는 회의라
+ *    상세로 바로 옮기는 편이 자연스럽다(`router.push`). 목록은 서버 액션이 이미 부른
+ *    `revalidatePath`로 다음 방문 때 최신 상태다.
+ */
+export function useOnlineMeetingForm({ onOpenChange }: UseOnlineMeetingFormOptions) {
+  const router = useRouter();
+  const [state, formAction] = useActionState(createOnlineMeetingAction, INITIAL_STATE);
+  const [form, setForm] = useState<OnlineMeetingFormValues>(EMPTY_FORM);
+  const handledCreatedId = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (state.created && state.created.id !== handledCreatedId.current) {
+      handledCreatedId.current = state.created.id;
+      onOpenChange(false);
+      setForm(EMPTY_FORM);
+      toast.success("비대면 회의를 등록했습니다");
+      router.push(`/app/meeting/${state.created.id}`);
+    }
+  }, [state.created, onOpenChange, router]);
+
+  function handleOpenChange(open: boolean) {
+    if (!open) setForm(EMPTY_FORM);
+    onOpenChange(open);
+  }
+
+  return { state, formAction, form, setForm, handleOpenChange };
+}

--- a/src/features/meeting/mapper.ts
+++ b/src/features/meeting/mapper.ts
@@ -364,6 +364,8 @@ export function toMeetingListItem(be: BeMeetingListItem): MeetingListItem {
     attendeeCount: be.attendeeCount,
     isHost: be.isHost,
     aiSummaryStatus: toAiSummaryStatus(be.summaryStatus),
+    // 실서버는 아직 비대면 회의를 모른다 — BE가 필드를 주면 그때 매퍼가 읽는다(이슈 #473).
+    isOnline: false,
   };
 }
 
@@ -666,6 +668,8 @@ export function toMeetingDetailView(
     pendingActionCount: be.pendingActionCount,
     isStalled: be.summaryStatus === BE_SUMMARY_STATUS.STALLED,
     isHost: options.isHost,
+    // 실서버는 아직 비대면 회의를 모른다 — BE가 필드를 주면 그때 매퍼가 읽는다(이슈 #473).
+    isOnline: false,
   };
 }
 

--- a/src/features/meeting/mock/meetings.test.ts
+++ b/src/features/meeting/mock/meetings.test.ts
@@ -1,7 +1,13 @@
 import { AUTHORITY } from "@/constants/authority";
+import { AI_SUMMARY_STATUS } from "@/constants/meeting";
 
 import type { MeetingDraft } from "../types";
-import { addMockMeeting, findMockMeeting, listMockMeetings } from "./meetings";
+import {
+  addMockMeeting,
+  addMockOnlineMeeting,
+  findMockMeeting,
+  listMockMeetings,
+} from "./meetings";
 
 const DRAFT: MeetingDraft = {
   title: "8월 킥오프 미팅",
@@ -16,6 +22,8 @@ const DRAFT: MeetingDraft = {
   hostId: 1,
   hostAuthority: AUTHORITY.OWNER,
   roomReservationId: "reservation-1",
+  isOnline: false,
+  recordingFileName: null,
 };
 
 describe("회의 mock 스토어", () => {
@@ -54,5 +62,50 @@ describe("회의 mock 스토어", () => {
 
   it("없는 id는 조회 시 null을 돌려준다", () => {
     expect(findMockMeeting("존재하지-않음")).toBeNull();
+  });
+});
+
+describe("비대면 회의 생성(이슈 #473) — addMockOnlineMeeting", () => {
+  const ONLINE_DRAFT: MeetingDraft = {
+    ...DRAFT,
+    isOnline: true,
+    roomId: null,
+    roomName: null,
+    roomReservationId: null,
+    recordingFileName: "회의록.m4a",
+  };
+
+  it("만들자마자 종료 처리된다 — endedAt이 즉시 채워진다", () => {
+    const created = addMockOnlineMeeting(ONLINE_DRAFT);
+
+    expect(created.isOnline).toBe(true);
+    expect(created.endedAt).not.toBeNull();
+    expect(created.endedAt).toBe(new Date(created.endedAt!).toISOString());
+  });
+
+  it("종료와 동시에 AI 분석 대기 상태로 들어간다 — endMockMeeting과 같은 규칙", () => {
+    const created = addMockOnlineMeeting(ONLINE_DRAFT);
+
+    expect(created.aiSummaryStatus).toBe(AI_SUMMARY_STATUS.PENDING);
+  });
+
+  it("회의실이 없다 — roomId·roomName·roomReservationId가 그대로 null이다", () => {
+    const created = addMockOnlineMeeting(ONLINE_DRAFT);
+
+    expect(created.roomId).toBeNull();
+    expect(created.roomName).toBeNull();
+    expect(created.roomReservationId).toBeNull();
+  });
+
+  it("첨부한 녹음 파일 이름을 그대로 담는다(§정직한 목업 — 바이트는 안 든다)", () => {
+    const created = addMockOnlineMeeting(ONLINE_DRAFT);
+
+    expect(created.recordingFileName).toBe("회의록.m4a");
+  });
+
+  it("취소되지 않은 채로 만들어진다", () => {
+    const created = addMockOnlineMeeting(ONLINE_DRAFT);
+
+    expect(created.canceledAt).toBeNull();
   });
 });

--- a/src/features/meeting/mock/meetings.ts
+++ b/src/features/meeting/mock/meetings.ts
@@ -50,6 +50,34 @@ export function addMockMeeting(draft: MeetingDraft): Meeting {
 }
 
 /**
+ * 비대면 회의 생성(이슈 #473) — **만들어지는 순간 이미 완료다**("제출하면 그 자리에서 완료
+ * 처리 — 캡처 화면으로 안 넘어갑니다", 팀 명세). `addMockMeeting`과 인자 모양은 같지만
+ * (판별식 유니언 조립은 호출부인 `actions.ts`가 한다, `rooms/mock/reservations.ts`와 같은
+ * 자리 나눔) 저장 직전에 "이미 끝났다"는 사실을 덧씌운다.
+ * ⚠️ **`start`·`end`가 없다.** 비대면 회의는 잡을 시간 자체가 없어(`OnlineMeetingDraft`에
+ *    `date`·`startTime`이 없다) 방금 완료된 시각을 그대로 쓴다 — 예정·진행중을 거치지 않는다.
+ * ⚠️ `roomId`·`roomName`·`roomReservationId`는 draft에서부터 이미 `null`이다(회의실이 없다) —
+ *    여기서 다시 지우지 않는다.
+ */
+export function addMockOnlineMeeting(draft: MeetingDraft): Meeting {
+  const now = new Date();
+  const meeting: Meeting = {
+    ...draft,
+    start: now,
+    end: now,
+    id: `meeting-${++store.sequence}`,
+    createdAt: now.toISOString(),
+    // 캡처를 거치지 않고 제출과 동시에 끝난다 — endMockMeeting을 따로 부르지 않는다.
+    endedAt: now.toISOString(),
+    canceledAt: null,
+    // 종료와 동시에 대기로 들어간다 — endMockMeeting과 같은 이유(§types).
+    aiSummaryStatus: AI_SUMMARY_STATUS.PENDING,
+  };
+  store.meetings = [...store.meetings, meeting];
+  return meeting;
+}
+
+/**
  * 회의 종료 — **완료를 만드는 유일한 길**이다.
  *
  * ⚠️ 완료는 시간이 지나서 되는 게 아니라 Host가 [회의 종료 및 제출]을 눌러야 된다

--- a/src/features/meeting/mock/seed.ts
+++ b/src/features/meeting/mock/seed.ts
@@ -86,6 +86,8 @@ export function ensureMockMeetingsSeeded(): void {
     hostId: 1,
     hostAuthority: AUTHORITY.OWNER,
     roomReservationId: "seed-reservation-1",
+    isOnline: false,
+    recordingFileName: null,
   });
   endMockMeeting(kickoff.id, "2026-07-14T10:31:00.000Z");
   /*
@@ -124,6 +126,8 @@ export function ensureMockMeetingsSeeded(): void {
     hostTeamId: 1,
     parentTeamActionId: 1,
     roomReservationId: "seed-reservation-2",
+    isOnline: false,
+    recordingFileName: null,
   });
   endMockMeeting(teamKickoff.id, "2026-07-21T10:32:00.000Z");
   setMockSummaryStatus(teamKickoff.id, AI_SUMMARY_STATUS.DISTRIBUTED);
@@ -158,6 +162,8 @@ export function ensureMockMeetingsSeeded(): void {
     hostId: 1,
     hostAuthority: AUTHORITY.OWNER,
     roomReservationId: "seed-reservation-3",
+    isOnline: false,
+    recordingFileName: null,
   });
 
   /*
@@ -181,6 +187,8 @@ export function ensureMockMeetingsSeeded(): void {
     hostId: 1,
     hostAuthority: AUTHORITY.OWNER,
     roomReservationId: "seed-reservation-5",
+    isOnline: false,
+    recordingFileName: null,
   });
 
   /*
@@ -200,6 +208,8 @@ export function ensureMockMeetingsSeeded(): void {
     hostId: 1,
     hostAuthority: AUTHORITY.OWNER,
     roomReservationId: "seed-reservation-4",
+    isOnline: false,
+    recordingFileName: null,
   });
   endMockMeeting(brand.id, "2026-07-28T14:29:00.000Z");
   /*
@@ -233,6 +243,8 @@ export function ensureMockMeetingsSeeded(): void {
     hostId: 1,
     hostAuthority: AUTHORITY.OWNER,
     roomReservationId: "seed-reservation-6",
+    isOnline: false,
+    recordingFileName: null,
   });
   endMockMeeting(pendingReview.id, "2026-08-04T11:31:00.000Z");
   setMockSummaryStatus(pendingReview.id, AI_SUMMARY_STATUS.REVIEWED);
@@ -260,6 +272,8 @@ export function ensureMockMeetingsSeeded(): void {
     hostId: 1,
     hostAuthority: AUTHORITY.OWNER,
     roomReservationId: "seed-reservation-7",
+    isOnline: false,
+    recordingFileName: null,
   });
   endMockMeeting(stalled.id, "2026-08-06T15:31:00.000Z");
   setMockSummaryStatus(stalled.id, AI_SUMMARY_STATUS.FAILED);
@@ -283,6 +297,8 @@ export function ensureMockMeetingsSeeded(): void {
     hostId: 1,
     hostAuthority: AUTHORITY.OWNER,
     roomReservationId: "seed-reservation-8",
+    isOnline: false,
+    recordingFileName: null,
   });
   cancelMockMeeting(canceled.id, "2026-08-11T09:00:00.000Z");
 }

--- a/src/features/meeting/server.test.ts
+++ b/src/features/meeting/server.test.ts
@@ -1,7 +1,9 @@
 import { AUTHORITY } from "@/constants/authority";
 import type { Actor } from "@/lib/permission";
 
-import { getMeetingCapture, getMeetingDirectory } from "./server";
+import { addMockOnlineMeeting } from "./mock/meetings";
+import { getMeetingCapture, getMeetingDetail, getMeetingDirectory } from "./server";
+import type { MeetingDraft } from "./types";
 
 /**
  * 캡처 진입 판정 — **접근 제어라 값으로 고정해 둔다**(CLAUDE.md §테스트: 로직은 짜자마자).
@@ -99,5 +101,59 @@ describe("getMeetingDirectory — 목록 차례", () => {
 
     expect(directory.hosted.every((item) => item.isHost)).toBe(true);
     expect(directory.invited.every((item) => !item.isHost)).toBe(true);
+  });
+});
+
+/**
+ * 비대면 회의(이슈 #473) — 목록 카드·상세가 `isOnline`을 세우고 회의실·시간을 빈 문자열로
+ * 비우는지 본다. 대면 회의(시드)는 그대로 채워져 있어야 한다(회귀 방지).
+ */
+describe("비대면 회의(이슈 #473) — isOnline·빈 schedule·roomName", () => {
+  const ONLINE_DRAFT: MeetingDraft = {
+    title: "비대면 회의 서버 테스트",
+    start: new Date(0),
+    end: new Date(0),
+    roomId: null,
+    roomName: null,
+    roomReservationId: null,
+    isOnline: true,
+    recordingFileName: null,
+    projectId: 1,
+    projectTag: "GOODS",
+    topics: [{ main: "제품", sub: "점검" }],
+    attendeeIds: [OWNER.id],
+    hostId: OWNER.id,
+    hostAuthority: AUTHORITY.OWNER,
+  };
+
+  it("목록 카드는 isOnline을 세우고 schedule·roomName을 빈 문자열로 비운다", async () => {
+    addMockOnlineMeeting(ONLINE_DRAFT);
+
+    const directory = await getMeetingDirectory(OWNER.id);
+    const item = directory.hosted.find((row) => row.title === "비대면 회의 서버 테스트");
+
+    expect(item?.isOnline).toBe(true);
+    expect(item?.schedule).toBe("");
+    expect(item?.roomName).toBe("");
+  });
+
+  it("상세도 isOnline을 세우고 schedule·roomName을 빈 문자열로 비운다", async () => {
+    const created = addMockOnlineMeeting(ONLINE_DRAFT);
+
+    const result = await getMeetingDetail(created.id, OWNER);
+    if (result.kind !== "ok") throw new Error("ok를 기대했다");
+
+    expect(result.detail.isOnline).toBe(true);
+    expect(result.detail.schedule).toBe("");
+    expect(result.detail.roomName).toBe("");
+  });
+
+  it("대면 회의(시드)는 그대로 schedule·roomName이 채워진다(회귀 방지)", async () => {
+    const result = await getMeetingDetail("meeting-1", OWNER);
+    if (result.kind !== "ok") throw new Error("ok를 기대했다");
+
+    expect(result.detail.isOnline).toBe(false);
+    expect(result.detail.schedule).not.toBe("");
+    expect(result.detail.roomName).not.toBe("");
   });
 });

--- a/src/features/meeting/server.ts
+++ b/src/features/meeting/server.ts
@@ -93,11 +93,14 @@ function toListItem(meeting: Meeting, viewerId: number, now: Date): MeetingListI
     projectTag: meeting.projectTag,
     originLabel: originLabelOf(meeting),
     topicSummary: `${firstTopic.main} · ${firstTopic.sub}`,
-    schedule: formatMeetingSchedule(meeting.start, meeting.end),
-    roomName: meeting.roomName,
+    // ⚠️ 비대면 회의는 회의실·시간이 없다(이슈 #473) — 카드는 `isOnline`을 보고 이 자리에
+    //    안내 한 줄을 그린다(`meeting-card.tsx`).
+    schedule: meeting.isOnline ? "" : formatMeetingSchedule(meeting.start, meeting.end),
+    roomName: meeting.roomName ?? "",
     attendeeCount: meeting.attendeeIds.length,
     isHost: meeting.hostId === viewerId,
     aiSummaryStatus: meeting.aiSummaryStatus,
+    isOnline: meeting.isOnline,
   };
 }
 
@@ -317,8 +320,9 @@ export async function getMeetingDetail(id: string, viewer: Actor): Promise<Meeti
           ? null
           : `/app/projects/${meeting.projectId}/team/${meeting.parentTeamActionId}`,
       agenda: toMockAgenda(meeting.topics),
-      schedule: formatMeetingSchedule(meeting.start, meeting.end),
-      roomName: meeting.roomName,
+      // ⚠️ 비대면 회의는 회의실·시간이 없다(이슈 #473) — 상세도 목록 카드와 같은 규칙이다.
+      schedule: meeting.isOnline ? "" : formatMeetingSchedule(meeting.start, meeting.end),
+      roomName: meeting.roomName ?? "",
       attendees: meeting.attendeeIds.map((attendeeId) => ({
         id: attendeeId,
         name: roster.get(attendeeId) ?? "알 수 없음",
@@ -330,6 +334,7 @@ export async function getMeetingDetail(id: string, viewer: Actor): Promise<Meeti
       pendingActionCount,
       isStalled,
       isHost: canOperateMeeting(viewer, { ownerId: meeting.hostId }),
+      isOnline: meeting.isOnline,
     },
   };
 }
@@ -408,7 +413,10 @@ export async function getMeetingCapture(id: string, viewer: Actor): Promise<Meet
       title: meeting.title,
       projectTag: meeting.projectTag,
       schedule: formatMeetingSchedule(meeting.start, meeting.end),
-      roomName: meeting.roomName,
+      // ⚠️ 비대면 회의(`roomName === null`)는 이 자리에 올 일이 없다 — 만들어지자마자 완료
+      //    상태라 위의 "이미 끝난 회의" 분기가 먼저 걸린다(캡처는 시작 전·진행중만 연다).
+      //    타입만 맞춘다(`meeting.roomName`이 `string | null`이 됐다, 이슈 #473).
+      roomName: meeting.roomName ?? "",
       attendees: meeting.attendeeIds.map((attendeeId) => {
         const member = roster.get(attendeeId);
         return {

--- a/src/features/meeting/types.ts
+++ b/src/features/meeting/types.ts
@@ -8,6 +8,8 @@
 import type { Authority } from "@/constants/authority";
 import type { AiSummaryStatus } from "@/constants/meeting";
 
+import type { MeetingTopicInput } from "../rooms/types";
+
 /** 회의 안건 대주제/소주제 한 쌍 — 자유 입력 텍스트다(고정 enum 아님, WORKFLOW.md §3-1). */
 export interface MeetingTopic {
   main: string;
@@ -18,8 +20,10 @@ interface MeetingCommon {
   title: string;
   start: Date;
   end: Date;
-  roomId: string;
-  roomName: string;
+  /** ⚠️ 비대면 회의(`isOnline`)는 회의실이 없다 — `null`이다(이슈 #473). */
+  roomId: string | null;
+  /** ⚠️ 비대면 회의는 `null`이다 — `roomId`와 같은 이유. */
+  roomName: string | null;
   /** ⚠️ 프로젝트 태그는 항상 필수다(WORKFLOW.md §3-1) — 프로젝트에 안 묶인 회의는 없다. */
   projectId: number;
   projectTag: string;
@@ -28,8 +32,21 @@ interface MeetingCommon {
   attendeeIds: number[];
   /** 개설자 — 회의 조작 권한의 기준(권한 ②축, `lib/permission.ts`의 `canOperateMeeting`). */
   hostId: number;
-  /** 이 회의를 만든 예약 — 같은 동작이라 항상 있다(WORKFLOW.md §3-1). */
-  roomReservationId: string;
+  /** 이 회의를 만든 예약 — 회의실 예약이 만든 회의라야 있다. 비대면 회의는 예약 자체가 없어
+   *  `null`이다(이슈 #473 — "회의실·시간 없이 예약"). */
+  roomReservationId: string | null;
+  /**
+   * 비대면(원격) 회의인가(이슈 #473). `true`면 회의실·시간이 없고, 제출 즉시 완료 처리된다
+   * (캡처 화면을 거치지 않는다) — 대면 회의(`false`)와 상태 흐름 자체가 다르다.
+   */
+  isOnline: boolean;
+  /**
+   * 첨부한 녹음 파일의 원래 이름 — **목에서만 쓰는 겉치레 값이다.** BE에 파일을 실제로
+   * 올리는 자리가 없어(이슈 #473, BE API 미확정) 바이트를 저장하지 않는다 — 파일명만
+   * 기억해 화면에 "첨부했다"는 사실만 보여준다(§정직한 목업: 실제 업로드인 척하지 않는다).
+   * 첨부 안 했으면 `null`이다.
+   */
+  recordingFileName: string | null;
 }
 
 /**
@@ -89,3 +106,25 @@ export type Meeting = MeetingDraft & {
    */
   aiSummaryStatus: AiSummaryStatus | null;
 };
+
+/**
+ * 비대면 회의 만들기 폼 입력(이슈 #473) — `RoomReservationDraft`와 같은 필드를 쓰되
+ * **회의실·시간대가 없다**(`roomId`·`date`·`startTime` 없음). 제출하면 그 자리에서 완료
+ * 처리되므로 잡을 시간 자체가 없다.
+ * ⚠️ `topics`는 `rooms/types.ts`의 `MeetingTopicInput`을 그대로 쓴다 — 회의 주제 입력은
+ *    대면·비대면이 같은 모양이라 타입을 새로 만들지 않는다(교차 도메인 재사용은
+ *    `rooms/mock/reservations.ts`가 `features/meeting`을 참조하는 것과 같은 전례다).
+ */
+export interface OnlineMeetingDraft {
+  title: string;
+  /** 항상 필수다(WORKFLOW.md §3-1과 같은 규칙) — 프로젝트에 안 묶인 회의는 없다. */
+  projectId: string;
+  topics: MeetingTopicInput[];
+  attendeeIds: number[];
+  /** Host가 Leader/Member일 때만 필수 — `RoomReservationDraft`와 같은 규칙. */
+  parentTeamActionId?: number;
+  /** 첨부한 녹음 파일 이름 — `Meeting.recordingFileName`과 같다(§정직한 목업). */
+  recordingFileName: string | null;
+}
+
+export type OnlineMeetingFormErrors = Partial<Record<keyof OnlineMeetingDraft, string>>;

--- a/src/features/meeting/types.ts
+++ b/src/features/meeting/types.ts
@@ -18,6 +18,13 @@ export interface MeetingTopic {
 
 interface MeetingCommon {
   title: string;
+  /**
+   * ⚠️ 비대면 회의(`isOnline`)는 WORKFLOW.md §3-1-A 확정대로 실제 일정이 없다("`startAt`·
+   *    `endAt`은 사용자가 입력하지 않고 DB에도 저장하지 않는다") — 여기서는 **제출 시각**을
+   *    담아 목록 정렬 키로만 쓴다(그 문서도 "시간 없는 회의를 어디에 둘지는 BE가 정한다"고
+   *    남겨 둔 채라 FE 임시값이다). 화면은 `isOnline`이면 이 값을 절대 읽지 않는다
+   *    (`schedule`이 빈 문자열로 비워진다) — 지어낸 일정이 화면에 보이는 일은 없다.
+   */
   start: Date;
   end: Date;
   /** ⚠️ 비대면 회의(`isOnline`)는 회의실이 없다 — `null`이다(이슈 #473). */

--- a/src/features/meeting/validate.test.ts
+++ b/src/features/meeting/validate.test.ts
@@ -1,0 +1,122 @@
+import { AUTHORITY } from "@/constants/authority";
+
+import { validateOnlineMeetingDraft } from "./validate";
+
+const OWNER_HOST = { role: AUTHORITY.OWNER };
+const LEADER_HOST = { role: AUTHORITY.LEADER };
+
+const VALID_DRAFT = {
+  title: "비대면 주간 싱크",
+  projectId: "1",
+  topics: [{ main: "제품", sub: "로드맵 검토" }],
+  attendeeIds: [1],
+  recordingFileName: null,
+};
+
+describe("비대면 회의 만들기 검증", () => {
+  it("전부 채우면 통과한다", () => {
+    expect(validateOnlineMeetingDraft(VALID_DRAFT, OWNER_HOST)).toEqual({});
+  });
+
+  it("제목이 비면 막는다", () => {
+    const errors = validateOnlineMeetingDraft({ ...VALID_DRAFT, title: "   " }, OWNER_HOST);
+    expect(errors.title).toBe("회의 제목을 입력해 주세요");
+  });
+
+  it("프로젝트를 안 고르면 막는다(WORKFLOW.md §3-1: 항상 필수)", () => {
+    const errors = validateOnlineMeetingDraft({ ...VALID_DRAFT, projectId: "" }, OWNER_HOST);
+    expect(errors.projectId).toBe("프로젝트를 선택해 주세요");
+  });
+
+  it("안건을 하나도 안 채우면 막는다", () => {
+    const errors = validateOnlineMeetingDraft(
+      { ...VALID_DRAFT, topics: [{ main: "", sub: "" }] },
+      OWNER_HOST,
+    );
+    expect(errors.topics).toBe("회의 안건(대주제·소주제)을 한 쌍 이상 입력해 주세요");
+  });
+
+  it("첫 안건의 소주제만 비어도 막는다", () => {
+    const errors = validateOnlineMeetingDraft(
+      { ...VALID_DRAFT, topics: [{ main: "제품", sub: "" }] },
+      OWNER_HOST,
+    );
+    expect(errors.topics).toBeDefined();
+  });
+
+  it("둘째 안건부터는 비어 있으면 막는다(첫 쌍만 있어도 안 됨)", () => {
+    const errors = validateOnlineMeetingDraft(
+      {
+        ...VALID_DRAFT,
+        topics: [
+          { main: "제품", sub: "로드맵 검토" },
+          { main: "", sub: "" },
+        ],
+      },
+      OWNER_HOST,
+    );
+    expect(errors.topics).toBe("빈 안건 칸을 채우거나 삭제해 주세요");
+  });
+
+  it("안건을 여러 쌍 다 채우면 통과한다", () => {
+    const errors = validateOnlineMeetingDraft(
+      {
+        ...VALID_DRAFT,
+        topics: [
+          { main: "제품", sub: "로드맵 검토" },
+          { main: "마케팅", sub: "캠페인 리뷰" },
+        ],
+      },
+      OWNER_HOST,
+    );
+    expect(errors.topics).toBeUndefined();
+  });
+
+  it("Host가 Owner면 상위 팀 액션 없이도 통과한다", () => {
+    const errors = validateOnlineMeetingDraft(VALID_DRAFT, OWNER_HOST);
+    expect(errors.parentTeamActionId).toBeUndefined();
+  });
+
+  it("Host가 Leader면 상위 팀 액션이 없으면 막는다", () => {
+    const errors = validateOnlineMeetingDraft(VALID_DRAFT, LEADER_HOST);
+    expect(errors.parentTeamActionId).toBe("상위 팀 액션을 선택해 주세요");
+  });
+
+  it("Host가 Leader여도 상위 팀 액션을 채우면 통과한다", () => {
+    const errors = validateOnlineMeetingDraft(
+      { ...VALID_DRAFT, parentTeamActionId: 1 },
+      LEADER_HOST,
+    );
+    expect(errors.parentTeamActionId).toBeUndefined();
+  });
+
+  it("Host가 Owner인데 상위 팀 액션을 넣으면 막는다(폼 조작 방어)", () => {
+    const errors = validateOnlineMeetingDraft(
+      { ...VALID_DRAFT, parentTeamActionId: 1 },
+      OWNER_HOST,
+    );
+    expect(errors.parentTeamActionId).toBe(
+      "Owner가 개설하는 회의에는 상위 팀 액션을 지정할 수 없습니다",
+    );
+  });
+
+  it("참석자가 한 명도 없으면 막는다", () => {
+    const errors = validateOnlineMeetingDraft({ ...VALID_DRAFT, attendeeIds: [] }, OWNER_HOST);
+    expect(errors.attendeeIds).toBe("참석자를 한 명 이상 선택해 주세요");
+  });
+
+  it("참석자 값이 정수가 아니면 막는다", () => {
+    const errors = validateOnlineMeetingDraft(
+      { ...VALID_DRAFT, attendeeIds: [Number.NaN] },
+      OWNER_HOST,
+    );
+    expect(errors.attendeeIds).toBe("참석자 값이 올바르지 않습니다");
+  });
+
+  it("회의실·날짜·시작 시각 검증은 없다 — 비대면 회의는 그 개념 자체가 없다(이슈 #473)", () => {
+    const errors = validateOnlineMeetingDraft(VALID_DRAFT, OWNER_HOST);
+    expect(errors).not.toHaveProperty("roomId");
+    expect(errors).not.toHaveProperty("date");
+    expect(errors).not.toHaveProperty("startTime");
+  });
+});

--- a/src/features/meeting/validate.ts
+++ b/src/features/meeting/validate.ts
@@ -1,0 +1,50 @@
+import type { Authority } from "@/constants/authority";
+import { requiresParentTeamAction } from "@/lib/permission";
+
+import type { OnlineMeetingDraft, OnlineMeetingFormErrors } from "./types";
+
+/**
+ * 비대면 회의 만들기 폼 검증(이슈 #473) — `rooms/validate.ts`의 `validateRoomReservationDraft`와
+ * **같은 규칙**을 쓰되 회의실·날짜·시작 시각 검사만 뺀다(잡을 시간 자체가 없다). 화면(모달)과
+ * 서버(Server Action)가 이 함수 하나로 본다.
+ * ⚠️ **참조 무결성도 여기서 안 본다** — `projectId`가 실제로 존재하는지, 골라 낸
+ *    `parentTeamActionId`가 진짜 그 프로젝트·그 팀의 것인지는 `actions.ts`가 목/실서버 조회
+ *    뒤에 따로 확인한다(§권한: 화면 숨김은 UX일 뿐 보안이 아니다). 여기는 **형식**만 본다.
+ * @param host "상위 팀 액션" 필수 여부는 회의를 여는 사람의 권한에 달렸다(`requiresParentTeamAction`,
+ *   WORKFLOW.md §3-1) — Owner면 이 필드가 없어도 되고, Leader/Member면 반드시 있어야 한다.
+ */
+export function validateOnlineMeetingDraft(
+  draft: OnlineMeetingDraft,
+  host: { role: Authority },
+): OnlineMeetingFormErrors {
+  const errors: OnlineMeetingFormErrors = {};
+
+  if (!draft.title.trim()) errors.title = "회의 제목을 입력해 주세요";
+
+  // ⚠️ 프로젝트는 항상 필수다(WORKFLOW.md §3-1 확정) — 프로젝트에 안 묶인 회의는 없다.
+  if (!draft.projectId.trim()) errors.projectId = "프로젝트를 선택해 주세요";
+
+  if (draft.topics.length === 0 || !draft.topics[0]?.main.trim() || !draft.topics[0]?.sub.trim()) {
+    errors.topics = "회의 안건(대주제·소주제)을 한 쌍 이상 입력해 주세요";
+  } else if (draft.topics.some((topic) => !topic.main.trim() || !topic.sub.trim())) {
+    errors.topics = "빈 안건 칸을 채우거나 삭제해 주세요";
+  }
+
+  // ⚠️ Owner가 개설하면 이 필드가 아예 없다(= 프로젝트 회의) — Leader/Member면 반드시 있어야
+  //    한다(= 팀 액션 회의, WORKFLOW.md §3-1 "상위 팀 액션 노출 조건").
+  if (requiresParentTeamAction(host)) {
+    if (!draft.parentTeamActionId) errors.parentTeamActionId = "상위 팀 액션을 선택해 주세요";
+  } else if (draft.parentTeamActionId !== undefined) {
+    // ⚠️ Owner는 반대로 이 필드를 아예 못 넣는다 — Owner 개설 회의(프로젝트 회의)엔 상위 팀
+    //    액션 개념이 없다(WORKFLOW.md §2). 폼이 조작돼 값이 들어와도 여기서 막는다.
+    errors.parentTeamActionId = "Owner가 개설하는 회의에는 상위 팀 액션을 지정할 수 없습니다";
+  }
+
+  if (draft.attendeeIds.length === 0) {
+    errors.attendeeIds = "참석자를 한 명 이상 선택해 주세요";
+  } else if (draft.attendeeIds.some((id) => !Number.isInteger(id))) {
+    errors.attendeeIds = "참석자 값이 올바르지 않습니다";
+  }
+
+  return errors;
+}

--- a/src/features/meeting/view-types.ts
+++ b/src/features/meeting/view-types.ts
@@ -31,10 +31,17 @@ export interface MeetingListItem {
    * 실서버는 `agendaPreview`(BE PR #461)로 채운다 — 없으면(미배포·안건 0건) 빈 문자열이다.
    */
   topicSummary: string;
-  /** `7월 14일(화) 10:00 – 10:30` — 서버가 우리 표기로 만들어 보낸다(§lib) */
+  /**
+   * `7월 14일(화) 10:00 – 10:30` — 서버가 우리 표기로 만들어 보낸다(§lib).
+   * ⚠️ **비대면 회의(`isOnline`)는 빈 문자열이다** — 회의실·시간이 없다(이슈 #473). 컴포넌트는
+   *    `isOnline`을 먼저 보고, `true`면 이 값을 그대로 그리지 않는다.
+   */
   schedule: string;
+  /** ⚠️ 비대면 회의는 빈 문자열이다 — `schedule`과 같은 이유. */
   roomName: string;
   attendeeCount: number;
+  /** 비대면(원격) 회의인가(이슈 #473) — `schedule`·`roomName` 대신 안내 한 줄을 그린다. */
+  isOnline: boolean;
   /**
    * 보는 사람이 이 회의의 Host인가.
    *
@@ -138,9 +145,13 @@ export interface MeetingDetail {
   parentTeamActionHref: string | null;
   /** 안건 — `null`이면 보여줄 안건이 없다(미배포 BE거나 안건 0건 — 왜인지는 모른다) */
   agenda: MeetingAgenda | null;
+  /** ⚠️ 비대면 회의(`isOnline`)는 빈 문자열이다 — `MeetingListItem.schedule`과 같은 이유. */
   schedule: string;
+  /** ⚠️ 비대면 회의는 빈 문자열이다. */
   roomName: string;
   attendees: MeetingAttendee[];
+  /** 비대면(원격) 회의인가(이슈 #473) — 발치 레일과 발화 기록 칸의 렌더가 이 값으로 갈린다. */
+  isOnline: boolean;
   /**
    * 산출물 머리말 — Owner 개설이면 `팀 액션`, 팀 액션 회의면 `개인 액션`.
    * ⚠️ 실서버 상세(MEET-04)엔 개설자 권한이 없어 둘을 못 가른다 — 그때는 상위어 `액션`이다.

--- a/src/features/rooms/mock/reservations.ts
+++ b/src/features/rooms/mock/reservations.ts
@@ -165,6 +165,10 @@ export function addMockReservation(draft: RoomReservationDraft, actor: Actor): R
     attendeeIds: reservation.attendeeIds,
     hostId: actor.id,
     roomReservationId: reservation.id,
+    // ⚠️ 회의실 예약이 만드는 회의는 대면이다 — 비대면(이슈 #473)은 `createOnlineMeetingAction`
+    //    (`features/meeting/actions.ts`)이 회의실 없이 따로 만든다.
+    isOnline: false,
+    recordingFileName: null,
   };
 
   // ⚠️ `Meeting`은 Owner 개설/팀 액션 개설을 판별식 유니언으로 나눠 둔다(hostTeamId·


### PR DESCRIPTION
## 📋 PR 타입

> 해당하는 타입을 선택해 주세요 (복수 선택 가능)

- [x] feature — 새로운 기능 추가

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- WORKFLOW.md §3-1-A 확정안대로 "비대면 회의" 기능을 구현한다 — 이미 끝난 외부 회의 녹음을 사후 제출해 AI 요약·분배만 돌리는 경로.
- 진입점: `/app/meeting` 목록 우측 상단 [비대면 회의] 버튼(예약 모달과 별개의 새 모달). 모달은 기존 예약 모달과 같은 필드에서 회의실·시간대만 빼고, 녹음 파일 첨부(선택)를 더한다. 파일은 이름만 기록하고 실제로 업로드하지 않는다(§정직한 목업, BE에 받는 자리가 아직 없음).
- 참석자: 기존 `attendee-scope.ts`(#452) 그대로 재사용 — Owner는 팀장만, Leader/Member는 자기 팀만.
- 제출 즉시 완료 처리 — `/capture`로 안 넘어가고 바로 상세로 이동, AI 요약이 곧바로 시작된다(기존 종료 흐름과 같은 `PENDING` 진입).
- 회의 목록·상세: `isOnline`이면 일정(시작~종료)·발화 기록 자리 둘 다 "온라인으로 진행된 회의입니다" 안내로 대체. 산출물(하달 액션) 섹션은 그대로.
- `/app/rooms` 캘린더에는 안 뜬다 — 회의실 예약 자체가 없어서 자연히 빠진다.
- BE API는 아직 미정(1안/2안 논의 중) — 실서버 분기는 추측 요청 대신 "아직 준비 중" 오류를 명시적으로 돌려준다. 확정되면 `actions.ts`·`server.ts`·`mapper.ts`만 실서버 호출로 바꾼다(§Mock→Live 격리막).
- 팀(현님) 공유 스펙을 반영했다. WORKFLOW.md 3-1-A 섹션(develop에 이미 반영됨, 커밋 `6533e28`)과 대조해 필드·참석자 규칙·즉시완료 상태·일정 처리·캘린더 미노출을 맞췄다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — `attendee-scope.ts`(#452) 그대로 재사용(Owner=팀장만, Leader/Member=자기 팀만)
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [x] 🕵️ **정직성** — 녹음 파일 미업로드·BE API 미정 상태를 주석·화면에 명시
- [x] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [x] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그)
- [ ] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [x] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인)
- [x] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음

---

## 🔗 연관 이슈

Closes #473

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

- BE API 미정 구간(1안/2안)에서 실서버 분기가 추측 없이 "준비 중" 오류만 돌려주는지
- `isOnline` 회의의 일정·발화 기록 안내 문구가 목록·상세 양쪽에서 일관되는지

---

## 📝 추가 메모

- 확인법: `npx tsc --noEmit` / `npx eslint <변경 파일> --max-warnings=0` / `npx jest --silent`(121 suites·1328 tests) / `npx next build` 전부 통과. 브라우저 확인: 목록에서 [비대면 회의] 생성 → 상세로 즉시 이동 → 일정/발화 기록 자리 온라인 안내 → 산출물 섹션 "요약 중" 표시 → 목록 카드도 온라인 안내 렌더 → `/app/rooms` 캘린더 미노출 → 다크모드 정상.
- 신규 테스트: `validate.test.ts` · `actions.test.ts`(mock 분기 추가) · `actions.online-real.test.ts`(신규) · `mock/meetings.test.ts`(`addMockOnlineMeeting`) · `server.test.ts`(isOnline 매핑) · `meeting-card.test.tsx`/`meeting-detail-view.test.tsx` · `online-meeting-dialog.test.tsx`(신규)
