### PR TITLE
[FIX] 프로덕션 500 4종 — 프로젝트 목록 실연동, 결제 전 구독 접근 차단 #478

### DIFF
--- a/src/app/(shell)/(authority)/manage/billing/(overview)/page.test.tsx
+++ b/src/app/(shell)/(authority)/manage/billing/(overview)/page.test.tsx
@@ -4,7 +4,16 @@
      아직 없어 이 페이지가 그 문 역할을 해야 하는데 빠져 있었다 — 다시 빠지면 이 테스트가 잡는다.
 */
 jest.mock("server-only", () => ({}));
-jest.mock("next/navigation", () => ({ redirect: jest.fn() }));
+/*
+  ⚠️ 그냥 return하는 mock이면 실제 `redirect()`(호출 즉시 던져서 렌더를 멈추는 함수)와
+     달리 아래 코드가 계속 실행된다 — `getBillingOverview`가 불려도 이 mock으로는 못 잡는다.
+     `NEXT_REDIRECT`를 던지게 해서 실제 동작과 같게 맞춘다(코드래빗 지적, 2026-08-14).
+*/
+jest.mock("next/navigation", () => ({
+  redirect: jest.fn(() => {
+    throw new Error("NEXT_REDIRECT");
+  }),
+}));
 jest.mock("@/mocks/config", () => ({ isMock: false }));
 
 jest.mock("@/features/shell/viewer", () => ({ getViewer: jest.fn() }));
@@ -30,7 +39,11 @@ jest.mock("@/features/billing/components/billing-view", () => ({
 
 import { redirect } from "next/navigation";
 
-import { getOnboardingSubscription } from "@/features/billing/server";
+import {
+  getBillingConfig,
+  getBillingOverview,
+  getOnboardingSubscription,
+} from "@/features/billing/server";
 import { getViewer } from "@/features/shell/viewer";
 
 import OwnerBillingPage from "./page";
@@ -41,12 +54,15 @@ describe("/manage/billing — 결제 전 회사는 여기서 막는다", () => {
     (getViewer as jest.Mock).mockResolvedValue({ role: "owner" });
   });
 
-  it("구독 상태가 UNPAID면 /subscription으로 돌려보낸다 — BillingView는 안 그린다", async () => {
+  it("구독 상태가 UNPAID면 /subscription으로 돌려보낸다 — 그 뒤 조회는 안 나간다", async () => {
     (getOnboardingSubscription as jest.Mock).mockResolvedValue({ status: "UNPAID" });
 
-    await OwnerBillingPage();
+    await expect(OwnerBillingPage()).rejects.toThrow("NEXT_REDIRECT");
 
     expect(redirect).toHaveBeenCalledWith("/subscription");
+    // ⚠️ 실제 redirect()는 던져서 렌더를 멈춘다 — 결제 전 회사의 404가 여기까지 오면 안 된다
+    expect(getBillingOverview).not.toHaveBeenCalled();
+    expect(getBillingConfig).not.toHaveBeenCalled();
   });
 
   it("ACTIVE면 그대로 통과해 화면을 그린다", async () => {

--- a/src/app/(shell)/(authority)/manage/billing/(overview)/page.test.tsx
+++ b/src/app/(shell)/(authority)/manage/billing/(overview)/page.test.tsx
@@ -1,0 +1,60 @@
+/*
+  ⚠️ 회귀 방지 — 2026-08-14 프로덕션에서 결제 전 회사가 사이드바 링크로 이 화면에 그대로
+     들어와 `getBillingOverview`의 404(BIL-001)가 새서 에러 화면이 떴다. `middleware.ts`가
+     아직 없어 이 페이지가 그 문 역할을 해야 하는데 빠져 있었다 — 다시 빠지면 이 테스트가 잡는다.
+*/
+jest.mock("server-only", () => ({}));
+jest.mock("next/navigation", () => ({ redirect: jest.fn() }));
+jest.mock("@/mocks/config", () => ({ isMock: false }));
+
+jest.mock("@/features/shell/viewer", () => ({ getViewer: jest.fn() }));
+
+jest.mock("@/features/billing/server", () => ({
+  getOnboardingSubscription: jest.fn(),
+  getBillingOverview: jest.fn(async () => ({ subscription: {}, payments: [] })),
+  getBillingConfig: jest.fn(async () => ({})),
+}));
+
+jest.mock("@/lib/permission", () => ({
+  canAccessManageScope: jest.fn(() => true),
+  canManageBilling: jest.fn(() => true),
+}));
+
+jest.mock("@/components/common/access-denied", () => ({
+  AccessDenied: () => <div data-testid="access-denied" />,
+}));
+
+jest.mock("@/features/billing/components/billing-view", () => ({
+  BillingView: () => <div data-testid="billing-view" />,
+}));
+
+import { redirect } from "next/navigation";
+
+import { getOnboardingSubscription } from "@/features/billing/server";
+import { getViewer } from "@/features/shell/viewer";
+
+import OwnerBillingPage from "./page";
+
+describe("/manage/billing — 결제 전 회사는 여기서 막는다", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getViewer as jest.Mock).mockResolvedValue({ role: "owner" });
+  });
+
+  it("구독 상태가 UNPAID면 /subscription으로 돌려보낸다 — BillingView는 안 그린다", async () => {
+    (getOnboardingSubscription as jest.Mock).mockResolvedValue({ status: "UNPAID" });
+
+    await OwnerBillingPage();
+
+    expect(redirect).toHaveBeenCalledWith("/subscription");
+  });
+
+  it("ACTIVE면 그대로 통과해 화면을 그린다", async () => {
+    (getOnboardingSubscription as jest.Mock).mockResolvedValue({ status: "ACTIVE" });
+
+    const ui = await OwnerBillingPage();
+
+    expect(redirect).not.toHaveBeenCalled();
+    expect(ui).toBeTruthy();
+  });
+});

--- a/src/app/(shell)/(authority)/manage/billing/(overview)/page.tsx
+++ b/src/app/(shell)/(authority)/manage/billing/(overview)/page.tsx
@@ -1,12 +1,19 @@
 import type { Metadata } from "next";
+import { redirect } from "next/navigation";
 
 import { AccessDenied } from "@/components/common/access-denied";
 import { BillingView } from "@/features/billing/components/billing-view";
-import { getBillingConfig, getBillingOverview } from "@/features/billing/server";
+import {
+  getBillingConfig,
+  getBillingOverview,
+  getOnboardingSubscription,
+} from "@/features/billing/server";
+import { canUseWorkspace } from "@/features/billing/subscription";
 import { roleHome } from "@/features/shell/home";
 import { getViewer } from "@/features/shell/viewer";
 import { canAccessManageScope } from "@/lib/permission";
 import { canManageBilling } from "@/lib/permission";
+import { isMock } from "@/mocks/config";
 
 export const metadata: Metadata = {
   title: "구독",
@@ -27,11 +34,27 @@ export const dynamic = "force-dynamic";
  * ⚠️ **OWNER 또는 Admin 겸직자만** 볼 수 있다. 지금은 로그인이 없어 화면 가드만 있고,
  *    Server Action·BFF가 붙으면 `canManageBilling`으로 서버에서 재검사한다 —
  *    화면 숨김은 UX일 뿐 보안이 아니다(§권한).
+ * ⚠️ **결제 전 회사는 여기 오면 안 된다.** `middleware.ts`가 아직 없어(`/subscription/page.tsx`
+ *    자체 주석 — "세션에 구독 상태가 실리면 middleware.ts가 막고 여기로 돌린다. 지금은
+ *    주소로 직접 들어와 확인한다") 이 화면에 오는 유일한 문 역할을 한다. `getBillingOverview`는
+ *    "이미 결제한 회사만 오는 자리"라는 전제로 404를 그대로 던지므로(그 파일 주석 참고), 그
+ *    전제를 여기서 지킨다 — 안 지키면 결제 전 회사가 사이드바 링크로 들어와 그 404가 그대로
+ *    새서 에러 화면이 뜬다(2026-08-14 실제 프로덕션에서 재현).
+ * ⚠️ **목에서는 이 문을 건너뛴다.** `getOnboardingSubscription()`의 목 값은 게이트
+ *    화면(`/subscription`)을 보여 주기 위해 일부러 `UNPAID`로 고정돼 있다(그 함수 주석
+ *    참고) — 실서버 판정과 같은 값으로 여기서 재사용하면 데모에서 구독 화면 자체가
+ *    통째로 막힌다.
  */
 export default async function OwnerBillingPage() {
   /* ⚠️ 문(권한)을 먼저 본다 — 돈이 걸린 화면이라 판정 전 조회를 한 번도 내보내지 않는다(§권한) */
   const viewer = await getViewer();
   if (!canAccessManageScope(viewer)) return <AccessDenied homeHref={roleHome(viewer.role)} />;
+
+  /* ⚠️ 실서버에서만 확인한다 — 결제 전이면 여기서 끝(아래 getBillingOverview는 결제 전 회사를 모른다) */
+  if (!isMock) {
+    const { status } = await getOnboardingSubscription();
+    if (!canUseWorkspace(status)) redirect("/subscription");
+  }
 
   const [overview, config] = await Promise.all([getBillingOverview(), getBillingConfig()]);
 

--- a/src/features/member/manage-server.test.ts
+++ b/src/features/member/manage-server.test.ts
@@ -62,4 +62,17 @@ describe("listAllManagedMembersForOrgChart — 실서버", () => {
     expect(serverApiMock).toHaveBeenCalledTimes(1);
     expect(roster).toHaveLength(1);
   });
+
+  /*
+    ⚠️ 코드래빗 지적(2026-08-14) — 상한을 넘으면 앞부분만 조용히 정상 리턴하면 안 된다.
+       회사 인원이 늘었는데 조직도가 말없이 일부만 보여주는 건 §정직성 위반이다.
+  */
+  it("상한(20페이지)을 넘으면 잘린 명부를 정상 결과로 돌려주지 않는다 — 던진다", async () => {
+    // totalPages=21 — 상한 20을 넘는다. 20번째 응답까지만 mock하면 충분하다(그 이상 안 부른다).
+    serverApiMock.mockResolvedValue(page([1], 0, 21));
+
+    await expect(listAllManagedMembersForOrgChart()).rejects.toThrow("상한을 넘어");
+
+    expect(serverApiMock).toHaveBeenCalledTimes(20);
+  });
 });

--- a/src/features/member/manage-server.test.ts
+++ b/src/features/member/manage-server.test.ts
@@ -1,0 +1,65 @@
+jest.mock("@/mocks/config", () => ({ isMock: false }));
+jest.mock("@/features/auth/session", () => ({ requireAccessToken: jest.fn() }));
+jest.mock("@/lib/api", () => ({ serverApi: jest.fn() }));
+
+import { requireAccessToken } from "@/features/auth/session";
+import { serverApi } from "@/lib/api";
+
+import { listAllManagedMembersForOrgChart } from "./manage-server";
+
+/**
+ * 조직도 전체 명부 — 2026-08-14 프로덕션에서 무조건 throw하던 것을 고쳤다.
+ * BE에 전체 조회 응답이 없어 **여러 페이지를 순회해 합치는 임시 우회**다(함수 주석 참고) —
+ * 이 순회가 실제로 끝까지 도는지, 중복 없이 합치는지를 잠근다.
+ */
+describe("listAllManagedMembersForOrgChart — 실서버", () => {
+  const requireAccessTokenMock = requireAccessToken as unknown as jest.Mock;
+  const serverApiMock = serverApi as unknown as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    requireAccessTokenMock.mockResolvedValue("token");
+  });
+
+  function page(memberIds: number[], pageIndex: number, totalPages: number) {
+    return {
+      totalElements: totalPages * memberIds.length,
+      totalPages,
+      hasNext: pageIndex < totalPages - 1,
+      page: pageIndex,
+      size: memberIds.length,
+      content: memberIds.map((id) => ({
+        memberId: id,
+        name: `사원${id}`,
+        teamName: "개발팀",
+        positionName: null,
+        role: "MEMBER",
+        isAdmin: false,
+        roleLabel: null,
+        workStatus: "ACTIVE",
+        joinedOn: null,
+      })),
+    };
+  }
+
+  it("totalPages만큼 페이지를 순회해 전부 합친다", async () => {
+    serverApiMock
+      .mockResolvedValueOnce(page([1, 2], 0, 3))
+      .mockResolvedValueOnce(page([3, 4], 1, 3))
+      .mockResolvedValueOnce(page([5, 6], 2, 3));
+
+    const roster = await listAllManagedMembersForOrgChart();
+
+    expect(serverApiMock).toHaveBeenCalledTimes(3);
+    expect(roster.map((m) => m.id)).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  it("첫 페이지에서 totalPages=1이면 한 번만 부른다 — 회사가 작으면 요청도 하나다", async () => {
+    serverApiMock.mockResolvedValueOnce(page([1], 0, 1));
+
+    const roster = await listAllManagedMembersForOrgChart();
+
+    expect(serverApiMock).toHaveBeenCalledTimes(1);
+    expect(roster).toHaveLength(1);
+  });
+});

--- a/src/features/member/manage-server.ts
+++ b/src/features/member/manage-server.ts
@@ -20,12 +20,13 @@ import {
   toManagedMember,
   toManagedMemberAction,
 } from "./manage-mapper";
-import type {
-  ManagedMember,
-  ManagedMemberActions,
-  ManagedMemberDetail,
-  MemberQuery,
-  PendingHandover,
+import {
+  type ManagedMember,
+  type ManagedMemberActions,
+  type ManagedMemberDetail,
+  MEMBER_FILTER,
+  type MemberQuery,
+  type PendingHandover,
 } from "./manage-types";
 import {
   findMockManagedMember,
@@ -124,6 +125,47 @@ export async function listManagedMembers(): Promise<ManagedMember[]> {
 
 /** 한 화면에 그리는 줄 수 — 첫 페이지를 서버가 렌더하고 그 아래부터 이어 붙인다 */
 export const MEMBER_PAGE_SIZE = 20;
+
+/**
+ * 조직도(`getPeopleDirectory`)가 명부 전체를 요구할 때 쓰는 **임시 우회**.
+ *
+ * ⚠️ **정공법이 아니다.** 조직도는 팀 단위로 구조를 그려야 해서 한 페이지만 받으면
+ *    팀이 반쯤 그려진다(`org-server.ts` 주석) — 그런데 BE엔 "회사 전체 명부"를 한 번에
+ *    주는 응답이 없다(`GET /api/members`는 페이지 단위뿐). 그래서 여러 페이지를 순회해
+ *    합친다. 회사가 커지면 요청도 늘고 화면도 그만큼 늦게 뜬다 — **BE에 조직도 전용
+ *    응답을 요청하고 나면 이 함수째 걷어낸다.**
+ * ⚠️ **상한을 두되 조용히 안 자른다.** 상한에 걸리면 그 사실 자체를 콘솔에 남긴다 —
+ *    회사 인원이 늘었는데 조직도가 말없이 일부만 보여주면 그게 §정직성 위반이다.
+ */
+const ORG_DIRECTORY_PAGE_SIZE = 200;
+const ORG_DIRECTORY_PAGE_LIMIT = 20; // 최대 4,000명 — 이 상한을 실제로 넘기면 BE 요청이 먼저다
+
+export async function listAllManagedMembersForOrgChart(): Promise<ManagedMember[]> {
+  if (isMock) return listManagedMembers();
+
+  const all: ManagedMember[] = [];
+  let page = 0;
+  let totalPages = 1;
+
+  while (page < totalPages && page < ORG_DIRECTORY_PAGE_LIMIT) {
+    const result = await getManagedMembersPage(
+      { keyword: "", filter: MEMBER_FILTER.ALL },
+      page,
+      ORG_DIRECTORY_PAGE_SIZE,
+    );
+    all.push(...result.items);
+    totalPages = result.totalPages;
+    page += 1;
+  }
+
+  if (page >= ORG_DIRECTORY_PAGE_LIMIT && page < totalPages) {
+    console.error(
+      `[org-chart] 회사 사원이 ${ORG_DIRECTORY_PAGE_LIMIT * ORG_DIRECTORY_PAGE_SIZE}명 상한을 넘어 조직도가 일부만 그려집니다 — BE 전용 응답이 필요합니다.`,
+    );
+  }
+
+  return all;
+}
 
 /**
  * 목록 한 페이지 — **거르기·자르기를 서버가 한다.**

--- a/src/features/member/manage-server.ts
+++ b/src/features/member/manage-server.ts
@@ -134,8 +134,12 @@ export const MEMBER_PAGE_SIZE = 20;
  *    주는 응답이 없다(`GET /api/members`는 페이지 단위뿐). 그래서 여러 페이지를 순회해
  *    합친다. 회사가 커지면 요청도 늘고 화면도 그만큼 늦게 뜬다 — **BE에 조직도 전용
  *    응답을 요청하고 나면 이 함수째 걷어낸다.**
- * ⚠️ **상한을 두되 조용히 안 자른다.** 상한에 걸리면 그 사실 자체를 콘솔에 남긴다 —
- *    회사 인원이 늘었는데 조직도가 말없이 일부만 보여주면 그게 §정직성 위반이다.
+ * ⚠️ **상한을 넘으면 던진다 — 잘린 명부를 정상 결과로 돌려주지 않는다**(코드래빗 지적,
+ *    2026-08-14). `console.error`만 남기고 앞의 20페이지를 그대로 리턴하면 호출부
+ *    (`getPeopleDirectory`)가 그걸 완전한 명부로 알고 `summary`·`chart`를 계산해,
+ *    회사 인원이 늘었는데 조직도가 말없이 일부만 보여준다(§정직성 위반). 던지면
+ *    화면이 기존 `error.tsx`(정직한 실패 상태 + [다시 시도])로 떨어진다 — 새 화면을
+ *    안 만들어도 된다.
  */
 const ORG_DIRECTORY_PAGE_SIZE = 200;
 const ORG_DIRECTORY_PAGE_LIMIT = 20; // 최대 4,000명 — 이 상한을 실제로 넘기면 BE 요청이 먼저다
@@ -159,8 +163,8 @@ export async function listAllManagedMembersForOrgChart(): Promise<ManagedMember[
   }
 
   if (page >= ORG_DIRECTORY_PAGE_LIMIT && page < totalPages) {
-    console.error(
-      `[org-chart] 회사 사원이 ${ORG_DIRECTORY_PAGE_LIMIT * ORG_DIRECTORY_PAGE_SIZE}명 상한을 넘어 조직도가 일부만 그려집니다 — BE 전용 응답이 필요합니다.`,
+    throw new Error(
+      `회사 사원이 ${ORG_DIRECTORY_PAGE_LIMIT * ORG_DIRECTORY_PAGE_SIZE}명 상한을 넘어 조직도를 통째로 불러오지 못했습니다 — BE 전용 응답이 필요합니다.`,
     );
   }
 

--- a/src/features/member/org-server.ts
+++ b/src/features/member/org-server.ts
@@ -1,13 +1,13 @@
 import "server-only";
 
-import { listManagedMembers } from "./manage-server";
+import { listAllManagedMembersForOrgChart } from "./manage-server";
 import { buildOrgChart, searchOrgMembers, summarizeOrg } from "./org-chart";
 import type { PeopleDirectory } from "./org-types";
 
 /**
  * 구성원 화면 조회 — **격리막**(CLAUDE.md §Mock 격리막).
  *
- * ⚠️ **명부를 따로 두지 않는다.** 사원 관리와 같은 `listManagedMembers()`를 읽고 모양만
+ * ⚠️ **명부를 따로 두지 않는다.** 사원 관리와 같은 명부 조회를 읽고 모양만
  *    바꾼다 — 두 벌로 들고 있으면 같은 회사가 화면마다 달라 보인다. 연동될 때도 고칠
  *    자리가 한 곳이다.
  * ⚠️ 조회 전용이다. 이 화면에는 바꾸는 일이 없어 `actions.ts`가 없다.
@@ -17,12 +17,13 @@ import type { PeopleDirectory } from "./org-types";
  * ⚠️ **퇴사자를 거르지 않는다.** 나간 사람은 목록에 남는다(CLAUDE.md §도메인 상수) — 그 사람이
  *    남긴 회의·액션·인수인계의 출처라 이름이 사라지면 추적이 끊긴다. 화면은 `퇴사` 뱃지로
  *    알린다. 소프트 딜리트(`DELETED`)만 그 앞의 매퍼가 거른다.
- * ⚠️ 지금은 명부를 통째로 받아 세운다. 조직도는 목록이 아니라 **구조**라 잘라 보내면
- *    팀이 반쯤 그려진다 — 사원이 수백 명이 되면 BE에 팀 단위 응답을 요청하고
- *    여기서 그 모양을 흡수한다(§연동 검증).
+ * ⚠️ **명부 전체가 필요하다** — 조직도는 목록이 아니라 **구조**라 한 페이지만 받으면
+ *    팀이 반쯤 그려진다. 실서버에는 전체를 한 번에 주는 응답이 없어(§연동 검증)
+ *    `listAllManagedMembersForOrgChart`가 여러 페이지를 순회해 합친다(임시 우회 —
+ *    그 함수 주석 참고). BE에 조직도 전용 응답이 생기면 여기만 고친다.
  */
 export async function getPeopleDirectory(keyword: string): Promise<PeopleDirectory> {
-  const roster = await listManagedMembers();
+  const roster = await listAllManagedMembersForOrgChart();
 
   return {
     summary: summarizeOrg(roster),

--- a/src/features/rooms/server.test.ts
+++ b/src/features/rooms/server.test.ts
@@ -119,10 +119,13 @@ describe("getReservableProjects — 실서버", () => {
     const projects = await getReservableProjects();
 
     expect(projects).toEqual([{ id: "12", name: "제품 v2.0", tag: "product-v2" }]);
-    // 완료된 프로젝트에 새 회의를 묶을 일이 없다 — 진행중만 요청한다
     expect(serverApiMock).toHaveBeenCalledWith(
       expect.stringContaining("status=IN_PROGRESS"),
       expect.objectContaining({ accessToken: "token" }),
     );
+    // ⚠️ page·size도 확인한다 — 기본 페이지 크기(20)로 조용히 바뀌어도 status만 보면 통과했다(코드래빗 지적)
+    const requestUrl = serverApiMock.mock.calls[0][0] as string;
+    expect(requestUrl).toContain("page=0");
+    expect(requestUrl).toContain("size=200"); // select 한 번에 받을 상한(RESERVABLE_PROJECTS_PAGE_SIZE)
   });
 });

--- a/src/features/rooms/server.test.ts
+++ b/src/features/rooms/server.test.ts
@@ -13,7 +13,7 @@ import { serverApi } from "@/lib/api";
 import { ep } from "@/lib/endpoints";
 import type { Actor } from "@/lib/permission";
 
-import { getReservableMembers } from "./server";
+import { getReservableMembers, getReservableProjects } from "./server";
 
 /**
  * 참석자 후보 명부 — **실서버 분기가 Owner와 Leader·Member에서 다른 API를 부른다.**
@@ -81,5 +81,48 @@ describe("getReservableMembers — 실서버", () => {
     expect(members).toEqual([
       { id: 3, name: "이서연", teamName: "개발팀", authority: AUTHORITY.MEMBER },
     ]);
+  });
+});
+
+/**
+ * 예약 폼의 "프로젝트" select — 2026-08-14 프로덕션에서 무조건 throw하던 것을 고쳤다.
+ * `getProjectsPage`(project 도메인, 이미 실연동)를 그대로 재사용하는지 확인한다.
+ */
+describe("getReservableProjects — 실서버", () => {
+  it("getProjectsPage를 재사용해 select 모양으로 줄인다 — 새 경로를 만들지 않는다", async () => {
+    serverApiMock.mockResolvedValue({
+      content: [
+        {
+          id: 12,
+          tag: "product-v2",
+          color: "blue",
+          name: "제품 v2.0",
+          description: "",
+          status: "IN_PROGRESS",
+          startDate: null,
+          dueDate: "2026-12-31",
+          teamCount: 1,
+          actionCount: 0,
+          completedActionCount: 0,
+          meetingCount: 0,
+          progressPct: 0,
+          teamNames: [],
+        },
+      ],
+      page: 0,
+      size: 200,
+      totalElements: 1,
+      totalPages: 1,
+      hasNext: false,
+    });
+
+    const projects = await getReservableProjects();
+
+    expect(projects).toEqual([{ id: "12", name: "제품 v2.0", tag: "product-v2" }]);
+    // 완료된 프로젝트에 새 회의를 묶을 일이 없다 — 진행중만 요청한다
+    expect(serverApiMock).toHaveBeenCalledWith(
+      expect.stringContaining("status=IN_PROGRESS"),
+      expect.objectContaining({ accessToken: "token" }),
+    );
   });
 });

--- a/src/features/rooms/server.ts
+++ b/src/features/rooms/server.ts
@@ -3,10 +3,12 @@ import "server-only";
 import { addDays, format, startOfWeek } from "date-fns";
 
 import { AUTHORITY } from "@/constants/authority";
+import { PROJECT_STATUS } from "@/constants/domain";
 import { requireAccessToken } from "@/features/auth/session";
 import { getTeamLeaders } from "@/features/member/manage-server";
 import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
 import { PROJECT_TEAM_ACTIONS_MOCK } from "@/features/project/mock/team-actions";
+import { getProjectsPage } from "@/features/project/server";
 import { ApiError, serverApi } from "@/lib/api";
 import { ep } from "@/lib/endpoints";
 import { type Actor, requiresParentTeamAction } from "@/lib/permission";
@@ -182,7 +184,19 @@ export async function getReservableMembers(actor: Actor): Promise<RoomMember[]> 
   }));
 }
 
-/** 예약 폼의 "프로젝트" select용 — 프로젝트 도메인의 전체 목록에서 경량 필드만 골라 낸다. */
+/** select 한 번에 받을 상한 — 이 회사 진행중 프로젝트가 이보다 많아지면 BE 전용 응답을 요청한다. */
+const RESERVABLE_PROJECTS_PAGE_SIZE = 200;
+
+/**
+ * 예약 폼의 "프로젝트" select용 — 프로젝트 도메인의 전체 목록에서 경량 필드만 골라 낸다.
+ *
+ * ⚠️ **`getProjectsPage`를 재사용한다.** 프로젝트 목록 API가 이미 실서버에 연동돼 있으므로
+ *    (`features/project/server.ts`) 여기서 새 경로를 만들지 않는다(§환각 API 방지) — 같은
+ *    회사의 프로젝트가 두 곳에서 다르게 보이면 안 된다.
+ * ⚠️ select는 **한 화면에 다 보여줄 목록**이라 페이지네이션이 안 맞는다. 진행중 프로젝트만
+ *    대상으로 좁히고(완료된 프로젝트에 새 회의를 묶을 일이 없다) 큰 페이지 하나로 받는다 —
+ *    회사 프로젝트가 이 상한을 넘으면 그때 BE에 전용 select 응답을 요청한다.
+ */
 export async function getReservableProjects(): Promise<RoomProjectOption[]> {
   if (isMock) {
     return TOP_LEVEL_PROJECTS.map((project) => ({
@@ -191,7 +205,17 @@ export async function getReservableProjects(): Promise<RoomProjectOption[]> {
       tag: project.tag,
     }));
   }
-  throw new Error("프로젝트 목록 조회 API가 아직 연결되지 않았습니다.");
+
+  const { items } = await getProjectsPage(
+    { status: PROJECT_STATUS.IN_PROGRESS, keyword: "" },
+    0,
+    RESERVABLE_PROJECTS_PAGE_SIZE,
+  );
+  return items.map((project) => ({
+    id: String(project.id),
+    name: project.name,
+    tag: project.tag,
+  }));
 }
 
 /**


### PR DESCRIPTION
## 📋 PR 타입

- [ ] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [x] 공유 셸 · 디자인 시스템
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

## 무엇
프로덕션 EC2 docker logs로 확인한 실제 스택트레이스 기준, 회의·회의실·구성원·구독 화면이 죽던 원인 4종 중 바로 고칠 수 있는 2건 처리.

## 왜
- `getReservableProjects()`(rooms/server.ts) — mock 분기만 있고 실서버 분기가 없이 무조건 throw. `/app/meeting`·`/app/rooms` 둘 다 Promise.all로 이 함수를 부르니 두 화면이 통째로 죽었음. BE `/api/projects`는 이미 있고 다른 화면(project/server.ts)에서 이미 씀 — 그 함수(`getProjectsPage`)를 재사용해 select 모양으로 줄임.
- `/manage/billing` — `middleware.ts`가 아직 없어 결제 전 회사가 사이드바 링크로 그대로 진입, `getBillingOverview`의 404(BIL-001)가 그대로 새서 에러 화면. 페이지 진입 시 `getOnboardingSubscription`으로 상태를 먼저 확인해 `/subscription`으로 리다이렉트. mock 모드에서는 그 판정 함수가 항상 UNPAID를 주므로(게이트 데모용) `isMock`이면 건너뜀.

## 확인법
- `npx tsc --noEmit` · `npx jest` — 128 suites / 1373 tests 통과
- 신규 회귀 테스트 2건: `rooms/server.test.ts`(프로젝트 목록 실서버 매핑) · `manage/billing/(overview)/page.test.tsx`(미결제 리다이렉트 + mock 우회 안 함)

## 남은 것 (별도 처리 예정)
- 구성원(`org-server.ts`·`team-handover/server.ts`)이 페이지 단위 전용으로 막아둔 `listManagedMembers()`를 여전히 직접 부름 — BE에 전체 명부 조회 API가 없어 설계 판단 필요
- 저장소 — BE에 프로젝트별 실사용량 API 자체가 없음(BE 요청 대상)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 결제 관리 페이지에서 구독 상태를 확인합니다.
  * 결제가 완료되지 않은 경우 구독 페이지로 자동 이동하며, 활성 구독자는 기존처럼 이용할 수 있습니다.
  * 예약 가능한 프로젝트를 진행 중인 프로젝트로 제한하고, 이름과 태그를 선택할 수 있도록 개선했습니다.
  * 예약 가능한 프로젝트를 최대 200개까지 표시합니다.
  * 조직도에서 전체 구성원 목록을 여러 페이지에 걸쳐 조회할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**, 그리고 **서버에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [ ] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시
- [ ] 🎨 디자인 토큰 사용 · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화
- [ ] ♿ a11y
- [ ] ♻️ 재사용 확인
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API 사용 시 미지원 · 권한거부 안내 있음

---

## 🔗 연관 이슈

Closes #478

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

-

---

## 📝 추가 메모
