### PR TITLE
[FEAT] 마이페이지 비밀번호 변경 API 연동  #485

### DIFF
--- a/src/app/(shell)/layout.tsx
+++ b/src/app/(shell)/layout.tsx
@@ -5,6 +5,8 @@ import { AnalysisProgressCard } from "@/features/notification/components/analysi
 import { NotificationBanner } from "@/features/notification/components/notification-banner";
 import { NotificationProvider } from "@/features/notification/notification-provider";
 import { guardWorkspaceEntry } from "@/features/onboarding/guard";
+import { PasswordChangeBanner } from "@/features/profile/components/password-change-banner";
+import { shouldShowPasswordChangeBanner } from "@/features/profile/server";
 import { RoleSidebar } from "@/features/shell/components/role-sidebar";
 import type { NavSection } from "@/features/shell/nav";
 import { dashboardFor, navFor } from "@/features/shell/nav-config";
@@ -59,9 +61,10 @@ export default async function ShellLayout({ children }: { children: ReactNode })
   */
   await guardWorkspaceEntry();
 
-  const [viewer, unreadNoticeCount] = await Promise.all([
+  const [viewer, unreadNoticeCount, showPasswordChangeBanner] = await Promise.all([
     getViewer(),
     getUnreadNoticeCount().catch(() => 0),
+    shouldShowPasswordChangeBanner(),
   ]);
   /*
     ⚠️ **역할이 목록을 정한다.** 전에는 `OWNER_NAV` 하나를 모두에게 줘서, 팀장·사원으로
@@ -99,6 +102,8 @@ export default async function ShellLayout({ children }: { children: ReactNode })
         <div className="bg-background flex min-w-0 flex-1 flex-col overflow-hidden">
           {/* 회의 개설·리마인더·취소·공지 — 본문 맨 위 줄로 들어간다(떠 있는 판이 아니다) */}
           <NotificationBanner />
+          {/* 발급받은 비밀번호 안내 — 강제 아님(`mustChangePassword` 아님), 닫으면 그만이다 */}
+          {showPasswordChangeBanner && <PasswordChangeBanner memberId={viewer.id} />}
           {children}
         </div>
         {/* 요약 진행 — 우하단 고정이라 어느 화면에 있든 같은 자리에 남는다 */}

--- a/src/features/auth/me.ts
+++ b/src/features/auth/me.ts
@@ -46,6 +46,7 @@ interface MyProfileResponse {
   workStatus: string;
   joinedOn: string | null;
   plan: string | null;
+  passwordChanged: boolean;
 }
 
 /** 화면이 보는 계약. BE 키 이름(`authority`·`roleName`)은 여기서 우리 말로 바뀐다. */
@@ -72,6 +73,8 @@ export interface Me {
   isOnboarded: boolean;
   joinedOn: string | null;
   plan: string | null;
+  /** `false`면 발급받은 비밀번호를 아직 쓰고 있다는 뜻 — 강제 변경은 아니다(`mustChangePassword`가 아니다). */
+  passwordChanged: boolean;
 }
 
 /**
@@ -134,5 +137,6 @@ function toMe(data: MyProfileResponse): Me {
     isOnboarded: data.isOnboarded,
     joinedOn: data.joinedOn,
     plan: data.plan,
+    passwordChanged: data.passwordChanged,
   };
 }

--- a/src/features/profile/actions.ts
+++ b/src/features/profile/actions.ts
@@ -1,0 +1,97 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+import { clearSession, requireAccessToken } from "@/features/auth/session";
+import { ApiError, serverApi, toUserMessage } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
+import { isMock } from "@/mocks/config";
+
+import { type ChangePasswordErrors, validateChangePassword } from "./password";
+
+/** 비밀번호 변경 폼 결과 — `useActionState`가 그대로 들고 있는 모양. */
+export interface ChangePasswordState {
+  errors: ChangePasswordErrors;
+  /** 칸에 못 매길 오류(현재 비번 틀림·과다 시도·통신 실패) */
+  error?: string;
+  /** 몇 번째 시도인가 — 다이얼로그가 입력칸의 `key`를 바꿔 되살리는 데 쓴다 */
+  attempt: number;
+}
+
+/**
+ * `PATCH /api/auth/me/password` 실패를 칸별 오류로 나눈다 — 마이페이지 담당자 문서(2026-08-14).
+ *
+ * ⚠️ **전부 400이다(429 제외).** "현재 비밀번호 틀림"(`AU-041`)도 400이라 401 인터셉터가
+ *    이걸 토큰 만료로 잡아 로그아웃시키지 않는다 — 그래서 이 액션은 상태 코드가 아니라
+ *    `errorCode`로만 가른다.
+ * ⚠️ `Z-001`(길이·조합·공백 위반)의 필드별 오류는 `details`에 실려 오지만, 그 봉투 모양이
+ *    아직 실코드로 확인되지 않았다(§연동 검증: Swagger·구두 추측 금지) — 여기서는 폼이 같은
+ *    규칙을 먼저 막아 두고(`changePasswordSchema`), 서버까지 뚫고 온 `Z-001`은 전체 오류
+ *    문구로만 보여준다.
+ */
+function toChangePasswordErrors(error: unknown): Pick<ChangePasswordState, "errors" | "error"> {
+  if (!(error instanceof ApiError)) return { errors: {}, error: toUserMessage(error) };
+
+  switch (error.code) {
+    case "AU-041":
+      return { errors: { currentPassword: error.message } };
+    case "AU-040":
+      return { errors: { newPasswordConfirm: error.message } };
+    case "AU-042":
+    case "AU-043":
+      return { errors: { newPassword: error.message } };
+    default:
+      return { errors: {}, error: error.message };
+  }
+}
+
+/**
+ * 비밀번호 변경(마이페이지) — 3칸 폼(현재·새·새 확인) 전용.
+ *
+ * ⚠️ **`memberId`는 안 보낸다.** 토큰에서 꺼내 쓰는 값이라 보내도 서버가 무시한다.
+ * ⚠️ **성공하면 모든 기기의 로그인이 풀린다**(BE가 전 세션을 폐기). 여기서 쿠키를 지우고
+ *    로그인 화면으로 보내지 않으면, 화면은 바뀐 비밀번호로 이미 로그아웃된 토큰을 들고
+ *    아무 요청에서나 401을 맞는다 — `logoutAction`과 같은 이유로 같은 자리에서 지운다.
+ */
+export async function changePasswordAction(
+  prevState: ChangePasswordState,
+  formData: FormData,
+): Promise<ChangePasswordState> {
+  const draft = {
+    currentPassword: String(formData.get("currentPassword") ?? ""),
+    newPassword: String(formData.get("newPassword") ?? ""),
+    newPasswordConfirm: String(formData.get("newPasswordConfirm") ?? ""),
+  };
+
+  const keep = (state: Omit<ChangePasswordState, "attempt">): ChangePasswordState => ({
+    ...state,
+    attempt: prevState.attempt + 1,
+  });
+
+  const errors = validateChangePassword(draft);
+  if (Object.keys(errors).length > 0) return keep({ errors });
+
+  if (isMock) {
+    // 목 모드에는 바꿀 서버가 없다 — 조용히 성공한 척하지 않는다(§정직성).
+    return keep({ errors: {}, error: "목 모드입니다. 실제 변경은 연동 후 동작합니다." });
+  }
+
+  const accessToken = await requireAccessToken();
+  try {
+    await serverApi<null>(ep.changePassword(), {
+      method: "PATCH",
+      accessToken,
+      json: {
+        currentPassword: draft.currentPassword,
+        newPassword: draft.newPassword,
+        newPasswordConfirm: draft.newPasswordConfirm,
+      },
+    });
+  } catch (error) {
+    return keep(toChangePasswordErrors(error));
+  }
+
+  await clearSession();
+  // ⚠️ `redirect`는 예외를 던진다 — try/catch 밖이다(§렌더링·데이터).
+  redirect("/login");
+}

--- a/src/features/profile/components/change-password-dialog.tsx
+++ b/src/features/profile/components/change-password-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useActionState, useEffect, useRef, useState } from "react";
+import { type FormEvent, useActionState, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -13,6 +13,14 @@ import { PASSWORD_POLICY_HINTS } from "../password";
 
 const INITIAL_STATE: ChangePasswordState = { errors: {}, attempt: 0 };
 
+interface PasswordDraft {
+  currentPassword: string;
+  newPassword: string;
+  newPasswordConfirm: string;
+}
+
+const EMPTY_DRAFT: PasswordDraft = { currentPassword: "", newPassword: "", newPasswordConfirm: "" };
+
 /**
  * 마이페이지 비밀번호 변경 — `PATCH /api/auth/me/password`(2026-08-14 담당자 문서).
  *
@@ -20,10 +28,16 @@ const INITIAL_STATE: ChangePasswordState = { errors: {}, attempt: 0 };
  *    있어 서버가 애초에 거절한다 — 현재 비밀번호 칸을 빼지 않는다.
  * ⚠️ 성공하면 액션이 스스로 `/login`으로 보낸다(모든 기기 로그아웃) — 여기서는 닫을 필요가
  *    없다. 실패만 이 다이얼로그에 남는다.
+ * ⚠️ **`<form action={...}>`을 안 쓴다.** 그 방식은 액션이 끝나면 폼을 통째로 리셋하는데,
+ *    실패해도 세 칸이 전부 비워져 처음부터 다시 적어야 했다 — 이 폼은 값을 직접 들고 있다가
+ *    (`draft`) 실패하면 그대로 두고, `formAction`은 버튼 클릭에서 손으로 부른다.
+ * ⚠️ **값을 들고 있어야 실시간 일치 판정도 된다.** 새 비밀번호·확인 두 칸을 다 아는 채로
+ *    타이핑마다 비교해야 제출 전에 알려줄 수 있다 — 서버 왕복 없이 그 자리에서 본다.
  */
 export function ChangePasswordDialog() {
   const [open, setOpen] = useState(false);
   const [state, formAction, isPending] = useActionState(changePasswordAction, INITIAL_STATE);
+  const [draft, setDraft] = useState<PasswordDraft>(EMPTY_DRAFT);
   const shownAttempt = useRef(0);
 
   useEffect(() => {
@@ -33,6 +47,22 @@ export function ChangePasswordDialog() {
       toast.error(state.error);
     }
   }, [state.attempt, state.error]);
+
+  /*
+    ⚠️ **확인칸이 비었으면 아무 말도 안 한다** — 아직 아무것도 안 적은 사람에게 "일치하지
+       않습니다"부터 보이면 오류로 시작하는 폼이 된다. 뭐라도 적은 뒤부터 그때그때 비교한다.
+  */
+  const confirmMatch =
+    draft.newPasswordConfirm.length === 0 ? null : draft.newPassword === draft.newPasswordConfirm;
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData();
+    formData.set("currentPassword", draft.currentPassword);
+    formData.set("newPassword", draft.newPassword);
+    formData.set("newPasswordConfirm", draft.newPasswordConfirm);
+    formAction(formData);
+  };
 
   return (
     <>
@@ -45,6 +75,8 @@ export function ChangePasswordDialog() {
         onOpenChange={(next) => {
           if (!next && isPending) return;
           setOpen(next);
+          // 창을 닫으면(취소 포함) 다음에 열 때는 빈 칸에서 시작한다.
+          if (!next) setDraft(EMPTY_DRAFT);
         }}
       >
         <DialogContent className="gap-0 p-0 sm:max-w-[420px]">
@@ -52,7 +84,7 @@ export function ChangePasswordDialog() {
             <DialogTitle>비밀번호 변경</DialogTitle>
           </DialogHeader>
 
-          <form action={formAction} key={state.attempt}>
+          <form onSubmit={handleSubmit}>
             <div className="flex flex-col gap-4 px-6 py-5">
               <div className="flex flex-col gap-2">
                 <Label htmlFor="current-password">현재 비밀번호</Label>
@@ -62,6 +94,10 @@ export function ChangePasswordDialog() {
                   type="password"
                   autoComplete="current-password"
                   required
+                  value={draft.currentPassword}
+                  onChange={(event) =>
+                    setDraft((prev) => ({ ...prev, currentPassword: event.target.value }))
+                  }
                   aria-describedby={
                     state.errors.currentPassword ? "current-password-error" : undefined
                   }
@@ -83,6 +119,10 @@ export function ChangePasswordDialog() {
                   autoComplete="new-password"
                   maxLength={16}
                   required
+                  value={draft.newPassword}
+                  onChange={(event) =>
+                    setDraft((prev) => ({ ...prev, newPassword: event.target.value }))
+                  }
                   aria-describedby="new-password-hints"
                   aria-invalid={state.errors.newPassword ? true : undefined}
                 />
@@ -107,18 +147,40 @@ export function ChangePasswordDialog() {
                   autoComplete="new-password"
                   maxLength={16}
                   required
-                  aria-describedby={
-                    state.errors.newPasswordConfirm ? "new-password-confirm-error" : undefined
+                  value={draft.newPasswordConfirm}
+                  onChange={(event) =>
+                    setDraft((prev) => ({ ...prev, newPasswordConfirm: event.target.value }))
                   }
-                  aria-invalid={state.errors.newPasswordConfirm ? true : undefined}
+                  aria-describedby="new-password-confirm-hint"
+                  aria-invalid={
+                    state.errors.newPasswordConfirm || confirmMatch === false ? true : undefined
+                  }
                 />
-                {state.errors.newPasswordConfirm && (
+                {/*
+                  ⚠️ **서버 오류가 우선이다.** 방금 제출해서 돌아온 문구가 있으면 그걸 보여주고,
+                     없으면 타이핑 중 실시간 판정을 보여준다 — 같은 뜻의 줄이 두 개 뜨지 않는다.
+                     (제출 전 클라이언트 검증이 같은 조건을 이미 막아서, 둘이 실제로 어긋날 일은 없다.)
+                */}
+                {state.errors.newPasswordConfirm ? (
                   <p
-                    id="new-password-confirm-error"
+                    id="new-password-confirm-hint"
                     className="text-destructive text-[12px] leading-4"
                   >
                     {state.errors.newPasswordConfirm}
                   </p>
+                ) : (
+                  confirmMatch !== null && (
+                    <p
+                      id="new-password-confirm-hint"
+                      className={
+                        confirmMatch
+                          ? "text-muted-foreground text-[12px] leading-4"
+                          : "text-destructive text-[12px] leading-4"
+                      }
+                    >
+                      {confirmMatch ? "비밀번호가 일치합니다" : "비밀번호가 일치하지 않습니다"}
+                    </p>
+                  )
                 )}
               </div>
             </div>

--- a/src/features/profile/components/change-password-dialog.tsx
+++ b/src/features/profile/components/change-password-dialog.tsx
@@ -40,6 +40,13 @@ export function ChangePasswordDialog() {
   const [draft, setDraft] = useState<PasswordDraft>(EMPTY_DRAFT);
   const shownAttempt = useRef(0);
 
+  // 닫는 경로(취소·ESC·바깥 클릭) 전부 여기로 모은다 — 한 곳만 고치면 전부 반영된다.
+  const handleClose = () => {
+    if (isPending) return;
+    setOpen(false);
+    setDraft(EMPTY_DRAFT);
+  };
+
   useEffect(() => {
     // 칸에 못 매는 오류만 토스트로 알린다 — 필드 오류는 칸 밑에 이미 보인다(§토스트).
     if (state.attempt !== shownAttempt.current && state.error) {
@@ -73,10 +80,11 @@ export function ChangePasswordDialog() {
       <Dialog
         open={open}
         onOpenChange={(next) => {
-          if (!next && isPending) return;
-          setOpen(next);
-          // 창을 닫으면(취소 포함) 다음에 열 때는 빈 칸에서 시작한다.
-          if (!next) setDraft(EMPTY_DRAFT);
+          if (next) {
+            setOpen(true);
+            return;
+          }
+          handleClose();
         }}
       >
         <DialogContent className="gap-0 p-0 sm:max-w-[420px]">
@@ -186,12 +194,7 @@ export function ChangePasswordDialog() {
             </div>
 
             <div className="border-border flex items-center justify-end gap-2 border-t px-6 py-4">
-              <Button
-                type="button"
-                variant="outline"
-                disabled={isPending}
-                onClick={() => setOpen(false)}
-              >
+              <Button type="button" variant="outline" disabled={isPending} onClick={handleClose}>
                 취소
               </Button>
               <Button type="submit" variant="ink" disabled={isPending}>

--- a/src/features/profile/components/change-password-dialog.tsx
+++ b/src/features/profile/components/change-password-dialog.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useActionState, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+import { changePasswordAction, type ChangePasswordState } from "../actions";
+import { PASSWORD_POLICY_HINTS } from "../password";
+
+const INITIAL_STATE: ChangePasswordState = { errors: {}, attempt: 0 };
+
+/**
+ * 마이페이지 비밀번호 변경 — `PATCH /api/auth/me/password`(2026-08-14 담당자 문서).
+ *
+ * ⚠️ **꼭 3칸이다.** "새 비밀번호 + 확인" 두 칸만 두면 토큰만 훔친 사람이 계정을 가져갈 수
+ *    있어 서버가 애초에 거절한다 — 현재 비밀번호 칸을 빼지 않는다.
+ * ⚠️ 성공하면 액션이 스스로 `/login`으로 보낸다(모든 기기 로그아웃) — 여기서는 닫을 필요가
+ *    없다. 실패만 이 다이얼로그에 남는다.
+ */
+export function ChangePasswordDialog() {
+  const [open, setOpen] = useState(false);
+  const [state, formAction, isPending] = useActionState(changePasswordAction, INITIAL_STATE);
+  const shownAttempt = useRef(0);
+
+  useEffect(() => {
+    // 칸에 못 매는 오류만 토스트로 알린다 — 필드 오류는 칸 밑에 이미 보인다(§토스트).
+    if (state.attempt !== shownAttempt.current && state.error) {
+      shownAttempt.current = state.attempt;
+      toast.error(state.error);
+    }
+  }, [state.attempt, state.error]);
+
+  return (
+    <>
+      <Button type="button" variant="outline" onClick={() => setOpen(true)}>
+        비밀번호 변경
+      </Button>
+
+      <Dialog
+        open={open}
+        onOpenChange={(next) => {
+          if (!next && isPending) return;
+          setOpen(next);
+        }}
+      >
+        <DialogContent className="gap-0 p-0 sm:max-w-[420px]">
+          <DialogHeader className="border-border border-b px-6 py-4">
+            <DialogTitle>비밀번호 변경</DialogTitle>
+          </DialogHeader>
+
+          <form action={formAction} key={state.attempt}>
+            <div className="flex flex-col gap-4 px-6 py-5">
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="current-password">현재 비밀번호</Label>
+                <Input
+                  id="current-password"
+                  name="currentPassword"
+                  type="password"
+                  autoComplete="current-password"
+                  required
+                  aria-describedby={
+                    state.errors.currentPassword ? "current-password-error" : undefined
+                  }
+                  aria-invalid={state.errors.currentPassword ? true : undefined}
+                />
+                {state.errors.currentPassword && (
+                  <p id="current-password-error" className="text-destructive text-[12px] leading-4">
+                    {state.errors.currentPassword}
+                  </p>
+                )}
+              </div>
+
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="new-password">새 비밀번호</Label>
+                <Input
+                  id="new-password"
+                  name="newPassword"
+                  type="password"
+                  autoComplete="new-password"
+                  maxLength={16}
+                  required
+                  aria-describedby="new-password-hints"
+                  aria-invalid={state.errors.newPassword ? true : undefined}
+                />
+                {state.errors.newPassword && (
+                  <p className="text-destructive text-[12px] leading-4">
+                    {state.errors.newPassword}
+                  </p>
+                )}
+                <ul id="new-password-hints" className="text-muted-foreground text-[12px] leading-4">
+                  {PASSWORD_POLICY_HINTS.map((hint) => (
+                    <li key={hint}>{hint}</li>
+                  ))}
+                </ul>
+              </div>
+
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="new-password-confirm">새 비밀번호 확인</Label>
+                <Input
+                  id="new-password-confirm"
+                  name="newPasswordConfirm"
+                  type="password"
+                  autoComplete="new-password"
+                  maxLength={16}
+                  required
+                  aria-describedby={
+                    state.errors.newPasswordConfirm ? "new-password-confirm-error" : undefined
+                  }
+                  aria-invalid={state.errors.newPasswordConfirm ? true : undefined}
+                />
+                {state.errors.newPasswordConfirm && (
+                  <p
+                    id="new-password-confirm-error"
+                    className="text-destructive text-[12px] leading-4"
+                  >
+                    {state.errors.newPasswordConfirm}
+                  </p>
+                )}
+              </div>
+            </div>
+
+            <div className="border-border flex items-center justify-end gap-2 border-t px-6 py-4">
+              <Button
+                type="button"
+                variant="outline"
+                disabled={isPending}
+                onClick={() => setOpen(false)}
+              >
+                취소
+              </Button>
+              <Button type="submit" variant="ink" disabled={isPending}>
+                {isPending ? "변경 중" : "변경"}
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/features/profile/components/password-change-banner.tsx
+++ b/src/features/profile/components/password-change-banner.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { Info, X } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+
+interface PasswordChangeBannerProps {
+  memberId: number;
+}
+
+function storageKey(memberId: number): string {
+  return `z_password_banner_dismissed_${memberId}`;
+}
+
+/**
+ * "발급받은 비밀번호를 아직 쓰고 있다" 안내 — `/me` 서버가 `passwordChanged: false`일 때만 그려진다.
+ *
+ * ⚠️ **강제가 아니다** — `mustChangePassword`가 아니라 안 바꿔도 서비스 이용에 제약이 없다
+ *    (마이페이지 담당자 문서, 2026-08-14). 그래서 변경 화면으로 막지 않고 닫기만 한다.
+ * ⚠️ **닫은 기록은 이 브라우저에만 남는다**(`localStorage`, `NotificationBanner`와 달리 서버가
+ *    아니라 여기서 "본 적 있다"를 기억해야 한다). 서버는 실제로 비밀번호를 바꾸기 전까지
+ *    계속 `false`를 주므로, 안 남기면 화면을 옮길 때마다 다시 뜬다.
+ * ⚠️ **하이드레이션 전에는 안 그린다.** 서버는 이 값을 모르는 채로 첫 HTML을 만드는데, 거기서
+ *    바로 그리면 저장소에 이미 닫은 기록이 있는 사람에게도 한 프레임 깜빡인다.
+ */
+export function PasswordChangeBanner({ memberId }: PasswordChangeBannerProps) {
+  const [dismissed, setDismissed] = useState(true);
+
+  useEffect(() => {
+    // ⚠️ 마이크로태스크로 미룬다 — 효과 본문에서 곧바로 `setState`하면 렌더가 겹쳐 돈다
+    //    (`scale-store.ts`의 `subscribeScale`과 같은 자리).
+    queueMicrotask(() => {
+      try {
+        setDismissed(localStorage.getItem(storageKey(memberId)) === "1");
+      } catch {
+        // 저장소가 막혀 있으면(사생활 모드 등) 이번 방문에서는 보여준다
+        setDismissed(false);
+      }
+    });
+  }, [memberId]);
+
+  if (dismissed) return null;
+
+  return (
+    // ⚠️ 바깥 여백(`px-8 pt-4`)까지 여기서 진다 — `NotificationBanner`와 같은 자리(본문 맨 위 줄)에
+    //    나란히 서므로, 셸이 아니라 이 배너 자체가 자기 자리를 잡는다.
+    <div role="status" className="flex shrink-0 flex-col px-8 pt-4">
+      <div className="border-border bg-secondary animate-in fade-in slide-in-from-top-1 flex items-start gap-2 rounded-lg border px-3.5 py-3 text-[12px] leading-[18px] duration-150">
+        <span className="flex h-[18px] shrink-0 items-center">
+          <Info className="text-muted-foreground size-3.5" aria-hidden />
+        </span>
+
+        <span className="min-w-0 flex-1 break-keep">
+          지금 쓰는 비밀번호는 발급받은 비밀번호예요. 마이페이지에서 직접 정한 비밀번호로 바꿔
+          주세요.
+        </span>
+
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          aria-label="안내 닫기"
+          className="text-muted-foreground -my-0.5 shrink-0"
+          onClick={() => {
+            try {
+              localStorage.setItem(storageKey(memberId), "1");
+            } catch {
+              // 저장이 안 되면 이번 새로고침 전까지만 닫힌 채로 남는다
+            }
+            setDismissed(true);
+          }}
+        >
+          <X aria-hidden />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/profile/components/profile-header.tsx
+++ b/src/features/profile/components/profile-header.tsx
@@ -1,8 +1,12 @@
+"use client";
+
 import { AUTHORITY_BADGE_CLASS, AUTHORITY_LABEL } from "@/constants/authority";
 import { LogoutButton } from "@/features/auth/components/logout-button";
+import { useProfileAvatar } from "@/hooks/use-profile-avatar";
 import { cn } from "@/lib/utils";
 
 import type { MyProfile } from "../types";
+import { ChangePasswordDialog } from "./change-password-dialog";
 
 interface ProfileHeaderProps {
   profile: MyProfile;
@@ -14,13 +18,16 @@ interface ProfileHeaderProps {
  * ⚠️ **카드 안으로 들어왔다**(2026-08-11). 전에는 카드 밖 한 줄로 떠 있어서, 폭을 넓히자
  *    이름과 [로그아웃] 사이가 1400px씩 벌어진 빈 띠가 됐다 — 같은 사람을 말하는 값이라
  *    한 카드에 담고, 아래 값들과 선 하나로 나눈다.
+ * ⚠️ **아바타는 이름 첫 글자가 아니라 `useProfileAvatar`가 그린다**(2026-08-14) — 목록·참석자
+ *    칸의 아바타와 같은 훅이라, 이 화면에서만 다른 그림(글자)이 뜨는 일이 없다. 색을 정하는
+ *    키도 그 훅과 같은 규칙으로 `profile.id`뿐이다(이름이 같아도 색이 갈리지 않는다).
  */
 export function ProfileHeader({ profile }: ProfileHeaderProps) {
+  const avatar = useProfileAvatar(profile.id, 56);
+
   return (
     <div className="flex items-center gap-3.5 px-7 py-6">
-      <div className="bg-foreground text-background flex size-14 shrink-0 items-center justify-center rounded-full text-[22px] font-medium">
-        {profile.name.charAt(0)}
-      </div>
+      {avatar}
 
       <div className="flex min-w-0 flex-1 flex-col gap-1">
         <p className="text-[17px] leading-[26px] font-semibold">{profile.name}</p>
@@ -45,7 +52,10 @@ export function ProfileHeader({ profile }: ProfileHeaderProps) {
         ⚠️ **나갈 문은 여기 하나뿐이다.** 사이드바 계정 줄(49px)에 끼우면 이름이 밀려 잘리고,
            로그아웃은 하루에 한 번 쓰는 일이라 늘 보이는 자리를 차지할 만큼 잦지 않다.
       */}
-      <LogoutButton />
+      <div className="flex shrink-0 items-center gap-2">
+        <ChangePasswordDialog />
+        <LogoutButton />
+      </div>
     </div>
   );
 }

--- a/src/features/profile/mock/profile.ts
+++ b/src/features/profile/mock/profile.ts
@@ -4,6 +4,9 @@ import type { MyProfile } from "../types";
 
 /** ⚠️ 목 데이터 — BE 연동 전. `getViewer()`(셸)와 별개로, 마이페이지 표시용 필드만 담는다. */
 export const MY_PROFILE_MOCK: MyProfile = {
+  // ⚠️ `getMockActor().id`(1)와 맞춘다 — 다른 목 화면(회의 참석자 등)에 이 사람이 같은 id로
+  //    등장할 때 아바타 색이 갈리지 않는다(`useProfileAvatar`는 id만 본다).
+  id: 1,
   name: "김서준",
   email: "seojun@techstart.kr",
   role: AUTHORITY.OWNER,

--- a/src/features/profile/password.test.ts
+++ b/src/features/profile/password.test.ts
@@ -1,0 +1,65 @@
+import { type ChangePasswordDraft, validateChangePassword } from "./password";
+
+const FILLED: ChangePasswordDraft = {
+  currentPassword: "oldPass1!",
+  newPassword: "newPass1!",
+  newPasswordConfirm: "newPass1!",
+};
+
+describe("validateChangePassword", () => {
+  it("다 채우고 정책을 지키면 오류가 없다", () => {
+    expect(validateChangePassword(FILLED)).toEqual({});
+  });
+
+  it("현재 비밀번호가 비면 잡아낸다", () => {
+    expect(validateChangePassword({ ...FILLED, currentPassword: "" }).currentPassword).toBe(
+      "현재 비밀번호를 입력해 주세요",
+    );
+  });
+
+  it("길이가 8자 미만이면 잡아낸다", () => {
+    expect(
+      validateChangePassword({ ...FILLED, newPassword: "ab1!", newPasswordConfirm: "ab1!" })
+        .newPassword,
+    ).toBe("비밀번호는 8~16자이며 영문, 숫자, 특수문자를 모두 포함해야 합니다");
+  });
+
+  it("길이가 16자를 넘으면 잡아낸다", () => {
+    const tooLong = "aB1!aB1!aB1!aB1!a";
+    expect(
+      validateChangePassword({ ...FILLED, newPassword: tooLong, newPasswordConfirm: tooLong })
+        .newPassword,
+    ).toBe("비밀번호는 8~16자이며 영문, 숫자, 특수문자를 모두 포함해야 합니다");
+  });
+
+  it("특수문자가 없으면 잡아낸다", () => {
+    expect(
+      validateChangePassword({ ...FILLED, newPassword: "abcd1234", newPasswordConfirm: "abcd1234" })
+        .newPassword,
+    ).toBe("비밀번호는 8~16자이며 영문, 숫자, 특수문자를 모두 포함해야 합니다");
+  });
+
+  it("공백이 있으면 잡아낸다", () => {
+    const withSpace = "ab 1234!";
+    expect(
+      validateChangePassword({ ...FILLED, newPassword: withSpace, newPasswordConfirm: withSpace })
+        .newPassword,
+    ).toBe("비밀번호는 8~16자이며 영문, 숫자, 특수문자를 모두 포함해야 합니다");
+  });
+
+  it("대문자·소문자를 가리지 않는다", () => {
+    expect(
+      validateChangePassword({
+        ...FILLED,
+        newPassword: "abcd1234!",
+        newPasswordConfirm: "abcd1234!",
+      }).newPassword,
+    ).toBeUndefined();
+  });
+
+  it("새 비밀번호와 확인이 다르면 확인 칸에 오류를 매긴다", () => {
+    const errors = validateChangePassword({ ...FILLED, newPasswordConfirm: "different1!" });
+    expect(errors.newPasswordConfirm).toBe("새 비밀번호가 일치하지 않습니다");
+    expect(errors.newPassword).toBeUndefined();
+  });
+});

--- a/src/features/profile/password.ts
+++ b/src/features/profile/password.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+
+/**
+ * 비밀번호 변경 폼의 **모양**과 검증 — 마이페이지 담당자 문서(2026-08-14)로 확인한 정책.
+ *
+ * ⚠️ **재사용 금지(이전 비밀번호)는 여기서 못 본다.** 서버만 아는 값이라 `AU-042`·`AU-043`으로
+ *    돌아오면 그 응답을 그대로 화면에 옮긴다(`actions.ts`) — 여기 스키마는 모양(길이·조합·공백)만 본다.
+ */
+const PASSWORD_PATTERN = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z0-9])[!-~]{8,16}$/;
+
+/** 입력칸 아래 안내 문구 — 정책이 바뀌면 여기만 고친다(라벨 하드코딩 금지와 같은 이유). */
+export const PASSWORD_POLICY_HINTS = [
+  "비밀번호는 8자 이상 16자 이하로 입력해 주세요.",
+  "영문, 숫자, 특수문자를 모두 포함해 주세요.",
+  "공백은 사용할 수 없어요.",
+  "이전에 사용한 비밀번호는 다시 사용할 수 없어요.",
+] as const;
+
+export const changePasswordSchema = z
+  .object({
+    currentPassword: z.string().min(1, "현재 비밀번호를 입력해 주세요"),
+    newPassword: z
+      .string()
+      .regex(PASSWORD_PATTERN, "비밀번호는 8~16자이며 영문, 숫자, 특수문자를 모두 포함해야 합니다"),
+    newPasswordConfirm: z.string().min(1, "새 비밀번호 확인을 입력해 주세요"),
+  })
+  .refine((draft) => draft.newPassword === draft.newPasswordConfirm, {
+    message: "새 비밀번호가 일치하지 않습니다",
+    path: ["newPasswordConfirm"],
+  });
+
+export type ChangePasswordDraft = z.infer<typeof changePasswordSchema>;
+export type ChangePasswordErrors = Partial<Record<keyof ChangePasswordDraft, string>>;
+
+/**
+ * 화면이 쓰는 모양(칸별 오류 한 줄)으로 옮긴다 — `credentials.ts`(로그인)와 같은 자리.
+ * ⚠️ 한 칸에 오류가 여러 개 나와도 **첫 줄만** 쓴다.
+ */
+export function validateChangePassword(input: ChangePasswordDraft): ChangePasswordErrors {
+  const result = changePasswordSchema.safeParse(input);
+  if (result.success) return {};
+
+  const errors: ChangePasswordErrors = {};
+  for (const issue of result.error.issues) {
+    const field = issue.path[0] as keyof ChangePasswordDraft | undefined;
+    if (field && errors[field] === undefined) errors[field] = issue.message;
+  }
+  return errors;
+}

--- a/src/features/profile/server.ts
+++ b/src/features/profile/server.ts
@@ -7,6 +7,20 @@ import { MY_PROFILE_MOCK } from "./mock/profile";
 import type { MyProfile } from "./types";
 
 /**
+ * "발급받은 비밀번호를 아직 쓰는가" — 로그인 뒤 배너(`PasswordChangeBanner`)를 띄울지 판정.
+ *
+ * ⚠️ 목에는 이 값을 낼 세션이 없다(`getMe()`가 늘 `null`) — **꺼진 채로 데모한다**(정직한
+ *    목업: 되는 척 안 한다). 배너 자체를 보려면 실연동 모드에서 `passwordChanged: false`인
+ *    계정으로 확인한다.
+ */
+export async function shouldShowPasswordChangeBanner(): Promise<boolean> {
+  if (isMock) return false;
+
+  const me = await getMe();
+  return me !== null && !me.passwordChanged;
+}
+
+/**
  * 마이페이지 기본 정보 — 격리막(CLAUDE.md).
  *
  * ⚠️ **부트스트랩(`GET /api/auth/me`)을 다시 쓴다.** 같은 값을 주는 경로가 하나뿐이라
@@ -21,6 +35,7 @@ export async function getMyProfile(): Promise<MyProfile> {
   if (!me) throw new Error("로그인이 필요합니다.");
 
   return {
+    id: me.id,
     name: me.name,
     email: me.email,
     role: me.authority,

--- a/src/features/profile/types.ts
+++ b/src/features/profile/types.ts
@@ -6,6 +6,8 @@ import type { Authority } from "@/constants/authority";
  *    편집·연차 등은 명세가 없어 만들지 않는다(§명세에 없는 화면·기능은 안 만든다).
  */
 export interface MyProfile {
+  /** 아바타 색을 정하는 키(`useProfileAvatar`) — 이름·부서와 달리 안 바뀐다. */
+  id: number;
   name: string;
   email: string;
   role: Authority;

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -113,6 +113,12 @@ export const ep = {
   refresh: () => "/api/auth/refresh",
   logout: () => "/api/auth/logout",
   me: () => "/api/auth/me",
+  /**
+   * 비밀번호 변경 — 마이페이지 담당자 문서(2026-08-14)로 확인. `memberId`는 토큰에서 꺼내므로
+   * 보내지 않는다. 성공하면 BE가 전 기기 로그인을 해제한다 — 호출부가 세션을 지우고
+   * 로그인 화면으로 보낸다(§연동 검증).
+   */
+  changePassword: () => "/api/auth/me/password",
 
   /* 기업 — [확인] identity/company/presentation/api/CompanyController.java */
   companyLookup: () => "/api/companies/lookup",


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

- `PATCH /api/auth/me/password` 연동 — 마이페이지에 "비밀번호 변경" 다이얼로그(3칸: 현재·새·새 확인) 추가
- 에러 코드(`AU-040`~`043`, `Z-001`, `AU-007` 429)를 칸별/전체 오류로 분기, 성공 시 세션을 지우고 `/login`으로 이동(전 기기 로그아웃에 맞춤)
- `Me`에 `passwordChanged` 필드를 추가하고, 로그인 뒤 셸 전체에 발급 비밀번호 안내 배너(닫으면 그만, 강제 아님)를 붙임

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/profile-change-password#{이슈번호}` 꼴, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [ ] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 이 기능엔 역할·소유권 축이 없음(본인 인증만). `memberId`는 토큰에서 꺼내고 요청값은 서버가 무시 — 서버가 최종 판단.
- [x] 🧬 **zod** — `changePasswordSchema`에서 `ChangePasswordDraft` 타입을 `z.infer`로 파생, `validateChangePassword`가 `safeParse`
- [x] 🕵️ **정직성** — 목 모드는 "목 모드입니다" 안내만 뜨고 실제 변경 안 함(주석·화면 둘 다 명시), Z-001 필드 상세는 봉투 미확인이라 전체 오류로만 처리한다고 주석 남김
- [x] 🎨 디자인 토�큰 사용 (생 hex 없음, 기존 `NotificationBanner`와 같은 토큰·구조 재사용)

**품질**

- [x] ⚡ 최적화 — 다이얼로그·배너 모두 상호작용 잎사귀만 `use client`, 나머지는 서버 컴포넌트/액션
- [x] ♿ a11y — `Label htmlFor`, 필드별 `aria-describedby`/`aria-invalid`, 닫기 버튼 `aria-label`
- [x] ♻️ 재사용 확인 — `components/ui`(Dialog·Input·Label·Button) 우선 사용, 배너는 `NotificationBanner` 구조 재사용
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 폼 pending(제출 중 잠금) · 필드별/전체 오류 · (목록이 아니라 폼이라 empty 해당 없음)
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음 (해당 없음)

---

## 🔗 연관 이슈

Closes #485

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- `AU-041`(현재 비밀번호 틀림)이 400으로 오는 걸 전제로, 401 인터셉터가 안 타는지 확인 부탁드립니다.
- 배너 닫힘을 `localStorage`(계정 id 키)로만 기억하는데, 서버 값(`passwordChanged`)이 아니라 브라우저 기억이라 다른 기기·시크릿 모드에서는 다시 뜹니다 — 의도한 동작인지 한 번 봐 주세요.
- `Z-001`의 `details`(필드별 오류) 파싱은 봉투 모양이 아직 실코드로 안 맞춰져서 안 했습니다 — 필요하면 다음 라운드에 붙이겠습니다.

---

## 📝 추가 메모

없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 프로필에서 현재 비밀번호와 새 비밀번호를 입력해 비밀번호를 변경할 수 있습니다.
  * 비밀번호 정책 안내와 입력값별 오류 메시지를 제공합니다.
  * 비밀번호를 변경하지 않은 경우 안내 배너가 표시되며, 닫은 배너는 다시 표시되지 않습니다.
  * 프로필 헤더에서 실제 사용자 아바타와 비밀번호 변경 메뉴를 확인할 수 있습니다.
  * 변경 완료 후 보안을 위해 로그인 화면으로 이동합니다.

* **테스트**
  * 비밀번호 필수 조건, 형식, 일치 여부 및 오류 표시를 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->