### PR TITLE
[CHORE] 배포 워크플로에 헬스체크·진단 로그 추가 #476

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,3 +75,23 @@ jobs:
               $IMAGE:$SHA
 
             docker image prune -f
+
+            # ⚠️ `docker run -d`는 컨테이너가 뜨기만 하면 성공이다 — 그 안의 Next.js가
+            #    BACKEND_API_URL을 잘못 읽어 매 요청마다 실패해도 이 워크플로는 초록으로
+            #    끝난다. 배포 뒤 상태를 여기서 직접 찍어서, AWS 콘솔 접근 없이 Actions 로그
+            #    만으로 원인을 좁힐 수 있게 한다.
+            echo "=== 배포 진단 ==="
+            echo "BACKEND_API_URL(FE 컨테이너가 실제로 읽는 값): $BACKEND_API_URL"
+
+            sleep 3
+
+            echo "--- FE 컨테이너 응답 확인 (localhost:3000) ---"
+            curl -m 5 -sS -o /dev/null -w "HTTP %{http_code}\n" http://localhost:3000 \
+              || echo "FE 컨테이너가 응답하지 않습니다 — docker logs 확인 필요"
+
+            echo "--- EC2에서 BE로 직접 도달 가능한지 확인 (BE actuator health) ---"
+            curl -m 5 -sS -o /dev/null -w "HTTP %{http_code}\n" "$BACKEND_API_URL/actuator/health" \
+              || echo "EC2에서 BE로 연결할 수 없습니다 — BACKEND_API_URL 오타이거나 BE가 안 떠 있거나 방화벽 차단"
+
+            echo "--- FE 컨테이너 최근 로그 50줄 ---"
+            docker logs --tail 50 zebra-fe


### PR DESCRIPTION
## 📋 PR 타입

- [ ] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [x] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

## 무엇
`.github/workflows/deploy.yml`의 `docker run -d` 이후에 배포 진단 스텝을 추가한다:
- FE 컨테이너가 실제로 읽는 `BACKEND_API_URL` 값
- FE 컨테이너 자체 응답 확인(`curl localhost:3000`)
- EC2에서 BE(`$BACKEND_API_URL/actuator/health`)로 실제 도달 가능한지
- FE 컨테이너 최근 로그 50줄

## 왜
`docker run -d`는 컨테이너가 뜨기만 하면 성공으로 찍힌다 — 그 안의 Next.js가 `BACKEND_API_URL`을 잘못 읽거나 BE에 도달을 못 해 매 요청마다 실패해도 이 워크플로는 그대로 초록으로 끝난다. 실제로 배포 서버에서 회의·회의실·구성원·구독·저장소 등 여러 화면이 동시에 "불러오지 못했습니다"로 실패하는 걸 겪었는데, 신고자가 AWS 콘솔·EC2 접근 권한이 전혀 없어 원인을 좁힐 방법이 없었다. 이 진단 로그를 남기면 **AWS 콘솔 접근 없이 GitHub Actions 로그만으로** 다음 배포부터 원인을 좁힐 수 있다.

BE는 `spring-boot-starter-actuator`가 있고 `management.endpoints.web.exposure.include: health,prometheus`로 `/actuator/health`를 이미 열어 두고 있어([확인] `application.yaml`), 이 엔드포인트로 EC2→BE 도달 여부를 직접 확인한다.

## 확인법
- `.github/workflows/deploy.yml` YAML 파싱 확인(`python3 -c "import yaml; yaml.safe_load(open(...))"`) 통과
- 스크립트 로직 리뷰: curl 실패는 각각 `|| echo ...`로 받아서 `set -e`에 걸려 스크립트가 중간에 끊기지 않는다(로그 마지막 줄 `docker logs`까지 항상 실행됨)
- 실제 동작 확인은 다음 `main` 배포 때 Actions 로그로 확인(로컬에서 이 SSH 스크립트 자체를 실행해볼 방법은 없음)

Closes #476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 배포 후 프론트엔드 컨테이너의 로컬 응답과 백엔드 상태 확인을 자동으로 검증합니다.
  * 연결 확인 실패 시 오류 메시지를 제공해 문제를 쉽게 파악할 수 있습니다.

* **진단 개선**
  * 배포 후 주요 환경 설정을 확인할 수 있습니다.
  * 문제 분석을 위해 프론트엔드 컨테이너의 최근 로그를 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**, 그리고 **서버에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [ ] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시
- [ ] 🎨 디자인 토큰 사용 · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화
- [ ] ♿ a11y
- [ ] ♻️ 재사용 확인
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API 사용 시 미지원 · 권한거부 안내 있음

---

## 🔗 연관 이슈

Closes #476

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

-

---

## 📝 추가 메모
