### PR TITLE
[FEAT] 비대면 회의 개설 API 연동(MEET-18) #481

### DIFF
--- a/src/features/meeting/actions.online-real.test.ts
+++ b/src/features/meeting/actions.online-real.test.ts
@@ -1,19 +1,30 @@
 // 서버 액션은 next 런타임 함수를 부른다 — jsdom엔 없으니 목으로 대체하고 호출만 검증한다.
 jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
-// 이 파일만 실서버 분기를 본다(`actions.attendees-real.test.ts`와 같은 패턴).
+// 이 파일만 실서버 분기를 본다(`rooms/actions.real.test.ts`와 같은 패턴).
 jest.mock("@/mocks/config", () => ({ isMock: false }));
+jest.mock("@/features/auth/session", () => ({ requireAccessToken: jest.fn() }));
 jest.mock("@/features/shell/viewer", () => ({
   getViewer: jest.fn(() => Promise.resolve({ id: 1, role: "OWNER" })),
 }));
 jest.mock("@/lib/api", () => ({
-  ApiError: class ApiError extends Error {},
+  ApiError: class ApiError extends Error {
+    status: number;
+    code?: string;
+    constructor(status: number, message: string, code?: string) {
+      super(message);
+      this.status = status;
+      this.code = code;
+    }
+  },
   serverApi: jest.fn(),
 }));
 
-import { serverApi } from "@/lib/api";
+import { requireAccessToken } from "@/features/auth/session";
+import { ApiError, serverApi } from "@/lib/api";
 
 import { createOnlineMeetingAction } from "./actions";
 
+const requireAccessTokenMock = requireAccessToken as unknown as jest.Mock;
 const serverApiMock = serverApi as unknown as jest.Mock;
 
 const VALID_FORM = () => {
@@ -26,28 +37,63 @@ const VALID_FORM = () => {
   return data;
 };
 
-/*
-  ⚠️ BE API가 아직 안 정해졌다(1안/2안 논의 중, 이슈 #473) — 추측 요청을 보내지 않는다
-     (CLAUDE.md §연동 검증: Swagger·구두 추측 금지). 확정되기 전까지 실서버 분기는 정직하게
-     "아직 준비 중"이라고만 말하고, `serverApi`를 절대 부르지 않아야 한다.
-*/
-describe("비대면 회의 만들기(이슈 #473) — 실서버 분기(!isMock)", () => {
+/**
+ * 비대면 회의 만들기(이슈 #473, MEET-18) — **실서버 분기**.
+ *
+ * ⚠️ 2026-08-14 팀 확정으로 BE 계약이 확정돼 더는 "아직 준비 중" 스텁이 아니다 — 이 파일은
+ *    실제로 `serverApi(ep.meetingsOnline())`를 부르고, `recordingConsent`를 안 실어 보내는지,
+ *    응답에서 `meetingId`를 그대로 `created.id`로 옮기는지를 본다(`rooms/actions.real.test.ts`와
+ *    같은 결의 실서버 분기 테스트).
+ */
+describe("비대면 회의 만들기(이슈 #473, MEET-18) — 실서버 분기(!isMock)", () => {
   beforeEach(() => {
-    serverApiMock.mockClear();
+    jest.clearAllMocks();
+    requireAccessTokenMock.mockResolvedValue("token");
   });
 
-  it("아직 준비 중이라는 오류를 돌려주고 serverApi를 부르지 않는다", async () => {
+  it("성공하면 recordingConsent 없이 보내고 응답의 meetingId를 그대로 돌려준다", async () => {
+    serverApiMock.mockResolvedValue({
+      meetingId: 42,
+      status: "DONE",
+      title: "비대면 주간 싱크",
+      isOnline: true,
+      recordingConsent: true,
+      host: { memberId: 1, name: "박대표" },
+      attendees: [{ memberId: 2, name: "김서준" }],
+    });
+
     const result = await createOnlineMeetingAction({ errors: {} }, VALID_FORM());
 
-    expect(result.errors.title).toBe("비대면 회의는 아직 준비 중입니다 — 곧 지원됩니다");
-    expect(result.created).toBeUndefined();
-    expect(serverApiMock).not.toHaveBeenCalled();
+    expect(result.errors).toEqual({});
+    expect(result.created).toEqual({ id: "42" });
+    const [, init] = serverApiMock.mock.calls[0];
+    expect(init.json).not.toHaveProperty("recordingConsent");
+    expect(init.json).not.toHaveProperty("meetingRoomId");
+    expect(init.json).not.toHaveProperty("startAt");
   });
 
-  it("폼 자체가 비어 있으면 그 검증 오류가 먼저 온다(실서버 안내보다 앞선다)", async () => {
+  it("폼 자체가 비어 있으면 그 검증 오류가 먼저 온다(BE 호출보다 앞선다)", async () => {
     const result = await createOnlineMeetingAction({ errors: {} }, new FormData());
 
     expect(result.errors.title).toBe("회의 제목을 입력해 주세요");
     expect(serverApiMock).not.toHaveBeenCalled();
+  });
+
+  it("PROJECT_NOT_FOUND는 projectId 칸 오류로 바뀐다(MEET-01의 PJ-001과 리터럴이 다르다)", async () => {
+    serverApiMock.mockRejectedValue(
+      new ApiError(404, "존재하지 않는 프로젝트", "PROJECT_NOT_FOUND"),
+    );
+
+    const result = await createOnlineMeetingAction({ errors: {} }, VALID_FORM());
+
+    expect(result.errors.projectId).toBe("존재하지 않는 프로젝트입니다");
+  });
+
+  it("MT-010은 attendeeIds 칸 오류로 바뀐다", async () => {
+    serverApiMock.mockRejectedValue(new ApiError(400, "무언가", "MT-010"));
+
+    const result = await createOnlineMeetingAction({ errors: {} }, VALID_FORM());
+
+    expect(result.errors.attendeeIds).toBe("존재하지 않는 참석자가 있습니다");
   });
 });

--- a/src/features/meeting/actions.ts
+++ b/src/features/meeting/actions.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from "next/cache";
 
 import { AUTHORITY, type Authority } from "@/constants/authority";
-import { MEETING_STATUS } from "@/constants/meeting";
+import { AI_SUMMARY_STATUS, MEETING_STATUS } from "@/constants/meeting";
 import { requireAccessToken } from "@/features/auth/session";
 import { getManagedMember } from "@/features/member/manage-server";
 import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
@@ -31,9 +31,15 @@ import {
   parseMeetingDetail,
 } from "./mapper";
 import {
+  type BeCreateOnlineMeetingResponse,
+  toCreateOnlineMeetingPayload,
+} from "./mapper/online-meetings";
+import {
   addMockOnlineMeeting,
   cancelMockMeeting,
   findMockMeeting,
+  setMockRecordingFileName,
+  setMockSummaryStatus,
   updateMockMeeting,
   updateMockMeetingAttendees,
 } from "./mock/meetings";
@@ -43,6 +49,7 @@ import type {
   MeetingTopic,
   OnlineMeetingDraft,
   OnlineMeetingFormErrors,
+  SubmitOnlineMeetingRecordingDraft,
 } from "./types";
 import { validateOnlineMeetingDraft } from "./validate";
 
@@ -395,7 +402,6 @@ export interface OnlineMeetingFormState {
 
 function readOnlineMeetingDraft(formData: FormData): OnlineMeetingDraft {
   const parentTeamActionId = formData.get("parentTeamActionId");
-  const recordingFileName = formData.get("recordingFileName");
   const mains = formData.getAll("topicMain");
   const subs = formData.getAll("topicSub");
 
@@ -405,19 +411,47 @@ function readOnlineMeetingDraft(formData: FormData): OnlineMeetingDraft {
     topics: mains.map((main, index) => ({ main: String(main), sub: String(subs[index] ?? "") })),
     attendeeIds: formData.getAll("attendeeIds").map(Number),
     parentTeamActionId: parentTeamActionId ? Number(parentTeamActionId) : undefined,
-    recordingFileName: recordingFileName ? String(recordingFileName) : null,
   };
+}
+
+/**
+ * `POST /api/meetings/online`(MEET-18) 실패를 폼 필드 오류로 바꾼다.
+ * ⚠️ `rooms/actions.ts`의 `toMeetingCreateFormErrors`(MEET-01)와 같은 자리 — 필드 슬롯이 없는
+ *    오류(`PROJECT_NOT_FOUND` 등 프로젝트 슬롯이 있는 것 빼고)는 `title` 칸에 얹는다.
+ * ⚠️ **`PROJECT_NOT_FOUND`가 이 엔드포인트만 리터럴이 다르다**(도메인 담당자 명세, 2026-08-14) —
+ *    MEET-01은 `PJ-001`을 쓰지만 여기는 그대로 이 문자열이다. 어긋나 보여도 그게 명세다.
+ */
+function toOnlineMeetingCreateFormErrors(error: unknown): OnlineMeetingFormErrors {
+  if (!(error instanceof ApiError)) throw error;
+
+  switch (error.code) {
+    case "MT-010":
+      return { attendeeIds: "존재하지 않는 참석자가 있습니다" };
+    case "MT-015":
+      return { topics: error.message };
+    case "MT-016":
+    case "MT-017":
+    case "MT-018":
+    case "MT-019":
+      return { parentTeamActionId: error.message };
+    case "PROJECT_NOT_FOUND":
+      return { projectId: "존재하지 않는 프로젝트입니다" };
+    default:
+      return { title: error.message };
+  }
 }
 
 /**
  * 비대면 회의 만들기(이슈 #473) — `/app/meeting` 목록의 [비대면 회의] 버튼이 부른다.
  *
- * ⚠️ **BE API가 아직 안 정해졌다**(1안/2안 논의 중, 팀원 회신 — 이슈 #473). 추측 요청을 보내지
- *    않는다(CLAUDE.md §연동 검증: Swagger·구두 추측 금지) — 실서버 분기는 확정될 때까지
- *    "아직 준비 중"이라고 정직하게 말한다(§정직성). 확정되면 이 분기만 실서버 호출로 바꾼다
- *    (§Mock 격리막).
+ * ⚠️ **BE API가 확정됐다**(MEET-18, 2026-08-14 도메인 담당자 문서) — 더는 "아직 준비 중"이
+ *    아니다. 다만 BE 실코드 대조 전이라 매퍼·엔드포인트 주석에 그 사실을 남겨 뒀다(§연동 검증).
+ * ⚠️ **`recordingConsent`를 안 보낸다** — 서버가 항상 `true`로 고정한다(팀 확정, 매퍼 주석).
  * ⚠️ **제출하면 그 자리에서 완료 처리된다** — 회의실 예약(`createRoomReservationAction`)과
  *    달리 캡처 화면으로 안 넘어간다(팀 명세). 그래서 회의실·시간을 아예 안 받는다.
+ * ⚠️ **성공해도 녹음 파일·AI 요약 요청은 여기서 안 한다**(2026-08-14 팀 확정) — 그 회의는
+ *    이미 완료 상태로 만들어졌고, 파일 첨부는 같은 다이얼로그의 **2단계**(`submitOnlineMeetingRecordingAction`)
+ *    가 뒤이어 처리하는 별개의 가벼운 흐름이다.
  * ⚠️ mock 분기의 검증 순서는 `createRoomReservationAction`과 맞춘다(프로젝트 → 참석자 범위 →
  *    상위 팀 액션) — 같은 도메인의 두 생성 경로가 다른 순서로 막히면 같은 실수가 화면마다
  *    다른 첫 오류로 보인다.
@@ -432,9 +466,18 @@ export async function createOnlineMeetingAction(
   if (Object.keys(errors).length > 0) return { errors };
 
   if (!isMock) {
-    // ⚠️ BE API가 아직 안 정해졌다(1안/2안 논의 중, 이슈 #473) — 추측 요청을 보내지 않는다
-    //    (CLAUDE.md §연동 검증: Swagger·구두 추측 금지). 확정되면 이 분기를 실서버 호출로 바꾼다.
-    return { errors: { title: "비대면 회의는 아직 준비 중입니다 — 곧 지원됩니다" } };
+    const accessToken = await requireAccessToken();
+    try {
+      const response = await serverApi<BeCreateOnlineMeetingResponse>(ep.meetingsOnline(), {
+        method: "POST",
+        accessToken,
+        json: toCreateOnlineMeetingPayload(draft),
+      });
+      revalidatePath(MEETING_LIST_PATH);
+      return { errors: {}, created: { id: String(response.meetingId) } };
+    } catch (error) {
+      return { errors: toOnlineMeetingCreateFormErrors(error) };
+    }
   }
 
   // ⚠️ 화면 select·피커가 이미 실제 목록에서만 고르게 해도, 폼은 조작될 수 있다
@@ -492,7 +535,8 @@ export async function createOnlineMeetingAction(
     roomName: null,
     roomReservationId: null,
     isOnline: true,
-    recordingFileName: draft.recordingFileName,
+    // ⚠️ 첨부는 이 액션의 몫이 아니다 — 다이얼로그 2단계가 성공 후 따로 붙인다(§types 주석).
+    recordingFileName: null,
     projectId: project.id,
     projectTag: project.tag,
     topics,
@@ -514,4 +558,55 @@ export async function createOnlineMeetingAction(
   const meeting = addMockOnlineMeeting(meetingDraft);
   revalidatePath(MEETING_LIST_PATH);
   return { errors: {}, created: { id: meeting.id } };
+}
+
+/** 비대면 회의 2단계([녹음 파일 제출]) 결과 — 다이얼로그가 이 값이 바뀐 걸 보고 닫는다. */
+export interface SubmitOnlineMeetingRecordingState {
+  error: string | null;
+  /** 성공한 제출의 표식(MEET-09 폼과 같은 이유로 `boolean` 대신 객체) */
+  submitted: { meetingId: string } | null;
+}
+
+function readSubmitOnlineMeetingRecordingDraft(
+  formData: FormData,
+): SubmitOnlineMeetingRecordingDraft {
+  return {
+    meetingId: String(formData.get("meetingId") ?? ""),
+    recordingFileName: String(formData.get("recordingFileName") ?? ""),
+  };
+}
+
+/**
+ * 비대면 회의 2단계 — [녹음 파일 제출] + [AI 요약 요청](이슈 #473, 2026-08-14 팀 확정).
+ *
+ * ⚠️ **회의는 이미 완료 상태로 존재한다** — 이 액션은 파일명을 덧붙이고 분석을 대기로 옮길
+ *    뿐, 회의를 새로 만들거나 상태를 바꾸지 않는다(`createOnlineMeetingAction`과 분리된 이유).
+ * ⚠️ **실서버 분기가 없다.** BE가 이 제출 자리(녹음 업로드·요약 요청 트리거)를 아직 안 내줬다
+ *    (§연동 검증: Swagger·구두 추측 금지) — 추측 엔드포인트를 만드는 대신 정직하게
+ *    "곧 지원됩니다"라고 말한다(§정직성, 기존 스텁과 같은 결).
+ * ⚠️ **파일명은 실제 업로드가 아니다**(§정직한 목업) — `setMockRecordingFileName`은 이름만 옮긴다.
+ */
+export async function submitOnlineMeetingRecordingAction(
+  _prev: SubmitOnlineMeetingRecordingState,
+  formData: FormData,
+): Promise<SubmitOnlineMeetingRecordingState> {
+  const draft = readSubmitOnlineMeetingRecordingDraft(formData);
+  if (!draft.meetingId) return { error: "회의를 찾을 수 없습니다", submitted: null };
+
+  if (!isMock) {
+    // ⚠️ BE가 아직 이 제출 엔드포인트를 안 내줬다 — 추측 요청을 보내지 않는다(§연동 검증).
+    return { error: "녹음 파일 제출은 아직 준비 중입니다 — 곧 지원됩니다", submitted: null };
+  }
+
+  if (!findMockMeeting(draft.meetingId)) {
+    return { error: "회의를 찾을 수 없습니다", submitted: null };
+  }
+
+  if (draft.recordingFileName) {
+    setMockRecordingFileName(draft.meetingId, draft.recordingFileName);
+  }
+  setMockSummaryStatus(draft.meetingId, AI_SUMMARY_STATUS.PENDING);
+  revalidatePath(`/app/meeting/${draft.meetingId}`);
+  revalidatePath(MEETING_LIST_PATH);
+  return { error: null, submitted: { meetingId: draft.meetingId } };
 }

--- a/src/features/meeting/components/meeting-card.test.tsx
+++ b/src/features/meeting/components/meeting-card.test.tsx
@@ -17,7 +17,6 @@ const BASE: MeetingListItem = {
   attendeeCount: 4,
   isHost: true,
   aiSummaryStatus: null,
-  isOnline: false,
 };
 
 function renderCard(patch: Partial<MeetingListItem> = {}) {
@@ -67,30 +66,6 @@ describe("MeetingCard — 발치 버튼", () => {
       "href",
       "/app/meeting/meeting-3/review",
     );
-  });
-});
-
-/** 비대면 회의(이슈 #473) — 발치의 일시·장소 자리가 안내 한 줄로 바뀐다. 인원수는 그대로다. */
-describe("MeetingCard — 비대면 회의(isOnline)", () => {
-  it("대면 회의는 일시·장소를 그대로 보여준다", () => {
-    renderCard({ isOnline: false });
-
-    expect(screen.getByText("8월 14일(금) 10:00 – 10:30")).toBeInTheDocument();
-    expect(screen.getByText("대회의실")).toBeInTheDocument();
-    expect(screen.queryByText("온라인으로 진행된 회의입니다")).not.toBeInTheDocument();
-  });
-
-  it("비대면 회의는 일시·장소 대신 안내 한 줄을 보여준다", () => {
-    renderCard({ isOnline: true, schedule: "", roomName: "" });
-
-    expect(screen.getByText("온라인으로 진행된 회의입니다")).toBeInTheDocument();
-    expect(screen.queryByText("대회의실")).not.toBeInTheDocument();
-  });
-
-  it("비대면 회의도 참석자 인원수는 그대로 보여준다", () => {
-    renderCard({ isOnline: true, schedule: "", roomName: "" });
-
-    expect(screen.getByText("4명")).toBeInTheDocument();
   });
 });
 

--- a/src/features/meeting/components/meeting-card.tsx
+++ b/src/features/meeting/components/meeting-card.tsx
@@ -1,4 +1,4 @@
-import { CalendarClock, ChevronRight, MapPin, Mic, Sparkles, Users, Video } from "lucide-react";
+import { CalendarClock, ChevronRight, MapPin, Mic, Sparkles, Users } from "lucide-react";
 import Link from "next/link";
 
 import { ProjectTag } from "@/components/common/project-tag";
@@ -167,29 +167,19 @@ function CardFooter({
       */}
       <div className="flex min-w-0 flex-nowrap items-center gap-x-3">
         {/*
-          ⚠️ **비대면 회의는 일시·장소 대신 안내 한 줄이다**(이슈 #473). 회의실·시간이 없어서
-             (`meeting.schedule`·`meeting.roomName`이 서버에서부터 빈 문자열로 온다) 그 칸을
-             그대로 그리면 빈 채로 보인다 — `isOnline`을 먼저 보고 아예 다른 것을 그린다.
+          ⚠️ **비대면 회의는 이제 이 목록에 안 온다**(2026-08-14 팀 확정 — `server.ts`의
+             `getMeetingDirectory` 주석). 일시·장소는 항상 채워져 있다고 봐도 된다.
         */}
-        {meeting.isOnline ? (
-          <span className="flex shrink-0 items-center gap-1.5 text-[13px] leading-5 font-medium">
-            <Video className="text-muted-foreground size-4 shrink-0" aria-hidden />
-            <span>온라인으로 진행된 회의입니다</span>
-          </span>
-        ) : (
-          <span className="flex shrink-0 items-center gap-1.5 text-[13px] leading-5 font-medium">
-            <CalendarClock className="text-muted-foreground size-4 shrink-0" aria-hidden />
-            <span className="tabular-nums">{meeting.schedule}</span>
-          </span>
-        )}
+        <span className="flex shrink-0 items-center gap-1.5 text-[13px] leading-5 font-medium">
+          <CalendarClock className="text-muted-foreground size-4 shrink-0" aria-hidden />
+          <span className="tabular-nums">{meeting.schedule}</span>
+        </span>
         <span className="bg-border h-3 w-px shrink-0" aria-hidden />
         <span className="text-muted-foreground flex min-w-0 items-center gap-x-3 text-[12px] leading-4">
-          {!meeting.isOnline && (
-            <span className="flex min-w-0 items-center gap-1.5">
-              <MapPin className="size-3.5 shrink-0" aria-hidden />
-              <span className="truncate">{meeting.roomName}</span>
-            </span>
-          )}
+          <span className="flex min-w-0 items-center gap-1.5">
+            <MapPin className="size-3.5 shrink-0" aria-hidden />
+            <span className="truncate">{meeting.roomName}</span>
+          </span>
           <span className="flex shrink-0 items-center gap-1.5">
             <Users className="size-3.5 shrink-0" aria-hidden />
             <span className="tabular-nums">{meeting.attendeeCount}명</span>

--- a/src/features/meeting/components/online-meeting-dialog.test.tsx
+++ b/src/features/meeting/components/online-meeting-dialog.test.tsx
@@ -1,7 +1,3 @@
-const pushMock = jest.fn();
-jest.mock("next/navigation", () => ({
-  useRouter: () => ({ push: pushMock }),
-}));
 jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
 jest.mock("@/lib/mock-actor", () => ({
   getMockActor: jest.fn(() => ({ id: 1, role: "OWNER" })),
@@ -20,6 +16,8 @@ import { OnlineMeetingDialog } from "./online-meeting-dialog";
      전제다 — `isMock`을 따로 목하지 않는다(`NEXT_PUBLIC_USE_MOCK`이 없으면 기본이 `true`라
      mock 분기가 실제로 돈다). Owner가 여는 폼이라 참석자 후보는 팀장뿐이다(2026-08-13,
      `attendee-scope.ts`).
+  ⚠️ **성공 후 흐름이 바뀌었다**(2026-08-14 팀 확정) — 더는 상세로 `router.push`하지 않는다.
+     같은 다이얼로그가 2단계(녹음 파일 제출)로 넘어간다 — `next/navigation` mock이 필요 없다.
 */
 const MEMBERS: RoomMember[] = [
   { id: 2, name: "김서준", teamName: "개발팀", authority: AUTHORITY.LEADER },
@@ -40,6 +38,19 @@ function renderDialog() {
   );
 }
 
+async function fillAndConfirmStep1(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("button", { name: "비대면 회의" }));
+  await user.type(screen.getByLabelText("회의 제목"), "새 비대면 회의");
+  await user.click(screen.getByRole("combobox", { name: "프로젝트" }));
+  await user.click(await screen.findByRole("option", { name: "굿즈 프로젝트" }));
+  await user.type(screen.getByLabelText("안건 1 대주제"), "제품");
+  await user.type(screen.getByLabelText("안건 1 소주제"), "점검");
+  await user.click(screen.getByRole("checkbox", { name: /김서준/ }));
+
+  await user.click(screen.getByRole("button", { name: "등록" }));
+  await user.click(screen.getByRole("button", { name: "등록" }));
+}
+
 describe("OnlineMeetingDialog", () => {
   it("트리거를 누르기 전에는 모달 제목이 없다", () => {
     renderDialog();
@@ -47,7 +58,7 @@ describe("OnlineMeetingDialog", () => {
     expect(screen.queryByText("비대면 회의 만들기")).not.toBeInTheDocument();
   });
 
-  it("[비대면 회의]를 누르면 회의실·시간 필드 없이 모달이 열린다", async () => {
+  it("[비대면 회의]를 누르면 회의실·시간 필드 없이 1단계가 열린다", async () => {
     const user = userEvent.setup();
     renderDialog();
 
@@ -56,7 +67,8 @@ describe("OnlineMeetingDialog", () => {
     expect(screen.getByRole("dialog", { name: "비대면 회의 만들기" })).toBeInTheDocument();
     expect(screen.queryByLabelText("회의실")).not.toBeInTheDocument();
     expect(screen.queryByText(/시작 시간/)).not.toBeInTheDocument();
-    expect(screen.getByText("녹음 파일 첨부 (선택)")).toBeInTheDocument();
+    // ⚠️ 녹음 파일 첨부는 2단계로 옮겨서 1단계엔 없다(2026-08-14).
+    expect(screen.queryByText("녹음 파일 첨부 (선택)")).not.toBeInTheDocument();
   });
 
   it("등록을 누르면 바로 등록하지 않고 확인 모달을 먼저 띄운다", async () => {
@@ -67,7 +79,6 @@ describe("OnlineMeetingDialog", () => {
     await user.click(screen.getByRole("button", { name: "등록" }));
 
     expect(screen.getByRole("dialog", { name: "이대로 등록하시겠습니까?" })).toBeInTheDocument();
-    expect(pushMock).not.toHaveBeenCalled();
   });
 
   it("제목 입력 중 Enter로 암시적 제출이 걸려도 확인 모달을 연다", async () => {
@@ -82,7 +93,6 @@ describe("OnlineMeetingDialog", () => {
     fireEvent.submit(form!);
 
     expect(screen.getByRole("dialog", { name: "이대로 등록하시겠습니까?" })).toBeInTheDocument();
-    expect(pushMock).not.toHaveBeenCalled();
   });
 
   it("필수값을 안 채우고 확인 모달에서 등록을 누르면 필드별 오류를 보여준다", async () => {
@@ -107,26 +117,43 @@ describe("OnlineMeetingDialog", () => {
           element?.tagName === "P" && element.textContent === "프로젝트를 선택해 주세요",
       ),
     ).toBeInTheDocument();
-    expect(pushMock).not.toHaveBeenCalled();
   });
 
-  it("성공하면 회의 상세로 이동한다", async () => {
+  it("1단계 성공하면 같은 창이 2단계(녹음 파일 제출)로 바뀐다 — 페이지 이동 없음", async () => {
     const user = userEvent.setup();
     renderDialog();
 
-    await user.click(screen.getByRole("button", { name: "비대면 회의" }));
-    await user.type(screen.getByLabelText("회의 제목"), "새 비대면 회의");
-    await user.click(screen.getByRole("combobox", { name: "프로젝트" }));
-    await user.click(await screen.findByRole("option", { name: "굿즈 프로젝트" }));
-    await user.type(screen.getByLabelText("안건 1 대주제"), "제품");
-    await user.type(screen.getByLabelText("안건 1 소주제"), "점검");
-    await user.click(screen.getByRole("checkbox", { name: /김서준/ }));
-
-    await user.click(screen.getByRole("button", { name: "등록" }));
-    await user.click(screen.getByRole("button", { name: "등록" }));
+    await fillAndConfirmStep1(user);
 
     await waitFor(() => {
-      expect(pushMock).toHaveBeenCalledWith(expect.stringMatching(/^\/app\/meeting\/meeting-/));
+      expect(screen.getByRole("dialog", { name: "녹음 파일 제출" })).toBeInTheDocument();
+    });
+    expect(screen.getByText("녹음 파일 첨부 (선택)")).toBeInTheDocument();
+  });
+
+  it("2단계에서 [나중에 하기]를 누르면 창이 닫힌다", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await fillAndConfirmStep1(user);
+    await screen.findByRole("dialog", { name: "녹음 파일 제출" });
+
+    await user.click(screen.getByRole("button", { name: "나중에 하기" }));
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("2단계에서 [AI 요약 요청]을 누르면 확인 모달 없이 바로 제출되고 창이 닫힌다", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await fillAndConfirmStep1(user);
+    await screen.findByRole("dialog", { name: "녹음 파일 제출" });
+
+    await user.click(screen.getByRole("button", { name: "AI 요약 요청" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
   });
 });

--- a/src/features/meeting/components/online-meeting-dialog.tsx
+++ b/src/features/meeting/components/online-meeting-dialog.tsx
@@ -21,6 +21,7 @@ import type { RoomMember, RoomProjectOption, RoomTeamActionOption } from "@/feat
 
 import { OnlineMeetingFields } from "./online-meeting-fields";
 import { useOnlineMeetingForm } from "./use-online-meeting-form";
+import { useOnlineMeetingRecordingForm } from "./use-online-meeting-recording-form";
 
 interface OnlineMeetingDialogProps {
   members: RoomMember[];
@@ -30,8 +31,22 @@ interface OnlineMeetingDialogProps {
   viewer: AttendeeScopeViewer;
 }
 
-/** 취소·제출 버튼 — `useFormStatus`는 `<form>`의 자손에서만 읽을 수 있다(`RoomReservationDialog`와 같은 이유). */
-function DialogActions({
+/** 제출 중인지를 창에 올려 보낸다 — `RoomReservationDialog`의 `PendingReporter`와 같다. */
+function PendingReporter({ onChange }: { onChange: (pending: boolean) => void }) {
+  const { pending } = useFormStatus();
+
+  useEffect(() => {
+    onChange(pending);
+  }, [pending, onChange]);
+
+  return null;
+}
+
+/**
+ * 취소·확인 2단계 제출 버튼 — 1단계(비대면 회의 등록)가 쓴다. `useFormStatus`는 `<form>`의
+ * 자손에서만 읽을 수 있다(`RoomReservationDialog`와 같은 이유).
+ */
+function ConfirmStepActions({
   onCancel,
   onRequestSubmit,
 }: {
@@ -52,41 +67,52 @@ function DialogActions({
   );
 }
 
-/** 제출 중인지를 창에 올려 보낸다 — `RoomReservationDialog`의 `PendingReporter`와 같다. */
-function PendingReporter({ onChange }: { onChange: (pending: boolean) => void }) {
+/**
+ * 건너뛰기·바로 제출 버튼 — 2단계(녹음 제출)가 쓴다. 확인 모달을 안 거친다 — 회의는 이미
+ * 완료 상태로 존재해서 이 제출은 되돌릴 게 없는 부가 조작이다(§토스트: 파괴적 작업만 Dialog).
+ */
+function SkipOrSubmitActions({ onSkip }: { onSkip: () => void }) {
   const { pending } = useFormStatus();
 
-  useEffect(() => {
-    onChange(pending);
-  }, [pending, onChange]);
+  return (
+    <div className="flex shrink-0 gap-2">
+      <Button type="button" variant="outline" disabled={pending} onClick={onSkip}>
+        나중에 하기
+      </Button>
+      <Button type="submit" variant="ink" disabled={pending}>
+        {pending ? "요청 중" : "AI 요약 요청"}
+      </Button>
+    </div>
+  );
+}
 
-  return null;
+interface OnlineMeetingStep1Props {
+  members: RoomMember[];
+  projects: RoomProjectOption[];
+  showParentTeamAction: boolean;
+  teamActions: RoomTeamActionOption[];
+  viewer: AttendeeScopeViewer;
+  onCreated: (meetingId: string) => void;
+  onPendingChange: (pending: boolean) => void;
+  onCancel: () => void;
 }
 
 /**
- * 비대면 회의 만들기 — `/app/meeting` 목록의 진입점(이슈 #473). `RoomReservationDialog`와
- * 같은 뼈대(`ConfirmDialog`를 안 쓰는 이유·확인 2단계 제출도 그대로)를 쓰되 **회의실·시간이
- * 없다.** 대신 녹음 파일 첨부 필드가 하나 더 있다.
- * ⚠️ **첨부는 실제 업로드가 아니다**(§정직한 목업). BE에 파일을 받을 자리가 없어(이슈 #473)
- *    파일 이름만 hidden input(`recordingFileName`)으로 실어 보낸다 — 바이트는 어디에도
- *    안 올라간다.
+ * 1단계 — 제목·프로젝트·안건·참석자(회의실·시간 없음). 성공하면 회의가 그 자리에서 완료
+ * 처리되고 `onCreated`로 부모에 알린다 — 여기서는 페이지 이동도, 창 닫기도 하지 않는다
+ * (2026-08-14 팀 확정, `use-online-meeting-form.ts` 주석).
  */
-export function OnlineMeetingDialog({
+function OnlineMeetingStep1({
   members,
   projects,
   showParentTeamAction,
   teamActions,
   viewer,
-}: OnlineMeetingDialogProps) {
-  const [open, setOpen] = useState(false);
-  const { state, formAction, form, setForm, handleOpenChange } = useOnlineMeetingForm({
-    onOpenChange: setOpen,
-  });
-
-  const [isPending, setIsPending] = useState(false);
-  const handlePendingChange = useCallback((next: boolean) => setIsPending(next), []);
-
-  const fileInputRef = useRef<HTMLInputElement>(null);
+  onCreated,
+  onPendingChange,
+  onCancel,
+}: OnlineMeetingStep1Props) {
+  const { state, formAction, form, setForm } = useOnlineMeetingForm({ onCreated });
   const formRef = useRef<HTMLFormElement>(null);
   const [showConfirm, setShowConfirm] = useState(false);
   const confirmedSubmitRef = useRef(false);
@@ -100,14 +126,167 @@ export function OnlineMeetingDialog({
     setShowConfirm(true);
   }
 
+  return (
+    <>
+      <form ref={formRef} action={formAction} onSubmit={handleFormSubmit}>
+        <PendingReporter onChange={onPendingChange} />
+        <input type="hidden" name="projectId" value={form.projectId} />
+        <input type="hidden" name="parentTeamActionId" value={form.parentTeamActionId} />
+
+        <div className="flex max-h-[70vh] flex-col gap-4 overflow-y-auto px-6 py-4">
+          <div className="grid grid-cols-1 gap-6 sm:grid-cols-[1fr_260px]">
+            <OnlineMeetingFields
+              form={form}
+              setForm={setForm}
+              errors={state.errors}
+              projects={projects}
+              showParentTeamAction={showParentTeamAction}
+              teamActions={teamActions}
+            />
+
+            <div className="flex flex-col gap-4">
+              <RoomAttendeePicker
+                members={members}
+                selectedIds={form.attendeeIds}
+                onChange={(attendeeIds) => setForm((prev) => ({ ...prev, attendeeIds }))}
+                viewer={viewer}
+              />
+              <FieldError reserveSpace message={state.errors.attendeeIds} />
+            </div>
+          </div>
+        </div>
+
+        <div className="border-border flex items-center justify-end gap-4 border-t px-6 py-4">
+          <ConfirmStepActions onCancel={onCancel} onRequestSubmit={() => setShowConfirm(true)} />
+        </div>
+      </form>
+
+      <ConfirmDialog
+        isOpen={showConfirm}
+        onOpenChange={setShowConfirm}
+        title="이대로 등록하시겠습니까?"
+        description="등록하면 곧바로 회의가 완료 처리됩니다."
+        confirmLabel="등록"
+        onConfirm={() => {
+          setShowConfirm(false);
+          confirmedSubmitRef.current = true;
+          formRef.current?.requestSubmit();
+        }}
+      />
+    </>
+  );
+}
+
+interface OnlineMeetingStep2Props {
+  meetingId: string;
+  onSubmitted: () => void;
+  onPendingChange: (pending: boolean) => void;
+  onSkip: () => void;
+}
+
+/**
+ * 2단계 — 녹음 파일 제출 + AI 요약 요청(2026-08-14 팀 확정). 회의는 1단계에서 이미 완료
+ * 상태로 만들어져 있어 이 단계는 **선택**이다 — [나중에 하기]로 건너뛰어도 회의는 그대로 남는다.
+ * ⚠️ **첨부는 실제 업로드가 아니다**(§정직한 목업) — 파일 이름만 hidden input으로 싣는다.
+ * ⚠️ 실서버(`!isMock`)에서는 서버 액션이 "곧 지원됩니다" 오류를 그대로 돌려준다 — 컴포넌트가
+ *    `isMock`을 직접 알면 안 된다(§Mock 격리막)는 규칙 그대로라, 여기서 따로 분기하지 않고
+ *    `state.error`를 그대로 보여준다.
+ */
+function OnlineMeetingStep2({
+  meetingId,
+  onSubmitted,
+  onPendingChange,
+  onSkip,
+}: OnlineMeetingStep2Props) {
+  const { state, formAction, recordingFileName, setRecordingFileName } =
+    useOnlineMeetingRecordingForm({ meetingId, onSubmitted });
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
   function handleFileChange(event: ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0] ?? null;
-    setForm((prev) => ({ ...prev, recordingFileName: file?.name ?? null }));
+    setRecordingFileName(file?.name ?? null);
   }
 
   function clearFile() {
-    setForm((prev) => ({ ...prev, recordingFileName: null }));
+    setRecordingFileName(null);
     if (fileInputRef.current) fileInputRef.current.value = "";
+  }
+
+  return (
+    <form action={formAction}>
+      <PendingReporter onChange={onPendingChange} />
+      <input type="hidden" name="meetingId" value={meetingId} />
+      <input type="hidden" name="recordingFileName" value={recordingFileName ?? ""} />
+
+      <div className="flex flex-col gap-4 px-6 py-4">
+        <p className="text-muted-foreground text-[13px] leading-5">
+          녹음 파일을 제출해 주세요. 제출 없이도 회의는 이미 완료 처리돼 있습니다.
+        </p>
+
+        <div className="flex flex-col gap-1.5">
+          <span id="online-meeting-recording-label" className="text-[13px] leading-5 font-medium">
+            녹음 파일 첨부 (선택)
+          </span>
+          {/* ⚠️ 바이너리는 안 보낸다 — 파일명만 읽어 hidden input으로 싣는다(위 주석). */}
+          <input ref={fileInputRef} type="file" className="hidden" onChange={handleFileChange} />
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="w-full min-w-0 justify-start"
+              aria-labelledby="online-meeting-recording-label"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <Paperclip aria-hidden />
+              <span className="truncate">{recordingFileName ?? "파일 첨부 (선택)"}</span>
+            </Button>
+            {recordingFileName && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                aria-label="녹음 파일 선택 해제"
+                onClick={clearFile}
+              >
+                <X aria-hidden />
+              </Button>
+            )}
+          </div>
+        </div>
+
+        <FieldError reserveSpace message={state.error ?? undefined} />
+      </div>
+
+      <div className="border-border flex items-center justify-end gap-4 border-t px-6 py-4">
+        <SkipOrSubmitActions onSkip={onSkip} />
+      </div>
+    </form>
+  );
+}
+
+/**
+ * 비대면 회의 만들기 — `/app/meeting` 목록의 진입점(이슈 #473). 2026-08-14 팀 확정으로 **2단계
+ * 다이얼로그**가 됐다:
+ *  1) 제목·프로젝트·안건·참석자를 받아 `POST /api/meetings/online`을 부른다(회의실·시간 없음).
+ *  2) 같은 창에서 곧바로 녹음 파일 제출 + AI 요약 요청으로 넘어간다(페이지 이동 없음).
+ * ⚠️ 회의는 1단계 성공 시점에 이미 완료 상태다 — 2단계는 선택이고, 건너뛰어도 회의는 남는다.
+ */
+export function OnlineMeetingDialog({
+  members,
+  projects,
+  showParentTeamAction,
+  teamActions,
+  viewer,
+}: OnlineMeetingDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [createdMeetingId, setCreatedMeetingId] = useState<string | null>(null);
+  const [isPending, setIsPending] = useState(false);
+  const handlePendingChange = useCallback((next: boolean) => setIsPending(next), []);
+
+  function closeDialog() {
+    setOpen(false);
+    setCreatedMeetingId(null);
   }
 
   return (
@@ -117,8 +296,8 @@ export function OnlineMeetingDialog({
         // ⚠️ 제출 중엔 Esc·바깥 클릭 전부 막는다 — 요청은 계속 가는데 창만 사라지면 결과를
         //    못 본다(`RoomReservationDialog`와 같은 이유).
         if (!next && isPending) return;
-        // `handleOpenChange`가 폼 리셋 + `setOpen`까지 한 번에 한다(훅 안에서 `onOpenChange`로 위임).
-        handleOpenChange(next);
+        if (!next) setCreatedMeetingId(null);
+        setOpen(next);
       }}
     >
       <DialogTrigger render={<Button type="button" variant="outline" />}>
@@ -128,101 +307,29 @@ export function OnlineMeetingDialog({
 
       <DialogContent className="gap-0 p-0 sm:max-w-[720px]">
         <DialogHeader className="border-border border-b px-6 py-4">
-          <DialogTitle>비대면 회의 만들기</DialogTitle>
+          <DialogTitle>{createdMeetingId ? "녹음 파일 제출" : "비대면 회의 만들기"}</DialogTitle>
         </DialogHeader>
 
-        <form ref={formRef} action={formAction} onSubmit={handleFormSubmit}>
-          <PendingReporter onChange={handlePendingChange} />
-          <input type="hidden" name="projectId" value={form.projectId} />
-          <input type="hidden" name="parentTeamActionId" value={form.parentTeamActionId} />
-          <input type="hidden" name="recordingFileName" value={form.recordingFileName ?? ""} />
-
-          <div className="flex max-h-[70vh] flex-col gap-4 overflow-y-auto px-6 py-4">
-            <div className="grid grid-cols-1 gap-6 sm:grid-cols-[1fr_260px]">
-              <OnlineMeetingFields
-                form={form}
-                setForm={setForm}
-                errors={state.errors}
-                projects={projects}
-                showParentTeamAction={showParentTeamAction}
-                teamActions={teamActions}
-              />
-
-              <div className="flex flex-col gap-4">
-                <RoomAttendeePicker
-                  members={members}
-                  selectedIds={form.attendeeIds}
-                  onChange={(attendeeIds) => setForm((prev) => ({ ...prev, attendeeIds }))}
-                  viewer={viewer}
-                />
-                <FieldError reserveSpace message={state.errors.attendeeIds} />
-
-                <div className="flex flex-col gap-1.5">
-                  <span
-                    id="online-meeting-recording-label"
-                    className="text-[13px] leading-5 font-medium"
-                  >
-                    녹음 파일 첨부 (선택)
-                  </span>
-                  {/* ⚠️ 바이너리는 안 보낸다 — 파일명만 읽어 hidden input으로 싣는다(위 주석). */}
-                  <input
-                    ref={fileInputRef}
-                    type="file"
-                    className="hidden"
-                    onChange={handleFileChange}
-                  />
-                  <div className="flex items-center gap-2">
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      className="w-full min-w-0 justify-start"
-                      aria-labelledby="online-meeting-recording-label"
-                      onClick={() => fileInputRef.current?.click()}
-                    >
-                      <Paperclip aria-hidden />
-                      <span className="truncate">
-                        {form.recordingFileName ?? "파일 첨부 (선택)"}
-                      </span>
-                    </Button>
-                    {form.recordingFileName && (
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon-sm"
-                        aria-label="녹음 파일 선택 해제"
-                        onClick={clearFile}
-                      >
-                        <X aria-hidden />
-                      </Button>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="border-border flex items-center justify-end gap-4 border-t px-6 py-4">
-            <DialogActions
-              onCancel={() => handleOpenChange(false)}
-              onRequestSubmit={() => setShowConfirm(true)}
-            />
-          </div>
-        </form>
+        {createdMeetingId ? (
+          <OnlineMeetingStep2
+            meetingId={createdMeetingId}
+            onSubmitted={closeDialog}
+            onPendingChange={handlePendingChange}
+            onSkip={closeDialog}
+          />
+        ) : (
+          <OnlineMeetingStep1
+            members={members}
+            projects={projects}
+            showParentTeamAction={showParentTeamAction}
+            teamActions={teamActions}
+            viewer={viewer}
+            onCreated={setCreatedMeetingId}
+            onPendingChange={handlePendingChange}
+            onCancel={() => setOpen(false)}
+          />
+        )}
       </DialogContent>
-
-      <ConfirmDialog
-        isOpen={showConfirm}
-        onOpenChange={setShowConfirm}
-        title="이대로 등록하시겠습니까?"
-        description="등록하면 곧바로 회의가 완료 처리되고 AI 요약이 시작됩니다."
-        confirmLabel="등록"
-        onConfirm={() => {
-          setShowConfirm(false);
-          confirmedSubmitRef.current = true;
-          formRef.current?.requestSubmit();
-        }}
-      />
     </Dialog>
   );
 }

--- a/src/features/meeting/components/use-online-meeting-form.ts
+++ b/src/features/meeting/components/use-online-meeting-form.ts
@@ -1,6 +1,5 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import { useActionState, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
@@ -19,26 +18,24 @@ const EMPTY_FORM = {
   attendeeIds: [] as number[],
   /** Select 값은 문자열이라 여기서도 문자열로 든다 — `useRoomReservationForm`과 같은 관례. */
   parentTeamActionId: "",
-  /** 첨부한 녹음 파일 이름 — 바이트는 안 든다(§정직한 목업, `Meeting.recordingFileName`). */
-  recordingFileName: null as string | null,
 };
 
 export type OnlineMeetingFormValues = typeof EMPTY_FORM;
 
 interface UseOnlineMeetingFormOptions {
-  onOpenChange: (open: boolean) => void;
+  /** 1단계 성공 뒤 다이얼로그가 2단계(녹음 제출)로 넘어갈 수 있게 방금 만든 회의 id를 알린다. */
+  onCreated: (meetingId: string) => void;
 }
 
 /**
- * 비대면 회의 만들기 모달의 폼 상태·제출 흐름(이슈 #473) — `useRoomReservationForm`과 같은
- * 골격이다(CLAUDE.md §폴더·네이밍: 로직=커스텀훅).
- * ⚠️ **성공 후 흐름이 회의실 예약과 다르다.** 예약은 같은 화면(캘린더)에 비관적으로 반영하지만,
- *    이 다이얼로그는 목록 화면 어디에도 그릴 자리가 없다 — 만들자마자 완료 처리되는 회의라
- *    상세로 바로 옮기는 편이 자연스럽다(`router.push`). 목록은 서버 액션이 이미 부른
- *    `revalidatePath`로 다음 방문 때 최신 상태다.
+ * 비대면 회의 만들기 모달의 **1단계**(제목·프로젝트·안건·참석자) 폼 상태·제출 흐름(이슈 #473) —
+ * `useRoomReservationForm`과 같은 골격이다(CLAUDE.md §폴더·네이밍: 로직=커스텀훅).
+ * ⚠️ **성공해도 창을 안 닫는다**(2026-08-14 팀 확정 — 이전엔 상세로 `router.push`했다). 비대면
+ *    회의는 만들자마자 완료 처리되지만, 같은 다이얼로그가 이어서 녹음 파일 제출·AI 요약 요청을
+ *    받는 **2단계**로 넘어간다 — 페이지 전환 없이 `onCreated`로 부모(다이얼로그)에 알리기만 한다.
+ * ⚠️ 폼은 여기서 안 비운다 — 2단계를 마치고 다이얼로그 전체가 닫힐 때 부모가 리셋한다.
  */
-export function useOnlineMeetingForm({ onOpenChange }: UseOnlineMeetingFormOptions) {
-  const router = useRouter();
+export function useOnlineMeetingForm({ onCreated }: UseOnlineMeetingFormOptions) {
   const [state, formAction] = useActionState(createOnlineMeetingAction, INITIAL_STATE);
   const [form, setForm] = useState<OnlineMeetingFormValues>(EMPTY_FORM);
   const handledCreatedId = useRef<string | null>(null);
@@ -46,17 +43,15 @@ export function useOnlineMeetingForm({ onOpenChange }: UseOnlineMeetingFormOptio
   useEffect(() => {
     if (state.created && state.created.id !== handledCreatedId.current) {
       handledCreatedId.current = state.created.id;
-      onOpenChange(false);
-      setForm(EMPTY_FORM);
       toast.success("비대면 회의를 등록했습니다");
-      router.push(`/app/meeting/${state.created.id}`);
+      onCreated(state.created.id);
     }
-  }, [state.created, onOpenChange, router]);
+  }, [state.created, onCreated]);
 
-  function handleOpenChange(open: boolean) {
-    if (!open) setForm(EMPTY_FORM);
-    onOpenChange(open);
+  function resetForm() {
+    setForm(EMPTY_FORM);
+    handledCreatedId.current = null;
   }
 
-  return { state, formAction, form, setForm, handleOpenChange };
+  return { state, formAction, form, setForm, resetForm };
 }

--- a/src/features/meeting/components/use-online-meeting-recording-form.ts
+++ b/src/features/meeting/components/use-online-meeting-recording-form.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useActionState, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+
+import {
+  submitOnlineMeetingRecordingAction,
+  type SubmitOnlineMeetingRecordingState,
+} from "../actions";
+
+const INITIAL_STATE: SubmitOnlineMeetingRecordingState = { error: null, submitted: null };
+
+interface UseOnlineMeetingRecordingFormOptions {
+  meetingId: string;
+  /** 제출(성공)이 끝나면 다이얼로그를 닫는다 — 회의는 1단계에서 이미 완료 상태로 존재해서
+   *  이 단계는 선택이다(닫아도 회의 자체는 그대로 남는다). */
+  onSubmitted: () => void;
+}
+
+/**
+ * 비대면 회의 만들기 다이얼로그의 **2단계**(녹음 파일 제출 + AI 요약 요청, 이슈 #473,
+ * 2026-08-14 팀 확정) — 파일명만 드는 가벼운 상태라 `useOnlineMeetingForm`처럼 따로 뗀다.
+ * ⚠️ **첨부는 실제 업로드가 아니다**(§정직한 목업) — 파일 이름만 hidden input으로 실어 보낸다,
+ *    `online-meeting-dialog.tsx`가 전에 하던 것과 같다.
+ */
+export function useOnlineMeetingRecordingForm({
+  meetingId,
+  onSubmitted,
+}: UseOnlineMeetingRecordingFormOptions) {
+  const [state, formAction] = useActionState(submitOnlineMeetingRecordingAction, INITIAL_STATE);
+  const [recordingFileName, setRecordingFileName] = useState<string | null>(null);
+  const handledMeetingId = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (state.submitted && state.submitted.meetingId !== handledMeetingId.current) {
+      handledMeetingId.current = state.submitted.meetingId;
+      toast.success("AI 요약을 요청했습니다");
+      onSubmitted();
+    }
+  }, [state.submitted, onSubmitted]);
+
+  return { state, formAction, recordingFileName, setRecordingFileName, meetingId };
+}

--- a/src/features/meeting/mapper.ts
+++ b/src/features/meeting/mapper.ts
@@ -365,8 +365,6 @@ export function toMeetingListItem(be: BeMeetingListItem): MeetingListItem {
     attendeeCount: be.attendeeCount,
     isHost: be.isHost,
     aiSummaryStatus: toAiSummaryStatus(be.summaryStatus),
-    // 실서버는 아직 비대면 회의를 모른다 — BE가 필드를 주면 그때 매퍼가 읽는다(이슈 #473).
-    isOnline: false,
   };
 }
 

--- a/src/features/meeting/mapper/online-meetings.ts
+++ b/src/features/meeting/mapper/online-meetings.ts
@@ -1,0 +1,69 @@
+/**
+ * 비대면 회의 생성(`POST /api/meetings/online`, MEET-18) BE shape → UI 계약(이슈 #473).
+ * [확인] 도메인 담당자 문서(2026-08-14, 팀 확정) 기준 — BE 실코드는 아직 대조 전이다
+ *   (§연동 검증: Swagger·구두 추측 금지, 문서와 코드가 다르면 코드가 맞다 — 구현 시 컨트롤러로 재확인).
+ * ⚠️ `rooms/mapper/meetings.ts`의 `toCreateMeetingPayload`/`toSentTopics`와 같은 자리 나눔이다 —
+ *    회의실·시간 필드만 없을 뿐 안건 접기 규칙은 같다.
+ */
+
+import type { MeetingTopicInput } from "../../rooms/types";
+import type { OnlineMeetingDraft } from "../types";
+
+/**
+ * `POST /api/meetings/online`(MEET-18) 요청 본문.
+ * ⚠️ `recordingConsent`는 **아예 안 싣는다** — 서버가 항상 `true`로 고정한다고 팀이 확정했다
+ *    (2026-08-14). 보내 봐야 서버가 무시하는 값이라, 보내는 척하면 거짓 UI다(§정직한 목업).
+ * ⚠️ `relatedActionId`: `parentTeamActionId`가 같은 개념이라 그대로 싣는다 — MEET-01과 같은 이름 매핑.
+ * ⚠️ `meetingRoomId`·`startAt`·`endAt`이 **아예 없다**(옵셔널이 아니라 필드 자체가 없다) — 비대면
+ *    회의는 회의실·시간을 안 받는다(팀 명세).
+ */
+export interface BeCreateOnlineMeetingPayload {
+  title: string;
+  projectId: number;
+  relatedActionId?: number;
+  attendeeMemberIds: number[];
+  mainTopic: string;
+  subTopics: string[];
+}
+
+/**
+ * 계약이 실제로 받는 안건 모양(대주제 1개 + 소주제 여러 개)으로 좁힌다 — `rooms/mapper/meetings.ts`의
+ * `toSentTopics`와 같은 규칙(§정직성: 버려진 값을 저장된 것처럼 보이면 안 된다). 회의실 예약과
+ * 안건 UI가 같은 모양(`MeetingTopicInput`)을 쓰기 때문에 접는 방식도 같아야 한다.
+ */
+function toSentTopics(topics: MeetingTopicInput[]): { mainTopic: string; subTopics: string[] } {
+  return {
+    mainTopic: topics[0]?.main.trim() ?? "",
+    subTopics: topics.map((topic) => topic.sub.trim()).filter((sub) => sub.length > 0),
+  };
+}
+
+export function toCreateOnlineMeetingPayload(
+  draft: OnlineMeetingDraft,
+): BeCreateOnlineMeetingPayload {
+  const { mainTopic, subTopics } = toSentTopics(draft.topics);
+  return {
+    title: draft.title.trim(),
+    projectId: Number(draft.projectId),
+    relatedActionId: draft.parentTeamActionId,
+    attendeeMemberIds: draft.attendeeIds,
+    mainTopic,
+    subTopics,
+  };
+}
+
+/**
+ * `POST /api/meetings/online` 성공 응답 — [확인] 도메인 담당자 문서(2026-08-14).
+ * ⚠️ `status`는 실제로 항상 `"DONE"`이다 — 비대면 회의는 만들어지는 순간 이미 완료다(팀 확정,
+ *    `mock/meetings.ts`의 `addMockOnlineMeeting`과 같은 규칙). `meetingRoom`·`startAt`·`endAt`은
+ *    응답에 아예 없다.
+ */
+export interface BeCreateOnlineMeetingResponse {
+  meetingId: number;
+  status: "DONE";
+  title: string;
+  isOnline: true;
+  recordingConsent: true;
+  host: { memberId: number; name: string };
+  attendees: { memberId: number; name: string; teamName?: string }[];
+}

--- a/src/features/meeting/mock/meetings.test.ts
+++ b/src/features/meeting/mock/meetings.test.ts
@@ -1,5 +1,4 @@
 import { AUTHORITY } from "@/constants/authority";
-import { AI_SUMMARY_STATUS } from "@/constants/meeting";
 
 import type { MeetingDraft } from "../types";
 import {
@@ -83,10 +82,14 @@ describe("비대면 회의 생성(이슈 #473) — addMockOnlineMeeting", () => 
     expect(created.endedAt).toBe(new Date(created.endedAt!).toISOString());
   });
 
-  it("종료와 동시에 AI 분석 대기 상태로 들어간다 — endMockMeeting과 같은 규칙", () => {
+  /*
+    ⚠️ 2026-08-14 팀 확정 — 대면 회의의 `endMockMeeting`과 달리 **대기로 안 들어간다.** 요약
+       요청은 다이얼로그 2단계([AI 요약 요청])에서 사람이 직접 눌러야 시작된다.
+  */
+  it("만들어진 시점엔 아직 AI 요약을 요청하지 않은 상태다", () => {
     const created = addMockOnlineMeeting(ONLINE_DRAFT);
 
-    expect(created.aiSummaryStatus).toBe(AI_SUMMARY_STATUS.PENDING);
+    expect(created.aiSummaryStatus).toBeNull();
   });
 
   it("회의실이 없다 — roomId·roomName·roomReservationId가 그대로 null이다", () => {

--- a/src/features/meeting/mock/meetings.ts
+++ b/src/features/meeting/mock/meetings.ts
@@ -58,6 +58,11 @@ export function addMockMeeting(draft: MeetingDraft): Meeting {
  *    `date`·`startTime`이 없다) 방금 완료된 시각을 그대로 쓴다 — 예정·진행중을 거치지 않는다.
  * ⚠️ `roomId`·`roomName`·`roomReservationId`는 draft에서부터 이미 `null`이다(회의실이 없다) —
  *    여기서 다시 지우지 않는다.
+ * ⚠️ **분석 대기(`PENDING`)로 안 들어간다**(2026-08-14 팀 확정, 대면 회의의 `endMockMeeting`과
+ *    다른 점). 대면 회의는 종료와 동시에 서버가 분석을 큐에 걸지만, 비대면 회의는 만들자마자
+ *    끝나 있어 녹음 파일 자체가 없다 — 요약 요청은 다이얼로그 2단계([AI 요약 요청])에서
+ *    사람이 직접 눌러야 시작된다(`setMockSummaryStatus`가 그때 `PENDING`으로 옮긴다). 그래서
+ *    여기서는 `null`("아직 요청 안 함")로 둔다.
  */
 export function addMockOnlineMeeting(draft: MeetingDraft): Meeting {
   const now = new Date();
@@ -70,8 +75,8 @@ export function addMockOnlineMeeting(draft: MeetingDraft): Meeting {
     // 캡처를 거치지 않고 제출과 동시에 끝난다 — endMockMeeting을 따로 부르지 않는다.
     endedAt: now.toISOString(),
     canceledAt: null,
-    // 종료와 동시에 대기로 들어간다 — endMockMeeting과 같은 이유(§types).
-    aiSummaryStatus: AI_SUMMARY_STATUS.PENDING,
+    // 아직 요약을 요청하지 않았다 — 위 주석 참고.
+    aiSummaryStatus: null,
   };
   store.meetings = [...store.meetings, meeting];
   return meeting;
@@ -161,5 +166,16 @@ export function updateMockMeeting(id: string, patch: { title: string }): Meeting
 export function setMockSummaryStatus(id: string, status: AiSummaryStatus): void {
   store.meetings = store.meetings.map((meeting) =>
     meeting.id === id ? { ...meeting, aiSummaryStatus: status } : meeting,
+  );
+}
+
+/**
+ * 비대면 회의 다이얼로그 2단계([녹음 파일 제출])가 파일명을 적어 둔다(이슈 #473, 2026-08-14).
+ * ⚠️ **여기서도 바이트는 안 든다** — 파일명만 옮긴다(§정직한 목업, `Meeting.recordingFileName`
+ *    주석과 같은 사정). 없는 회의를 조용히 넘기지 않고 값이 없으면 아무 일도 안 한다.
+ */
+export function setMockRecordingFileName(id: string, fileName: string): void {
+  store.meetings = store.meetings.map((meeting) =>
+    meeting.id === id ? { ...meeting, recordingFileName: fileName } : meeting,
   );
 }

--- a/src/features/meeting/server.test.ts
+++ b/src/features/meeting/server.test.ts
@@ -126,15 +126,17 @@ describe("비대면 회의(이슈 #473) — isOnline·빈 schedule·roomName", (
     hostAuthority: AUTHORITY.OWNER,
   };
 
-  it("목록 카드는 isOnline을 세우고 schedule·roomName을 빈 문자열로 비운다", async () => {
-    addMockOnlineMeeting(ONLINE_DRAFT);
+  /*
+    ⚠️ 2026-08-14 팀 확정으로 실서버 목록·대시보드(MEET-02·03·17)가 비대면 회의를 서버에서부터
+       걸러 준다 — 목도 같은 동작을 미리 따라 한다(`server.ts`의 `getMeetingDirectory` 주석).
+  */
+  it("비대면 회의는 목록(호스트·초대 탭 모두)에 나오지 않는다", async () => {
+    const created = addMockOnlineMeeting(ONLINE_DRAFT);
 
     const directory = await getMeetingDirectory(OWNER.id);
-    const item = directory.hosted.find((row) => row.title === "비대면 회의 서버 테스트");
 
-    expect(item?.isOnline).toBe(true);
-    expect(item?.schedule).toBe("");
-    expect(item?.roomName).toBe("");
+    expect(directory.hosted.some((row) => row.id === created.id)).toBe(false);
+    expect(directory.invited.some((row) => row.id === created.id)).toBe(false);
   });
 
   it("상세도 isOnline을 세우고 schedule·roomName을 빈 문자열로 비운다", async () => {

--- a/src/features/meeting/server.ts
+++ b/src/features/meeting/server.ts
@@ -96,14 +96,11 @@ function toListItem(meeting: Meeting, viewerId: number, now: Date): MeetingListI
     projectTag: meeting.projectTag,
     originLabel: originLabelOf(meeting),
     topicSummary: `${firstTopic.main} · ${firstTopic.sub}`,
-    // ⚠️ 비대면 회의는 회의실·시간이 없다(이슈 #473) — 카드는 `isOnline`을 보고 이 자리에
-    //    안내 한 줄을 그린다(`meeting-card.tsx`).
-    schedule: meeting.isOnline ? "" : formatMeetingSchedule(meeting.start, meeting.end),
+    schedule: formatMeetingSchedule(meeting.start, meeting.end),
     roomName: meeting.roomName ?? "",
     attendeeCount: meeting.attendeeIds.length,
     isHost: meeting.hostId === viewerId,
     aiSummaryStatus: meeting.aiSummaryStatus,
-    isOnline: meeting.isOnline,
   };
 }
 
@@ -112,14 +109,19 @@ function toListItem(meeting: Meeting, viewerId: number, now: Date): MeetingListI
  *
  * ⚠️ **목록은 전 구성원 공개**다(§3-2-1) — 여기서 권한으로 거르지 않는다. 막는 건 상세다.
  * ⚠️ 차례: 진행중 → 예정(가까운 순) → 완료(최근 순). 지금 다뤄야 하는 회의가 위로 온다.
+ * ⚠️ **비대면 회의(`isOnline`)는 목록에 아예 안 낸다**(2026-08-14 팀 확정 — 실서버 목록·대시보드
+ *    (MEET-02·03·17)가 서버에서부터 `isOnline=false`만 준다). 목이 실서버 동작을 미리 따라 하지
+ *    않으면 화면이 실서버로 넘어가는 날 갑자기 카드가 사라져 버그처럼 보인다 — 상세(`getMeetingDetail`)
+ *    는 여전히 `/app/meeting/:id` 직접 링크로 열린다(§Mock 격리막: 목록·상세는 다른 조회다).
  */
 export async function getMeetingDirectory(viewerId: number): Promise<MeetingDirectory> {
   if (!isMock) return getLiveMeetingDirectory();
 
   ensureMockMeetingsSeeded();
   const now = new Date();
-  const byId = new Map(listMockMeetings().map((meeting) => [meeting.id, meeting]));
-  const rows = listMockMeetings().map((meeting) => ({
+  const listableMeetings = listMockMeetings().filter((meeting) => !meeting.isOnline);
+  const byId = new Map(listableMeetings.map((meeting) => [meeting.id, meeting]));
+  const rows = listableMeetings.map((meeting) => ({
     item: toListItem(meeting, viewerId, now),
     startMs: meeting.start.getTime(),
   }));
@@ -273,6 +275,12 @@ export async function getMeetingDetail(id: string, viewer: Actor): Promise<Meeti
        시간·장소·참석자·안건은 이미 정해진 값이다 — 없는 건 회의가 남기는 것(기록·산출물)뿐이라
        그 두 칸만 안내로 채운다(§view-types `MeetingContentPending`).
     ⚠️ 순서가 있다. 회의가 안 끝났으면 요약은 시작조차 안 했으므로 회의 상태를 먼저 본다.
+    ⚠️ **비대면 회의는 완료 + `aiSummaryStatus: null`("아직 요청 안 함")로 며칠이고 남을 수 있다**
+       (2026-08-14 팀 확정 — [AI 요약 요청]을 안 누르면 계속 이 상태다). 아래 삼항이 그 조합을
+       `null`(=다 찼다)로 흘려보내는데, 산출물 칸은 `outputs`가 빈 배열이라 "0건"으로 자연히
+       읽혀 깨지진 않는다 — 다만 "아직 요청 안 함"과 "정말 하달할 게 없음"을 문구로는 못
+       가른다. 새 `MeetingContentPending` 값을 추가하는 건 이 이슈 범위 밖이라(화면 문구·
+       아이콘 맵까지 늘어난다) 지금은 이 fallthrough를 그대로 둔다.
   */
   const status = meetingStatusOf(meeting, new Date());
   const pendingReason: MeetingContentPending | null =

--- a/src/features/meeting/types.ts
+++ b/src/features/meeting/types.ts
@@ -130,8 +130,17 @@ export interface OnlineMeetingDraft {
   attendeeIds: number[];
   /** Host가 Leader/Member일 때만 필수 — `RoomReservationDraft`와 같은 규칙. */
   parentTeamActionId?: number;
-  /** 첨부한 녹음 파일 이름 — `Meeting.recordingFileName`과 같다(§정직한 목업). */
-  recordingFileName: string | null;
 }
 
 export type OnlineMeetingFormErrors = Partial<Record<keyof OnlineMeetingDraft, string>>;
+
+/**
+ * 비대면 회의 만들기 2단계 — 녹음 파일 제출 + AI 요약 요청(2026-08-14 팀 확정).
+ * ⚠️ 회의는 1단계에서 이미 만들어져 있다 — 이 드래프트는 그 회의에 파일명을 덧붙이고
+ *    분석을 대기 상태로 옮기는 별도의 가벼운 흐름이다(`Meeting.recordingFileName`과 같다,
+ *    §정직한 목업 — 바이트는 안 든다).
+ */
+export interface SubmitOnlineMeetingRecordingDraft {
+  meetingId: string;
+  recordingFileName: string;
+}

--- a/src/features/meeting/validate.test.ts
+++ b/src/features/meeting/validate.test.ts
@@ -10,7 +10,6 @@ const VALID_DRAFT = {
   projectId: "1",
   topics: [{ main: "제품", sub: "로드맵 검토" }],
   attendeeIds: [1],
-  recordingFileName: null,
 };
 
 describe("비대면 회의 만들기 검증", () => {

--- a/src/features/meeting/view-types.ts
+++ b/src/features/meeting/view-types.ts
@@ -9,7 +9,12 @@ import type { AiSummaryStatus, MeetingStatus } from "@/constants/meeting";
  *    고쳐야 하기 때문이다(§Mock 격리막) — 옮기는 일은 `server.ts` 한 곳이 한다.
  */
 
-/** 목록 카드 한 장 */
+/**
+ * 목록 카드 한 장.
+ * ⚠️ **비대면 회의(`isOnline`)는 여기 안 온다**(2026-08-14 팀 확정 — 실서버 목록·대시보드가
+ *    서버에서부터 걸러 준다, `server.ts`의 `getMeetingDirectory` 주석). `isOnline` 필드가 없는
+ *    이유다 — 상세(`MeetingDetail`)는 직접 링크로 계속 열리므로 거기는 남겨 둔다.
+ */
 export interface MeetingListItem {
   id: string;
   title: string;
@@ -31,17 +36,10 @@ export interface MeetingListItem {
    * 실서버는 `agendaPreview`(BE PR #461)로 채운다 — 없으면(미배포·안건 0건) 빈 문자열이다.
    */
   topicSummary: string;
-  /**
-   * `7월 14일(화) 10:00 – 10:30` — 서버가 우리 표기로 만들어 보낸다(§lib).
-   * ⚠️ **비대면 회의(`isOnline`)는 빈 문자열이다** — 회의실·시간이 없다(이슈 #473). 컴포넌트는
-   *    `isOnline`을 먼저 보고, `true`면 이 값을 그대로 그리지 않는다.
-   */
+  /** `7월 14일(화) 10:00 – 10:30` — 서버가 우리 표기로 만들어 보낸다(§lib). */
   schedule: string;
-  /** ⚠️ 비대면 회의는 빈 문자열이다 — `schedule`과 같은 이유. */
   roomName: string;
   attendeeCount: number;
-  /** 비대면(원격) 회의인가(이슈 #473) — `schedule`·`roomName` 대신 안내 한 줄을 그린다. */
-  isOnline: boolean;
   /**
    * 보는 사람이 이 회의의 Host인가.
    *

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -136,6 +136,12 @@ export const ep = {
    */
   meetings: (params?: MeetingListParams) => `/api/meetings${toQuery(params)}`,
   /**
+   * 비대면 회의 생성(`POST`, MEET-18, 이슈 #473) — **FE 제안 경로**, 아직 BE 실코드로 대조 전이다
+   *   (§연동 검증: 계약은 도메인 담당자 문서로 확정됐지만 컨트롤러는 못 봤다). 구현 착수 전 재대조할 것.
+   * ⚠️ `meetings()`(MEET-01)와 경로가 다르다 — 비대면 회의는 회의실·시간이 없어 별도 엔드포인트다.
+   */
+  meetingsOnline: () => "/api/meetings/online",
+  /**
    * 한 회의의 세 갈래가 **같은 경로**를 쓴다 — `GET` 상세(MEET-04, 캡처 진입도 이걸 쓴다) ·
    * `PATCH` 수정(MEET-05) · `DELETE` 취소(MEET-06). 없으면 404 `MT-001`, 열람 권한 없으면 403 `MT-011`.
    *


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

- `POST /api/meetings/online`(MEET-18) 실서버 호출로 전환 — 이슈 #473의 "아직 준비 중" 스텁을
  제거하고 실제 API 연동, 에러코드(`MT-010`/`MT-015`/`MT-016~019`/`PROJECT_NOT_FOUND`)를 폼
  필드 오류로 매핑
- 비대면 회의 만들기 다이얼로그를 2단계로 분리 — 1단계(개설)는 실API를 부르고, 성공하면
  페이지 이동 없이 같은 창에서 2단계(녹음 파일 제출 + AI 요약 요청)로 넘어감(팀 확정)
- `recordingConsent` 서버 고정(`true`)에 맞춰 클라이언트 전송 필드에서 제거, 회의 목록·대시보드가
  비대면 회의를 전부 제외하는 정책에 맞춰 mock 목록 필터링 및 카드의 죽은 `isOnline` 분기 정리

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 역할 가드(MEET-01과 동일) + 참석자 범위 재검사, 서버(Server Action)에서 재검사
- [ ] 🧬 **zod** — 이 도메인의 기존 MEET-01 매퍼(`rooms/mapper/meetings.ts`)가 이미 zod 없이 평범한
      TS 인터페이스로 짜여 있어 같은 관례를 따름(zod 미도입 상태 그대로 유지)
- [x] 🕵️ **정직성** — 녹음 파일 첨부는 실제 업로드가 아님을 주석·화면 문구로 명시, 2단계 실서버
      분기는 "곧 지원됩니다"로 정직하게 안내
- [x] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [x] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그)
- [x] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [x] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인) — 기존
      `OnlineMeetingFields`/`RoomAttendeePicker`/`ConfirmDialog` 재사용
- [x] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음 — 해당 없음(파일
      선택은 표준 `<input type="file">`)

---

## 🔗 연관 이슈

Closes #481

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

- `PROJECT_NOT_FOUND` 에러코드가 MEET-01의 `PJ-001`과 다른 리터럴인데, 이건 도메인 담당자가
  이 엔드포인트에 한해 그렇게 명시한 값이라 그대로 반영했습니다 — 실코드 대조 시 재확인 필요
- 2단계(녹음 제출)는 아직 BE 엔드포인트가 없어 mock 전용 동작 + 실서버 "곧 지원됩니다" 스텁으로
  남겨뒀습니다 — 스코프에 넣을지 별도 이슈로 뺄지 검토 부탁드립니다
- `aiSummaryStatus`를 개설 즉시 `PENDING`이 아니라 `null`(미요청)로 바꿨는데, 상세 화면
  `pendingReason` 계산에서 이 상태가 자연스럽게 읽히는지 한 번 봐주세요(새 상태값을 추가하진
  않았습니다)

---

## 📝 추가 메모

`src/lib/endpoints.ts`의 `meetingsOnline()` 경로와 응답 shape은 아직 BE 실코드로 대조 전입니다
(컨트롤러 병합 후 확인 예정).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 온라인 회의 생성이 실제 서비스와 연동됩니다.
  - 회의 생성 후 녹음 파일을 제출하거나 건너뛸 수 있는 2단계 흐름을 제공합니다.
  - 녹음 제출 시 AI 요약 요청 상태가 관리됩니다.
  - 제목, 프로젝트, 참석자, 안건 관련 오류를 안내합니다.

- **변경 사항**
  - 온라인 회의는 일반 회의 목록에서 제외됩니다.
  - 회의 카드가 일정과 회의실 정보를 일관되게 표시합니다.
  - 온라인 회의 생성 전에는 AI 요약 상태가 표시되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->