### PR TITLE
[FIX] 인수인계서 신청 화면 초기 조회를 실서버에 잇는다 #493

### DIFF
--- a/src/app/(shell)/app/handover/page.tsx
+++ b/src/app/(shell)/app/handover/page.tsx
@@ -1,11 +1,15 @@
 import type { Metadata } from "next";
 
+import { AccessDenied } from "@/components/common/access-denied";
 import { HANDOVER_TYPE } from "@/constants/domain";
 import { HandoverControls } from "@/features/handover/components/handover-controls";
 import { OffboardingForm } from "@/features/handover/components/offboarding-form";
 import { VacationForm } from "@/features/handover/components/vacation-form";
 import { parseHandoverPreview, parseHandoverType } from "@/features/handover/lib";
 import { getHandoverContext } from "@/features/handover/server";
+import { roleHome } from "@/features/shell/home";
+import { getViewer } from "@/features/shell/viewer";
+import { canWriteHandover } from "@/lib/permission";
 
 export const metadata: Metadata = {
   title: "인수인계서",
@@ -17,10 +21,17 @@ interface HandoverPageProps {
 
 /**
  * 인수인계서 신청 — 휴직/오프보딩(WORKFLOW.md §7).
- * ⚠️ Owner는 이 화면에 안 온다(`canWriteHandover`) — 지금은 로그인 세션이 없어 실제 가드
- *    대신 미리보기 토글로 인물을 바꾼다(`HandoverControls` 주석 참고).
+ * ⚠️ Owner는 이 화면에 안 온다 — `canWriteHandover`로 실제 가드를 건다(2026-08-15,
+ *    "로그인 세션이 없어 미리보기 토글로 대신한다"던 이전 상태를 벗어남).
+ *    미리보기 토글(`?as=`)은 mock 모드에서만 의미가 있고, 실서버에서는
+ *    `getHandoverContext`가 그 값을 무시하고 실제 로그인 세션(`getViewer`)만 본다.
  */
 export default async function HandoverPage({ searchParams }: HandoverPageProps) {
+  const viewer = await getViewer();
+  if (!canWriteHandover(viewer)) {
+    return <AccessDenied homeHref={roleHome(viewer.role)} />;
+  }
+
   const params = await searchParams;
   const preview = parseHandoverPreview(params.as);
   const type = parseHandoverType(params.type);

--- a/src/features/handover/components/handover-controls.tsx
+++ b/src/features/handover/components/handover-controls.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 import type { HandoverType } from "@/constants/domain";
 import { cn } from "@/lib/utils";
+import { isMock } from "@/mocks/config";
 
 import {
   DEFAULT_HANDOVER_PREVIEW,
@@ -34,32 +35,37 @@ export function HandoverControls({ activePreview, activeType }: HandoverControls
       {/*
         ⚠️ **무채색이다**(2026-08-11). 주황 테두리·바탕이었는데, 이건 연동 전 임시 도구이지
            경고가 아니다 — 색으로 알리는 건 에러(빨강)뿐이다(DESIGN §5).
+        ⚠️ **mock 모드에서만 보인다**(2026-08-15). 실서버에서는 `getViewer()`가 실제 로그인
+           본인을 이미 정해서 바꿔 볼 "인물"이라는 개념 자체가 없다 — 실서버인데 이 토글이
+           남아 있으면 실제 신청 화면에 아직 로그인 전 임시 도구가 뜨는 것처럼 보인다.
       */}
-      <div className="border-border bg-secondary/50 flex items-center gap-3 rounded-lg border px-3 py-2">
-        <span className="text-muted-foreground shrink-0 text-[12px] leading-4 font-medium">
-          임시 미리보기
-        </span>
-        <div role="group" aria-label="미리보기 인물" className="flex items-center gap-1">
-          {HANDOVER_PREVIEW_TABS.map((tab) => (
-            <Link
-              key={tab.preview}
-              href={buildHref(tab.preview, activeType)}
-              aria-pressed={activePreview === tab.preview}
-              className={cn(
-                "rounded-md px-2 py-1 text-[12px] leading-4 transition-colors",
-                activePreview === tab.preview
-                  ? "bg-foreground text-background font-medium"
-                  : "text-muted-foreground hover:bg-muted",
-              )}
-            >
-              {tab.label}
-            </Link>
-          ))}
+      {isMock && (
+        <div className="border-border bg-secondary/50 flex items-center gap-3 rounded-lg border px-3 py-2">
+          <span className="text-muted-foreground shrink-0 text-[12px] leading-4 font-medium">
+            임시 미리보기
+          </span>
+          <div role="group" aria-label="미리보기 인물" className="flex items-center gap-1">
+            {HANDOVER_PREVIEW_TABS.map((tab) => (
+              <Link
+                key={tab.preview}
+                href={buildHref(tab.preview, activeType)}
+                aria-pressed={activePreview === tab.preview}
+                className={cn(
+                  "rounded-md px-2 py-1 text-[12px] leading-4 transition-colors",
+                  activePreview === tab.preview
+                    ? "bg-foreground text-background font-medium"
+                    : "text-muted-foreground hover:bg-muted",
+                )}
+              >
+                {tab.label}
+              </Link>
+            ))}
+          </div>
+          <span className="text-muted-foreground text-[11px] leading-4">
+            — 로그인 연동 전까지만 쓰는 화면 확인용입니다.
+          </span>
         </div>
-        <span className="text-muted-foreground text-[11px] leading-4">
-          — 로그인 연동 전까지만 쓰는 화면 확인용입니다.
-        </span>
-      </div>
+      )}
 
       <nav aria-label="인수인계 종류" className="border-border flex gap-4 border-b">
         {HANDOVER_TYPE_TABS.map((tab) => (

--- a/src/features/handover/server.test.ts
+++ b/src/features/handover/server.test.ts
@@ -1,0 +1,123 @@
+jest.mock("@/mocks/config", () => ({ isMock: false }));
+jest.mock("@/features/auth/session", () => ({ requireAccessToken: jest.fn() }));
+jest.mock("@/features/shell/viewer", () => ({ getViewer: jest.fn() }));
+jest.mock("@/lib/api", () => ({
+  ApiError: class ApiError extends Error {},
+  serverApi: jest.fn(),
+}));
+
+import { AUTHORITY } from "@/constants/authority";
+import { requireAccessToken } from "@/features/auth/session";
+import { getViewer } from "@/features/shell/viewer";
+import { serverApi } from "@/lib/api";
+
+import { HANDOVER_PREVIEW } from "./lib";
+import { getHandoverContext } from "./server";
+
+/**
+ * 인수인계 신청 화면 컨텍스트 — **실서버 분기가 신청자 role에 따라 팀원 명부를 부를지 가른다.**
+ *
+ * ⚠️ MEMBER는 `GET /api/team/members`를 아예 안 부른다 — 그 엔드포인트가 LEADER 전용이라
+ *    MEMBER 토큰으로 부르면 403이다. 자가 재할당 대상(teammates)이 원래 필요 없는
+ *    MEMBER가 이 API를 실수로 타면 신청 화면 전체가 죽는다.
+ */
+
+const requireAccessTokenMock = requireAccessToken as unknown as jest.Mock;
+const getViewerMock = getViewer as unknown as jest.Mock;
+const serverApiMock = serverApi as unknown as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  requireAccessTokenMock.mockResolvedValue("token");
+});
+
+describe("getHandoverContext — 실서버", () => {
+  it("MEMBER는 담당 액션만 받고, 팀원 명부(GET /api/team/members)는 안 부른다", async () => {
+    getViewerMock.mockResolvedValue({
+      id: 3,
+      name: "이하윤",
+      role: AUTHORITY.MEMBER,
+      teamName: "개발팀",
+    });
+    serverApiMock.mockResolvedValueOnce({
+      content: [
+        {
+          id: 101,
+          actionType: "PERSONAL",
+          title: "온보딩 플로우 와이어프레임 검토",
+          status: "IN_PROGRESS",
+          dueDate: "2026-08-20",
+          projectTag: "GOODS",
+          parentActionTitle: "앱 개발 착수",
+        },
+        {
+          id: 102,
+          actionType: "PERSONAL",
+          title: "완료된 액션",
+          status: "DONE",
+          dueDate: "2026-08-01",
+          projectTag: "GOODS",
+          parentActionTitle: "앱 개발 착수",
+        },
+        {
+          id: 103,
+          actionType: "TEAM",
+          title: "팀 액션은 섞이면 안 됨",
+          status: "IN_PROGRESS",
+          dueDate: "2026-08-20",
+          projectTag: "GOODS",
+          parentActionTitle: null,
+        },
+      ],
+    });
+
+    const context = await getHandoverContext(HANDOVER_PREVIEW.MEMBER);
+
+    expect(context.applicant).toEqual({
+      id: 3,
+      name: "이하윤",
+      role: AUTHORITY.MEMBER,
+      teamName: "개발팀",
+    });
+    // ⚠️ 완료 액션(102)과 TEAM 타입(103)은 빠지고 진행중 PERSONAL(101)만 남아야 한다.
+    expect(context.actions).toEqual([
+      {
+        id: 101,
+        projectTag: "GOODS",
+        parentTeamActionName: "앱 개발 착수",
+        title: "온보딩 플로우 와이어프레임 검토",
+        status: "IN_PROGRESS",
+        dueDate: "2026-08-20",
+      },
+    ]);
+    expect(context.teammates).toEqual([]);
+    expect(serverApiMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("LEADER는 담당 액션과 함께 본인 제외 팀원 명부(GET /api/team/members)도 받는다", async () => {
+    getViewerMock.mockResolvedValue({
+      id: 2,
+      name: "김서준",
+      role: AUTHORITY.LEADER,
+      teamName: "개발팀",
+    });
+    serverApiMock.mockResolvedValueOnce({ content: [] }).mockResolvedValueOnce([
+      { memberId: 2, name: "김서준", positionName: "팀장", roleName: "리더", status: "ACTIVE" },
+      {
+        memberId: 3,
+        name: "이하윤",
+        positionName: "사원",
+        roleName: "프론트엔드",
+        status: "ACTIVE",
+      },
+    ]);
+
+    const context = await getHandoverContext(HANDOVER_PREVIEW.LEADER);
+
+    // ⚠️ 본인(memberId 2)은 후보에서 빠져야 한다 — 자기 자신에게 재배정할 수 없다.
+    expect(context.teammates).toEqual([
+      { id: 3, name: "이하윤", position: "사원", role: "프론트엔드" },
+    ]);
+    expect(serverApiMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/features/handover/server.ts
+++ b/src/features/handover/server.ts
@@ -1,12 +1,27 @@
+import "server-only";
+
 import { ACTION_STATUS, AUTHORITY } from "@/constants/domain";
+import { isVisibleMemberStatus } from "@/constants/member";
+import type { BeActionSummary } from "@/features/action/mapper";
+import { requireAccessToken } from "@/features/auth/session";
+import type { BePageResponse } from "@/features/project/mapper";
 import {
   TEAM_ACTION_DETAIL_MOCK,
   TEAM_ACTION_PERSONAL_ITEMS_MOCK,
 } from "@/features/project/mock/team-action-detail";
+import { getViewer } from "@/features/shell/viewer";
 import { TEAM_MEMBER_ROSTER_MOCK } from "@/features/team/members/mock/roster";
+import { serverApi } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
+import { isMock } from "@/mocks/config";
 
 import { HANDOVER_PREVIEW, type HandoverPreview } from "./lib";
-import type { HandoverActionItem, HandoverApplicant, HandoverContext } from "./types";
+import type {
+  HandoverActionItem,
+  HandoverApplicant,
+  HandoverContext,
+  HandoverTeammateOption,
+} from "./types";
 
 /**
  * ⚠️ 새 mock 데이터를 만들지 않는다 — `TEAM_ACTION_PERSONAL_ITEMS_MOCK`(project 피처)이
@@ -41,7 +56,86 @@ function buildActions(memberName: string): HandoverActionItem[] {
   return actions;
 }
 
+/** 담당 액션 select류 상한 — `rooms/server.ts`의 `RESERVABLE_PROJECTS_PAGE_SIZE`와 같은 패턴. */
+const HANDOVER_ACTIONS_PAGE_SIZE = 200;
+
+/**
+ * 실서버 — 내 담당 액션 전체(완료 제외). `GET /api/actions`가 토큰의 본인 소유 PERSONAL만
+ * 주므로 담당자를 따로 안 걸러도 된다(`action/server.ts`의 `getMyActionsPage`와 같은 전제).
+ * ⚠️ `MyActionListItem`(내 액션 화면 계약)을 재사용하지 않는다 — 이 화면엔
+ *    `parentTeamActionName`(BE `parentActionTitle`)이 필요한데 그쪽 계약엔 없어서, 굳이
+ *    맞추려면 안 쓰는 화면까지 필드가 늘어난다. 여기서 직접 BE 응답을 받아 필요한 만큼만 뽑는다.
+ */
+async function fetchMyHandoverActions(accessToken: string): Promise<HandoverActionItem[]> {
+  const response = await serverApi<BePageResponse<BeActionSummary>>(
+    ep.actions({ sort: "dueDate", order: "asc", page: 0, size: HANDOVER_ACTIONS_PAGE_SIZE }),
+    { accessToken },
+  );
+  return response.content
+    .filter((action) => action.actionType === "PERSONAL" && action.status !== ACTION_STATUS.DONE)
+    .map((action) => ({
+      id: action.id,
+      projectTag: action.projectTag ?? "",
+      parentTeamActionName: action.parentActionTitle ?? "",
+      title: action.title,
+      status: action.status,
+      dueDate: action.dueDate,
+    }));
+}
+
+/** [확인] `GET /api/team/members` 응답 — `team-handover/server.ts`의 `BeTeamMemberStatus`와 같은 계약. */
+interface BeTeamMember {
+  memberId: number;
+  name: string;
+  positionName: string | null;
+  roleName: string | null;
+  status: string;
+}
+
+/**
+ * 실서버 — 팀장 본인 휴직의 자가 재할당 대상(본인 제외, 같은 팀).
+ * ⚠️ `GET /api/team/members`는 **호출자 토큰의 팀만** 돌려주는 LEADER 전용 엔드포인트다
+ *    (`team-handover/server.ts`와 동일 근거) — 그래서 이 화면에서 신청자가 실제로 LEADER일
+ *    때만 부른다, MEMBER면 호출 자체를 안 한다(403을 미리 피한다).
+ * ⚠️ 퇴사자는 거르고 그 외 상태는 남긴다(`isVisibleMemberStatus`) — 소프트 딜리트만 빠진다.
+ */
+async function fetchTeammatesForSelfReassign(
+  accessToken: string,
+  viewerId: number,
+): Promise<HandoverTeammateOption[]> {
+  const members = await serverApi<BeTeamMember[]>(ep.teamMembers(), { accessToken });
+  return members
+    .filter((member) => member.memberId !== viewerId && isVisibleMemberStatus(member.status))
+    .map((member) => ({
+      id: member.memberId,
+      name: member.name,
+      position: member.positionName ?? "",
+      role: member.roleName ?? "",
+    }));
+}
+
 export async function getHandoverContext(preview: HandoverPreview): Promise<HandoverContext> {
+  if (!isMock) {
+    const viewer = await getViewer();
+    const accessToken = await requireAccessToken();
+
+    const applicant: HandoverApplicant = {
+      id: viewer.id,
+      name: viewer.name,
+      role: viewer.role,
+      teamName: viewer.teamName ?? "",
+    };
+
+    const [actions, teammates] = await Promise.all([
+      fetchMyHandoverActions(accessToken),
+      applicant.role === AUTHORITY.LEADER
+        ? fetchTeammatesForSelfReassign(accessToken, viewer.id)
+        : Promise.resolve([]),
+    ]);
+
+    return { applicant, actions, teammates };
+  }
+
   const applicantName = APPLICANT_NAME_BY_PREVIEW[preview];
   const roster = TEAM_MEMBER_ROSTER_MOCK.find((member) => member.name === applicantName);
   if (!roster) throw new Error("mock 데이터 오류 — 로스터에 없는 미리보기 인물입니다.");


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

인수인계 도메인은 신청 제출·중간승인·최종승인·팀장급 귀속까지 실 API 연동이 끝나 있었지만(#383/#388/#392), `/app/handover`(신청 화면)가 처음 데이터를 불러오는 `getHandoverContext()`만 `isMock` 분기 자체가 없어 100% 목데이터로 남아 있었습니다. 관련해서 놓쳐 있던 것 셋을 같이 고칩니다.

- `features/handover/server.ts`: `getHandoverContext()`에 실서버 분기 추가
  - `applicant` — `getViewer()`(실제 로그인 세션)에서 그대로 가져옴
  - `actions` — `GET /api/actions`(본인 소유 PERSONAL만 자동 스코프, [확인] `ActionController`)에서 완료 제외하고 뽑음. `MyActionListItem`(내 액션 화면 계약)을 재사용하지 않고 직접 매핑함 — 이 화면엔 `parentTeamActionName`(BE `parentActionTitle`)이 필요한데 그쪽 계약엔 없어서, 안 쓰는 화면까지 필드를 늘리는 대신 여기서 필요한 만큼만 뽑음
  - `teammates`(팀장 본인 휴직의 자가 재할당 대상) — 신청자가 실제로 LEADER일 때만 `GET /api/team/members`(LEADER 전용, [확인] `team-handover/server.ts`와 동일 계약) 호출. MEMBER면 호출 자체를 안 해서 403을 미리 피함
- `app/(shell)/app/handover/page.tsx`: `canWriteHandover` 가드 적용(WORKFLOW §7 "Owner 제외 전 역할") — 지금까지 이 가드가 전혀 안 걸려 있어 Owner도 이 화면에 들어갈 수 있었음
- `features/handover/components/handover-controls.tsx`: "임시 미리보기" 토글을 `isMock`일 때만 노출 — 실서버에서는 로그인 본인이 이미 정해져서 "바꿔 볼 인물"이라는 개념이 없음

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`fix/handover-context-live#493`, base `develop`)
- [x] 커밋 컨벤션 준수 (`fix: 제목 #493`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [x] 🔐 **권한 2축 검사** — `canWriteHandover`(역할 가드) 적용. BE도 각 엔드포인트에서 재검사함([확인] `GET /api/team/members`는 BE가 LEADER 전용으로 이미 막음)
- [x] 🕵️ **정직성** — mock 전용 UI(임시 미리보기)를 실서버에서 숨김, 목데이터를 실서버인 척 보여주지 않음

**품질**

- [x] ♻️ 재사용 확인 — `getMyActionsPage`/`MyActionListItem` 재사용을 검토했으나 `parentTeamActionName` 계약 불일치로 직접 매핑 선택(이유는 코드 주석 참고)
- [x] 🧪 `typecheck`·`lint`·전체 `jest`(130 suites/1378 tests) 통과 확인
- [x] 새 회귀 테스트 2건 추가(`server.test.ts`) — MEMBER는 팀원 명부 API를 안 부르는지, LEADER는 본인 제외 명부를 받는지

---

## 🔗 연관 이슈

Closes #493

---

## 💬 리뷰 포인트

- `fetchMyHandoverActions`가 `size=200`으로 한 번에 받습니다(`rooms/server.ts`의 `RESERVABLE_PROJECTS_PAGE_SIZE` 패턴과 동일) — `ActionController`엔 size `@Max` 제약이 없는 것까지 BE 코드로 확인했습니다.
- `GET /api/team/members`가 LEADER 전용이라 신청자 role로 미리 분기해서 호출 자체를 건너뛰게 했습니다 — MEMBER가 이 API를 탔다가 403으로 화면이 죽는 걸 막기 위함입니다.

---

## 📝 추가 메모

없음

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |
