### PR TITLE
[FIX] 구성원(/app/people) 조회 시 403/400 에러 수정  #491

### DIFF
--- a/src/features/member/manage-server.test.ts
+++ b/src/features/member/manage-server.test.ts
@@ -8,9 +8,11 @@ import { serverApi } from "@/lib/api";
 import { listAllManagedMembersForOrgChart } from "./manage-server";
 
 /**
- * 조직도 전체 명부 — 2026-08-14 프로덕션에서 무조건 throw하던 것을 고쳤다.
- * BE에 전체 조회 응답이 없어 **여러 페이지를 순회해 합치는 임시 우회**다(함수 주석 참고) —
- * 이 순회가 실제로 끝까지 도는지, 중복 없이 합치는지를 잠근다.
+ * 조직도 전체 명부 — 2026-08-14 프로덕션 장애 수정.
+ * `GET /api/members`를 페이지 순회하던 이전 구현은 `size` 상한(`@Max(100)`)과
+ * OWNER·ADMIN 전용 가드 때문에 `/app/people`(전 구성원용 화면)에서 깨졌다 — BE 조직도
+ * 전용 응답(`GET /api/members/org-chart`) 한 번 호출로 바꿨다. 이 테스트는 그 호출이
+ * 한 번만 나가고, 응답을 그대로 매핑하는지를 잠근다.
  */
 describe("listAllManagedMembersForOrgChart — 실서버", () => {
   const requireAccessTokenMock = requireAccessToken as unknown as jest.Mock;
@@ -21,76 +23,39 @@ describe("listAllManagedMembersForOrgChart — 실서버", () => {
     requireAccessTokenMock.mockResolvedValue("token");
   });
 
-  function page(memberIds: number[], pageIndex: number, totalPages: number) {
+  function member(id: number) {
     return {
-      totalElements: totalPages * memberIds.length,
-      totalPages,
-      hasNext: pageIndex < totalPages - 1,
-      page: pageIndex,
-      size: memberIds.length,
-      content: memberIds.map((id) => ({
-        memberId: id,
-        name: `사원${id}`,
-        teamName: "개발팀",
-        positionName: null,
-        role: "MEMBER",
-        isAdmin: false,
-        roleLabel: null,
-        workStatus: "ACTIVE",
-        joinedOn: null,
-      })),
+      memberId: id,
+      name: `사원${id}`,
+      teamName: "개발팀",
+      positionName: null,
+      role: "MEMBER",
+      isAdmin: false,
+      roleLabel: null,
+      workStatus: "ACTIVE",
+      joinedOn: null,
     };
   }
 
-  it("totalPages만큼 페이지를 순회해 전부 합친다", async () => {
-    serverApiMock
-      .mockResolvedValueOnce(page([1, 2], 0, 3))
-      .mockResolvedValueOnce(page([3, 4], 1, 3))
-      .mockResolvedValueOnce(page([5, 6], 2, 3));
-
-    const roster = await listAllManagedMembersForOrgChart();
-
-    expect(serverApiMock).toHaveBeenCalledTimes(3);
-    expect(roster.map((m) => m.id)).toEqual([1, 2, 3, 4, 5, 6]);
-  });
-
-  it("첫 페이지에서 totalPages=1이면 한 번만 부른다 — 회사가 작으면 요청도 하나다", async () => {
-    serverApiMock.mockResolvedValueOnce(page([1], 0, 1));
+  it("조직도 전용 응답을 한 번만 호출해 그대로 매핑한다 — 페이지 순회를 안 한다", async () => {
+    serverApiMock.mockResolvedValueOnce([member(1), member(2), member(3)]);
 
     const roster = await listAllManagedMembersForOrgChart();
 
     expect(serverApiMock).toHaveBeenCalledTimes(1);
-    expect(roster).toHaveLength(1);
+    expect(serverApiMock.mock.calls[0][0]).toBe("/api/members/org-chart");
+    expect(roster.map((m) => m.id)).toEqual([1, 2, 3]);
   });
 
-  /*
-    ⚠️ 회귀 방지(2026-08-14 실제 프로덕션 재현) — BE `MemberController.list`의 `size`는
-       `@Max(100)`이다. 200을 보내면 사원 5명뿐인 회사에서도 그 자리에서 400이 나서
-       조직도 전체가 죽는다. 다시 200으로 늘어나면 이 테스트가 잡는다.
-  */
-  it("size는 100을 넘지 않는다 — BE @Max(100)", async () => {
-    serverApiMock.mockResolvedValueOnce(page([1], 0, 1));
+  it("삭제된 사람은 뺀다 — 퇴사자는 남는다", async () => {
+    serverApiMock.mockResolvedValueOnce([
+      member(1),
+      { ...member(2), workStatus: "DELETED" },
+      { ...member(3), workStatus: "RESIGNED" },
+    ]);
 
-    await listAllManagedMembersForOrgChart();
+    const roster = await listAllManagedMembersForOrgChart();
 
-    /*
-      ⚠️ **정확히 "100"인지 본다**(코드래빗 지적, 2026-08-14). `toContain("size=100")`는
-         `size=1000`도 통과시켜 BE `@Max(100)` 위반을 이 테스트가 놓친다.
-    */
-    const requestUrl = serverApiMock.mock.calls[0][0] as string;
-    expect(new URL(requestUrl, "http://localhost").searchParams.get("size")).toBe("100");
-  });
-
-  /*
-    ⚠️ 코드래빗 지적(2026-08-14) — 상한을 넘으면 앞부분만 조용히 정상 리턴하면 안 된다.
-       회사 인원이 늘었는데 조직도가 말없이 일부만 보여주는 건 §정직성 위반이다.
-  */
-  it("상한(40페이지)을 넘으면 잘린 명부를 정상 결과로 돌려주지 않는다 — 던진다", async () => {
-    // totalPages=41 — 상한 40을 넘는다. 40번째 응답까지만 mock하면 충분하다(그 이상 안 부른다).
-    serverApiMock.mockResolvedValue(page([1], 0, 41));
-
-    await expect(listAllManagedMembersForOrgChart()).rejects.toThrow("상한을 넘어");
-
-    expect(serverApiMock).toHaveBeenCalledTimes(40);
+    expect(roster.map((m) => m.id)).toEqual([1, 3]);
   });
 });

--- a/src/features/member/manage-server.ts
+++ b/src/features/member/manage-server.ts
@@ -24,7 +24,6 @@ import {
   type ManagedMember,
   type ManagedMemberActions,
   type ManagedMemberDetail,
-  MEMBER_FILTER,
   type MemberQuery,
   type PendingHandover,
 } from "./manage-types";
@@ -127,53 +126,25 @@ export async function listManagedMembers(): Promise<ManagedMember[]> {
 export const MEMBER_PAGE_SIZE = 20;
 
 /**
- * 조직도(`getPeopleDirectory`)가 명부 전체를 요구할 때 쓰는 **임시 우회**.
+ * 조직도(`getPeopleDirectory`)가 쓰는 명부 전체 — BE 조직도 전용 응답 하나로 받는다.
  *
- * ⚠️ **정공법이 아니다.** 조직도는 팀 단위로 구조를 그려야 해서 한 페이지만 받으면
- *    팀이 반쯤 그려진다(`org-server.ts` 주석) — 그런데 BE엔 "회사 전체 명부"를 한 번에
- *    주는 응답이 없다(`GET /api/members`는 페이지 단위뿐). 그래서 여러 페이지를 순회해
- *    합친다. 회사가 커지면 요청도 늘고 화면도 그만큼 늦게 뜬다 — **BE에 조직도 전용
- *    응답을 요청하고 나면 이 함수째 걷어낸다.**
- * ⚠️⚠️ **`size`는 100을 넘으면 안 된다**(2026-08-14 실제 프로덕션에서 재현 — BE
- *    `MemberController.list`가 `size`를 `@Max(100)`으로 검증한다. 200을 보내면 사원이
- *    단 몇 명인 회사에서도 그 자리에서 400이 나서 조직도 전체가 죽는다). 원래 200으로
- *    잡았던 건 요청 수를 줄이려던 것뿐이라 100으로 낮추고, 상한(4,000명)을 지키려
- *    페이지 수를 그만큼 늘렸다.
- * ⚠️ **상한을 넘으면 던진다 — 잘린 명부를 정상 결과로 돌려주지 않는다**(코드래빗 지적,
- *    2026-08-14). `console.error`만 남기고 일부만 그대로 리턴하면 호출부
- *    (`getPeopleDirectory`)가 그걸 완전한 명부로 알고 `summary`·`chart`를 계산해,
- *    회사 인원이 늘었는데 조직도가 말없이 일부만 보여준다(§정직성 위반). 던지면
- *    화면이 기존 `error.tsx`(정직한 실패 상태 + [다시 시도])로 떨어진다 — 새 화면을
- *    안 만들어도 된다.
+ * ⚠️ **더 이상 `GET /api/members`를 페이지 순회하지 않는다**(2026-08-14, 프로덕션 장애
+ *    수정). 그 API는 `size`가 `@Max(100)`인 데다 `hasAnyRole('OWNER','ADMIN')` 전용이라,
+ *    `/app/people`(전 구성원이 쓰는 화면)에서 Leader·Member 계정이 열면 403이 났다.
+ *    BE가 조직도 전용 응답(`GET /api/members/org-chart`)을 이미 열어 두고 있어 — 페이지
+ *    단위가 아니라 명부 전체를 한 번에 주고, 권한도 전 구성원에게 열려 있다 — 그걸 그대로
+ *    쓴다.
+ * ⚠️ [가정 shape·미검증] BE 실코드를 아직 대조하지 못했다 — 응답이 `GET /api/members`와
+ *    같은 `BeMemberListItem[]`(페이지 봉투 없이 배열만)이라고 가정한다. 다르면 여기 매핑만
+ *    고치면 된다(§Mock 격리막).
  */
-const ORG_DIRECTORY_PAGE_SIZE = 100; // BE MemberController.list @Max(100)
-const ORG_DIRECTORY_PAGE_LIMIT = 40; // 최대 4,000명 — 이 상한을 실제로 넘기면 BE 요청이 먼저다
-
 export async function listAllManagedMembersForOrgChart(): Promise<ManagedMember[]> {
   if (isMock) return listManagedMembers();
 
-  const all: ManagedMember[] = [];
-  let page = 0;
-  let totalPages = 1;
+  const accessToken = await requireAccessToken();
+  const content = await serverApi<BeMemberListItem[]>(ep.memberOrgChart(), { accessToken });
 
-  while (page < totalPages && page < ORG_DIRECTORY_PAGE_LIMIT) {
-    const result = await getManagedMembersPage(
-      { keyword: "", filter: MEMBER_FILTER.ALL },
-      page,
-      ORG_DIRECTORY_PAGE_SIZE,
-    );
-    all.push(...result.items);
-    totalPages = result.totalPages;
-    page += 1;
-  }
-
-  if (page >= ORG_DIRECTORY_PAGE_LIMIT && page < totalPages) {
-    throw new Error(
-      `회사 사원이 ${ORG_DIRECTORY_PAGE_LIMIT * ORG_DIRECTORY_PAGE_SIZE}명 상한을 넘어 조직도를 통째로 불러오지 못했습니다 — BE 전용 응답이 필요합니다.`,
-    );
-  }
-
-  return all;
+  return content.map(toManagedMember).filter((member) => isVisibleMemberStatus(member.status));
 }
 
 /**

--- a/src/features/member/org-server.ts
+++ b/src/features/member/org-server.ts
@@ -18,9 +18,8 @@ import type { PeopleDirectory } from "./org-types";
  *    남긴 회의·액션·인수인계의 출처라 이름이 사라지면 추적이 끊긴다. 화면은 `퇴사` 뱃지로
  *    알린다. 소프트 딜리트(`DELETED`)만 그 앞의 매퍼가 거른다.
  * ⚠️ **명부 전체가 필요하다** — 조직도는 목록이 아니라 **구조**라 한 페이지만 받으면
- *    팀이 반쯤 그려진다. 실서버에는 전체를 한 번에 주는 응답이 없어(§연동 검증)
- *    `listAllManagedMembersForOrgChart`가 여러 페이지를 순회해 합친다(임시 우회 —
- *    그 함수 주석 참고). BE에 조직도 전용 응답이 생기면 여기만 고친다.
+ *    팀이 반쯤 그려진다. `listAllManagedMembersForOrgChart`가 BE 조직도 전용 응답
+ *    (`GET /api/members/org-chart`)을 한 번에 받아 온다(그 함수 주석 참고).
  */
 export async function getPeopleDirectory(keyword: string): Promise<PeopleDirectory> {
   const roster = await listAllManagedMembersForOrgChart();

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -364,7 +364,7 @@ export const ep = {
   /* 조직 — [확인] identity/member/presentation/api/{Member,ManageMember}Controller.java */
   members: () => "/api/members",
   member: (id: number) => `/api/members/${id}`,
-  /** 조직도 — OWNER·ADMIN 전용 */
+  /** 조직도 — `/api/members`와 달리 전 구성원(OWNER·LEADER·MEMBER)에게 열려 있다 */
   memberOrgChart: () => "/api/members/org-chart",
   /**
    * 내 팀 로스터 — 회의 참석자 픽커 전용(`/api/members`와 다르다, 그건 관리 화면용).


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독

---

## 🙋 관련 역할

- [x] LEADER (팀장)
- [x] MEMBER (사원)
- [ ] 공통

---

## 📝 작업 내용

- `/app/people` 진입 시 발생하던 400/403 에러 수정
- `listAllManagedMembersForOrgChart()`가 관리자 전용 `GET /api/members`를
  `size=200` 페이지 순회하던 로직을 제거하고, BE 조직도 전용 응답
  `GET /api/members/org-chart` 단일 호출로 교체 — 전 구성원 접근 가능,
  `size` 상한 문제도 함께 해소
- 관련 주석·테스트를 새 구현에 맞춰 갱신

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`fix/member-people-orgchart#{이슈번호}` 꼴, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [ ] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 권한 2축 검사 — 이번 변경은 전 구성원 접근을 여는 것으로, 별도 리소스 소유권
      검사 대상 아님(조회 전용, 서버에서 토큰의 `companyId`로 회사 스코프 확정)
- [ ] 🧬 zod — 해당 없음(기존 매퍼 방식 유지, zod 미도입 영역)
- [x] 🕵️ 정직성 — 응답 shape 미검증분은 "가정 shape·미검증" 주석으로 명시
- [ ] 🎨 디자인 토큰 — 해당 없음(서버 로직 변경만)

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [ ] ♿ a11y — 해당 없음
- [x] ♻️ 재사용 확인 — 기존 매퍼(`toManagedMember`)·타입(`ManagedMember`) 그대로 재사용
- [x] 🧪 loading / error / empty — 기존 `error.tsx` 그대로 재사용(변경 없음)
- [ ] 브라우저 전용 API — 해당 없음

---

## 🔗 연관 이슈

Closes #491

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
| 400/403 에러 화면 | 조직도 정상 렌더 |

---

## 💬 리뷰 포인트

- `GET /api/members/org-chart` 응답 shape을 BE 실코드로 대조 못 해 `MemberListItemResponse[]`로
  가정했습니다. BE 담당자 확인 부탁드립니다.
- 페이지 순회 관련 상수(`ORG_DIRECTORY_PAGE_SIZE` 등)·상한 초과 예외 로직을 전부 제거했는데,
  빠뜨린 참조가 없는지 봐주세요.

---

## 📝 추가 메모

`GET /api/members/org-chart` 응답 shape은 미검증 상태입니다 — BE 실코드/문서 확인 후
필요하면 매퍼(`toManagedMember`/`BeMemberListItem`)만 조정하면 됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 조직도 구성원 정보를 전용 API에서 한 번에 불러오도록 개선했습니다.
  * 조직도 조회 권한이 전체 구성원으로 확대되었습니다.
  * 삭제된 구성원은 제외하고, 퇴사한 구성원은 조직도에 유지합니다.

* **테스트**
  * 조직도 데이터 조회 및 구성원 상태 필터링 검증을 추가·갱신했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->