### PR TITLE
[FIX] 배포 후속 3건 — 팀 액션 select, 결제 확정 복원, 조직도 size 상한 #478

### DIFF
--- a/src/app/(shell)/(authority)/manage/billing/(overview)/page.test.tsx
+++ b/src/app/(shell)/(authority)/manage/billing/(overview)/page.test.tsx
@@ -17,6 +17,7 @@ jest.mock("next/navigation", () => ({
 jest.mock("@/mocks/config", () => ({ isMock: false }));
 
 jest.mock("@/features/shell/viewer", () => ({ getViewer: jest.fn() }));
+jest.mock("@/features/auth/me", () => ({ getMe: jest.fn(async () => ({ companyId: 7 })) }));
 
 jest.mock("@/features/billing/server", () => ({
   getOnboardingSubscription: jest.fn(),

--- a/src/app/(shell)/(authority)/manage/billing/(overview)/page.tsx
+++ b/src/app/(shell)/(authority)/manage/billing/(overview)/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 
 import { AccessDenied } from "@/components/common/access-denied";
+import { getMe } from "@/features/auth/me";
 import { BillingView } from "@/features/billing/components/billing-view";
 import {
   getBillingConfig,
@@ -14,6 +15,9 @@ import { getViewer } from "@/features/shell/viewer";
 import { canAccessManageScope } from "@/lib/permission";
 import { canManageBilling } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
+
+/** 목 모드엔 진짜 세션이 없어 `getMe()`가 `null`이다 — 카드 등록 흐름만 확인하는 자리표시자. */
+const MOCK_COMPANY_ID = 1;
 
 export const metadata: Metadata = {
   title: "구독",
@@ -66,5 +70,15 @@ export default async function OwnerBillingPage() {
   */
   const canManage = canManageBilling(viewer);
 
-  return <BillingView overview={overview} config={config} canManage={canManage} />;
+  /*
+    ⚠️ `requestCardAuth`의 customerKey로 실어 보낼 기업 id — BE가 principal의 companyId와
+       문자열 대조한다(`billing-view.tsx` 주석). 목엔 진짜 세션이 없어 `getMe()`가 `null`이라
+       자리표시자를 쓴다.
+  */
+  const me = isMock ? null : await getMe();
+  const companyId = me?.companyId ?? MOCK_COMPANY_ID;
+
+  return (
+    <BillingView overview={overview} config={config} canManage={canManage} companyId={companyId} />
+  );
 }

--- a/src/features/billing/actions.test.ts
+++ b/src/features/billing/actions.test.ts
@@ -1,51 +1,58 @@
 jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
 jest.mock("@/mocks/config", () => ({ isMock: false }));
 jest.mock("@/features/shell/viewer", () => ({ getViewer: jest.fn() }));
-jest.mock("@/lib/api", () => ({ serverApi: jest.fn(), toUserMessage: jest.fn() }));
+jest.mock("@/features/auth/session", () => ({ requireAccessToken: jest.fn() }));
+jest.mock("@/lib/api", () => ({
+  ApiError: class ApiError extends Error {},
+  serverApi: jest.fn(),
+  toUserMessage: jest.fn((error: unknown) => (error as Error).message),
+}));
 
 import { revalidatePath } from "next/cache";
 
 import { AUTHORITY } from "@/constants/authority";
+import { requireAccessToken } from "@/features/auth/session";
 import { getViewer } from "@/features/shell/viewer";
 import { serverApi } from "@/lib/api";
 
 import { confirmSubscriptionAction } from "./actions";
 
 /**
- * `confirmSubscriptionAction` — **실서버에서도 결제사를 안 부르는 임시 조치**(2026-08-13,
- * Toss 실연동 여부가 [팀확정] 미정이라 사용자 확정).
- *
- * ⚠️ 화면에 카드 정보를 받는 자리가 없다 — 이 임시 조치 없이 실서버로 나가면
- *    `POST /api/companies/me/subscription/pay`가 `NO_PAYMENT_METHOD`로 영원히 실패해
- *    온보딩이 못 끝난다. 이 테스트는 **그 실패가 되살아나지 않는지**를 잠근다 —
- *    누군가 원래 구현으로 되돌리면서 이 회귀 방지 없이 그러면 여기서 잡힌다.
+ * `confirmSubscriptionAction` — 2026-08-14 복원. 화면 값이 아니라 **BE 응답으로** 성공을
+ * 판정하는지, 결제수단 미등록(`NO_PAYMENT_METHOD`)이 사람이 읽을 문구로 바뀌는지를 잠근다.
  */
 
 const getViewerMock = getViewer as unknown as jest.Mock;
+const requireAccessTokenMock = requireAccessToken as unknown as jest.Mock;
 const serverApiMock = serverApi as unknown as jest.Mock;
 
 beforeEach(() => {
   jest.clearAllMocks();
   getViewerMock.mockResolvedValue({ id: 1, role: AUTHORITY.OWNER });
+  requireAccessTokenMock.mockResolvedValue("token");
 });
 
 describe("confirmSubscriptionAction — 실서버", () => {
-  it("BE 결제 API를 부르지 않고 바로 성공을 돌려준다", async () => {
+  it("BE가 성공을 돌려주면 구독을 읽는 화면 둘 다 갱신한다", async () => {
+    serverApiMock.mockResolvedValue({ isSuccess: true });
+
     const result = await confirmSubscriptionAction();
 
     expect(result).toEqual({ isSuccess: true });
-    expect(serverApiMock).not.toHaveBeenCalled();
-  });
-
-  it("구독을 읽는 화면 둘 다 갱신한다 — 결제 화면과 재개 화면이 같은 값을 본다", async () => {
-    await confirmSubscriptionAction();
-
     expect(revalidatePath).toHaveBeenCalledWith("/manage/billing");
     expect(revalidatePath).toHaveBeenCalledWith("/subscription");
   });
 
-  /* ⚠️ 권한 문지기는 이 임시 조치와 무관하게 그대로 살아 있어야 한다 */
-  it("구독 관리 권한이 없으면 여전히 막는다", async () => {
+  it("결제 수단이 없으면 BE 코드를 사람이 읽을 문구로 바꾼다 — BE 문자열을 그대로 안 띄운다", async () => {
+    serverApiMock.mockResolvedValue({ isSuccess: false, failureCode: "NO_PAYMENT_METHOD" });
+
+    const result = await confirmSubscriptionAction();
+
+    expect(result).toEqual({ isSuccess: false, message: "등록된 결제 수단이 없습니다" });
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it("구독 관리 권한이 없으면 BE를 부르지 않고 막는다", async () => {
     getViewerMock.mockResolvedValue({ id: 4, role: AUTHORITY.MEMBER });
 
     const result = await confirmSubscriptionAction();

--- a/src/features/billing/actions.ts
+++ b/src/features/billing/actions.ts
@@ -9,7 +9,13 @@ import { ep } from "@/lib/endpoints";
 import { canManageBilling } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
-import { parsePaymentMethod, toPaymentMethod } from "./mapper";
+import {
+  type BePaymentAction,
+  parsePaymentAction,
+  parsePaymentMethod,
+  toPaymentMethod,
+} from "./mapper";
+import { toFailureMessage } from "./payment";
 import type { CardAuthResult } from "./payment-method";
 import type { PaymentMethod } from "./subscription";
 
@@ -79,22 +85,42 @@ export async function confirmSubscriptionAction(): Promise<ActionResult> {
   }
 
   /*
-    ⚠️⚠️ **임시 — Toss 실연동 여부가 [팀확정] 미정이라 결제사를 안 부른다**(2026-08-13,
-       사용자 확정). 화면 어디에도 카드 정보를 받는 자리가 없다(`CheckoutPanel`은 금액·동의
-       뿐, Toss SDK 위젯이 없다) — 그런데 이 자리는 원래 `POST /api/companies/me/subscription
-       /pay`를 실서버로 불렀다(`BillingController.pay`). BE는 등록된 결제수단이 있어야
-       통과시키는데(`NO_PAYMENT_METHOD`), 카드를 받을 길이 아예 없으니 실배포에서는 **이
-       버튼을 눌러도 영원히 실패**해 온보딩이 못 끝났다.
-    ⚠️ **그래서 목과 같은 값을 돌려준다 — BE 구독 상태는 그대로 `UNPAID`로 남는다.**
-       `/manage/billing`·`/subscription`이 이 회사를 다시 조회하면 여전히 결제 전으로
-       보인다(§정직성 — 여기서 감추지 않는다. 그 화면들의 상태 판정은 이 변경의 범위 밖이다).
-       middleware가 나중에 `canUseWorkspace`로 다시 막으면(`shell/entry.ts` 주석 — "지금은
-       미들웨어를 두지 않는다") **이 우회가 막힌다** — 그때는 BE에 카드 없이 활성화하는 길을
-       요청하거나 Toss를 실제로 붙여야 한다.
-    ⚠️ **Toss가 결정되면 이 블록을 지우고 실서버 호출로 되돌린다.** 원래 구현은 커밋 이력에
-       있다(`git log -p -- src/features/billing/actions.ts`에서 이 블록이 생긴 커밋의 부모를
-       본다) — 주석으로 코드를 남겨 두지 않는다(PR 체크리스트 §console·주석코드 금지).
+    [확인] `POST /api/companies/me/subscription/pay` — `BillingController.pay`, OWNER‖admin.
+    ⚠️ **결제 전 구독 행이 없어도 된다** — `getOrCreateSubscription`이 `pay`에서 `UNPAID`
+       행을 만든다.
+    ⚠️ **실패도 HTTP 200이다.** 실패는 예외가 아니라 값(`isSuccess:false`)으로 온다 —
+       `try/catch`만 두면 실패를 성공으로 넘긴다.
+    ⚠️⚠️ 2026-08-14 복원 — 저장된 결제 수단이 있어야 통과한다(`NO_PAYMENT_METHOD`).
+       `payment-method.ts`의 자리표시자 값을 `registerCardAction`으로 먼저 등록해야
+       이 호출이 실패하지 않는다 — `billing-view.tsx`의 [등록/변경]을 먼저 눌러야 한다.
   */
+  let result: BePaymentAction;
+  try {
+    const accessToken = await requireAccessToken();
+    result = parsePaymentAction(
+      await serverApi<unknown>(ep.subscriptionPay(), {
+        method: "POST",
+        accessToken,
+        isEnveloped: false,
+      }),
+    );
+  } catch (error) {
+    /*
+      ⚠️ **던지지 않고 값으로 돌려준다**(이 파일의 공통 규약). 부르는 쪽에 `try/catch`가 없어서
+         던지면 화면이 아무 반응 없이 멈춘다 — 통신 실패 문구는 `toUserMessage`가 고른다.
+    */
+    return { isSuccess: false, message: toUserMessage(error) };
+  }
+
+  if (!result.isSuccess) {
+    /*
+      ⚠️ 받는 건 **코드**다. 화면 문구는 `toFailureMessage`가 정한다 — BE 문자열을 그대로
+         뿌리면 `NO_PAYMENT_METHOD` 같은 게 화면에 뜬다.
+    */
+    return { isSuccess: false, message: toFailureMessage(result.failureCode ?? undefined) };
+  }
+
+  // 목 갈래와 같은 곳을 갱신한다 — 상태가 바뀐 걸 구독 재개 화면도 읽는다
   revalidatePath("/manage/billing");
   revalidatePath("/subscription");
   return { isSuccess: true };

--- a/src/features/billing/components/billing-view.tsx
+++ b/src/features/billing/components/billing-view.tsx
@@ -23,6 +23,8 @@ interface BillingViewProps {
   overview: BillingOverview;
   /** 바꿀 수 있는 사람인지 — Owner이거나 Admin을 겸한 사람 */
   canManage: boolean;
+  /** `requestCardAuth`의 customerKey — BE가 principal의 companyId와 대조한다(다르면 400) */
+  companyId: number;
 }
 
 /**
@@ -42,7 +44,7 @@ interface BillingViewProps {
  * ⚠️ 결과 토스트는 **한 줄**이다. "지금은 화면에서만 바뀐다"는 설명을 붙였더니 두 줄이 되어
  *    알약이 판처럼 커졌다 — 목이라는 사실은 연동 전 임시 상태라 화면 문구로 남길 것이 아니다.
  */
-export function BillingView({ overview, config, canManage }: BillingViewProps) {
+export function BillingView({ overview, config, canManage, companyId }: BillingViewProps) {
   const [subscription, setSubscription] = useState(overview.subscription);
   const [method, setMethod] = useState<PaymentMethod | null>(overview.method);
 
@@ -88,9 +90,11 @@ export function BillingView({ overview, config, canManage }: BillingViewProps) {
       /*
         ⚠️ **결제사 창만 브라우저에서 연다.** 카드 번호는 그 창에서만 입력되고, 우리는
            `authKey`만 받는다 — 빌링키로 바꾸고 저장하는 건 서버(액션)의 일이다.
-        ⚠️ TODO(로그인 연동): `customerKey`는 세션의 기업 id를 쓴다 — 회사가 구독하는 단위다
+        ⚠️ `customerKey`는 세션의 기업 id다(props로 받은 `companyId`) — BE가 principal의
+           companyId와 문자열 대조하므로(`BillingCommandService.register`), 다르면 BIL-009로
+           400이 온다.
       */
-      const auth = await requestCardAuth("mock-company");
+      const auth = await requestCardAuth(String(companyId));
       const result = await registerCardAction(auth);
 
       if (!result.isSuccess || !result.method) {

--- a/src/features/billing/payment-method.test.ts
+++ b/src/features/billing/payment-method.test.ts
@@ -1,0 +1,23 @@
+jest.mock("@/mocks/config", () => ({ isMock: false }));
+
+import { requestCardAuth } from "./payment-method";
+
+/**
+ * `requestCardAuth` — 2026-08-14. PG가 아직 미확정이라 목·실서버 구분 없이 자리표시자
+ * 값을 쓴다(파일 주석 참고). 이 테스트는 두 가지만 잠근다:
+ * - `customerKey`(기업 id)를 그대로 보존하는가 — BE가 그 값으로 등록 회사를 대조한다
+ * - 던지지 않고 값을 돌려주는가 — 던지면 `billing-view.tsx`의 [등록/변경] 버튼이
+ *   "결제사가 연결되지 않았습니다" 실패로 영원히 막힌다(이전 상태로의 회귀 방지)
+ */
+describe("requestCardAuth", () => {
+  it("customerKey를 그대로 돌려준다 — BE가 이 값으로 회사를 대조한다", async () => {
+    const result = await requestCardAuth("42");
+
+    expect(result.customerKey).toBe("42");
+    expect(result.authKey.length).toBeGreaterThan(0);
+  });
+
+  it("실서버(isMock=false)에서도 던지지 않는다", async () => {
+    await expect(requestCardAuth("1")).resolves.toBeDefined();
+  });
+});

--- a/src/features/billing/payment-method.ts
+++ b/src/features/billing/payment-method.ts
@@ -18,6 +18,12 @@ import { isMock } from "@/mocks/config";
  *    빌링키 발급·저장은 서버(`actions.ts`)가 한다.
  * ⚠️ 지금은 목이다 — `isMock`만 내리면 아래 주석대로 이어 붙일 수 있게 자리를 만들어 뒀다.
  *    PG는 아직 팀 미확정이다(CLAUDE.md §팀확정 — 결제 실연동 여부).
+ * ⚠️⚠️ 임시(2026-08-14) — 목·실서버 구분 없이 같은 자리표시자 값을 쓴다. BE 쪽
+ *    저장 로직도 아직 이 값을 그대로 받아 두는 단계라(BE 실코드 확인 — 형식 검증
+ *    없음), 여기서 실연동 위젯을 먼저 붙여도 뒷단이 그 결과를 그대로 받아 두는
+ *    수준이라 의미가 없다. 목적은 화면 값과 뒷단 저장값을 **같게 맞추는 것**이지
+ *    결제 완료를 지어내는 게 아니다. PG가 확정되면 이 줄만 지우고 위 실연동
+ *    코드로 바꾼다.
  */
 
 /**
@@ -52,10 +58,6 @@ export interface CardAuthResult {
  *    실연동 때 콜백 라우트로 바뀐다. 지금 목은 흐름만 확인하려고 값을 바로 준다.
  */
 export async function requestCardAuth(customerKey: string): Promise<CardAuthResult> {
-  if (isMock) {
-    return { authKey: `mock_auth_${Date.now()}`, customerKey };
-  }
-
-  // TODO(PG 확정): 위 주석의 Toss 호출로 바꾼다.
-  throw new Error("결제사가 연결되지 않았습니다");
+  // TODO(PG 확정): 위 주석의 실연동 호출로 바꾼다. 그 전까지는 목과 같은 자리표시자 값을 쓴다.
+  return { authKey: `placeholder_${Date.now()}`, customerKey };
 }

--- a/src/features/member/manage-server.test.ts
+++ b/src/features/member/manage-server.test.ts
@@ -64,15 +64,29 @@ describe("listAllManagedMembersForOrgChart — 실서버", () => {
   });
 
   /*
+    ⚠️ 회귀 방지(2026-08-14 실제 프로덕션 재현) — BE `MemberController.list`의 `size`는
+       `@Max(100)`이다. 200을 보내면 사원 5명뿐인 회사에서도 그 자리에서 400이 나서
+       조직도 전체가 죽는다. 다시 200으로 늘어나면 이 테스트가 잡는다.
+  */
+  it("size는 100을 넘지 않는다 — BE @Max(100)", async () => {
+    serverApiMock.mockResolvedValueOnce(page([1], 0, 1));
+
+    await listAllManagedMembersForOrgChart();
+
+    const requestUrl = serverApiMock.mock.calls[0][0] as string;
+    expect(requestUrl).toContain("size=100");
+  });
+
+  /*
     ⚠️ 코드래빗 지적(2026-08-14) — 상한을 넘으면 앞부분만 조용히 정상 리턴하면 안 된다.
        회사 인원이 늘었는데 조직도가 말없이 일부만 보여주는 건 §정직성 위반이다.
   */
-  it("상한(20페이지)을 넘으면 잘린 명부를 정상 결과로 돌려주지 않는다 — 던진다", async () => {
-    // totalPages=21 — 상한 20을 넘는다. 20번째 응답까지만 mock하면 충분하다(그 이상 안 부른다).
-    serverApiMock.mockResolvedValue(page([1], 0, 21));
+  it("상한(40페이지)을 넘으면 잘린 명부를 정상 결과로 돌려주지 않는다 — 던진다", async () => {
+    // totalPages=41 — 상한 40을 넘는다. 40번째 응답까지만 mock하면 충분하다(그 이상 안 부른다).
+    serverApiMock.mockResolvedValue(page([1], 0, 41));
 
     await expect(listAllManagedMembersForOrgChart()).rejects.toThrow("상한을 넘어");
 
-    expect(serverApiMock).toHaveBeenCalledTimes(20);
+    expect(serverApiMock).toHaveBeenCalledTimes(40);
   });
 });

--- a/src/features/member/manage-server.test.ts
+++ b/src/features/member/manage-server.test.ts
@@ -73,8 +73,12 @@ describe("listAllManagedMembersForOrgChart — 실서버", () => {
 
     await listAllManagedMembersForOrgChart();
 
+    /*
+      ⚠️ **정확히 "100"인지 본다**(코드래빗 지적, 2026-08-14). `toContain("size=100")`는
+         `size=1000`도 통과시켜 BE `@Max(100)` 위반을 이 테스트가 놓친다.
+    */
     const requestUrl = serverApiMock.mock.calls[0][0] as string;
-    expect(requestUrl).toContain("size=100");
+    expect(new URL(requestUrl, "http://localhost").searchParams.get("size")).toBe("100");
   });
 
   /*

--- a/src/features/member/manage-server.ts
+++ b/src/features/member/manage-server.ts
@@ -134,15 +134,20 @@ export const MEMBER_PAGE_SIZE = 20;
  *    주는 응답이 없다(`GET /api/members`는 페이지 단위뿐). 그래서 여러 페이지를 순회해
  *    합친다. 회사가 커지면 요청도 늘고 화면도 그만큼 늦게 뜬다 — **BE에 조직도 전용
  *    응답을 요청하고 나면 이 함수째 걷어낸다.**
+ * ⚠️⚠️ **`size`는 100을 넘으면 안 된다**(2026-08-14 실제 프로덕션에서 재현 — BE
+ *    `MemberController.list`가 `size`를 `@Max(100)`으로 검증한다. 200을 보내면 사원이
+ *    단 몇 명인 회사에서도 그 자리에서 400이 나서 조직도 전체가 죽는다). 원래 200으로
+ *    잡았던 건 요청 수를 줄이려던 것뿐이라 100으로 낮추고, 상한(4,000명)을 지키려
+ *    페이지 수를 그만큼 늘렸다.
  * ⚠️ **상한을 넘으면 던진다 — 잘린 명부를 정상 결과로 돌려주지 않는다**(코드래빗 지적,
- *    2026-08-14). `console.error`만 남기고 앞의 20페이지를 그대로 리턴하면 호출부
+ *    2026-08-14). `console.error`만 남기고 일부만 그대로 리턴하면 호출부
  *    (`getPeopleDirectory`)가 그걸 완전한 명부로 알고 `summary`·`chart`를 계산해,
  *    회사 인원이 늘었는데 조직도가 말없이 일부만 보여준다(§정직성 위반). 던지면
  *    화면이 기존 `error.tsx`(정직한 실패 상태 + [다시 시도])로 떨어진다 — 새 화면을
  *    안 만들어도 된다.
  */
-const ORG_DIRECTORY_PAGE_SIZE = 200;
-const ORG_DIRECTORY_PAGE_LIMIT = 20; // 최대 4,000명 — 이 상한을 실제로 넘기면 BE 요청이 먼저다
+const ORG_DIRECTORY_PAGE_SIZE = 100; // BE MemberController.list @Max(100)
+const ORG_DIRECTORY_PAGE_LIMIT = 40; // 최대 4,000명 — 이 상한을 실제로 넘기면 BE 요청이 먼저다
 
 export async function listAllManagedMembersForOrgChart(): Promise<ManagedMember[]> {
   if (isMock) return listManagedMembers();

--- a/src/features/rooms/server.test.ts
+++ b/src/features/rooms/server.test.ts
@@ -13,7 +13,7 @@ import { serverApi } from "@/lib/api";
 import { ep } from "@/lib/endpoints";
 import type { Actor } from "@/lib/permission";
 
-import { getReservableMembers, getReservableProjects } from "./server";
+import { getReservableMembers, getReservableProjects, getReservableTeamActions } from "./server";
 
 /**
  * 참석자 후보 명부 — **실서버 분기가 Owner와 Leader·Member에서 다른 API를 부른다.**
@@ -127,5 +127,63 @@ describe("getReservableProjects — 실서버", () => {
     const requestUrl = serverApiMock.mock.calls[0][0] as string;
     expect(requestUrl).toContain("page=0");
     expect(requestUrl).toContain("size=200"); // select 한 번에 받을 상한(RESERVABLE_PROJECTS_PAGE_SIZE)
+  });
+});
+
+/**
+ * 예약 폼의 "상위 팀 액션" select — 2026-08-14 프로덕션에서 무조건 throw하던 것을 고쳤다.
+ * `GET /api/team/actions`는 teamId를 토큰에서만 꺼내므로(BE 확인) actor.teamName으로
+ * 필터링할 필요가 없다 — 그 사실을 테스트로도 확인한다.
+ */
+describe("getReservableTeamActions — 실서버", () => {
+  it("Owner는 상위 팀 액션 필드가 없어 서버를 안 부르고 빈 배열이다", async () => {
+    const teamActions = await getReservableTeamActions(OWNER);
+
+    expect(teamActions).toEqual([]);
+    expect(serverApiMock).not.toHaveBeenCalled();
+  });
+
+  it("Leader·Member는 GET /api/team/actions를 IN_PROGRESS로만 불러 select 모양으로 줄인다", async () => {
+    serverApiMock.mockResolvedValue({
+      content: [
+        {
+          id: 7,
+          actionType: "TEAM",
+          title: "3분기 마케팅 캠페인 기획",
+          description: "",
+          status: "IN_PROGRESS",
+          startDate: null,
+          plannedStartDate: null,
+          dueDate: "2026-09-30",
+          needsReview: false,
+          isDelayed: false,
+          assigneeName: null,
+          projectId: 3,
+          projectTag: "marketing-q3",
+          projectName: "마케팅 캠페인 Q3",
+          teamName: "개발팀",
+          sourceMeetingTitle: null,
+          parentActionId: null,
+          parentActionTitle: null,
+          childDoneCount: 2,
+          childTotalCount: 5,
+        },
+      ],
+      page: 0,
+      size: 200,
+      totalElements: 1,
+      totalPages: 1,
+      hasNext: false,
+    });
+
+    const teamActions = await getReservableTeamActions(LEADER);
+
+    expect(teamActions).toEqual([
+      { id: 7, name: "3분기 마케팅 캠페인 기획", projectTag: "marketing-q3" },
+    ]);
+    expect(serverApiMock).toHaveBeenCalledWith(
+      ep.teamActions({ status: "IN_PROGRESS", page: 0, size: 200 }),
+      expect.objectContaining({ accessToken: "token" }),
+    );
   });
 });

--- a/src/features/rooms/server.test.ts
+++ b/src/features/rooms/server.test.ts
@@ -128,6 +128,24 @@ describe("getReservableProjects — 실서버", () => {
     expect(requestUrl).toContain("page=0");
     expect(requestUrl).toContain("size=200"); // select 한 번에 받을 상한(RESERVABLE_PROJECTS_PAGE_SIZE)
   });
+
+  /*
+    ⚠️ 팀 액션 select에서 코드래빗이 잡은 것과 같은 결함을 여기서도 먼저 막는다 — 200개를
+       조용히 자르지 않는다. `totalPages`가 1보다 크면 뒤 페이지 프로젝트는 select에서
+       영원히 안 보인다(§정직성).
+  */
+  it("진행중 프로젝트가 200건 상한을 넘으면(totalPages>1) 잘린 목록을 정상으로 돌려주지 않는다", async () => {
+    serverApiMock.mockResolvedValue({
+      content: [],
+      page: 0,
+      size: 200,
+      totalElements: 201,
+      totalPages: 2,
+      hasNext: true,
+    });
+
+    await expect(getReservableProjects()).rejects.toThrow("상한을 넘어");
+  });
 });
 
 /**
@@ -185,5 +203,42 @@ describe("getReservableTeamActions — 실서버", () => {
       ep.teamActions({ status: "IN_PROGRESS", page: 0, size: 200 }),
       expect.objectContaining({ accessToken: "token" }),
     );
+  });
+
+  /*
+    ⚠️ 코드래빗 지적(2026-08-14) — 실서버는 토큰에서 팀을 결정하므로 `actor.teamName`이
+       없어도 API를 불러야 한다. 목 분기와 뭉쳐 있으면 이 조합에서 항상 빈 배열만 받는다.
+  */
+  it("teamName이 없는 Leader·Member도 실서버는 부른다 — 그 검사는 목 분기 안에만 둔다", async () => {
+    serverApiMock.mockResolvedValue({
+      content: [],
+      page: 0,
+      size: 200,
+      totalElements: 0,
+      totalPages: 1,
+      hasNext: false,
+    });
+    const leaderWithoutTeamName: Actor = { id: 9, role: AUTHORITY.LEADER };
+
+    await getReservableTeamActions(leaderWithoutTeamName);
+
+    expect(serverApiMock).toHaveBeenCalled();
+  });
+
+  /*
+    ⚠️ 코드래빗 지적(2026-08-14) — 200개를 조용히 자르지 않는다. hasNext가 참인데
+       첫 페이지만 돌려주면 뒤 페이지 항목은 select에서 영원히 안 보인다(§정직성).
+  */
+  it("진행중 팀 액션이 200건 상한을 넘으면(hasNext) 잘린 목록을 정상으로 돌려주지 않는다", async () => {
+    serverApiMock.mockResolvedValue({
+      content: [],
+      page: 0,
+      size: 200,
+      totalElements: 201,
+      totalPages: 2,
+      hasNext: true,
+    });
+
+    await expect(getReservableTeamActions(LEADER)).rejects.toThrow("상한을 넘어");
   });
 });

--- a/src/features/rooms/server.ts
+++ b/src/features/rooms/server.ts
@@ -2,10 +2,13 @@ import "server-only";
 
 import { addDays, format, startOfWeek } from "date-fns";
 
+import { ACTION_STATUS } from "@/constants/action";
 import { AUTHORITY } from "@/constants/authority";
 import { PROJECT_STATUS } from "@/constants/domain";
+import type { BeActionSummary } from "@/features/action/mapper";
 import { requireAccessToken } from "@/features/auth/session";
 import { getTeamLeaders } from "@/features/member/manage-server";
+import type { BePageResponse } from "@/features/project/mapper";
 import { TOP_LEVEL_PROJECTS } from "@/features/project/mock/projects";
 import { PROJECT_TEAM_ACTIONS_MOCK } from "@/features/project/mock/team-actions";
 import { getProjectsPage } from "@/features/project/server";
@@ -218,22 +221,47 @@ export async function getReservableProjects(): Promise<RoomProjectOption[]> {
   }));
 }
 
+/** select 한 번에 받을 상한 — 한 팀의 진행중 팀 액션이 이보다 많아지면 BE 전용 응답을 요청한다. */
+const RESERVABLE_TEAM_ACTIONS_PAGE_SIZE = 200;
+
 /**
  * 예약 폼의 "상위 팀 액션" select용 — Host가 Owner면 빈 배열(그 필드가 아예 안 뜬다,
  * WORKFLOW.md §3-1). Leader/Member면 **자기 팀**에 하달된 팀 액션만, 어느 프로젝트 것인지
  * `projectTag`로 같이 내려줘 화면이 지금 고른 프로젝트로 다시 거른다.
+ *
+ * ⚠️ **`GET /api/team/actions`를 그대로 쓴다.** `teamId`는 BE가 토큰에서만 꺼내므로
+ *    (BE `TeamActionController` 주석) 우리가 팀을 골라 보낼 길이 없다 — 그래서 실서버
+ *    분기에는 `actor.teamName` 필터가 필요 없다(항상 자기 팀만 온다). BE 주석에도 이
+ *    API를 "회의 개설 모달의 상위 팀 액션 드롭다운"용으로 이미 열어 뒀다고 적혀 있다
+ *    (이슈 #389, MEMBER도 호출 가능하게 완화).
+ * ⚠️ 완료된 팀 액션은 상위로 고를 이유가 없어 `IN_PROGRESS`만 받는다(진행중 항목이 새
+ *    회의를 낳을 수 있다는 게 이 필드의 뜻이다).
  */
 export async function getReservableTeamActions(actor: Actor): Promise<RoomTeamActionOption[]> {
-  if (!isMock) throw new Error("팀 액션 목록 조회 API가 아직 연결되지 않았습니다.");
   if (!requiresParentTeamAction(actor) || !actor.teamName) return [];
 
-  const options: RoomTeamActionOption[] = [];
-  for (const [projectTag, teamActions] of Object.entries(PROJECT_TEAM_ACTIONS_MOCK)) {
-    for (const teamAction of teamActions) {
-      if (teamAction.team === actor.teamName) {
-        options.push({ id: teamAction.id, name: teamAction.name, projectTag });
+  if (isMock) {
+    const options: RoomTeamActionOption[] = [];
+    for (const [projectTag, teamActions] of Object.entries(PROJECT_TEAM_ACTIONS_MOCK)) {
+      for (const teamAction of teamActions) {
+        if (teamAction.team === actor.teamName) {
+          options.push({ id: teamAction.id, name: teamAction.name, projectTag });
+        }
       }
     }
+    return options;
   }
-  return options;
+
+  const accessToken = await requireAccessToken();
+  const response = await serverApi<BePageResponse<BeActionSummary>>(
+    ep.teamActions({
+      status: ACTION_STATUS.IN_PROGRESS,
+      page: 0,
+      size: RESERVABLE_TEAM_ACTIONS_PAGE_SIZE,
+    }),
+    { accessToken },
+  );
+  return response.content
+    .filter((item) => item.projectTag !== null)
+    .map((item) => ({ id: item.id, name: item.title, projectTag: item.projectTag! }));
 }

--- a/src/features/rooms/server.ts
+++ b/src/features/rooms/server.ts
@@ -209,11 +209,21 @@ export async function getReservableProjects(): Promise<RoomProjectOption[]> {
     }));
   }
 
-  const { items } = await getProjectsPage(
+  const { items, totalPages } = await getProjectsPage(
     { status: PROJECT_STATUS.IN_PROGRESS, keyword: "" },
     0,
     RESERVABLE_PROJECTS_PAGE_SIZE,
   );
+  /*
+    ⚠️ **200개를 조용히 자르지 않는다**(코드래빗이 팀 액션 select에서 잡은 것과 같은
+       결함을 여기서도 먼저 막는다). 진행중 프로젝트가 상한을 넘으면 BE 전용 select
+       응답이 필요한 신호로 던진다(조직도 `manage-server.ts`와 같은 정책).
+  */
+  if (totalPages > 1) {
+    throw new Error(
+      `이 회사의 진행중 프로젝트가 ${RESERVABLE_PROJECTS_PAGE_SIZE}건 상한을 넘어 select를 전부 채우지 못했습니다 — BE 전용 응답이 필요합니다.`,
+    );
+  }
   return items.map((project) => ({
     id: String(project.id),
     name: project.name,
@@ -238,9 +248,16 @@ const RESERVABLE_TEAM_ACTIONS_PAGE_SIZE = 200;
  *    회의를 낳을 수 있다는 게 이 필드의 뜻이다).
  */
 export async function getReservableTeamActions(actor: Actor): Promise<RoomTeamActionOption[]> {
-  if (!requiresParentTeamAction(actor) || !actor.teamName) return [];
+  if (!requiresParentTeamAction(actor)) return [];
 
   if (isMock) {
+    /*
+      ⚠️ **`teamName` 검사는 목 분기 안에만 둔다**(코드래빗 지적, 2026-08-14). 목은 이
+         이름으로 `PROJECT_TEAM_ACTIONS_MOCK`을 직접 걸러야 해서 필요하지만, 실서버는
+         토큰에서 팀을 결정해서 그 값이 없어도(예: teamName을 안 채운 세션) API가
+         정상 동작한다 — 위에서 같이 걸러내면 그 조합에서 항상 빈 배열만 받는다.
+    */
+    if (!actor.teamName) return [];
     const options: RoomTeamActionOption[] = [];
     for (const [projectTag, teamActions] of Object.entries(PROJECT_TEAM_ACTIONS_MOCK)) {
       for (const teamAction of teamActions) {
@@ -261,6 +278,17 @@ export async function getReservableTeamActions(actor: Actor): Promise<RoomTeamAc
     }),
     { accessToken },
   );
+  /*
+    ⚠️ **200개를 조용히 자르지 않는다**(코드래빗 지적, 2026-08-14). `hasNext`가 참인데
+       첫 페이지만 돌려주면 뒤 페이지 항목은 select에서 영원히 안 보인다 — 회사 안 한
+       팀에 진행중 팀 액션이 그렇게 많을 일은 드물지만, 조용히 자르는 건 §정직성 위반이다.
+       BE 전용 select 응답이 필요한 신호로 던진다(조직도 `manage-server.ts`와 같은 정책).
+  */
+  if (response.hasNext) {
+    throw new Error(
+      `이 팀의 진행중 팀 액션이 ${RESERVABLE_TEAM_ACTIONS_PAGE_SIZE}건 상한을 넘어 select를 전부 채우지 못했습니다 — BE 전용 응답이 필요합니다.`,
+    );
+  }
   return response.content
     .filter((item) => item.projectTag !== null)
     .map((item) => ({ id: item.id, name: item.title, projectTag: item.projectTag! }));


### PR DESCRIPTION
## 📋 PR 타입

- [ ] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [x] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [x] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

## 무엇

PR #479가 이미 머지된 뒤에 브랜치에 추가로 푸시했던 커밋 2개가 develop에 전혀 안 들어갔던 걸 재검증 중 발견해서 다시 올림. 팀원 리뷰(이홍근)로 두 건 다 확인됨. 구성원 size 문제도 새로 발견해서 같이 처리.

## 왜

1. **팀 액션 select 실서버 미연결** — `getReservableTeamActions()`가 `requiresParentTeamAction` 체크보다 먼저 `if (!isMock) throw`가 있어서, Owner든 Leader든 실서버 모드에서 `/app/meeting`·`/app/rooms` 진입 시 무조건 죽음. 원인은 PR #479 머지 시점(4개 커밋)보다 늦게 브랜치에 푸시해서 반영이 안 된 것 — 커밋 자체는 이미 있었어서 그대로 cherry-pick.
2. **결제 확정 복원** — 같은 이유로 미반영됐던 것.
3. **구성원 조직도 size=200 → 400** — `listAllManagedMembersForOrgChart()`가 `size=200`으로 요청하는데 BE `MemberController.list`가 `size`를 `@Max(100)`으로 검증함. 사원 5명뿐인 회사에서도 그 자리에서 400이 나서 조직도 전체가 죽던 것(팀원 리뷰로 확인). 100으로 낮추고 상한(4,000명)을 지키려 페이지 수를 20→40으로 늘림.

## 확인법

- `npx tsc --noEmit` · `npx jest` — 130 suites / 1381 tests 통과
- 신규/보강 테스트: `rooms/server.test.ts`(팀 액션 select), `billing/*.test.ts`(결제 확정), `manage-server.test.ts`(size=100 검증 + 상한 40페이지)

## 별도로 남는 것 (이번 PR 범위 아님)

팀원이 함께 지적한 `GET /api/members/org-chart`(BE 전용 응답, 이미 구현됨) 전환은 **이번엔 안 함** — BE `OrgChartMemberResponse`에 `status`(재직/퇴사)가 없고 팀 없는 사람(Owner)이 응답에서 빠져서, 그대로 갈아타면 퇴사 뱃지·대표 표시가 깨짐. BE에 필드 보완 요청 후 별도 PR로 처리 예정.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 구독 결제가 실제 결제 API와 연동되어 처리됩니다.
  - 결제 성공 시 관련 화면이 자동으로 갱신됩니다.
  - 결제 수단 인증에 현재 회사 정보가 사용됩니다.
  - 실서버에서도 예약 가능한 팀 액션을 조회할 수 있습니다.

- **버그 수정**
  - 결제 실패 및 결제 수단 미등록 상황에서 사용자에게 안내 메시지를 제공합니다.
  - 권한이 없는 경우 결제 요청이 실행되지 않습니다.
  - 조직도 전체 명부를 안정적으로 조회하도록 페이지 처리 범위를 개선했습니다.
  - 예약 가능한 프로젝트와 팀 액션을 조회할 때 누락을 방지합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**, 그리고 **서버에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [ ] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시
- [ ] 🎨 디자인 토큰 사용 · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화
- [ ] ♿ a11y
- [ ] ♻️ 재사용 확인
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API 사용 시 미지원 · 권한거부 안내 있음

---

## 🔗 연관 이슈

Closes #478

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

-

---

## 📝 추가 메모
