### PR TITLE
[FIX] 비대면 회의 다이얼로그 닫기 버튼 위치·녹음 파일 검증 보완  #483

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -58,10 +58,15 @@ function DialogContent({
   return (
     <DialogPortal>
       <DialogOverlay />
+      {/*
+        ⚠️ `overflow-hidden` 없이는 `p-0` + 직접 여백을 잡는 헤더(각진 모서리)가 이 `rounded-xl`
+           밖으로 삐져나온다(DESIGN.md §2 "세로 띠를 쓰면 카드에 overflow-hidden"과 같은 이유 —
+           각진 자식이 둥근 부모를 못 넘게 여기서 한 번만 자른다).
+      */}
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 overflow-hidden rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className
         )}
         {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -59,14 +59,17 @@ function DialogContent({
     <DialogPortal>
       <DialogOverlay />
       {/*
-        ⚠️ `overflow-hidden` 없이는 `p-0` + 직접 여백을 잡는 헤더(각진 모서리)가 이 `rounded-xl`
-           밖으로 삐져나온다(DESIGN.md §2 "세로 띠를 쓰면 카드에 overflow-hidden"과 같은 이유 —
-           각진 자식이 둥근 부모를 못 넘게 여기서 한 번만 자른다).
+        ⚠️ **`overflow-hidden`은 여기서 공용으로 안 건다.** `p-0` + 직접 여백을 잡는 헤더(각진
+           모서리)가 `rounded-xl` 밖으로 삐져나오는 건 사실이지만, 그걸 여기서 한 번에 자르면
+           `overflow-y-auto`로 세로 스크롤을 걸어 둔 다이얼로그(정보 상세 등)까지 함께 잘려
+           스크롤이 죽는다 — `overflow`와 `overflow-y`는 서로 다른 유틸리티라 `cn`(tailwind-merge)이
+           덮어쓰지 못한다. 모서리를 잘라야 하는 개별 다이얼로그가 각자 `overflow-hidden`을
+           든다(DESIGN.md §2와 같은 이유, 적용 범위만 좁힌다).
       */}
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 overflow-hidden rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className
         )}
         {...props}

--- a/src/features/meeting/actions.online-real.test.ts
+++ b/src/features/meeting/actions.online-real.test.ts
@@ -1,19 +1,30 @@
 // 서버 액션은 next 런타임 함수를 부른다 — jsdom엔 없으니 목으로 대체하고 호출만 검증한다.
 jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
-// 이 파일만 실서버 분기를 본다(`actions.attendees-real.test.ts`와 같은 패턴).
+// 이 파일만 실서버 분기를 본다(`rooms/actions.real.test.ts`와 같은 패턴).
 jest.mock("@/mocks/config", () => ({ isMock: false }));
+jest.mock("@/features/auth/session", () => ({ requireAccessToken: jest.fn() }));
 jest.mock("@/features/shell/viewer", () => ({
   getViewer: jest.fn(() => Promise.resolve({ id: 1, role: "OWNER" })),
 }));
 jest.mock("@/lib/api", () => ({
-  ApiError: class ApiError extends Error {},
+  ApiError: class ApiError extends Error {
+    status: number;
+    code?: string;
+    constructor(status: number, message: string, code?: string) {
+      super(message);
+      this.status = status;
+      this.code = code;
+    }
+  },
   serverApi: jest.fn(),
 }));
 
-import { serverApi } from "@/lib/api";
+import { requireAccessToken } from "@/features/auth/session";
+import { ApiError, serverApi } from "@/lib/api";
 
 import { createOnlineMeetingAction } from "./actions";
 
+const requireAccessTokenMock = requireAccessToken as unknown as jest.Mock;
 const serverApiMock = serverApi as unknown as jest.Mock;
 
 const VALID_FORM = () => {
@@ -26,28 +37,63 @@ const VALID_FORM = () => {
   return data;
 };
 
-/*
-  ⚠️ BE API가 아직 안 정해졌다(1안/2안 논의 중, 이슈 #473) — 추측 요청을 보내지 않는다
-     (CLAUDE.md §연동 검증: Swagger·구두 추측 금지). 확정되기 전까지 실서버 분기는 정직하게
-     "아직 준비 중"이라고만 말하고, `serverApi`를 절대 부르지 않아야 한다.
-*/
-describe("비대면 회의 만들기(이슈 #473) — 실서버 분기(!isMock)", () => {
+/**
+ * 비대면 회의 만들기(이슈 #473, MEET-18) — **실서버 분기**.
+ *
+ * ⚠️ 2026-08-14 팀 확정으로 BE 계약이 확정돼 더는 "아직 준비 중" 스텁이 아니다 — 이 파일은
+ *    실제로 `serverApi(ep.meetingsOnline())`를 부르고, `recordingConsent`를 안 실어 보내는지,
+ *    응답에서 `meetingId`를 그대로 `created.id`로 옮기는지를 본다(`rooms/actions.real.test.ts`와
+ *    같은 결의 실서버 분기 테스트).
+ */
+describe("비대면 회의 만들기(이슈 #473, MEET-18) — 실서버 분기(!isMock)", () => {
   beforeEach(() => {
-    serverApiMock.mockClear();
+    jest.clearAllMocks();
+    requireAccessTokenMock.mockResolvedValue("token");
   });
 
-  it("아직 준비 중이라는 오류를 돌려주고 serverApi를 부르지 않는다", async () => {
+  it("성공하면 recordingConsent 없이 보내고 응답의 meetingId를 그대로 돌려준다", async () => {
+    serverApiMock.mockResolvedValue({
+      meetingId: 42,
+      status: "DONE",
+      title: "비대면 주간 싱크",
+      isOnline: true,
+      recordingConsent: true,
+      host: { memberId: 1, name: "박대표" },
+      attendees: [{ memberId: 2, name: "김서준" }],
+    });
+
     const result = await createOnlineMeetingAction({ errors: {} }, VALID_FORM());
 
-    expect(result.errors.title).toBe("비대면 회의는 아직 준비 중입니다 — 곧 지원됩니다");
-    expect(result.created).toBeUndefined();
-    expect(serverApiMock).not.toHaveBeenCalled();
+    expect(result.errors).toEqual({});
+    expect(result.created).toEqual({ id: "42" });
+    const [, init] = serverApiMock.mock.calls[0];
+    expect(init.json).not.toHaveProperty("recordingConsent");
+    expect(init.json).not.toHaveProperty("meetingRoomId");
+    expect(init.json).not.toHaveProperty("startAt");
   });
 
-  it("폼 자체가 비어 있으면 그 검증 오류가 먼저 온다(실서버 안내보다 앞선다)", async () => {
+  it("폼 자체가 비어 있으면 그 검증 오류가 먼저 온다(BE 호출보다 앞선다)", async () => {
     const result = await createOnlineMeetingAction({ errors: {} }, new FormData());
 
     expect(result.errors.title).toBe("회의 제목을 입력해 주세요");
     expect(serverApiMock).not.toHaveBeenCalled();
+  });
+
+  it("PROJECT_NOT_FOUND는 projectId 칸 오류로 바뀐다(MEET-01의 PJ-001과 리터럴이 다르다)", async () => {
+    serverApiMock.mockRejectedValue(
+      new ApiError(404, "존재하지 않는 프로젝트", "PROJECT_NOT_FOUND"),
+    );
+
+    const result = await createOnlineMeetingAction({ errors: {} }, VALID_FORM());
+
+    expect(result.errors.projectId).toBe("존재하지 않는 프로젝트입니다");
+  });
+
+  it("MT-010은 attendeeIds 칸 오류로 바뀐다", async () => {
+    serverApiMock.mockRejectedValue(new ApiError(400, "무언가", "MT-010"));
+
+    const result = await createOnlineMeetingAction({ errors: {} }, VALID_FORM());
+
+    expect(result.errors.attendeeIds).toBe("존재하지 않는 참석자가 있습니다");
   });
 });

--- a/src/features/meeting/actions.online-real.test.ts
+++ b/src/features/meeting/actions.online-real.test.ts
@@ -96,4 +96,31 @@ describe("비대면 회의 만들기(이슈 #473, MEET-18) — 실서버 분기(
 
     expect(result.errors.attendeeIds).toBe("존재하지 않는 참석자가 있습니다");
   });
+
+  it("MT-015는 topics 칸 오류로 바뀐다", async () => {
+    serverApiMock.mockRejectedValue(new ApiError(400, "안건 오류", "MT-015"));
+
+    const result = await createOnlineMeetingAction({ errors: {} }, VALID_FORM());
+
+    expect(result.errors.topics).toBe("안건 오류");
+  });
+
+  it.each(["MT-016", "MT-017", "MT-018", "MT-019"])(
+    "%s는 parentTeamActionId 칸 오류로 바뀐다",
+    async (code) => {
+      serverApiMock.mockRejectedValue(new ApiError(400, "상위 팀 액션 오류", code));
+
+      const result = await createOnlineMeetingAction({ errors: {} }, VALID_FORM());
+
+      expect(result.errors.parentTeamActionId).toBe("상위 팀 액션 오류");
+    },
+  );
+
+  it("목록에 없는 오류 코드는 title 칸으로 떨어진다(필드 슬롯이 없는 오류의 기본 자리)", async () => {
+    serverApiMock.mockRejectedValue(new ApiError(400, "알 수 없는 오류", "MT-999"));
+
+    const result = await createOnlineMeetingAction({ errors: {} }, VALID_FORM());
+
+    expect(result.errors.title).toBe("알 수 없는 오류");
+  });
 });

--- a/src/features/meeting/actions.ts
+++ b/src/features/meeting/actions.ts
@@ -18,7 +18,12 @@ import { getViewer } from "@/features/shell/viewer";
 import { ApiError, serverApi } from "@/lib/api";
 import { ep } from "@/lib/endpoints";
 import { getMockActor } from "@/lib/mock-actor";
-import { type Actor, canManageMeeting, requiresParentTeamAction } from "@/lib/permission";
+import {
+  type Actor,
+  canCaptureMeeting,
+  canManageMeeting,
+  requiresParentTeamAction,
+} from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
 import { checkMeetingTitle } from "./lib";
@@ -562,7 +567,10 @@ export async function createOnlineMeetingAction(
 
 /** 비대면 회의 2단계([녹음 파일 제출]) 결과 — 다이얼로그가 이 값이 바뀐 걸 보고 닫는다. */
 export interface SubmitOnlineMeetingRecordingState {
+  /** 칸에 매길 실패(권한 없음·파일 없음 등) — `FieldError`로 빨갛게 보여준다. */
   error: string | null;
+  /** 실패가 아니라 **아직 지원 안 함** 안내 — `error`와 자리를 나눠 평범한 안내문으로 보여준다. */
+  notice: string | null;
   /** 성공한 제출의 표식(MEET-09 폼과 같은 이유로 `boolean` 대신 객체) */
   submitted: { meetingId: string } | null;
 }
@@ -581,9 +589,15 @@ function readSubmitOnlineMeetingRecordingDraft(
  *
  * ⚠️ **회의는 이미 완료 상태로 존재한다** — 이 액션은 파일명을 덧붙이고 분석을 대기로 옮길
  *    뿐, 회의를 새로 만들거나 상태를 바꾸지 않는다(`createOnlineMeetingAction`과 분리된 이유).
+ * ⚠️ **녹음 파일은 선택이 아니다.** AI 요약을 요청하려면 녹음이 있어야 한다 — 빈 값·공백만
+ *    있는 값은 여기서 막고, 파일명이 확정된 뒤에만 분석을 대기(`PENDING`)로 옮긴다.
+ * ⚠️ **권한은 그 회의 담당자 1명뿐**이다(§권한 ②: 리소스 소유권, `canCaptureMeeting`과 같은
+ *    축 — 캡처·녹음·종료와 한 묶음). `canManageMeeting`(host·OWNER·ADMIN)을 여기서 쓰면
+ *    담당자가 아닌 OWNER도 남의 회의에 파일을 밀어 넣을 수 있어 축이 하나로 무너진다.
  * ⚠️ **실서버 분기가 없다.** BE가 이 제출 자리(녹음 업로드·요약 요청 트리거)를 아직 안 내줬다
  *    (§연동 검증: Swagger·구두 추측 금지) — 추측 엔드포인트를 만드는 대신 정직하게
- *    "곧 지원됩니다"라고 말한다(§정직성, 기존 스텁과 같은 결).
+ *    "곧 지원됩니다"라고 안내한다(§정직성, 기존 스텁과 같은 결). 이건 **실패가 아니라 안내**라
+ *    `error`가 아니라 `notice`에 실어 화면이 빨간 오류로 보여주지 않게 한다.
  * ⚠️ **파일명은 실제 업로드가 아니다**(§정직한 목업) — `setMockRecordingFileName`은 이름만 옮긴다.
  */
 export async function submitOnlineMeetingRecordingAction(
@@ -591,22 +605,37 @@ export async function submitOnlineMeetingRecordingAction(
   formData: FormData,
 ): Promise<SubmitOnlineMeetingRecordingState> {
   const draft = readSubmitOnlineMeetingRecordingDraft(formData);
-  if (!draft.meetingId) return { error: "회의를 찾을 수 없습니다", submitted: null };
+  if (!draft.meetingId) {
+    return { error: "회의를 찾을 수 없습니다", notice: null, submitted: null };
+  }
+
+  const recordingFileName = draft.recordingFileName.trim();
+  if (!recordingFileName) {
+    return { error: "녹음 파일을 첨부해 주세요", notice: null, submitted: null };
+  }
 
   if (!isMock) {
     // ⚠️ BE가 아직 이 제출 엔드포인트를 안 내줬다 — 추측 요청을 보내지 않는다(§연동 검증).
-    return { error: "녹음 파일 제출은 아직 준비 중입니다 — 곧 지원됩니다", submitted: null };
+    return {
+      error: null,
+      notice: "녹음 파일 제출은 아직 준비 중입니다 — 곧 지원됩니다",
+      submitted: null,
+    };
   }
 
-  if (!findMockMeeting(draft.meetingId)) {
-    return { error: "회의를 찾을 수 없습니다", submitted: null };
+  const meeting = findMockMeeting(draft.meetingId);
+  if (!meeting) {
+    return { error: "회의를 찾을 수 없습니다", notice: null, submitted: null };
   }
 
-  if (draft.recordingFileName) {
-    setMockRecordingFileName(draft.meetingId, draft.recordingFileName);
+  const actor = getMockActor();
+  if (!canCaptureMeeting(actor, meeting)) {
+    return { error: "녹음 파일을 제출할 권한이 없습니다", notice: null, submitted: null };
   }
+
+  setMockRecordingFileName(draft.meetingId, recordingFileName);
   setMockSummaryStatus(draft.meetingId, AI_SUMMARY_STATUS.PENDING);
   revalidatePath(`/app/meeting/${draft.meetingId}`);
   revalidatePath(MEETING_LIST_PATH);
-  return { error: null, submitted: { meetingId: draft.meetingId } };
+  return { error: null, notice: null, submitted: { meetingId: draft.meetingId } };
 }

--- a/src/features/meeting/actions.ts
+++ b/src/features/meeting/actions.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from "next/cache";
 
 import { AUTHORITY, type Authority } from "@/constants/authority";
-import { MEETING_STATUS } from "@/constants/meeting";
+import { AI_SUMMARY_STATUS, MEETING_STATUS } from "@/constants/meeting";
 import { requireAccessToken } from "@/features/auth/session";
 import { getManagedMember } from "@/features/member/manage-server";
 import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
@@ -31,9 +31,15 @@ import {
   parseMeetingDetail,
 } from "./mapper";
 import {
+  type BeCreateOnlineMeetingResponse,
+  toCreateOnlineMeetingPayload,
+} from "./mapper/online-meetings";
+import {
   addMockOnlineMeeting,
   cancelMockMeeting,
   findMockMeeting,
+  setMockRecordingFileName,
+  setMockSummaryStatus,
   updateMockMeeting,
   updateMockMeetingAttendees,
 } from "./mock/meetings";
@@ -43,6 +49,7 @@ import type {
   MeetingTopic,
   OnlineMeetingDraft,
   OnlineMeetingFormErrors,
+  SubmitOnlineMeetingRecordingDraft,
 } from "./types";
 import { validateOnlineMeetingDraft } from "./validate";
 
@@ -395,7 +402,6 @@ export interface OnlineMeetingFormState {
 
 function readOnlineMeetingDraft(formData: FormData): OnlineMeetingDraft {
   const parentTeamActionId = formData.get("parentTeamActionId");
-  const recordingFileName = formData.get("recordingFileName");
   const mains = formData.getAll("topicMain");
   const subs = formData.getAll("topicSub");
 
@@ -405,19 +411,47 @@ function readOnlineMeetingDraft(formData: FormData): OnlineMeetingDraft {
     topics: mains.map((main, index) => ({ main: String(main), sub: String(subs[index] ?? "") })),
     attendeeIds: formData.getAll("attendeeIds").map(Number),
     parentTeamActionId: parentTeamActionId ? Number(parentTeamActionId) : undefined,
-    recordingFileName: recordingFileName ? String(recordingFileName) : null,
   };
+}
+
+/**
+ * `POST /api/meetings/online`(MEET-18) 실패를 폼 필드 오류로 바꾼다.
+ * ⚠️ `rooms/actions.ts`의 `toMeetingCreateFormErrors`(MEET-01)와 같은 자리 — 필드 슬롯이 없는
+ *    오류(`PROJECT_NOT_FOUND` 등 프로젝트 슬롯이 있는 것 빼고)는 `title` 칸에 얹는다.
+ * ⚠️ **`PROJECT_NOT_FOUND`가 이 엔드포인트만 리터럴이 다르다**(도메인 담당자 명세, 2026-08-14) —
+ *    MEET-01은 `PJ-001`을 쓰지만 여기는 그대로 이 문자열이다. 어긋나 보여도 그게 명세다.
+ */
+function toOnlineMeetingCreateFormErrors(error: unknown): OnlineMeetingFormErrors {
+  if (!(error instanceof ApiError)) throw error;
+
+  switch (error.code) {
+    case "MT-010":
+      return { attendeeIds: "존재하지 않는 참석자가 있습니다" };
+    case "MT-015":
+      return { topics: error.message };
+    case "MT-016":
+    case "MT-017":
+    case "MT-018":
+    case "MT-019":
+      return { parentTeamActionId: error.message };
+    case "PROJECT_NOT_FOUND":
+      return { projectId: "존재하지 않는 프로젝트입니다" };
+    default:
+      return { title: error.message };
+  }
 }
 
 /**
  * 비대면 회의 만들기(이슈 #473) — `/app/meeting` 목록의 [비대면 회의] 버튼이 부른다.
  *
- * ⚠️ **BE API가 아직 안 정해졌다**(1안/2안 논의 중, 팀원 회신 — 이슈 #473). 추측 요청을 보내지
- *    않는다(CLAUDE.md §연동 검증: Swagger·구두 추측 금지) — 실서버 분기는 확정될 때까지
- *    "아직 준비 중"이라고 정직하게 말한다(§정직성). 확정되면 이 분기만 실서버 호출로 바꾼다
- *    (§Mock 격리막).
+ * ⚠️ **BE API가 확정됐다**(MEET-18, 2026-08-14 도메인 담당자 문서) — 더는 "아직 준비 중"이
+ *    아니다. 다만 BE 실코드 대조 전이라 매퍼·엔드포인트 주석에 그 사실을 남겨 뒀다(§연동 검증).
+ * ⚠️ **`recordingConsent`를 안 보낸다** — 서버가 항상 `true`로 고정한다(팀 확정, 매퍼 주석).
  * ⚠️ **제출하면 그 자리에서 완료 처리된다** — 회의실 예약(`createRoomReservationAction`)과
  *    달리 캡처 화면으로 안 넘어간다(팀 명세). 그래서 회의실·시간을 아예 안 받는다.
+ * ⚠️ **성공해도 녹음 파일·AI 요약 요청은 여기서 안 한다**(2026-08-14 팀 확정) — 그 회의는
+ *    이미 완료 상태로 만들어졌고, 파일 첨부는 같은 다이얼로그의 **2단계**(`submitOnlineMeetingRecordingAction`)
+ *    가 뒤이어 처리하는 별개의 가벼운 흐름이다.
  * ⚠️ mock 분기의 검증 순서는 `createRoomReservationAction`과 맞춘다(프로젝트 → 참석자 범위 →
  *    상위 팀 액션) — 같은 도메인의 두 생성 경로가 다른 순서로 막히면 같은 실수가 화면마다
  *    다른 첫 오류로 보인다.
@@ -432,9 +466,18 @@ export async function createOnlineMeetingAction(
   if (Object.keys(errors).length > 0) return { errors };
 
   if (!isMock) {
-    // ⚠️ BE API가 아직 안 정해졌다(1안/2안 논의 중, 이슈 #473) — 추측 요청을 보내지 않는다
-    //    (CLAUDE.md §연동 검증: Swagger·구두 추측 금지). 확정되면 이 분기를 실서버 호출로 바꾼다.
-    return { errors: { title: "비대면 회의는 아직 준비 중입니다 — 곧 지원됩니다" } };
+    const accessToken = await requireAccessToken();
+    try {
+      const response = await serverApi<BeCreateOnlineMeetingResponse>(ep.meetingsOnline(), {
+        method: "POST",
+        accessToken,
+        json: toCreateOnlineMeetingPayload(draft),
+      });
+      revalidatePath(MEETING_LIST_PATH);
+      return { errors: {}, created: { id: String(response.meetingId) } };
+    } catch (error) {
+      return { errors: toOnlineMeetingCreateFormErrors(error) };
+    }
   }
 
   // ⚠️ 화면 select·피커가 이미 실제 목록에서만 고르게 해도, 폼은 조작될 수 있다
@@ -492,7 +535,8 @@ export async function createOnlineMeetingAction(
     roomName: null,
     roomReservationId: null,
     isOnline: true,
-    recordingFileName: draft.recordingFileName,
+    // ⚠️ 첨부는 이 액션의 몫이 아니다 — 다이얼로그 2단계가 성공 후 따로 붙인다(§types 주석).
+    recordingFileName: null,
     projectId: project.id,
     projectTag: project.tag,
     topics,
@@ -514,4 +558,55 @@ export async function createOnlineMeetingAction(
   const meeting = addMockOnlineMeeting(meetingDraft);
   revalidatePath(MEETING_LIST_PATH);
   return { errors: {}, created: { id: meeting.id } };
+}
+
+/** 비대면 회의 2단계([녹음 파일 제출]) 결과 — 다이얼로그가 이 값이 바뀐 걸 보고 닫는다. */
+export interface SubmitOnlineMeetingRecordingState {
+  error: string | null;
+  /** 성공한 제출의 표식(MEET-09 폼과 같은 이유로 `boolean` 대신 객체) */
+  submitted: { meetingId: string } | null;
+}
+
+function readSubmitOnlineMeetingRecordingDraft(
+  formData: FormData,
+): SubmitOnlineMeetingRecordingDraft {
+  return {
+    meetingId: String(formData.get("meetingId") ?? ""),
+    recordingFileName: String(formData.get("recordingFileName") ?? ""),
+  };
+}
+
+/**
+ * 비대면 회의 2단계 — [녹음 파일 제출] + [AI 요약 요청](이슈 #473, 2026-08-14 팀 확정).
+ *
+ * ⚠️ **회의는 이미 완료 상태로 존재한다** — 이 액션은 파일명을 덧붙이고 분석을 대기로 옮길
+ *    뿐, 회의를 새로 만들거나 상태를 바꾸지 않는다(`createOnlineMeetingAction`과 분리된 이유).
+ * ⚠️ **실서버 분기가 없다.** BE가 이 제출 자리(녹음 업로드·요약 요청 트리거)를 아직 안 내줬다
+ *    (§연동 검증: Swagger·구두 추측 금지) — 추측 엔드포인트를 만드는 대신 정직하게
+ *    "곧 지원됩니다"라고 말한다(§정직성, 기존 스텁과 같은 결).
+ * ⚠️ **파일명은 실제 업로드가 아니다**(§정직한 목업) — `setMockRecordingFileName`은 이름만 옮긴다.
+ */
+export async function submitOnlineMeetingRecordingAction(
+  _prev: SubmitOnlineMeetingRecordingState,
+  formData: FormData,
+): Promise<SubmitOnlineMeetingRecordingState> {
+  const draft = readSubmitOnlineMeetingRecordingDraft(formData);
+  if (!draft.meetingId) return { error: "회의를 찾을 수 없습니다", submitted: null };
+
+  if (!isMock) {
+    // ⚠️ BE가 아직 이 제출 엔드포인트를 안 내줬다 — 추측 요청을 보내지 않는다(§연동 검증).
+    return { error: "녹음 파일 제출은 아직 준비 중입니다 — 곧 지원됩니다", submitted: null };
+  }
+
+  if (!findMockMeeting(draft.meetingId)) {
+    return { error: "회의를 찾을 수 없습니다", submitted: null };
+  }
+
+  if (draft.recordingFileName) {
+    setMockRecordingFileName(draft.meetingId, draft.recordingFileName);
+  }
+  setMockSummaryStatus(draft.meetingId, AI_SUMMARY_STATUS.PENDING);
+  revalidatePath(`/app/meeting/${draft.meetingId}`);
+  revalidatePath(MEETING_LIST_PATH);
+  return { error: null, submitted: { meetingId: draft.meetingId } };
 }

--- a/src/features/meeting/components/meeting-attendees-edit-dialog.tsx
+++ b/src/features/meeting/components/meeting-attendees-edit-dialog.tsx
@@ -91,7 +91,7 @@ export function MeetingAttendeesEditDialog({
           setOpen(next);
         }}
       >
-        <DialogContent className="gap-0 p-0 sm:max-w-[420px]">
+        <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-[420px]">
           <DialogHeader className="border-border border-b px-6 py-4">
             <DialogTitle>참석자 수정</DialogTitle>
           </DialogHeader>

--- a/src/features/meeting/components/meeting-card.test.tsx
+++ b/src/features/meeting/components/meeting-card.test.tsx
@@ -17,7 +17,6 @@ const BASE: MeetingListItem = {
   attendeeCount: 4,
   isHost: true,
   aiSummaryStatus: null,
-  isOnline: false,
 };
 
 function renderCard(patch: Partial<MeetingListItem> = {}) {
@@ -67,30 +66,6 @@ describe("MeetingCard — 발치 버튼", () => {
       "href",
       "/app/meeting/meeting-3/review",
     );
-  });
-});
-
-/** 비대면 회의(이슈 #473) — 발치의 일시·장소 자리가 안내 한 줄로 바뀐다. 인원수는 그대로다. */
-describe("MeetingCard — 비대면 회의(isOnline)", () => {
-  it("대면 회의는 일시·장소를 그대로 보여준다", () => {
-    renderCard({ isOnline: false });
-
-    expect(screen.getByText("8월 14일(금) 10:00 – 10:30")).toBeInTheDocument();
-    expect(screen.getByText("대회의실")).toBeInTheDocument();
-    expect(screen.queryByText("온라인으로 진행된 회의입니다")).not.toBeInTheDocument();
-  });
-
-  it("비대면 회의는 일시·장소 대신 안내 한 줄을 보여준다", () => {
-    renderCard({ isOnline: true, schedule: "", roomName: "" });
-
-    expect(screen.getByText("온라인으로 진행된 회의입니다")).toBeInTheDocument();
-    expect(screen.queryByText("대회의실")).not.toBeInTheDocument();
-  });
-
-  it("비대면 회의도 참석자 인원수는 그대로 보여준다", () => {
-    renderCard({ isOnline: true, schedule: "", roomName: "" });
-
-    expect(screen.getByText("4명")).toBeInTheDocument();
   });
 });
 

--- a/src/features/meeting/components/meeting-card.tsx
+++ b/src/features/meeting/components/meeting-card.tsx
@@ -1,4 +1,4 @@
-import { CalendarClock, ChevronRight, MapPin, Mic, Sparkles, Users, Video } from "lucide-react";
+import { CalendarClock, ChevronRight, MapPin, Mic, Sparkles, Users } from "lucide-react";
 import Link from "next/link";
 
 import { ProjectTag } from "@/components/common/project-tag";
@@ -167,29 +167,19 @@ function CardFooter({
       */}
       <div className="flex min-w-0 flex-nowrap items-center gap-x-3">
         {/*
-          ⚠️ **비대면 회의는 일시·장소 대신 안내 한 줄이다**(이슈 #473). 회의실·시간이 없어서
-             (`meeting.schedule`·`meeting.roomName`이 서버에서부터 빈 문자열로 온다) 그 칸을
-             그대로 그리면 빈 채로 보인다 — `isOnline`을 먼저 보고 아예 다른 것을 그린다.
+          ⚠️ **비대면 회의는 이제 이 목록에 안 온다**(2026-08-14 팀 확정 — `server.ts`의
+             `getMeetingDirectory` 주석). 일시·장소는 항상 채워져 있다고 봐도 된다.
         */}
-        {meeting.isOnline ? (
-          <span className="flex shrink-0 items-center gap-1.5 text-[13px] leading-5 font-medium">
-            <Video className="text-muted-foreground size-4 shrink-0" aria-hidden />
-            <span>온라인으로 진행된 회의입니다</span>
-          </span>
-        ) : (
-          <span className="flex shrink-0 items-center gap-1.5 text-[13px] leading-5 font-medium">
-            <CalendarClock className="text-muted-foreground size-4 shrink-0" aria-hidden />
-            <span className="tabular-nums">{meeting.schedule}</span>
-          </span>
-        )}
+        <span className="flex shrink-0 items-center gap-1.5 text-[13px] leading-5 font-medium">
+          <CalendarClock className="text-muted-foreground size-4 shrink-0" aria-hidden />
+          <span className="tabular-nums">{meeting.schedule}</span>
+        </span>
         <span className="bg-border h-3 w-px shrink-0" aria-hidden />
         <span className="text-muted-foreground flex min-w-0 items-center gap-x-3 text-[12px] leading-4">
-          {!meeting.isOnline && (
-            <span className="flex min-w-0 items-center gap-1.5">
-              <MapPin className="size-3.5 shrink-0" aria-hidden />
-              <span className="truncate">{meeting.roomName}</span>
-            </span>
-          )}
+          <span className="flex min-w-0 items-center gap-1.5">
+            <MapPin className="size-3.5 shrink-0" aria-hidden />
+            <span className="truncate">{meeting.roomName}</span>
+          </span>
           <span className="flex shrink-0 items-center gap-1.5">
             <Users className="size-3.5 shrink-0" aria-hidden />
             <span className="tabular-nums">{meeting.attendeeCount}명</span>

--- a/src/features/meeting/components/meeting-edit-dialog.tsx
+++ b/src/features/meeting/components/meeting-edit-dialog.tsx
@@ -55,7 +55,7 @@ export function MeetingEditDialog({ meetingId, currentTitle }: MeetingEditDialog
           setOpen(next);
         }}
       >
-        <DialogContent className="gap-0 p-0 sm:max-w-[420px]">
+        <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-[420px]">
           <DialogHeader className="border-border border-b px-6 py-4">
             <DialogTitle>회의 수정</DialogTitle>
           </DialogHeader>

--- a/src/features/meeting/components/online-meeting-dialog.test.tsx
+++ b/src/features/meeting/components/online-meeting-dialog.test.tsx
@@ -1,7 +1,3 @@
-const pushMock = jest.fn();
-jest.mock("next/navigation", () => ({
-  useRouter: () => ({ push: pushMock }),
-}));
 jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
 jest.mock("@/lib/mock-actor", () => ({
   getMockActor: jest.fn(() => ({ id: 1, role: "OWNER" })),
@@ -20,6 +16,8 @@ import { OnlineMeetingDialog } from "./online-meeting-dialog";
      전제다 — `isMock`을 따로 목하지 않는다(`NEXT_PUBLIC_USE_MOCK`이 없으면 기본이 `true`라
      mock 분기가 실제로 돈다). Owner가 여는 폼이라 참석자 후보는 팀장뿐이다(2026-08-13,
      `attendee-scope.ts`).
+  ⚠️ **성공 후 흐름이 바뀌었다**(2026-08-14 팀 확정) — 더는 상세로 `router.push`하지 않는다.
+     같은 다이얼로그가 2단계(녹음 파일 제출)로 넘어간다 — `next/navigation` mock이 필요 없다.
 */
 const MEMBERS: RoomMember[] = [
   { id: 2, name: "김서준", teamName: "개발팀", authority: AUTHORITY.LEADER },
@@ -40,6 +38,19 @@ function renderDialog() {
   );
 }
 
+async function fillAndConfirmStep1(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("button", { name: "비대면 회의" }));
+  await user.type(screen.getByLabelText("회의 제목"), "새 비대면 회의");
+  await user.click(screen.getByRole("combobox", { name: "프로젝트" }));
+  await user.click(await screen.findByRole("option", { name: "굿즈 프로젝트" }));
+  await user.type(screen.getByLabelText("안건 1 대주제"), "제품");
+  await user.type(screen.getByLabelText("안건 1 소주제"), "점검");
+  await user.click(screen.getByRole("checkbox", { name: /김서준/ }));
+
+  await user.click(screen.getByRole("button", { name: "등록" }));
+  await user.click(screen.getByRole("button", { name: "등록" }));
+}
+
 describe("OnlineMeetingDialog", () => {
   it("트리거를 누르기 전에는 모달 제목이 없다", () => {
     renderDialog();
@@ -47,7 +58,7 @@ describe("OnlineMeetingDialog", () => {
     expect(screen.queryByText("비대면 회의 만들기")).not.toBeInTheDocument();
   });
 
-  it("[비대면 회의]를 누르면 회의실·시간 필드 없이 모달이 열린다", async () => {
+  it("[비대면 회의]를 누르면 회의실·시간 필드 없이 1단계가 열린다", async () => {
     const user = userEvent.setup();
     renderDialog();
 
@@ -56,7 +67,8 @@ describe("OnlineMeetingDialog", () => {
     expect(screen.getByRole("dialog", { name: "비대면 회의 만들기" })).toBeInTheDocument();
     expect(screen.queryByLabelText("회의실")).not.toBeInTheDocument();
     expect(screen.queryByText(/시작 시간/)).not.toBeInTheDocument();
-    expect(screen.getByText("녹음 파일 첨부 (선택)")).toBeInTheDocument();
+    // ⚠️ 녹음 파일 첨부는 2단계로 옮겨서 1단계엔 없다(2026-08-14).
+    expect(screen.queryByText("녹음 파일 첨부 (선택)")).not.toBeInTheDocument();
   });
 
   it("등록을 누르면 바로 등록하지 않고 확인 모달을 먼저 띄운다", async () => {
@@ -67,7 +79,6 @@ describe("OnlineMeetingDialog", () => {
     await user.click(screen.getByRole("button", { name: "등록" }));
 
     expect(screen.getByRole("dialog", { name: "이대로 등록하시겠습니까?" })).toBeInTheDocument();
-    expect(pushMock).not.toHaveBeenCalled();
   });
 
   it("제목 입력 중 Enter로 암시적 제출이 걸려도 확인 모달을 연다", async () => {
@@ -82,7 +93,6 @@ describe("OnlineMeetingDialog", () => {
     fireEvent.submit(form!);
 
     expect(screen.getByRole("dialog", { name: "이대로 등록하시겠습니까?" })).toBeInTheDocument();
-    expect(pushMock).not.toHaveBeenCalled();
   });
 
   it("필수값을 안 채우고 확인 모달에서 등록을 누르면 필드별 오류를 보여준다", async () => {
@@ -107,26 +117,43 @@ describe("OnlineMeetingDialog", () => {
           element?.tagName === "P" && element.textContent === "프로젝트를 선택해 주세요",
       ),
     ).toBeInTheDocument();
-    expect(pushMock).not.toHaveBeenCalled();
   });
 
-  it("성공하면 회의 상세로 이동한다", async () => {
+  it("1단계 성공하면 같은 창이 2단계(녹음 파일 제출)로 바뀐다 — 페이지 이동 없음", async () => {
     const user = userEvent.setup();
     renderDialog();
 
-    await user.click(screen.getByRole("button", { name: "비대면 회의" }));
-    await user.type(screen.getByLabelText("회의 제목"), "새 비대면 회의");
-    await user.click(screen.getByRole("combobox", { name: "프로젝트" }));
-    await user.click(await screen.findByRole("option", { name: "굿즈 프로젝트" }));
-    await user.type(screen.getByLabelText("안건 1 대주제"), "제품");
-    await user.type(screen.getByLabelText("안건 1 소주제"), "점검");
-    await user.click(screen.getByRole("checkbox", { name: /김서준/ }));
-
-    await user.click(screen.getByRole("button", { name: "등록" }));
-    await user.click(screen.getByRole("button", { name: "등록" }));
+    await fillAndConfirmStep1(user);
 
     await waitFor(() => {
-      expect(pushMock).toHaveBeenCalledWith(expect.stringMatching(/^\/app\/meeting\/meeting-/));
+      expect(screen.getByRole("dialog", { name: "녹음 파일 제출" })).toBeInTheDocument();
+    });
+    expect(screen.getByText("녹음 파일 첨부 (선택)")).toBeInTheDocument();
+  });
+
+  it("2단계에서 [나중에 하기]를 누르면 창이 닫힌다", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await fillAndConfirmStep1(user);
+    await screen.findByRole("dialog", { name: "녹음 파일 제출" });
+
+    await user.click(screen.getByRole("button", { name: "나중에 하기" }));
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("2단계에서 [AI 요약 요청]을 누르면 확인 모달 없이 바로 제출되고 창이 닫힌다", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await fillAndConfirmStep1(user);
+    await screen.findByRole("dialog", { name: "녹음 파일 제출" });
+
+    await user.click(screen.getByRole("button", { name: "AI 요약 요청" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
   });
 });

--- a/src/features/meeting/components/online-meeting-dialog.test.tsx
+++ b/src/features/meeting/components/online-meeting-dialog.test.tsx
@@ -3,7 +3,7 @@ jest.mock("@/lib/mock-actor", () => ({
   getMockActor: jest.fn(() => ({ id: 1, role: "OWNER" })),
 }));
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { AUTHORITY } from "@/constants/authority";
@@ -27,7 +27,7 @@ const TEAM_ACTIONS: RoomTeamActionOption[] = [];
 const OWNER_VIEWER = { id: 1, role: AUTHORITY.OWNER, teamName: null } as const;
 
 function renderDialog() {
-  render(
+  return render(
     <OnlineMeetingDialog
       members={MEMBERS}
       projects={PROJECTS}
@@ -48,7 +48,11 @@ async function fillAndConfirmStep1(user: ReturnType<typeof userEvent.setup>) {
   await user.click(screen.getByRole("checkbox", { name: /김서준/ }));
 
   await user.click(screen.getByRole("button", { name: "등록" }));
-  await user.click(screen.getByRole("button", { name: "등록" }));
+
+  // ⚠️ 확인 모달이 뜬 뒤엔 폼 안의 [등록] 버튼이 여전히 DOM에 남아 있다 — 전역으로 다시 찾으면
+  //    두 개가 잡혀 모호해진다. 뜨는 걸 기다린 뒤 그 다이얼로그 안에서만 찾는다.
+  const confirmDialog = await screen.findByRole("dialog", { name: "이대로 등록하시겠습니까?" });
+  await user.click(within(confirmDialog).getByRole("button", { name: "등록" }));
 }
 
 describe("OnlineMeetingDialog", () => {
@@ -68,7 +72,7 @@ describe("OnlineMeetingDialog", () => {
     expect(screen.queryByLabelText("회의실")).not.toBeInTheDocument();
     expect(screen.queryByText(/시작 시간/)).not.toBeInTheDocument();
     // ⚠️ 녹음 파일 첨부는 2단계로 옮겨서 1단계엔 없다(2026-08-14).
-    expect(screen.queryByText("녹음 파일 첨부 (선택)")).not.toBeInTheDocument();
+    expect(screen.queryByText("녹음 파일 첨부")).not.toBeInTheDocument();
   });
 
   it("등록을 누르면 바로 등록하지 않고 확인 모달을 먼저 띄운다", async () => {
@@ -128,7 +132,7 @@ describe("OnlineMeetingDialog", () => {
     await waitFor(() => {
       expect(screen.getByRole("dialog", { name: "녹음 파일 제출" })).toBeInTheDocument();
     });
-    expect(screen.getByText("녹음 파일 첨부 (선택)")).toBeInTheDocument();
+    expect(screen.getByText("녹음 파일 첨부")).toBeInTheDocument();
   });
 
   it("2단계에서 [나중에 하기]를 누르면 창이 닫힌다", async () => {
@@ -140,15 +144,37 @@ describe("OnlineMeetingDialog", () => {
 
     await user.click(screen.getByRole("button", { name: "나중에 하기" }));
 
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    // ⚠️ 닫힘은 상태 변경 두 단계(`setOpen`·`setCreatedMeetingId`)를 거쳐 언마운트된다 —
+    //    AI 요약 요청 테스트와 같은 이유로 비동기로 기다린다.
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
   });
 
-  it("2단계에서 [AI 요약 요청]을 누르면 확인 모달 없이 바로 제출되고 창이 닫힌다", async () => {
+  /* ⚠️ 녹음 파일은 선택이 아니다 — 첨부 전엔 [AI 요약 요청]이 눌리지 않는다. */
+  it("녹음 파일을 첨부하기 전에는 [AI 요약 요청] 버튼이 비활성 상태다", async () => {
     const user = userEvent.setup();
     renderDialog();
 
     await fillAndConfirmStep1(user);
     await screen.findByRole("dialog", { name: "녹음 파일 제출" });
+
+    expect(screen.getByRole("button", { name: "AI 요약 요청" })).toBeDisabled();
+  });
+
+  it("2단계에서 파일을 첨부하고 [AI 요약 요청]을 누르면 확인 모달 없이 바로 제출되고 창이 닫힌다", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await fillAndConfirmStep1(user);
+    await screen.findByRole("dialog", { name: "녹음 파일 제출" });
+
+    // ⚠️ `container.querySelector`로는 못 찾는다 — `DialogContent`는 `DialogPortal`을 거쳐
+    //    `document.body`(또는 범위 테마 컨테이너)에 그려져 RTL의 `container` 바깥에 있다.
+    const fileInput = document.querySelector<HTMLInputElement>('input[type="file"]');
+    expect(fileInput).not.toBeNull();
+    const file = new File(["dummy audio content"], "recording.mp3", { type: "audio/mpeg" });
+    await user.upload(fileInput!, file);
 
     await user.click(screen.getByRole("button", { name: "AI 요약 요청" }));
 

--- a/src/features/meeting/components/online-meeting-dialog.tsx
+++ b/src/features/meeting/components/online-meeting-dialog.tsx
@@ -21,6 +21,7 @@ import type { RoomMember, RoomProjectOption, RoomTeamActionOption } from "@/feat
 
 import { OnlineMeetingFields } from "./online-meeting-fields";
 import { useOnlineMeetingForm } from "./use-online-meeting-form";
+import { useOnlineMeetingRecordingForm } from "./use-online-meeting-recording-form";
 
 interface OnlineMeetingDialogProps {
   members: RoomMember[];
@@ -30,8 +31,22 @@ interface OnlineMeetingDialogProps {
   viewer: AttendeeScopeViewer;
 }
 
-/** 취소·제출 버튼 — `useFormStatus`는 `<form>`의 자손에서만 읽을 수 있다(`RoomReservationDialog`와 같은 이유). */
-function DialogActions({
+/** 제출 중인지를 창에 올려 보낸다 — `RoomReservationDialog`의 `PendingReporter`와 같다. */
+function PendingReporter({ onChange }: { onChange: (pending: boolean) => void }) {
+  const { pending } = useFormStatus();
+
+  useEffect(() => {
+    onChange(pending);
+  }, [pending, onChange]);
+
+  return null;
+}
+
+/**
+ * 취소·확인 2단계 제출 버튼 — 1단계(비대면 회의 등록)가 쓴다. `useFormStatus`는 `<form>`의
+ * 자손에서만 읽을 수 있다(`RoomReservationDialog`와 같은 이유).
+ */
+function ConfirmStepActions({
   onCancel,
   onRequestSubmit,
 }: {
@@ -52,41 +67,52 @@ function DialogActions({
   );
 }
 
-/** 제출 중인지를 창에 올려 보낸다 — `RoomReservationDialog`의 `PendingReporter`와 같다. */
-function PendingReporter({ onChange }: { onChange: (pending: boolean) => void }) {
+/**
+ * 건너뛰기·바로 제출 버튼 — 2단계(녹음 제출)가 쓴다. 확인 모달을 안 거친다 — 회의는 이미
+ * 완료 상태로 존재해서 이 제출은 되돌릴 게 없는 부가 조작이다(§토스트: 파괴적 작업만 Dialog).
+ */
+function SkipOrSubmitActions({ onSkip }: { onSkip: () => void }) {
   const { pending } = useFormStatus();
 
-  useEffect(() => {
-    onChange(pending);
-  }, [pending, onChange]);
+  return (
+    <div className="flex shrink-0 gap-2">
+      <Button type="button" variant="outline" disabled={pending} onClick={onSkip}>
+        나중에 하기
+      </Button>
+      <Button type="submit" variant="ink" disabled={pending}>
+        {pending ? "요청 중" : "AI 요약 요청"}
+      </Button>
+    </div>
+  );
+}
 
-  return null;
+interface OnlineMeetingStep1Props {
+  members: RoomMember[];
+  projects: RoomProjectOption[];
+  showParentTeamAction: boolean;
+  teamActions: RoomTeamActionOption[];
+  viewer: AttendeeScopeViewer;
+  onCreated: (meetingId: string) => void;
+  onPendingChange: (pending: boolean) => void;
+  onCancel: () => void;
 }
 
 /**
- * 비대면 회의 만들기 — `/app/meeting` 목록의 진입점(이슈 #473). `RoomReservationDialog`와
- * 같은 뼈대(`ConfirmDialog`를 안 쓰는 이유·확인 2단계 제출도 그대로)를 쓰되 **회의실·시간이
- * 없다.** 대신 녹음 파일 첨부 필드가 하나 더 있다.
- * ⚠️ **첨부는 실제 업로드가 아니다**(§정직한 목업). BE에 파일을 받을 자리가 없어(이슈 #473)
- *    파일 이름만 hidden input(`recordingFileName`)으로 실어 보낸다 — 바이트는 어디에도
- *    안 올라간다.
+ * 1단계 — 제목·프로젝트·안건·참석자(회의실·시간 없음). 성공하면 회의가 그 자리에서 완료
+ * 처리되고 `onCreated`로 부모에 알린다 — 여기서는 페이지 이동도, 창 닫기도 하지 않는다
+ * (2026-08-14 팀 확정, `use-online-meeting-form.ts` 주석).
  */
-export function OnlineMeetingDialog({
+function OnlineMeetingStep1({
   members,
   projects,
   showParentTeamAction,
   teamActions,
   viewer,
-}: OnlineMeetingDialogProps) {
-  const [open, setOpen] = useState(false);
-  const { state, formAction, form, setForm, handleOpenChange } = useOnlineMeetingForm({
-    onOpenChange: setOpen,
-  });
-
-  const [isPending, setIsPending] = useState(false);
-  const handlePendingChange = useCallback((next: boolean) => setIsPending(next), []);
-
-  const fileInputRef = useRef<HTMLInputElement>(null);
+  onCreated,
+  onPendingChange,
+  onCancel,
+}: OnlineMeetingStep1Props) {
+  const { state, formAction, form, setForm } = useOnlineMeetingForm({ onCreated });
   const formRef = useRef<HTMLFormElement>(null);
   const [showConfirm, setShowConfirm] = useState(false);
   const confirmedSubmitRef = useRef(false);
@@ -100,14 +126,167 @@ export function OnlineMeetingDialog({
     setShowConfirm(true);
   }
 
+  return (
+    <>
+      <form ref={formRef} action={formAction} onSubmit={handleFormSubmit}>
+        <PendingReporter onChange={onPendingChange} />
+        <input type="hidden" name="projectId" value={form.projectId} />
+        <input type="hidden" name="parentTeamActionId" value={form.parentTeamActionId} />
+
+        <div className="flex max-h-[70vh] flex-col gap-4 overflow-y-auto px-6 py-4">
+          <div className="grid grid-cols-1 gap-6 sm:grid-cols-[1fr_260px]">
+            <OnlineMeetingFields
+              form={form}
+              setForm={setForm}
+              errors={state.errors}
+              projects={projects}
+              showParentTeamAction={showParentTeamAction}
+              teamActions={teamActions}
+            />
+
+            <div className="flex flex-col gap-4">
+              <RoomAttendeePicker
+                members={members}
+                selectedIds={form.attendeeIds}
+                onChange={(attendeeIds) => setForm((prev) => ({ ...prev, attendeeIds }))}
+                viewer={viewer}
+              />
+              <FieldError reserveSpace message={state.errors.attendeeIds} />
+            </div>
+          </div>
+        </div>
+
+        <div className="border-border flex items-center justify-end gap-4 border-t px-6 py-4">
+          <ConfirmStepActions onCancel={onCancel} onRequestSubmit={() => setShowConfirm(true)} />
+        </div>
+      </form>
+
+      <ConfirmDialog
+        isOpen={showConfirm}
+        onOpenChange={setShowConfirm}
+        title="이대로 등록하시겠습니까?"
+        description="등록하면 곧바로 회의가 완료 처리됩니다."
+        confirmLabel="등록"
+        onConfirm={() => {
+          setShowConfirm(false);
+          confirmedSubmitRef.current = true;
+          formRef.current?.requestSubmit();
+        }}
+      />
+    </>
+  );
+}
+
+interface OnlineMeetingStep2Props {
+  meetingId: string;
+  onSubmitted: () => void;
+  onPendingChange: (pending: boolean) => void;
+  onSkip: () => void;
+}
+
+/**
+ * 2단계 — 녹음 파일 제출 + AI 요약 요청(2026-08-14 팀 확정). 회의는 1단계에서 이미 완료
+ * 상태로 만들어져 있어 이 단계는 **선택**이다 — [나중에 하기]로 건너뛰어도 회의는 그대로 남는다.
+ * ⚠️ **첨부는 실제 업로드가 아니다**(§정직한 목업) — 파일 이름만 hidden input으로 싣는다.
+ * ⚠️ 실서버(`!isMock`)에서는 서버 액션이 "곧 지원됩니다" 오류를 그대로 돌려준다 — 컴포넌트가
+ *    `isMock`을 직접 알면 안 된다(§Mock 격리막)는 규칙 그대로라, 여기서 따로 분기하지 않고
+ *    `state.error`를 그대로 보여준다.
+ */
+function OnlineMeetingStep2({
+  meetingId,
+  onSubmitted,
+  onPendingChange,
+  onSkip,
+}: OnlineMeetingStep2Props) {
+  const { state, formAction, recordingFileName, setRecordingFileName } =
+    useOnlineMeetingRecordingForm({ meetingId, onSubmitted });
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
   function handleFileChange(event: ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0] ?? null;
-    setForm((prev) => ({ ...prev, recordingFileName: file?.name ?? null }));
+    setRecordingFileName(file?.name ?? null);
   }
 
   function clearFile() {
-    setForm((prev) => ({ ...prev, recordingFileName: null }));
+    setRecordingFileName(null);
     if (fileInputRef.current) fileInputRef.current.value = "";
+  }
+
+  return (
+    <form action={formAction}>
+      <PendingReporter onChange={onPendingChange} />
+      <input type="hidden" name="meetingId" value={meetingId} />
+      <input type="hidden" name="recordingFileName" value={recordingFileName ?? ""} />
+
+      <div className="flex flex-col gap-4 px-6 py-4">
+        <p className="text-muted-foreground text-[13px] leading-5">
+          녹음 파일을 제출해 주세요. 제출 없이도 회의는 이미 완료 처리돼 있습니다.
+        </p>
+
+        <div className="flex flex-col gap-1.5">
+          <span id="online-meeting-recording-label" className="text-[13px] leading-5 font-medium">
+            녹음 파일 첨부 (선택)
+          </span>
+          {/* ⚠️ 바이너리는 안 보낸다 — 파일명만 읽어 hidden input으로 싣는다(위 주석). */}
+          <input ref={fileInputRef} type="file" className="hidden" onChange={handleFileChange} />
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="w-full min-w-0 justify-start"
+              aria-labelledby="online-meeting-recording-label"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <Paperclip aria-hidden />
+              <span className="truncate">{recordingFileName ?? "파일 첨부 (선택)"}</span>
+            </Button>
+            {recordingFileName && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                aria-label="녹음 파일 선택 해제"
+                onClick={clearFile}
+              >
+                <X aria-hidden />
+              </Button>
+            )}
+          </div>
+        </div>
+
+        <FieldError reserveSpace message={state.error ?? undefined} />
+      </div>
+
+      <div className="border-border flex items-center justify-end gap-4 border-t px-6 py-4">
+        <SkipOrSubmitActions onSkip={onSkip} />
+      </div>
+    </form>
+  );
+}
+
+/**
+ * 비대면 회의 만들기 — `/app/meeting` 목록의 진입점(이슈 #473). 2026-08-14 팀 확정으로 **2단계
+ * 다이얼로그**가 됐다:
+ *  1) 제목·프로젝트·안건·참석자를 받아 `POST /api/meetings/online`을 부른다(회의실·시간 없음).
+ *  2) 같은 창에서 곧바로 녹음 파일 제출 + AI 요약 요청으로 넘어간다(페이지 이동 없음).
+ * ⚠️ 회의는 1단계 성공 시점에 이미 완료 상태다 — 2단계는 선택이고, 건너뛰어도 회의는 남는다.
+ */
+export function OnlineMeetingDialog({
+  members,
+  projects,
+  showParentTeamAction,
+  teamActions,
+  viewer,
+}: OnlineMeetingDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [createdMeetingId, setCreatedMeetingId] = useState<string | null>(null);
+  const [isPending, setIsPending] = useState(false);
+  const handlePendingChange = useCallback((next: boolean) => setIsPending(next), []);
+
+  function closeDialog() {
+    setOpen(false);
+    setCreatedMeetingId(null);
   }
 
   return (
@@ -117,8 +296,8 @@ export function OnlineMeetingDialog({
         // ⚠️ 제출 중엔 Esc·바깥 클릭 전부 막는다 — 요청은 계속 가는데 창만 사라지면 결과를
         //    못 본다(`RoomReservationDialog`와 같은 이유).
         if (!next && isPending) return;
-        // `handleOpenChange`가 폼 리셋 + `setOpen`까지 한 번에 한다(훅 안에서 `onOpenChange`로 위임).
-        handleOpenChange(next);
+        if (!next) setCreatedMeetingId(null);
+        setOpen(next);
       }}
     >
       <DialogTrigger render={<Button type="button" variant="outline" />}>
@@ -128,101 +307,29 @@ export function OnlineMeetingDialog({
 
       <DialogContent className="gap-0 p-0 sm:max-w-[720px]">
         <DialogHeader className="border-border border-b px-6 py-4">
-          <DialogTitle>비대면 회의 만들기</DialogTitle>
+          <DialogTitle>{createdMeetingId ? "녹음 파일 제출" : "비대면 회의 만들기"}</DialogTitle>
         </DialogHeader>
 
-        <form ref={formRef} action={formAction} onSubmit={handleFormSubmit}>
-          <PendingReporter onChange={handlePendingChange} />
-          <input type="hidden" name="projectId" value={form.projectId} />
-          <input type="hidden" name="parentTeamActionId" value={form.parentTeamActionId} />
-          <input type="hidden" name="recordingFileName" value={form.recordingFileName ?? ""} />
-
-          <div className="flex max-h-[70vh] flex-col gap-4 overflow-y-auto px-6 py-4">
-            <div className="grid grid-cols-1 gap-6 sm:grid-cols-[1fr_260px]">
-              <OnlineMeetingFields
-                form={form}
-                setForm={setForm}
-                errors={state.errors}
-                projects={projects}
-                showParentTeamAction={showParentTeamAction}
-                teamActions={teamActions}
-              />
-
-              <div className="flex flex-col gap-4">
-                <RoomAttendeePicker
-                  members={members}
-                  selectedIds={form.attendeeIds}
-                  onChange={(attendeeIds) => setForm((prev) => ({ ...prev, attendeeIds }))}
-                  viewer={viewer}
-                />
-                <FieldError reserveSpace message={state.errors.attendeeIds} />
-
-                <div className="flex flex-col gap-1.5">
-                  <span
-                    id="online-meeting-recording-label"
-                    className="text-[13px] leading-5 font-medium"
-                  >
-                    녹음 파일 첨부 (선택)
-                  </span>
-                  {/* ⚠️ 바이너리는 안 보낸다 — 파일명만 읽어 hidden input으로 싣는다(위 주석). */}
-                  <input
-                    ref={fileInputRef}
-                    type="file"
-                    className="hidden"
-                    onChange={handleFileChange}
-                  />
-                  <div className="flex items-center gap-2">
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      className="w-full min-w-0 justify-start"
-                      aria-labelledby="online-meeting-recording-label"
-                      onClick={() => fileInputRef.current?.click()}
-                    >
-                      <Paperclip aria-hidden />
-                      <span className="truncate">
-                        {form.recordingFileName ?? "파일 첨부 (선택)"}
-                      </span>
-                    </Button>
-                    {form.recordingFileName && (
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon-sm"
-                        aria-label="녹음 파일 선택 해제"
-                        onClick={clearFile}
-                      >
-                        <X aria-hidden />
-                      </Button>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="border-border flex items-center justify-end gap-4 border-t px-6 py-4">
-            <DialogActions
-              onCancel={() => handleOpenChange(false)}
-              onRequestSubmit={() => setShowConfirm(true)}
-            />
-          </div>
-        </form>
+        {createdMeetingId ? (
+          <OnlineMeetingStep2
+            meetingId={createdMeetingId}
+            onSubmitted={closeDialog}
+            onPendingChange={handlePendingChange}
+            onSkip={closeDialog}
+          />
+        ) : (
+          <OnlineMeetingStep1
+            members={members}
+            projects={projects}
+            showParentTeamAction={showParentTeamAction}
+            teamActions={teamActions}
+            viewer={viewer}
+            onCreated={setCreatedMeetingId}
+            onPendingChange={handlePendingChange}
+            onCancel={() => setOpen(false)}
+          />
+        )}
       </DialogContent>
-
-      <ConfirmDialog
-        isOpen={showConfirm}
-        onOpenChange={setShowConfirm}
-        title="이대로 등록하시겠습니까?"
-        description="등록하면 곧바로 회의가 완료 처리되고 AI 요약이 시작됩니다."
-        confirmLabel="등록"
-        onConfirm={() => {
-          setShowConfirm(false);
-          confirmedSubmitRef.current = true;
-          formRef.current?.requestSubmit();
-        }}
-      />
     </Dialog>
   );
 }

--- a/src/features/meeting/components/online-meeting-dialog.tsx
+++ b/src/features/meeting/components/online-meeting-dialog.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { Paperclip, Video, X } from "lucide-react";
-import type { ChangeEvent, FormEvent } from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { Video, X } from "lucide-react";
+import type { FormEvent } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useFormStatus } from "react-dom";
 
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
@@ -20,13 +20,10 @@ import type { AttendeeScopeViewer } from "@/features/rooms/attendee-scope";
 import { RoomAttendeePicker } from "@/features/rooms/components/room-attendee-picker";
 import type { RoomMember, RoomProjectOption, RoomTeamActionOption } from "@/features/rooms/types";
 
-import { RECORDING_FILE_ACCEPTED_EXTENSIONS, validateRecordingFile } from "../recording-file";
 import { OnlineMeetingFields } from "./online-meeting-fields";
+import { PendingReporter } from "./online-meeting-shared";
+import { OnlineMeetingStep2 } from "./online-meeting-step2";
 import { useOnlineMeetingForm } from "./use-online-meeting-form";
-import { useOnlineMeetingRecordingForm } from "./use-online-meeting-recording-form";
-
-/** 파일 피커의 `accept` 속성 — 확장자 앞에 점을 붙인다. 실제 차단은 `validateRecordingFile`이 한다. */
-const RECORDING_FILE_ACCEPT = RECORDING_FILE_ACCEPTED_EXTENSIONS.map((ext) => `.${ext}`).join(",");
 
 interface OnlineMeetingDialogProps {
   members: RoomMember[];
@@ -34,17 +31,6 @@ interface OnlineMeetingDialogProps {
   showParentTeamAction: boolean;
   teamActions: RoomTeamActionOption[];
   viewer: AttendeeScopeViewer;
-}
-
-/** 제출 중인지를 창에 올려 보낸다 — `RoomReservationDialog`의 `PendingReporter`와 같다. */
-function PendingReporter({ onChange }: { onChange: (pending: boolean) => void }) {
-  const { pending } = useFormStatus();
-
-  useEffect(() => {
-    onChange(pending);
-  }, [pending, onChange]);
-
-  return null;
 }
 
 /**
@@ -67,25 +53,6 @@ function ConfirmStepActions({
       </Button>
       <Button type="button" variant="ink" disabled={pending} onClick={onRequestSubmit}>
         {pending ? "등록 중" : "등록"}
-      </Button>
-    </div>
-  );
-}
-
-/**
- * 건너뛰기·바로 제출 버튼 — 2단계(녹음 제출)가 쓴다. 확인 모달을 안 거친다 — 회의는 이미
- * 완료 상태로 존재해서 이 제출은 되돌릴 게 없는 부가 조작이다(§토스트: 파괴적 작업만 Dialog).
- */
-function SkipOrSubmitActions({ onSkip }: { onSkip: () => void }) {
-  const { pending } = useFormStatus();
-
-  return (
-    <div className="flex shrink-0 gap-2">
-      <Button type="button" variant="outline" disabled={pending} onClick={onSkip}>
-        나중에 하기
-      </Button>
-      <Button type="submit" variant="ink" disabled={pending}>
-        {pending ? "요청 중" : "AI 요약 요청"}
       </Button>
     </div>
   );
@@ -182,119 +149,6 @@ function OnlineMeetingStep1({
   );
 }
 
-interface OnlineMeetingStep2Props {
-  meetingId: string;
-  onSubmitted: () => void;
-  onPendingChange: (pending: boolean) => void;
-  onSkip: () => void;
-}
-
-/**
- * 2단계 — 녹음 파일 제출 + AI 요약 요청(2026-08-14 팀 확정). 회의는 1단계에서 이미 완료
- * 상태로 만들어져 있어 이 단계는 **선택**이다 — [나중에 하기]로 건너뛰어도 회의는 그대로 남는다.
- * ⚠️ **첨부는 실제 업로드가 아니다**(§정직한 목업) — 파일 이름만 hidden input으로 싣는다.
- * ⚠️ 실서버(`!isMock`)에서는 서버 액션이 "곧 지원됩니다" 오류를 그대로 돌려준다 — 컴포넌트가
- *    `isMock`을 직접 알면 안 된다(§Mock 격리막)는 규칙 그대로라, 여기서 따로 분기하지 않고
- *    `state.error`를 그대로 보여준다.
- */
-function OnlineMeetingStep2({
-  meetingId,
-  onSubmitted,
-  onPendingChange,
-  onSkip,
-}: OnlineMeetingStep2Props) {
-  const { state, formAction, recordingFileName, setRecordingFileName } =
-    useOnlineMeetingRecordingForm({ meetingId, onSubmitted });
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  // ⚠️ 형식·용량은 여기서 1차로만 거른다 — 최종 검증은 서버 몫이다(§권한: 화면 검증은
-  //    보안이 아니다). 서버 오류(`state.error`)와 자리가 같아 파일을 다시 고르면 없어진다.
-  const [fileError, setFileError] = useState<string | null>(null);
-
-  function handleFileChange(event: ChangeEvent<HTMLInputElement>) {
-    const file = event.target.files?.[0] ?? null;
-    if (!file) {
-      setFileError(null);
-      setRecordingFileName(null);
-      return;
-    }
-
-    const error = validateRecordingFile(file);
-    if (error) {
-      setFileError(error);
-      setRecordingFileName(null);
-      if (fileInputRef.current) fileInputRef.current.value = "";
-      return;
-    }
-
-    setFileError(null);
-    setRecordingFileName(file.name);
-  }
-
-  function clearFile() {
-    setFileError(null);
-    setRecordingFileName(null);
-    if (fileInputRef.current) fileInputRef.current.value = "";
-  }
-
-  return (
-    <form action={formAction}>
-      <PendingReporter onChange={onPendingChange} />
-      <input type="hidden" name="meetingId" value={meetingId} />
-      <input type="hidden" name="recordingFileName" value={recordingFileName ?? ""} />
-
-      <div className="flex flex-col gap-4 px-6 py-4">
-        <p className="text-muted-foreground text-[13px] leading-5">
-          녹음 파일을 제출해 주세요. 제출 없이도 회의는 이미 완료 처리돼 있습니다.
-        </p>
-
-        <div className="flex flex-col gap-1.5">
-          <span id="online-meeting-recording-label" className="text-[13px] leading-5 font-medium">
-            녹음 파일 첨부 (선택)
-          </span>
-          {/* ⚠️ 바이너리는 안 보낸다 — 파일명만 읽어 hidden input으로 싣는다(위 주석). */}
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept={RECORDING_FILE_ACCEPT}
-            className="hidden"
-            onChange={handleFileChange}
-          />
-          <div className="flex items-center gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="min-w-0 flex-1 justify-start"
-              aria-labelledby="online-meeting-recording-label"
-              onClick={() => fileInputRef.current?.click()}
-            >
-              <Paperclip aria-hidden />
-              <span className="truncate">{recordingFileName ?? "파일 첨부 (선택)"}</span>
-            </Button>
-            {recordingFileName && (
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-sm"
-                aria-label="녹음 파일 선택 해제"
-                onClick={clearFile}
-              >
-                <X aria-hidden />
-              </Button>
-            )}
-          </div>
-        </div>
-
-        <FieldError reserveSpace message={fileError ?? state.error ?? undefined} />
-      </div>
-
-      <div className="border-border flex items-center justify-end gap-4 border-t px-6 py-4">
-        <SkipOrSubmitActions onSkip={onSkip} />
-      </div>
-    </form>
-  );
-}
-
 /**
  * 비대면 회의 만들기 — `/app/meeting` 목록의 진입점(이슈 #473). 2026-08-14 팀 확정으로 **2단계
  * 다이얼로그**가 됐다:
@@ -341,10 +195,13 @@ export function OnlineMeetingDialog({
            헤더가 직접 여백(`px-6 py-4`)을 잡아서, 기본값을 그대로 쓰면 버튼이 모서리 밖으로
            걸쳐 뜬다. `showCloseButton={false}`로 끄고 헤더 여백 안에 자연스럽게 배치한다.
       */}
-      <DialogContent className="gap-0 p-0 sm:max-w-[720px]" showCloseButton={false}>
+      <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-[720px]" showCloseButton={false}>
         <DialogHeader className="border-border flex-row items-center justify-between border-b px-6 py-4">
           <DialogTitle>{createdMeetingId ? "녹음 파일 제출" : "비대면 회의 만들기"}</DialogTitle>
-          <DialogClose render={<Button type="button" variant="ghost" size="icon-sm" />}>
+          <DialogClose
+            disabled={isPending}
+            render={<Button type="button" variant="ghost" size="icon-sm" />}
+          >
             <X aria-hidden />
             <span className="sr-only">닫기</span>
           </DialogClose>

--- a/src/features/meeting/components/online-meeting-dialog.tsx
+++ b/src/features/meeting/components/online-meeting-dialog.tsx
@@ -10,6 +10,7 @@ import { FieldError } from "@/components/common/field-error";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogHeader,
   DialogTitle,
@@ -19,9 +20,13 @@ import type { AttendeeScopeViewer } from "@/features/rooms/attendee-scope";
 import { RoomAttendeePicker } from "@/features/rooms/components/room-attendee-picker";
 import type { RoomMember, RoomProjectOption, RoomTeamActionOption } from "@/features/rooms/types";
 
+import { RECORDING_FILE_ACCEPTED_EXTENSIONS, validateRecordingFile } from "../recording-file";
 import { OnlineMeetingFields } from "./online-meeting-fields";
 import { useOnlineMeetingForm } from "./use-online-meeting-form";
 import { useOnlineMeetingRecordingForm } from "./use-online-meeting-recording-form";
+
+/** 파일 피커의 `accept` 속성 — 확장자 앞에 점을 붙인다. 실제 차단은 `validateRecordingFile`이 한다. */
+const RECORDING_FILE_ACCEPT = RECORDING_FILE_ACCEPTED_EXTENSIONS.map((ext) => `.${ext}`).join(",");
 
 interface OnlineMeetingDialogProps {
   members: RoomMember[];
@@ -201,13 +206,32 @@ function OnlineMeetingStep2({
   const { state, formAction, recordingFileName, setRecordingFileName } =
     useOnlineMeetingRecordingForm({ meetingId, onSubmitted });
   const fileInputRef = useRef<HTMLInputElement>(null);
+  // ⚠️ 형식·용량은 여기서 1차로만 거른다 — 최종 검증은 서버 몫이다(§권한: 화면 검증은
+  //    보안이 아니다). 서버 오류(`state.error`)와 자리가 같아 파일을 다시 고르면 없어진다.
+  const [fileError, setFileError] = useState<string | null>(null);
 
   function handleFileChange(event: ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0] ?? null;
-    setRecordingFileName(file?.name ?? null);
+    if (!file) {
+      setFileError(null);
+      setRecordingFileName(null);
+      return;
+    }
+
+    const error = validateRecordingFile(file);
+    if (error) {
+      setFileError(error);
+      setRecordingFileName(null);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      return;
+    }
+
+    setFileError(null);
+    setRecordingFileName(file.name);
   }
 
   function clearFile() {
+    setFileError(null);
     setRecordingFileName(null);
     if (fileInputRef.current) fileInputRef.current.value = "";
   }
@@ -228,7 +252,13 @@ function OnlineMeetingStep2({
             녹음 파일 첨부 (선택)
           </span>
           {/* ⚠️ 바이너리는 안 보낸다 — 파일명만 읽어 hidden input으로 싣는다(위 주석). */}
-          <input ref={fileInputRef} type="file" className="hidden" onChange={handleFileChange} />
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept={RECORDING_FILE_ACCEPT}
+            className="hidden"
+            onChange={handleFileChange}
+          />
           <div className="flex items-center gap-2">
             <Button
               type="button"
@@ -255,7 +285,7 @@ function OnlineMeetingStep2({
           </div>
         </div>
 
-        <FieldError reserveSpace message={state.error ?? undefined} />
+        <FieldError reserveSpace message={fileError ?? state.error ?? undefined} />
       </div>
 
       <div className="border-border flex items-center justify-end gap-4 border-t px-6 py-4">
@@ -305,9 +335,19 @@ export function OnlineMeetingDialog({
         비대면 회의
       </DialogTrigger>
 
-      <DialogContent className="gap-0 p-0 sm:max-w-[720px]">
-        <DialogHeader className="border-border border-b px-6 py-4">
+      {/*
+        ⚠️ **닫기(X) 버튼을 헤더 안에 직접 그린다.** `DialogContent`의 기본 닫기 버튼은
+           `p-4` 여백을 전제로 `top-2 right-2`에 절대 위치한다 — 이 다이얼로그는 `p-0`을 쓰고
+           헤더가 직접 여백(`px-6 py-4`)을 잡아서, 기본값을 그대로 쓰면 버튼이 모서리 밖으로
+           걸쳐 뜬다. `showCloseButton={false}`로 끄고 헤더 여백 안에 자연스럽게 배치한다.
+      */}
+      <DialogContent className="gap-0 p-0 sm:max-w-[720px]" showCloseButton={false}>
+        <DialogHeader className="border-border flex-row items-center justify-between border-b px-6 py-4">
           <DialogTitle>{createdMeetingId ? "녹음 파일 제출" : "비대면 회의 만들기"}</DialogTitle>
+          <DialogClose render={<Button type="button" variant="ghost" size="icon-sm" />}>
+            <X aria-hidden />
+            <span className="sr-only">닫기</span>
+          </DialogClose>
         </DialogHeader>
 
         {createdMeetingId ? (

--- a/src/features/meeting/components/online-meeting-dialog.tsx
+++ b/src/features/meeting/components/online-meeting-dialog.tsx
@@ -264,7 +264,7 @@ function OnlineMeetingStep2({
               type="button"
               variant="outline"
               size="sm"
-              className="w-full min-w-0 justify-start"
+              className="min-w-0 flex-1 justify-start"
               aria-labelledby="online-meeting-recording-label"
               onClick={() => fileInputRef.current?.click()}
             >

--- a/src/features/meeting/components/online-meeting-shared.tsx
+++ b/src/features/meeting/components/online-meeting-shared.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useEffect } from "react";
+import { useFormStatus } from "react-dom";
+
+/**
+ * 제출 중인지를 창에 올려 보낸다 — `OnlineMeetingStep1`·`OnlineMeetingStep2`가 함께 쓴다
+ * (`RoomReservationDialog`의 `PendingReporter`와 같은 이유).
+ */
+export function PendingReporter({ onChange }: { onChange: (pending: boolean) => void }) {
+  const { pending } = useFormStatus();
+
+  useEffect(() => {
+    onChange(pending);
+  }, [pending, onChange]);
+
+  return null;
+}

--- a/src/features/meeting/components/online-meeting-step2.tsx
+++ b/src/features/meeting/components/online-meeting-step2.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { Paperclip, X } from "lucide-react";
+import type { ChangeEvent } from "react";
+import { useRef, useState } from "react";
+import { useFormStatus } from "react-dom";
+
+import { FieldError } from "@/components/common/field-error";
+import { Button } from "@/components/ui/button";
+
+import { RECORDING_FILE_ACCEPTED_EXTENSIONS, validateRecordingFile } from "../recording-file";
+import { PendingReporter } from "./online-meeting-shared";
+import { useOnlineMeetingRecordingForm } from "./use-online-meeting-recording-form";
+
+/** 파일 피커의 `accept` 속성 — 확장자 앞에 점을 붙인다. 실제 차단은 `validateRecordingFile`이 한다. */
+const RECORDING_FILE_ACCEPT = RECORDING_FILE_ACCEPTED_EXTENSIONS.map((ext) => `.${ext}`).join(",");
+
+/**
+ * 건너뛰기·바로 제출 버튼 — 2단계(녹음 제출)가 쓴다. 확인 모달을 안 거친다 — 회의는 이미
+ * 완료 상태로 존재해서 이 제출은 되돌릴 게 없는 부가 조작이다(§토스트: 파괴적 작업만 Dialog).
+ * ⚠️ **녹음 파일은 선택이 아니다** — AI 요약 요청은 파일이 있어야만 눌린다(`canSubmit`).
+ *    [나중에 하기]로 이 단계 자체를 건너뛰는 건 여전히 자유다(회의는 이미 완료 상태).
+ */
+function SkipOrSubmitActions({ onSkip, canSubmit }: { onSkip: () => void; canSubmit: boolean }) {
+  const { pending } = useFormStatus();
+
+  return (
+    <div className="flex shrink-0 gap-2">
+      <Button type="button" variant="outline" disabled={pending} onClick={onSkip}>
+        나중에 하기
+      </Button>
+      <Button type="submit" variant="ink" disabled={pending || !canSubmit}>
+        {pending ? "요청 중" : "AI 요약 요청"}
+      </Button>
+    </div>
+  );
+}
+
+interface OnlineMeetingStep2Props {
+  meetingId: string;
+  onSubmitted: () => void;
+  onPendingChange: (pending: boolean) => void;
+  onSkip: () => void;
+}
+
+/**
+ * 2단계 — 녹음 파일 제출 + AI 요약 요청(2026-08-14 팀 확정). 회의는 1단계에서 이미 완료
+ * 상태로 만들어져 있어 이 **단계**는 선택이다 — [나중에 하기]로 건너뛰어도 회의는 그대로 남는다.
+ * 다만 **녹음 파일 자체는 선택이 아니다** — AI 요약을 요청하려면 파일을 첨부해야 한다.
+ * ⚠️ **첨부는 실제 업로드가 아니다**(§정직한 목업) — 파일 이름만 hidden input으로 싣는다.
+ * ⚠️ 실서버(`!isMock`)에서는 서버 액션이 `notice`(안내, 오류 아님)를 돌려준다 — 컴포넌트가
+ *    `isMock`을 직접 알면 안 된다(§Mock 격리막)는 규칙 그대로라, 여기서 따로 분기하지 않고
+ *    `state.notice`를 그대로 보여준다.
+ */
+export function OnlineMeetingStep2({
+  meetingId,
+  onSubmitted,
+  onPendingChange,
+  onSkip,
+}: OnlineMeetingStep2Props) {
+  const { state, formAction, recordingFileName, setRecordingFileName } =
+    useOnlineMeetingRecordingForm({ meetingId, onSubmitted });
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  // ⚠️ 형식·용량은 여기서 1차로만 거른다 — 최종 검증은 서버 몫이다(§권한: 화면 검증은
+  //    보안이 아니다). 파일을 다시 고르면 **이 클라이언트 오류만** 사라진다 — 서버 오류
+  //    (`state.error`)는 다음 제출(`useActionState`의 다음 dispatch) 전까지 그대로 남아서,
+  //    `fileError`가 `null`이 되면 아래 `FieldError`는 `state.error`로 바로 돌아간다.
+  const [fileError, setFileError] = useState<string | null>(null);
+
+  function handleFileChange(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0] ?? null;
+    if (!file) {
+      setFileError(null);
+      setRecordingFileName(null);
+      return;
+    }
+
+    const error = validateRecordingFile(file);
+    if (error) {
+      setFileError(error);
+      setRecordingFileName(null);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      return;
+    }
+
+    setFileError(null);
+    setRecordingFileName(file.name);
+  }
+
+  function clearFile() {
+    setFileError(null);
+    setRecordingFileName(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  }
+
+  return (
+    <form action={formAction}>
+      <PendingReporter onChange={onPendingChange} />
+      <input type="hidden" name="meetingId" value={meetingId} />
+      <input type="hidden" name="recordingFileName" value={recordingFileName ?? ""} />
+
+      <div className="flex flex-col gap-4 px-6 py-4">
+        <p className="text-muted-foreground text-[13px] leading-5">
+          AI 요약을 요청하려면 녹음 파일을 첨부해야 합니다. 지금 건너뛰어도 회의는 이미 완료 처리돼
+          있습니다.
+        </p>
+
+        <div className="flex flex-col gap-1.5">
+          <span id="online-meeting-recording-label" className="text-[13px] leading-5 font-medium">
+            녹음 파일 첨부
+          </span>
+          {/* ⚠️ 바이너리는 안 보낸다 — 파일명만 읽어 hidden input으로 싣는다(위 주석). */}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept={RECORDING_FILE_ACCEPT}
+            className="hidden"
+            onChange={handleFileChange}
+          />
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="min-w-0 flex-1 justify-start"
+              aria-labelledby="online-meeting-recording-label online-meeting-recording-filename"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <Paperclip aria-hidden />
+              {/*
+                ⚠️ **`aria-labelledby`는 버튼의 시각적 자식을 완전히 대신한다** — 스크린리더는
+                   여기 참조된 요소들의 글만 읽고 버튼 안의 다른 텍스트는 안 읽는다. 그래서 고른
+                   파일명이 접근성 이름에 들어가려면 이 span도 `id`로 같이 참조돼야 한다.
+              */}
+              <span id="online-meeting-recording-filename" className="truncate">
+                {recordingFileName ?? "선택된 파일 없음"}
+              </span>
+            </Button>
+            {recordingFileName && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                aria-label="녹음 파일 선택 해제"
+                onClick={clearFile}
+              >
+                <X aria-hidden />
+              </Button>
+            )}
+          </div>
+        </div>
+
+        <FieldError reserveSpace message={fileError ?? state.error ?? undefined} />
+        {state.notice && (
+          <p className="text-muted-foreground text-[12px] leading-4">{state.notice}</p>
+        )}
+      </div>
+
+      <div className="border-border flex items-center justify-end gap-4 border-t px-6 py-4">
+        <SkipOrSubmitActions onSkip={onSkip} canSubmit={Boolean(recordingFileName)} />
+      </div>
+    </form>
+  );
+}

--- a/src/features/meeting/components/use-online-meeting-form.ts
+++ b/src/features/meeting/components/use-online-meeting-form.ts
@@ -1,6 +1,5 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import { useActionState, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
@@ -19,26 +18,24 @@ const EMPTY_FORM = {
   attendeeIds: [] as number[],
   /** Select 값은 문자열이라 여기서도 문자열로 든다 — `useRoomReservationForm`과 같은 관례. */
   parentTeamActionId: "",
-  /** 첨부한 녹음 파일 이름 — 바이트는 안 든다(§정직한 목업, `Meeting.recordingFileName`). */
-  recordingFileName: null as string | null,
 };
 
 export type OnlineMeetingFormValues = typeof EMPTY_FORM;
 
 interface UseOnlineMeetingFormOptions {
-  onOpenChange: (open: boolean) => void;
+  /** 1단계 성공 뒤 다이얼로그가 2단계(녹음 제출)로 넘어갈 수 있게 방금 만든 회의 id를 알린다. */
+  onCreated: (meetingId: string) => void;
 }
 
 /**
- * 비대면 회의 만들기 모달의 폼 상태·제출 흐름(이슈 #473) — `useRoomReservationForm`과 같은
- * 골격이다(CLAUDE.md §폴더·네이밍: 로직=커스텀훅).
- * ⚠️ **성공 후 흐름이 회의실 예약과 다르다.** 예약은 같은 화면(캘린더)에 비관적으로 반영하지만,
- *    이 다이얼로그는 목록 화면 어디에도 그릴 자리가 없다 — 만들자마자 완료 처리되는 회의라
- *    상세로 바로 옮기는 편이 자연스럽다(`router.push`). 목록은 서버 액션이 이미 부른
- *    `revalidatePath`로 다음 방문 때 최신 상태다.
+ * 비대면 회의 만들기 모달의 **1단계**(제목·프로젝트·안건·참석자) 폼 상태·제출 흐름(이슈 #473) —
+ * `useRoomReservationForm`과 같은 골격이다(CLAUDE.md §폴더·네이밍: 로직=커스텀훅).
+ * ⚠️ **성공해도 창을 안 닫는다**(2026-08-14 팀 확정 — 이전엔 상세로 `router.push`했다). 비대면
+ *    회의는 만들자마자 완료 처리되지만, 같은 다이얼로그가 이어서 녹음 파일 제출·AI 요약 요청을
+ *    받는 **2단계**로 넘어간다 — 페이지 전환 없이 `onCreated`로 부모(다이얼로그)에 알리기만 한다.
+ * ⚠️ 폼은 여기서 안 비운다 — 2단계를 마치고 다이얼로그 전체가 닫힐 때 부모가 리셋한다.
  */
-export function useOnlineMeetingForm({ onOpenChange }: UseOnlineMeetingFormOptions) {
-  const router = useRouter();
+export function useOnlineMeetingForm({ onCreated }: UseOnlineMeetingFormOptions) {
   const [state, formAction] = useActionState(createOnlineMeetingAction, INITIAL_STATE);
   const [form, setForm] = useState<OnlineMeetingFormValues>(EMPTY_FORM);
   const handledCreatedId = useRef<string | null>(null);
@@ -46,17 +43,15 @@ export function useOnlineMeetingForm({ onOpenChange }: UseOnlineMeetingFormOptio
   useEffect(() => {
     if (state.created && state.created.id !== handledCreatedId.current) {
       handledCreatedId.current = state.created.id;
-      onOpenChange(false);
-      setForm(EMPTY_FORM);
       toast.success("비대면 회의를 등록했습니다");
-      router.push(`/app/meeting/${state.created.id}`);
+      onCreated(state.created.id);
     }
-  }, [state.created, onOpenChange, router]);
+  }, [state.created, onCreated]);
 
-  function handleOpenChange(open: boolean) {
-    if (!open) setForm(EMPTY_FORM);
-    onOpenChange(open);
+  function resetForm() {
+    setForm(EMPTY_FORM);
+    handledCreatedId.current = null;
   }
 
-  return { state, formAction, form, setForm, handleOpenChange };
+  return { state, formAction, form, setForm, resetForm };
 }

--- a/src/features/meeting/components/use-online-meeting-form.ts
+++ b/src/features/meeting/components/use-online-meeting-form.ts
@@ -33,7 +33,10 @@ interface UseOnlineMeetingFormOptions {
  * ⚠️ **성공해도 창을 안 닫는다**(2026-08-14 팀 확정 — 이전엔 상세로 `router.push`했다). 비대면
  *    회의는 만들자마자 완료 처리되지만, 같은 다이얼로그가 이어서 녹음 파일 제출·AI 요약 요청을
  *    받는 **2단계**로 넘어간다 — 페이지 전환 없이 `onCreated`로 부모(다이얼로그)에 알리기만 한다.
- * ⚠️ 폼은 여기서 안 비운다 — 2단계를 마치고 다이얼로그 전체가 닫힐 때 부모가 리셋한다.
+ * ⚠️ 폼은 여기서 안 비운다 — 성공하면 부모(`OnlineMeetingDialog`)가 2단계로 갈아 끼워 이
+ *    컴포넌트(와 이 훅)를 **언마운트**한다. 다시 1단계로 돌아오는 유일한 길은 다이얼로그를
+ *    닫았다 여는 것뿐이라, 그때는 이 훅이 처음부터 다시 마운트돼 `EMPTY_FORM`으로 시작한다 —
+ *    되돌리는 함수가 따로 없다.
  */
 export function useOnlineMeetingForm({ onCreated }: UseOnlineMeetingFormOptions) {
   const [state, formAction] = useActionState(createOnlineMeetingAction, INITIAL_STATE);
@@ -48,10 +51,5 @@ export function useOnlineMeetingForm({ onCreated }: UseOnlineMeetingFormOptions)
     }
   }, [state.created, onCreated]);
 
-  function resetForm() {
-    setForm(EMPTY_FORM);
-    handledCreatedId.current = null;
-  }
-
-  return { state, formAction, form, setForm, resetForm };
+  return { state, formAction, form, setForm };
 }

--- a/src/features/meeting/components/use-online-meeting-recording-form.ts
+++ b/src/features/meeting/components/use-online-meeting-recording-form.ts
@@ -8,7 +8,11 @@ import {
   type SubmitOnlineMeetingRecordingState,
 } from "../actions";
 
-const INITIAL_STATE: SubmitOnlineMeetingRecordingState = { error: null, submitted: null };
+const INITIAL_STATE: SubmitOnlineMeetingRecordingState = {
+  error: null,
+  notice: null,
+  submitted: null,
+};
 
 interface UseOnlineMeetingRecordingFormOptions {
   meetingId: string;
@@ -24,7 +28,6 @@ interface UseOnlineMeetingRecordingFormOptions {
  *    `online-meeting-dialog.tsx`가 전에 하던 것과 같다.
  */
 export function useOnlineMeetingRecordingForm({
-  meetingId,
   onSubmitted,
 }: UseOnlineMeetingRecordingFormOptions) {
   const [state, formAction] = useActionState(submitOnlineMeetingRecordingAction, INITIAL_STATE);
@@ -39,5 +42,5 @@ export function useOnlineMeetingRecordingForm({
     }
   }, [state.submitted, onSubmitted]);
 
-  return { state, formAction, recordingFileName, setRecordingFileName, meetingId };
+  return { state, formAction, recordingFileName, setRecordingFileName };
 }

--- a/src/features/meeting/components/use-online-meeting-recording-form.ts
+++ b/src/features/meeting/components/use-online-meeting-recording-form.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useActionState, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+
+import {
+  submitOnlineMeetingRecordingAction,
+  type SubmitOnlineMeetingRecordingState,
+} from "../actions";
+
+const INITIAL_STATE: SubmitOnlineMeetingRecordingState = { error: null, submitted: null };
+
+interface UseOnlineMeetingRecordingFormOptions {
+  meetingId: string;
+  /** 제출(성공)이 끝나면 다이얼로그를 닫는다 — 회의는 1단계에서 이미 완료 상태로 존재해서
+   *  이 단계는 선택이다(닫아도 회의 자체는 그대로 남는다). */
+  onSubmitted: () => void;
+}
+
+/**
+ * 비대면 회의 만들기 다이얼로그의 **2단계**(녹음 파일 제출 + AI 요약 요청, 이슈 #473,
+ * 2026-08-14 팀 확정) — 파일명만 드는 가벼운 상태라 `useOnlineMeetingForm`처럼 따로 뗀다.
+ * ⚠️ **첨부는 실제 업로드가 아니다**(§정직한 목업) — 파일 이름만 hidden input으로 실어 보낸다,
+ *    `online-meeting-dialog.tsx`가 전에 하던 것과 같다.
+ */
+export function useOnlineMeetingRecordingForm({
+  meetingId,
+  onSubmitted,
+}: UseOnlineMeetingRecordingFormOptions) {
+  const [state, formAction] = useActionState(submitOnlineMeetingRecordingAction, INITIAL_STATE);
+  const [recordingFileName, setRecordingFileName] = useState<string | null>(null);
+  const handledMeetingId = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (state.submitted && state.submitted.meetingId !== handledMeetingId.current) {
+      handledMeetingId.current = state.submitted.meetingId;
+      toast.success("AI 요약을 요청했습니다");
+      onSubmitted();
+    }
+  }, [state.submitted, onSubmitted]);
+
+  return { state, formAction, recordingFileName, setRecordingFileName, meetingId };
+}

--- a/src/features/meeting/mapper.ts
+++ b/src/features/meeting/mapper.ts
@@ -365,8 +365,6 @@ export function toMeetingListItem(be: BeMeetingListItem): MeetingListItem {
     attendeeCount: be.attendeeCount,
     isHost: be.isHost,
     aiSummaryStatus: toAiSummaryStatus(be.summaryStatus),
-    // 실서버는 아직 비대면 회의를 모른다 — BE가 필드를 주면 그때 매퍼가 읽는다(이슈 #473).
-    isOnline: false,
   };
 }
 

--- a/src/features/meeting/mapper/online-meetings.ts
+++ b/src/features/meeting/mapper/online-meetings.ts
@@ -1,0 +1,69 @@
+/**
+ * 비대면 회의 생성(`POST /api/meetings/online`, MEET-18) BE shape → UI 계약(이슈 #473).
+ * [확인] 도메인 담당자 문서(2026-08-14, 팀 확정) 기준 — BE 실코드는 아직 대조 전이다
+ *   (§연동 검증: Swagger·구두 추측 금지, 문서와 코드가 다르면 코드가 맞다 — 구현 시 컨트롤러로 재확인).
+ * ⚠️ `rooms/mapper/meetings.ts`의 `toCreateMeetingPayload`/`toSentTopics`와 같은 자리 나눔이다 —
+ *    회의실·시간 필드만 없을 뿐 안건 접기 규칙은 같다.
+ */
+
+import type { MeetingTopicInput } from "../../rooms/types";
+import type { OnlineMeetingDraft } from "../types";
+
+/**
+ * `POST /api/meetings/online`(MEET-18) 요청 본문.
+ * ⚠️ `recordingConsent`는 **아예 안 싣는다** — 서버가 항상 `true`로 고정한다고 팀이 확정했다
+ *    (2026-08-14). 보내 봐야 서버가 무시하는 값이라, 보내는 척하면 거짓 UI다(§정직한 목업).
+ * ⚠️ `relatedActionId`: `parentTeamActionId`가 같은 개념이라 그대로 싣는다 — MEET-01과 같은 이름 매핑.
+ * ⚠️ `meetingRoomId`·`startAt`·`endAt`이 **아예 없다**(옵셔널이 아니라 필드 자체가 없다) — 비대면
+ *    회의는 회의실·시간을 안 받는다(팀 명세).
+ */
+export interface BeCreateOnlineMeetingPayload {
+  title: string;
+  projectId: number;
+  relatedActionId?: number;
+  attendeeMemberIds: number[];
+  mainTopic: string;
+  subTopics: string[];
+}
+
+/**
+ * 계약이 실제로 받는 안건 모양(대주제 1개 + 소주제 여러 개)으로 좁힌다 — `rooms/mapper/meetings.ts`의
+ * `toSentTopics`와 같은 규칙(§정직성: 버려진 값을 저장된 것처럼 보이면 안 된다). 회의실 예약과
+ * 안건 UI가 같은 모양(`MeetingTopicInput`)을 쓰기 때문에 접는 방식도 같아야 한다.
+ */
+function toSentTopics(topics: MeetingTopicInput[]): { mainTopic: string; subTopics: string[] } {
+  return {
+    mainTopic: topics[0]?.main.trim() ?? "",
+    subTopics: topics.map((topic) => topic.sub.trim()).filter((sub) => sub.length > 0),
+  };
+}
+
+export function toCreateOnlineMeetingPayload(
+  draft: OnlineMeetingDraft,
+): BeCreateOnlineMeetingPayload {
+  const { mainTopic, subTopics } = toSentTopics(draft.topics);
+  return {
+    title: draft.title.trim(),
+    projectId: Number(draft.projectId),
+    relatedActionId: draft.parentTeamActionId,
+    attendeeMemberIds: draft.attendeeIds,
+    mainTopic,
+    subTopics,
+  };
+}
+
+/**
+ * `POST /api/meetings/online` 성공 응답 — [확인] 도메인 담당자 문서(2026-08-14).
+ * ⚠️ `status`는 실제로 항상 `"DONE"`이다 — 비대면 회의는 만들어지는 순간 이미 완료다(팀 확정,
+ *    `mock/meetings.ts`의 `addMockOnlineMeeting`과 같은 규칙). `meetingRoom`·`startAt`·`endAt`은
+ *    응답에 아예 없다.
+ */
+export interface BeCreateOnlineMeetingResponse {
+  meetingId: number;
+  status: "DONE";
+  title: string;
+  isOnline: true;
+  recordingConsent: true;
+  host: { memberId: number; name: string };
+  attendees: { memberId: number; name: string; teamName?: string }[];
+}

--- a/src/features/meeting/mock/meetings.test.ts
+++ b/src/features/meeting/mock/meetings.test.ts
@@ -1,4 +1,5 @@
 import { AUTHORITY } from "@/constants/authority";
+import { AI_SUMMARY_STATUS } from "@/constants/meeting";
 
 import type { MeetingDraft } from "../types";
 import {
@@ -6,6 +7,8 @@ import {
   addMockOnlineMeeting,
   findMockMeeting,
   listMockMeetings,
+  setMockRecordingFileName,
+  setMockSummaryStatus,
 } from "./meetings";
 
 const DRAFT: MeetingDraft = {
@@ -71,7 +74,9 @@ describe("비대면 회의 생성(이슈 #473) — addMockOnlineMeeting", () => 
     roomId: null,
     roomName: null,
     roomReservationId: null,
-    recordingFileName: "회의록.m4a",
+    // ⚠️ `createOnlineMeetingAction`은 항상 `null`로 만든다 — 첨부는 이 액션의 몫이 아니라
+    //    다이얼로그 **2단계**(`submitOnlineMeetingRecordingAction`)가 따로 붙인다(actions.ts 주석).
+    recordingFileName: null,
   };
 
   it("만들자마자 종료 처리된다 — endedAt이 즉시 채워진다", () => {
@@ -100,15 +105,40 @@ describe("비대면 회의 생성(이슈 #473) — addMockOnlineMeeting", () => 
     expect(created.roomReservationId).toBeNull();
   });
 
-  it("첨부한 녹음 파일 이름을 그대로 담는다(§정직한 목업 — 바이트는 안 든다)", () => {
-    const created = addMockOnlineMeeting(ONLINE_DRAFT);
-
-    expect(created.recordingFileName).toBe("회의록.m4a");
-  });
-
   it("취소되지 않은 채로 만들어진다", () => {
     const created = addMockOnlineMeeting(ONLINE_DRAFT);
 
     expect(created.canceledAt).toBeNull();
+  });
+
+  /*
+    ⚠️ 실제 2단계 흐름 재현(이슈 #473, 2026-08-14) — 1단계(`createOnlineMeetingAction`이
+       부르는 `addMockOnlineMeeting`)는 녹음 파일 없이 회의를 만들고, 2단계
+       (`submitOnlineMeetingRecordingAction`)가 `setMockRecordingFileName`으로 파일명을
+       따로 붙인다. 한 함수만 따로 테스트하면 두 단계가 실제로 이어지는지는 안 잡힌다.
+  */
+  describe("2단계([녹음 파일 제출]) — setMockRecordingFileName", () => {
+    it("만들어질 때는 녹음 파일이 없다", () => {
+      const created = addMockOnlineMeeting(ONLINE_DRAFT);
+
+      expect(created.recordingFileName).toBeNull();
+    });
+
+    it("setMockRecordingFileName을 부르면 파일명이 그 회의에 붙는다(§정직한 목업 — 이름만 옮긴다)", () => {
+      const created = addMockOnlineMeeting(ONLINE_DRAFT);
+
+      setMockRecordingFileName(created.id, "회의록.m4a");
+
+      expect(findMockMeeting(created.id)?.recordingFileName).toBe("회의록.m4a");
+    });
+
+    it("파일 제출과 함께 분석 대기(PENDING)로 옮겨진다", () => {
+      const created = addMockOnlineMeeting(ONLINE_DRAFT);
+
+      setMockRecordingFileName(created.id, "회의록.m4a");
+      setMockSummaryStatus(created.id, AI_SUMMARY_STATUS.PENDING);
+
+      expect(findMockMeeting(created.id)?.aiSummaryStatus).toBe(AI_SUMMARY_STATUS.PENDING);
+    });
   });
 });

--- a/src/features/meeting/mock/meetings.test.ts
+++ b/src/features/meeting/mock/meetings.test.ts
@@ -1,5 +1,4 @@
 import { AUTHORITY } from "@/constants/authority";
-import { AI_SUMMARY_STATUS } from "@/constants/meeting";
 
 import type { MeetingDraft } from "../types";
 import {
@@ -83,10 +82,14 @@ describe("비대면 회의 생성(이슈 #473) — addMockOnlineMeeting", () => 
     expect(created.endedAt).toBe(new Date(created.endedAt!).toISOString());
   });
 
-  it("종료와 동시에 AI 분석 대기 상태로 들어간다 — endMockMeeting과 같은 규칙", () => {
+  /*
+    ⚠️ 2026-08-14 팀 확정 — 대면 회의의 `endMockMeeting`과 달리 **대기로 안 들어간다.** 요약
+       요청은 다이얼로그 2단계([AI 요약 요청])에서 사람이 직접 눌러야 시작된다.
+  */
+  it("만들어진 시점엔 아직 AI 요약을 요청하지 않은 상태다", () => {
     const created = addMockOnlineMeeting(ONLINE_DRAFT);
 
-    expect(created.aiSummaryStatus).toBe(AI_SUMMARY_STATUS.PENDING);
+    expect(created.aiSummaryStatus).toBeNull();
   });
 
   it("회의실이 없다 — roomId·roomName·roomReservationId가 그대로 null이다", () => {

--- a/src/features/meeting/mock/meetings.ts
+++ b/src/features/meeting/mock/meetings.ts
@@ -172,7 +172,9 @@ export function setMockSummaryStatus(id: string, status: AiSummaryStatus): void 
 /**
  * 비대면 회의 다이얼로그 2단계([녹음 파일 제출])가 파일명을 적어 둔다(이슈 #473, 2026-08-14).
  * ⚠️ **여기서도 바이트는 안 든다** — 파일명만 옮긴다(§정직한 목업, `Meeting.recordingFileName`
- *    주석과 같은 사정). 없는 회의를 조용히 넘기지 않고 값이 없으면 아무 일도 안 한다.
+ *    주석과 같은 사정). `.map()`으로 훑다가 `id`가 맞는 회의만 바꿔 끼운다 — 맞는 회의가
+ *    없으면 `store.meetings`는 그대로고, 던지거나 알리지도 않는다(호출부가 이미
+ *    `findMockMeeting`으로 존재를 확인하고 부른다는 전제).
  */
 export function setMockRecordingFileName(id: string, fileName: string): void {
   store.meetings = store.meetings.map((meeting) =>

--- a/src/features/meeting/mock/meetings.ts
+++ b/src/features/meeting/mock/meetings.ts
@@ -58,6 +58,11 @@ export function addMockMeeting(draft: MeetingDraft): Meeting {
  *    `date`·`startTime`이 없다) 방금 완료된 시각을 그대로 쓴다 — 예정·진행중을 거치지 않는다.
  * ⚠️ `roomId`·`roomName`·`roomReservationId`는 draft에서부터 이미 `null`이다(회의실이 없다) —
  *    여기서 다시 지우지 않는다.
+ * ⚠️ **분석 대기(`PENDING`)로 안 들어간다**(2026-08-14 팀 확정, 대면 회의의 `endMockMeeting`과
+ *    다른 점). 대면 회의는 종료와 동시에 서버가 분석을 큐에 걸지만, 비대면 회의는 만들자마자
+ *    끝나 있어 녹음 파일 자체가 없다 — 요약 요청은 다이얼로그 2단계([AI 요약 요청])에서
+ *    사람이 직접 눌러야 시작된다(`setMockSummaryStatus`가 그때 `PENDING`으로 옮긴다). 그래서
+ *    여기서는 `null`("아직 요청 안 함")로 둔다.
  */
 export function addMockOnlineMeeting(draft: MeetingDraft): Meeting {
   const now = new Date();
@@ -70,8 +75,8 @@ export function addMockOnlineMeeting(draft: MeetingDraft): Meeting {
     // 캡처를 거치지 않고 제출과 동시에 끝난다 — endMockMeeting을 따로 부르지 않는다.
     endedAt: now.toISOString(),
     canceledAt: null,
-    // 종료와 동시에 대기로 들어간다 — endMockMeeting과 같은 이유(§types).
-    aiSummaryStatus: AI_SUMMARY_STATUS.PENDING,
+    // 아직 요약을 요청하지 않았다 — 위 주석 참고.
+    aiSummaryStatus: null,
   };
   store.meetings = [...store.meetings, meeting];
   return meeting;
@@ -161,5 +166,16 @@ export function updateMockMeeting(id: string, patch: { title: string }): Meeting
 export function setMockSummaryStatus(id: string, status: AiSummaryStatus): void {
   store.meetings = store.meetings.map((meeting) =>
     meeting.id === id ? { ...meeting, aiSummaryStatus: status } : meeting,
+  );
+}
+
+/**
+ * 비대면 회의 다이얼로그 2단계([녹음 파일 제출])가 파일명을 적어 둔다(이슈 #473, 2026-08-14).
+ * ⚠️ **여기서도 바이트는 안 든다** — 파일명만 옮긴다(§정직한 목업, `Meeting.recordingFileName`
+ *    주석과 같은 사정). 없는 회의를 조용히 넘기지 않고 값이 없으면 아무 일도 안 한다.
+ */
+export function setMockRecordingFileName(id: string, fileName: string): void {
+  store.meetings = store.meetings.map((meeting) =>
+    meeting.id === id ? { ...meeting, recordingFileName: fileName } : meeting,
   );
 }

--- a/src/features/meeting/recording-file.ts
+++ b/src/features/meeting/recording-file.ts
@@ -1,0 +1,38 @@
+/**
+ * 비대면 회의 2단계(녹음 파일 제출)의 **1차 클라이언트 검증** — BE가 받는 형식·용량 제한을
+ * 그대로 화면에서도 미리 막는다(백엔드 담당자 확인, 2026-08-14). 서버가 최종 검증한다
+ * (§권한: 화면 검증은 UX일 뿐 보안이 아니다) — 여기는 사용자가 잘못된 파일을 골랐을 때
+ * 업로드를 기다리지 않고 바로 알려주는 자리일 뿐이다.
+ */
+
+export const RECORDING_FILE_ACCEPTED_EXTENSIONS = [
+  "wav",
+  "mp3",
+  "mp4",
+  "m4a",
+  "flac",
+  "ogg",
+  "webm",
+  "amr",
+] as const;
+
+/** 5GiB(2^30 바이트 기준) — 파일 하나당 상한(백엔드 담당자 확인). */
+export const RECORDING_FILE_MAX_BYTES = 5 * 1024 * 1024 * 1024;
+
+const ACCEPTED_EXTENSIONS_LABEL = RECORDING_FILE_ACCEPTED_EXTENSIONS.join(", ");
+
+function extensionOf(fileName: string): string {
+  const dotIndex = fileName.lastIndexOf(".");
+  return dotIndex === -1 ? "" : fileName.slice(dotIndex + 1).toLowerCase();
+}
+
+/** 통과하면 `null`, 막을 사유가 있으면 화면에 보여줄 문구를 돌려준다. */
+export function validateRecordingFile(file: File): string | null {
+  if (!RECORDING_FILE_ACCEPTED_EXTENSIONS.includes(extensionOf(file.name) as never)) {
+    return `지원하지 않는 형식입니다 (${ACCEPTED_EXTENSIONS_LABEL}만 가능)`;
+  }
+  if (file.size > RECORDING_FILE_MAX_BYTES) {
+    return "파일 용량이 5GiB를 넘었습니다";
+  }
+  return null;
+}

--- a/src/features/meeting/recording-file.ts
+++ b/src/features/meeting/recording-file.ts
@@ -5,7 +5,7 @@
  * 업로드를 기다리지 않고 바로 알려주는 자리일 뿐이다.
  */
 
-export const RECORDING_FILE_ACCEPTED_EXTENSIONS = [
+export const RECORDING_FILE_ACCEPTED_EXTENSIONS: readonly string[] = [
   "wav",
   "mp3",
   "mp4",
@@ -14,7 +14,7 @@ export const RECORDING_FILE_ACCEPTED_EXTENSIONS = [
   "ogg",
   "webm",
   "amr",
-] as const;
+];
 
 /** 5GiB(2^30 바이트 기준) — 파일 하나당 상한(백엔드 담당자 확인). */
 export const RECORDING_FILE_MAX_BYTES = 5 * 1024 * 1024 * 1024;
@@ -28,7 +28,7 @@ function extensionOf(fileName: string): string {
 
 /** 통과하면 `null`, 막을 사유가 있으면 화면에 보여줄 문구를 돌려준다. */
 export function validateRecordingFile(file: File): string | null {
-  if (!RECORDING_FILE_ACCEPTED_EXTENSIONS.includes(extensionOf(file.name) as never)) {
+  if (!RECORDING_FILE_ACCEPTED_EXTENSIONS.includes(extensionOf(file.name))) {
     return `지원하지 않는 형식입니다 (${ACCEPTED_EXTENSIONS_LABEL}만 가능)`;
   }
   if (file.size > RECORDING_FILE_MAX_BYTES) {

--- a/src/features/meeting/server.test.ts
+++ b/src/features/meeting/server.test.ts
@@ -126,15 +126,17 @@ describe("비대면 회의(이슈 #473) — isOnline·빈 schedule·roomName", (
     hostAuthority: AUTHORITY.OWNER,
   };
 
-  it("목록 카드는 isOnline을 세우고 schedule·roomName을 빈 문자열로 비운다", async () => {
-    addMockOnlineMeeting(ONLINE_DRAFT);
+  /*
+    ⚠️ 2026-08-14 팀 확정으로 실서버 목록·대시보드(MEET-02·03·17)가 비대면 회의를 서버에서부터
+       걸러 준다 — 목도 같은 동작을 미리 따라 한다(`server.ts`의 `getMeetingDirectory` 주석).
+  */
+  it("비대면 회의는 목록(호스트·초대 탭 모두)에 나오지 않는다", async () => {
+    const created = addMockOnlineMeeting(ONLINE_DRAFT);
 
     const directory = await getMeetingDirectory(OWNER.id);
-    const item = directory.hosted.find((row) => row.title === "비대면 회의 서버 테스트");
 
-    expect(item?.isOnline).toBe(true);
-    expect(item?.schedule).toBe("");
-    expect(item?.roomName).toBe("");
+    expect(directory.hosted.some((row) => row.id === created.id)).toBe(false);
+    expect(directory.invited.some((row) => row.id === created.id)).toBe(false);
   });
 
   it("상세도 isOnline을 세우고 schedule·roomName을 빈 문자열로 비운다", async () => {

--- a/src/features/meeting/server.test.ts
+++ b/src/features/meeting/server.test.ts
@@ -121,7 +121,9 @@ describe("비대면 회의(이슈 #473) — isOnline·빈 schedule·roomName", (
     projectId: 1,
     projectTag: "GOODS",
     topics: [{ main: "제품", sub: "점검" }],
-    attendeeIds: [OWNER.id],
+    // ⚠️ OTHER_LEADER를 진짜 참석자로 넣는다 — host(OWNER) 관점만으로는 "초대 탭"이 원래도
+    //    비어 있어 걸러지는지 확인이 안 된다(host는 애초에 자기 회의에 초대받지 않는다).
+    attendeeIds: [OWNER.id, OTHER_LEADER.id],
     hostId: OWNER.id,
     hostAuthority: AUTHORITY.OWNER,
   };
@@ -133,10 +135,13 @@ describe("비대면 회의(이슈 #473) — isOnline·빈 schedule·roomName", (
   it("비대면 회의는 목록(호스트·초대 탭 모두)에 나오지 않는다", async () => {
     const created = addMockOnlineMeeting(ONLINE_DRAFT);
 
-    const directory = await getMeetingDirectory(OWNER.id);
+    const hostDirectory = await getMeetingDirectory(OWNER.id);
+    expect(hostDirectory.hosted.some((row) => row.id === created.id)).toBe(false);
+    expect(hostDirectory.invited.some((row) => row.id === created.id)).toBe(false);
 
-    expect(directory.hosted.some((row) => row.id === created.id)).toBe(false);
-    expect(directory.invited.some((row) => row.id === created.id)).toBe(false);
+    // ⚠️ 진짜 초대받은 사람(host가 아닌 OTHER_LEADER) 기준으로도 «참여해야 할» 탭에 안 뜬다.
+    const attendeeDirectory = await getMeetingDirectory(OTHER_LEADER.id);
+    expect(attendeeDirectory.invited.some((row) => row.id === created.id)).toBe(false);
   });
 
   it("상세도 isOnline을 세우고 schedule·roomName을 빈 문자열로 비운다", async () => {

--- a/src/features/meeting/server.ts
+++ b/src/features/meeting/server.ts
@@ -96,14 +96,11 @@ function toListItem(meeting: Meeting, viewerId: number, now: Date): MeetingListI
     projectTag: meeting.projectTag,
     originLabel: originLabelOf(meeting),
     topicSummary: `${firstTopic.main} · ${firstTopic.sub}`,
-    // ⚠️ 비대면 회의는 회의실·시간이 없다(이슈 #473) — 카드는 `isOnline`을 보고 이 자리에
-    //    안내 한 줄을 그린다(`meeting-card.tsx`).
-    schedule: meeting.isOnline ? "" : formatMeetingSchedule(meeting.start, meeting.end),
+    schedule: formatMeetingSchedule(meeting.start, meeting.end),
     roomName: meeting.roomName ?? "",
     attendeeCount: meeting.attendeeIds.length,
     isHost: meeting.hostId === viewerId,
     aiSummaryStatus: meeting.aiSummaryStatus,
-    isOnline: meeting.isOnline,
   };
 }
 
@@ -112,14 +109,19 @@ function toListItem(meeting: Meeting, viewerId: number, now: Date): MeetingListI
  *
  * ⚠️ **목록은 전 구성원 공개**다(§3-2-1) — 여기서 권한으로 거르지 않는다. 막는 건 상세다.
  * ⚠️ 차례: 진행중 → 예정(가까운 순) → 완료(최근 순). 지금 다뤄야 하는 회의가 위로 온다.
+ * ⚠️ **비대면 회의(`isOnline`)는 목록에 아예 안 낸다**(2026-08-14 팀 확정 — 실서버 목록·대시보드
+ *    (MEET-02·03·17)가 서버에서부터 `isOnline=false`만 준다). 목이 실서버 동작을 미리 따라 하지
+ *    않으면 화면이 실서버로 넘어가는 날 갑자기 카드가 사라져 버그처럼 보인다 — 상세(`getMeetingDetail`)
+ *    는 여전히 `/app/meeting/:id` 직접 링크로 열린다(§Mock 격리막: 목록·상세는 다른 조회다).
  */
 export async function getMeetingDirectory(viewerId: number): Promise<MeetingDirectory> {
   if (!isMock) return getLiveMeetingDirectory();
 
   ensureMockMeetingsSeeded();
   const now = new Date();
-  const byId = new Map(listMockMeetings().map((meeting) => [meeting.id, meeting]));
-  const rows = listMockMeetings().map((meeting) => ({
+  const listableMeetings = listMockMeetings().filter((meeting) => !meeting.isOnline);
+  const byId = new Map(listableMeetings.map((meeting) => [meeting.id, meeting]));
+  const rows = listableMeetings.map((meeting) => ({
     item: toListItem(meeting, viewerId, now),
     startMs: meeting.start.getTime(),
   }));
@@ -273,6 +275,12 @@ export async function getMeetingDetail(id: string, viewer: Actor): Promise<Meeti
        시간·장소·참석자·안건은 이미 정해진 값이다 — 없는 건 회의가 남기는 것(기록·산출물)뿐이라
        그 두 칸만 안내로 채운다(§view-types `MeetingContentPending`).
     ⚠️ 순서가 있다. 회의가 안 끝났으면 요약은 시작조차 안 했으므로 회의 상태를 먼저 본다.
+    ⚠️ **비대면 회의는 완료 + `aiSummaryStatus: null`("아직 요청 안 함")로 며칠이고 남을 수 있다**
+       (2026-08-14 팀 확정 — [AI 요약 요청]을 안 누르면 계속 이 상태다). 아래 삼항이 그 조합을
+       `null`(=다 찼다)로 흘려보내는데, 산출물 칸은 `outputs`가 빈 배열이라 "0건"으로 자연히
+       읽혀 깨지진 않는다 — 다만 "아직 요청 안 함"과 "정말 하달할 게 없음"을 문구로는 못
+       가른다. 새 `MeetingContentPending` 값을 추가하는 건 이 이슈 범위 밖이라(화면 문구·
+       아이콘 맵까지 늘어난다) 지금은 이 fallthrough를 그대로 둔다.
   */
   const status = meetingStatusOf(meeting, new Date());
   const pendingReason: MeetingContentPending | null =

--- a/src/features/meeting/types.ts
+++ b/src/features/meeting/types.ts
@@ -130,8 +130,17 @@ export interface OnlineMeetingDraft {
   attendeeIds: number[];
   /** Host가 Leader/Member일 때만 필수 — `RoomReservationDraft`와 같은 규칙. */
   parentTeamActionId?: number;
-  /** 첨부한 녹음 파일 이름 — `Meeting.recordingFileName`과 같다(§정직한 목업). */
-  recordingFileName: string | null;
 }
 
 export type OnlineMeetingFormErrors = Partial<Record<keyof OnlineMeetingDraft, string>>;
+
+/**
+ * 비대면 회의 만들기 2단계 — 녹음 파일 제출 + AI 요약 요청(2026-08-14 팀 확정).
+ * ⚠️ 회의는 1단계에서 이미 만들어져 있다 — 이 드래프트는 그 회의에 파일명을 덧붙이고
+ *    분석을 대기 상태로 옮기는 별도의 가벼운 흐름이다(`Meeting.recordingFileName`과 같다,
+ *    §정직한 목업 — 바이트는 안 든다).
+ */
+export interface SubmitOnlineMeetingRecordingDraft {
+  meetingId: string;
+  recordingFileName: string;
+}

--- a/src/features/meeting/validate.test.ts
+++ b/src/features/meeting/validate.test.ts
@@ -10,7 +10,6 @@ const VALID_DRAFT = {
   projectId: "1",
   topics: [{ main: "제품", sub: "로드맵 검토" }],
   attendeeIds: [1],
-  recordingFileName: null,
 };
 
 describe("비대면 회의 만들기 검증", () => {

--- a/src/features/meeting/validate.ts
+++ b/src/features/meeting/validate.ts
@@ -22,7 +22,13 @@ export function validateOnlineMeetingDraft(
   if (!draft.title.trim()) errors.title = "회의 제목을 입력해 주세요";
 
   // ⚠️ 프로젝트는 항상 필수다(WORKFLOW.md §3-1 확정) — 프로젝트에 안 묶인 회의는 없다.
-  if (!draft.projectId.trim()) errors.projectId = "프로젝트를 선택해 주세요";
+  // ⚠️ **숫자여야 한다** — `toCreateOnlineMeetingPayload`가 `Number()`로 그대로 바꿔 보낸다.
+  //    여기서 막지 않으면 `"abc"` 같은 값이 `NaN`으로 바뀌어 그 사실을 모른 채 서버로 나간다.
+  if (!draft.projectId.trim()) {
+    errors.projectId = "프로젝트를 선택해 주세요";
+  } else if (!Number.isInteger(Number(draft.projectId))) {
+    errors.projectId = "프로젝트 값이 올바르지 않습니다";
+  }
 
   if (draft.topics.length === 0 || !draft.topics[0]?.main.trim() || !draft.topics[0]?.sub.trim()) {
     errors.topics = "회의 안건(대주제·소주제)을 한 쌍 이상 입력해 주세요";

--- a/src/features/meeting/view-types.ts
+++ b/src/features/meeting/view-types.ts
@@ -9,7 +9,12 @@ import type { AiSummaryStatus, MeetingStatus } from "@/constants/meeting";
  *    고쳐야 하기 때문이다(§Mock 격리막) — 옮기는 일은 `server.ts` 한 곳이 한다.
  */
 
-/** 목록 카드 한 장 */
+/**
+ * 목록 카드 한 장.
+ * ⚠️ **비대면 회의(`isOnline`)는 여기 안 온다**(2026-08-14 팀 확정 — 실서버 목록·대시보드가
+ *    서버에서부터 걸러 준다, `server.ts`의 `getMeetingDirectory` 주석). `isOnline` 필드가 없는
+ *    이유다 — 상세(`MeetingDetail`)는 직접 링크로 계속 열리므로 거기는 남겨 둔다.
+ */
 export interface MeetingListItem {
   id: string;
   title: string;
@@ -31,17 +36,10 @@ export interface MeetingListItem {
    * 실서버는 `agendaPreview`(BE PR #461)로 채운다 — 없으면(미배포·안건 0건) 빈 문자열이다.
    */
   topicSummary: string;
-  /**
-   * `7월 14일(화) 10:00 – 10:30` — 서버가 우리 표기로 만들어 보낸다(§lib).
-   * ⚠️ **비대면 회의(`isOnline`)는 빈 문자열이다** — 회의실·시간이 없다(이슈 #473). 컴포넌트는
-   *    `isOnline`을 먼저 보고, `true`면 이 값을 그대로 그리지 않는다.
-   */
+  /** `7월 14일(화) 10:00 – 10:30` — 서버가 우리 표기로 만들어 보낸다(§lib). */
   schedule: string;
-  /** ⚠️ 비대면 회의는 빈 문자열이다 — `schedule`과 같은 이유. */
   roomName: string;
   attendeeCount: number;
-  /** 비대면(원격) 회의인가(이슈 #473) — `schedule`·`roomName` 대신 안내 한 줄을 그린다. */
-  isOnline: boolean;
   /**
    * 보는 사람이 이 회의의 Host인가.
    *

--- a/src/features/notice/components/notice-form-dialog.tsx
+++ b/src/features/notice/components/notice-form-dialog.tsx
@@ -157,7 +157,7 @@ export function NoticeFormDialog({
         ⚠️ **뷰포트의 70%다**(2026-08-12 확정). 에디터가 서식 버튼·긴 글을 들고 있어 기존
            확인 창 폭(420)으로는 답답했다 — 넓은 화면일수록 창도 넓어져야 한다.
       */}
-      <DialogContent className="flex max-h-[calc(100dvh-4rem)] flex-col gap-0 p-0 sm:max-w-[70vw]">
+      <DialogContent className="flex max-h-[calc(100dvh-4rem)] flex-col gap-0 overflow-y-auto p-0 sm:max-w-[70vw]">
         <DialogHeader className="border-border shrink-0 border-b px-6 py-4">
           <DialogTitle>{formTitle}</DialogTitle>
         </DialogHeader>

--- a/src/features/rooms/components/room-reservation-dialog.tsx
+++ b/src/features/rooms/components/room-reservation-dialog.tsx
@@ -185,7 +185,7 @@ export function RoomReservationDialog({
         handleOpenChange(next);
       }}
     >
-      <DialogContent className="gap-0 p-0 sm:max-w-[720px]">
+      <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-[720px]">
         <DialogHeader className="border-border border-b px-6 py-4">
           <DialogTitle>회의실 예약</DialogTitle>
         </DialogHeader>

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -136,6 +136,12 @@ export const ep = {
    */
   meetings: (params?: MeetingListParams) => `/api/meetings${toQuery(params)}`,
   /**
+   * 비대면 회의 생성(`POST`, MEET-18, 이슈 #473) — **FE 제안 경로**, 아직 BE 실코드로 대조 전이다
+   *   (§연동 검증: 계약은 도메인 담당자 문서로 확정됐지만 컨트롤러는 못 봤다). 구현 착수 전 재대조할 것.
+   * ⚠️ `meetings()`(MEET-01)와 경로가 다르다 — 비대면 회의는 회의실·시간이 없어 별도 엔드포인트다.
+   */
+  meetingsOnline: () => "/api/meetings/online",
+  /**
    * 한 회의의 세 갈래가 **같은 경로**를 쓴다 — `GET` 상세(MEET-04, 캡처 진입도 이걸 쓴다) ·
    * `PATCH` 수정(MEET-05) · `DELETE` 취소(MEET-06). 없으면 404 `MT-001`, 열람 권한 없으면 403 `MT-011`.
    *


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- 비대면 회의 다이얼로그 2단계(녹음 파일 제출)의 닫기(X) 버튼이 모달 모서리 밖으로 걸쳐
  뜨던 문제 수정 — `DialogContent`의 기본 닫기 버튼(`p-4` 여백 전제)을 끄고
  (`showCloseButton={false}`), 헤더(`px-6 py-4`) 안에 직접 배치
- 녹음 파일 첨부에 형식(`wav/mp3/mp4/m4a/flac/ogg/webm/amr`)·용량(파일당 5GiB) 클라이언트
  1차 검증 추가 — 지원 형식 외 파일이나 초과 용량 파일은 첨부 즉시 거부하고 인라인 오류 표시,
  `<input accept>`로 OS 파일 피커도 같이 제한

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 해당 없음(UI 레이아웃·클라이언트 검증 변경, 권한 로직 변경 없음)
- [ ] 🧬 **zod** — 해당 없음(파일 검증은 확장자·크기 비교뿐, 스키마 대상 아님)
- [x] 🕵️ **정직성** — 이 검증은 "1차"일 뿐 최종 검증은 서버 몫이라고 주석에 명시
- [x] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [x] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로 — 닫기 버튼에 `sr-only` 라벨 유지
- [x] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인) — 기존 `DialogClose` 재사용
- [ ] 🧪 `loading` / `error` / `empty` 3상태 — 해당 없음(레이아웃·검증 보완)
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음 — 해당 없음

---

## 🔗 연관 이슈

Closes #483 

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

- 닫기 버튼을 `DialogContent`의 기본 절대 위치 버튼 대신 헤더 안에 직접 그리는 방식으로
  바꿨습니다 — 다른 `p-0` 다이얼로그(예: 회의실 예약)에도 같은 문제가 있을 수 있는데, 이번
  PR은 비대면 회의 다이얼로그만 수정했습니다(범위 밖)
- 파일 검증은 확장자 기반이라 MIME 스니핑은 하지 않습니다 — 1차 차단 목적에는 충분하다고
  판단했는데, 더 엄격한 검증이 필요하면 말씀해 주세요

---

## 📝 추가 메모

같은 `p-0` + 커스텀 헤더 패턴을 쓰는 다른 다이얼로그(`RoomReservationDialog` 등)도 같은
닫기 버튼 위치 문제가 있을 가능성이 있습니다 — 필요하면 별도 이슈로 빼겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 비대면 회의 생성이 실제 서비스와 연동됩니다.
  - 회의 생성 후 녹음 파일 제출 및 AI 요약 요청을 선택적으로 진행할 수 있습니다.
  - 녹음 파일 형식과 최대 5GiB 용량을 제출 전에 확인합니다.
  - 제출을 나중에 건너뛸 수 있으며, 처리 중에는 창이 닫히지 않습니다.
- **개선**
  - 회의 목록 카드에서 일정과 장소가 일관되게 표시됩니다.
- **버그 수정**
  - 팝업 내부 콘텐츠가 둥근 테두리 밖으로 표시되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->