### PR TITLE
[FIX] 첨부 없이 넘어가기 전에 확인창을 둔다 #501

### DIFF
--- a/src/features/project/components/project-form.tsx
+++ b/src/features/project/components/project-form.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import type { ChangeEvent, CSSProperties } from "react";
 import { useActionState, useCallback, useEffect, useRef, useState } from "react";
 
+import { ConfirmDialog } from "@/components/common/confirm-dialog";
 import { DatePickerField } from "@/components/common/date-picker-field";
 import { FieldError } from "@/components/common/field-error";
 import { Button, buttonVariants } from "@/components/ui/button";
@@ -76,6 +77,7 @@ export function ProjectForm({ action, teamOptions, cancelHref }: ProjectFormProp
   const [teamRows, setTeamRows] = useState<TeamRow[]>([{ rowId: nextRowId++, team: "" }]);
   const [attachment, setAttachment] = useState<File | null>(null);
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
+  const [isSkipAttachmentConfirmOpen, setIsSkipAttachmentConfirmOpen] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const router = useRouter();
@@ -503,10 +505,29 @@ export function ProjectForm({ action, teamOptions, cancelHref }: ProjectFormProp
                   >
                     다시 시도
                   </Button>
-                  <Button type="button" variant="ghost" size="sm" onClick={goToList}>
-                    첨부 없이 이동
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setIsSkipAttachmentConfirmOpen(true)}
+                  >
+                    첨부 없이 완료
                   </Button>
                 </div>
+                {/*
+                  ⚠️ **프로젝트는 이미 만들어졌다** — 이 확인창이 "생성할까요?"를 묻지 않는
+                     이유다(§정직성). 여기서 되돌릴 수 없는 건 첨부뿐이고, 나중에 다시 첨부할
+                     수 있는지는 아직 확인된 바 없어 그렇다고도 아니라고도 단언하지 않는다
+                     (DESIGN §9 "화면은 사실만 말한다").
+                */}
+                <ConfirmDialog
+                  isOpen={isSkipAttachmentConfirmOpen}
+                  onOpenChange={setIsSkipAttachmentConfirmOpen}
+                  title="첨부파일 없이 넘어갈까요?"
+                  description="프로젝트는 이미 만들어졌습니다. 지금 넘어가면 첨부파일 없는 채로 남습니다."
+                  confirmLabel="넘어가기"
+                  onConfirm={goToList}
+                />
               </div>
             ) : (
               <p className="text-muted-foreground text-[12px] leading-4">


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계

---

## 🙋 관련 역할

- [x] OWNER (대표)

---

## 📝 작업 내용

프로젝트 생성 후 첨부 업로드가 실패했을 때 뜨는 [첨부 없이 이동] 버튼이 확인창 없이 즉시 목록으로 이동하던 것을 고칩니다.

- 버튼 클릭 시 바로 `goToList()`를 부르는 대신 `ConfirmDialog`를 먼저 띄우도록 변경
- 버튼 문구 "첨부 없이 이동" → "첨부 없이 완료"(이 시점엔 프로젝트가 이미 생성돼 있어 "이동"만으론 뭘 완료하는 건지 안 드러남)
- 확인창 문구는 "생성하시겠습니까"가 아니라 "넘어갈까요"로 — 프로젝트는 이미 만들어진 상태이므로(§정직성, 실제 상태와 다른 문구를 쓰지 않음)
- 나중에 프로젝트 상세에서 첨부파일을 다시 추가할 수 있는지는 코드로 확인되지 않아 description에서 단언하지 않음(있다/없다 둘 다 안 씀)

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`fix/project-form-skip-attachment-confirm#501`, base `develop`)
- [x] 커밋 컨벤션 준수 (`fix: 제목 #501`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [x] 🕵️ **정직성** — 확인창 문구가 실제 상태(프로젝트는 이미 생성됨)와 어긋나지 않게 씀, 확인 안 된 사실(나중에 재첨부 가능 여부)은 단언하지 않음

**품질**

- [x] ♻️ 재사용 확인 — `components/common/confirm-dialog.tsx`(기존 `member-delete-card.tsx`와 같은 사용 패턴) 그대로 재사용, 새 컴포넌트 안 만듦
- [x] `typecheck`·`lint` 통과, 전체 `jest`(129 suites/1376 tests) 통과 확인 — 해당 파일에 기존 테스트는 없었음

---

## 🔗 연관 이슈

Closes #501

---

## 💬 리뷰 포인트

- 되돌릴 수 없는 정도가 약해서(`isDestructive` 안 씀, 빨강 버튼 아님) 이 판단이 맞는지 리뷰 부탁드립니다 — 데이터 손실이 아니라 "이번엔 첨부를 안 하고 넘어간다"는 성격이라 파괴적 스타일까지는 필요 없다고 봤습니다.

---

## 📝 추가 메모

로컬 dev 서버로 시각 확인을 시도했으나 프리뷰 환경 자체의 이슈로 로딩이 안 풀려 스크린샷은 못 남겼습니다(서버 로그·번들 로딩은 전부 정상). 리뷰 시 실제 화면 확인 부탁드립니다.

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |
