### PR TITLE
[FIX] BE PR #489 미배포 상태 방어 — team.roles undefined로 사원관리·기업설정 다운 #505

### DIFF
--- a/src/features/company/mapper.test.ts
+++ b/src/features/company/mapper.test.ts
@@ -119,6 +119,18 @@ describe("toDepartmentNode — 역할을 담는다", () => {
   it("역할이 없는 팀은 빈 배열이다", () => {
     expect(toDepartmentNode({ ...BE_TEAM, roles: [] }).children).toEqual([]);
   });
+
+  /*
+    ⚠️ **`roles` 필드 자체가 없어도 죽지 않는다**(2026-08-14 프로덕션 재현 — BE PR #489가
+       아직 배포 전이라 `GET /api/teams` 응답에 `roles`가 없다). `undefined`에 `.map`을
+       그대로 부르면 `/manage/members`·`/owner/setting` 전체가 Server Component
+       에러로 죽는다 — 빈 배열로 접어서 견딘다.
+  */
+  it("BE가 roles 필드를 아직 안 주면(undefined) 죽지 않고 빈 배열이다", () => {
+    const legacyTeam = { ...BE_TEAM, roles: undefined } as unknown as BeTeam;
+
+    expect(toDepartmentNode(legacyTeam).children).toEqual([]);
+  });
 });
 
 describe("withoutSystemRoles — 팀 편집 화면 전용 필터", () => {

--- a/src/features/company/mapper.ts
+++ b/src/features/company/mapper.ts
@@ -39,8 +39,12 @@ export interface BeTeam {
    * 이 팀에서 고를 수 있는 역할들. [확인] BE `RoleNode`(신규, 2026-08-14 BE PR #489).
    * ⚠️ **`없음`(roleId 2)이 항상 끼어 온다** — 전역 시드 행을 모든 팀 목록에 얹어 준다.
    * ⚠️ **`리더`(roleId 1)는 안 온다** — BE가 팀장 표시용이라 목록에서 뺀다.
+   * ⚠️ **선택적이라고 타입에 그대로 적는다**(2026-08-14 프로덕션 재현 — BE PR #489가 아직
+   *    실제로는 배포 전이라 이 필드 자체가 안 온다). 비필수(`?`)로 안 적으면, 이 필드를
+   *    직접 읽는 새 코드가 생겨도 타입체커가 "`undefined`일 수 있다"고 못 잡아 줘서
+   *    `toDepartmentNode`가 겪었던 `.map()` 크래시를 그대로 되풀이할 수 있다.
    */
-  roles: { roleId: number; name: string }[];
+  roles?: { roleId: number; name: string }[];
 }
 
 /**

--- a/src/features/company/mapper.ts
+++ b/src/features/company/mapper.ts
@@ -127,6 +127,11 @@ export function toCompanyUpdateBody(draft: CompanyProfileDraft): BeCompanyUpdate
  * ⚠️ **역할을 그대로 담는다**(2026-08-14 BE PR #489 — 전에는 BE가 안 줘서 늘 빈 배열이었다).
  *    `없음`도 그대로 온다 — 역할 **선택**(`team-roles.ts`)엔 필요한 값이라 여기서 안 거른다.
  *    팀 **편집** 화면(`getCompanySetting()`)만 `withoutSystemRoles`로 따로 걸러 낸다.
+ * ⚠️ **`roles`가 아직 안 올 수 있다**(2026-08-14 프로덕션 재현 — BE PR #489가 실제로는
+ *    아직 배포 전이라 `GET /api/teams` 응답에 `roles` 필드 자체가 없다). 그대로
+ *    `team.roles.map(...)`을 부르면 `undefined`에 `.map`을 호출해 **`/manage/members`·
+ *    `/owner/setting` 전체가 Server Component 에러로 죽는다** — `roles`가 없으면 빈
+ *    배열로 접어서, BE가 그 필드를 내려주기 전까지는 "역할 없음"과 같은 모양으로 견딘다.
  * ⚠️ **팀장(`leaderMemberId`·`leaderName`)을 못 담는다.** 우리 노드에 자리가 없어 지금은
  *    버린다 — 화면에 팀장이 안 보이는 건 그래서다.
  */
@@ -134,7 +139,7 @@ export function toDepartmentNode(team: BeTeam): DepartmentNode {
   return {
     id: String(team.teamId),
     name: team.name,
-    children: team.roles.map((role) => ({
+    children: (team.roles ?? []).map((role) => ({
       id: String(role.roleId),
       name: role.name,
       children: [],

--- a/src/features/member/manage-mapper.ts
+++ b/src/features/member/manage-mapper.ts
@@ -57,12 +57,16 @@ export interface BeMemberListItem {
  *
  * ⚠️ **`roleId`는 상세에만 있다**(2026-08-14 BE PR #489). 목록·조직도는 계속 `roleLabel`
  *    (표시용)만 주고, 폼이 선택 상태를 잡을 때 쓰는 id는 상세 조회에만 실려 온다.
+ * ⚠️ **선택적이라고 타입에 그대로 적는다**(2026-08-14 프로덕션 재현 — BE PR #489가 아직
+ *    실제로는 배포 전이라 이 필드 자체가 안 온다, `undefined`). 비필수(`?`)로 안 적으면
+ *    이 필드를 직접 읽는 새 코드가 생겨도 타입체커가 못 잡아 준다(`manage-server.ts`의
+ *    `!= null` 정규화가 왜 필요한지도 이 타입만 봐서는 안 보인다).
  */
 export interface BeMemberDetail extends BeMemberListItem {
   teamId: number | null;
   jobPositionId: number | null;
   email: string | null;
-  roleId: number | null;
+  roleId?: number | null;
 }
 
 /**

--- a/src/features/member/manage-server.test.ts
+++ b/src/features/member/manage-server.test.ts
@@ -1,11 +1,11 @@
 jest.mock("@/mocks/config", () => ({ isMock: false }));
 jest.mock("@/features/auth/session", () => ({ requireAccessToken: jest.fn() }));
-jest.mock("@/lib/api", () => ({ serverApi: jest.fn() }));
+jest.mock("@/lib/api", () => ({ serverApi: jest.fn(), ApiError: class ApiError extends Error {} }));
 
 import { requireAccessToken } from "@/features/auth/session";
 import { serverApi } from "@/lib/api";
 
-import { listAllManagedMembersForOrgChart } from "./manage-server";
+import { getManagedMember, listAllManagedMembersForOrgChart } from "./manage-server";
 
 /**
  * 조직도 전체 명부 — 2026-08-14 프로덕션 장애 수정.
@@ -91,5 +91,88 @@ describe("listAllManagedMembersForOrgChart — 실서버", () => {
     const roster = await listAllManagedMembersForOrgChart();
 
     expect(roster.map((m) => m.id)).toEqual([1, 3]);
+  });
+});
+
+/**
+ * 사원 상세 실서버 조회 — `roleId` 정규화(2026-08-14 프로덕션 재현).
+ *
+ * ⚠️ **`manage-actions.role-id.test.ts`는 이 실코드를 안 지난다** — 그 파일은
+ *    `getManagedMember` 자체를 `jest.mock`으로 통째로 갈아치운다. `!= null`(BE PR #489
+ *    미배포 시 `undefined`도 걸러야 한다)이 실제로 지켜지는지는 여기서만 잠긴다 — 나중에
+ *    누가 `eqeqeq` 린트에 맞춰 `!==`로 되돌려도 다른 테스트는 못 잡는다.
+ */
+describe("getManagedMember — 실서버 roleId", () => {
+  const requireAccessTokenMock = requireAccessToken as unknown as jest.Mock;
+  const serverApiMock = serverApi as unknown as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    requireAccessTokenMock.mockResolvedValue("token");
+  });
+
+  function detail(overrides: Partial<Record<string, unknown>> = {}) {
+    return {
+      memberId: 4,
+      name: "박도현",
+      teamName: "개발팀",
+      positionName: "사원",
+      role: "MEMBER",
+      isAdmin: false,
+      roleLabel: null,
+      workStatus: "ACTIVE",
+      joinedOn: "2023-01-15",
+      teamId: 1,
+      jobPositionId: 1,
+      email: "dohyun@zgroup.co.kr",
+      ...overrides,
+    };
+  }
+
+  /** 담당 액션·대기 신청 조회는 이 테스트의 관심사가 아니다 — 빈 값으로 통일해 둔다 */
+  function stubSideCalls() {
+    serverApiMock.mockImplementation((url: string) => {
+      if (url.startsWith("/api/handovers")) return Promise.resolve([]);
+      if (url.startsWith("/api/company/actions")) {
+        return Promise.resolve({ content: [], totalElements: 0 });
+      }
+      throw new Error(`이 테스트가 예상하지 않은 serverApi 호출: ${url}`);
+    });
+  }
+
+  it("BE에 roleId 필드 자체가 없으면(#489 미배포) null이다 — 문자열 'undefined'가 아니다", async () => {
+    stubSideCalls();
+    serverApiMock.mockImplementationOnce((url: string) => {
+      expect(url).toBe("/api/members/4");
+      return Promise.resolve(detail({ roleId: undefined }));
+    });
+
+    const result = await getManagedMember(4);
+
+    expect(result?.roleId).toBeNull();
+  });
+
+  it("BE가 roleId를 실제로 주면 문자열로 옮긴다", async () => {
+    stubSideCalls();
+    serverApiMock.mockImplementationOnce((url: string) => {
+      expect(url).toBe("/api/members/4");
+      return Promise.resolve(detail({ roleId: 3 }));
+    });
+
+    const result = await getManagedMember(4);
+
+    expect(result?.roleId).toBe("3");
+  });
+
+  it("roleId가 명시적으로 null이면 그대로 null이다", async () => {
+    stubSideCalls();
+    serverApiMock.mockImplementationOnce((url: string) => {
+      expect(url).toBe("/api/members/4");
+      return Promise.resolve(detail({ roleId: null }));
+    });
+
+    const result = await getManagedMember(4);
+
+    expect(result?.roleId).toBeNull();
   });
 });

--- a/src/features/member/manage-server.test.ts
+++ b/src/features/member/manage-server.test.ts
@@ -60,6 +60,22 @@ describe("listAllManagedMembersForOrgChart — 실서버", () => {
     expect(roster.map((m) => m.teamName)).toEqual([null, "개발팀", "개발팀", "디자인팀"]);
   });
 
+  /*
+    ⚠️ **`members` 필드가 없는 팀도 있을 수 있다**(2026-08-14 프로덕션 재현) — 이 shape은
+       [가정 shape·미검증]이라 사람이 없는 팀에서 BE가 `members`를 빈 배열이 아니라
+       필드째 빼고 줄 가능성을 배제할 수 없다. 그때 죽지 않고 그 팀만 빈 것으로 본다.
+  */
+  it("members 필드가 없는 팀이 와도 죽지 않는다", async () => {
+    serverApiMock.mockResolvedValueOnce([
+      { teamName: "개발팀", members: [member(1)] },
+      { teamName: "신규팀" },
+    ]);
+
+    const roster = await listAllManagedMembersForOrgChart();
+
+    expect(roster.map((m) => m.id)).toEqual([1]);
+  });
+
   it("삭제된 사람은 뺀다 — 퇴사자는 남는다", async () => {
     serverApiMock.mockResolvedValueOnce([
       {

--- a/src/features/member/manage-server.ts
+++ b/src/features/member/manage-server.ts
@@ -362,12 +362,15 @@ export async function getManagedMember(id: number): Promise<ManagedMemberDetail 
   /*
     ⚠️ **id를 문자열로 옮긴다** — 팀·직급 id와 같은 관례다(BE 숫자를 화면 계층에서는
        문자열로 다루고, BFF로 나갈 때만 다시 숫자로 바꾼다).
+    ⚠️ **`!= null`이다(`!==` 아님)** — BE PR #489가 아직 배포 전이면 `roleId` 필드
+       자체가 없어 `undefined`로 온다. `!== null`만 보면 `String(undefined)`가 되어
+       역할 셀렉트에 문자열 `"undefined"`가 값으로 실린다(2026-08-14 프로덕션 재현).
   */
   return {
     member,
     actions,
     pendingHandover,
-    roleId: detail.roleId !== null ? String(detail.roleId) : null,
+    roleId: detail.roleId != null ? String(detail.roleId) : null,
   };
 }
 

--- a/src/features/member/manage-server.ts
+++ b/src/features/member/manage-server.ts
@@ -166,8 +166,16 @@ export async function listAllManagedMembersForOrgChart(): Promise<ManagedMember[
   const accessToken = await requireAccessToken();
   const teams = await serverApi<BeOrgChartTeam[]>(ep.memberOrgChart(), { accessToken });
 
+  /*
+    ⚠️ **`members`가 없는 팀을 방어한다**(2026-08-14 프로덕션 재현). 이 shape은 위
+       [가정 shape·미검증]대로 아직 BE 실코드로 대조 못 했다 — 사람이 없는 팀에서
+       `members`가 빈 배열이 아니라 필드째 빠져 오면 `team.members.map(...)`이
+       `undefined`에 `.map`을 호출해 `/app/people` 전체가 죽는다.
+  */
   return teams
-    .flatMap((team) => team.members.map((member) => ({ ...member, teamName: team.teamName })))
+    .flatMap((team) =>
+      (team.members ?? []).map((member) => ({ ...member, teamName: team.teamName })),
+    )
     .map(toManagedMember)
     .filter((member) => isVisibleMemberStatus(member.status));
 }


### PR DESCRIPTION
## 📋 PR 타입

- [ ] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [x] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [x] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

## 🔥 프로덕션 긴급 수정
`/manage/members`·`/owner/setting`이 지금 전부 Server Component 에러로 죽어 있습니다.

## 원인
제 PR #502(역할 id 전환)가 `GET /api/teams` 응답에 BE PR #489(`roles` 필드)가 **이미 배포됐다고 가정**했는데, 실제로는 아직 배포 전이었습니다. `toDepartmentNode`가 `team.roles.map(...)`을 무조건 호출해 `roles`가 `undefined`인 실제 응답에서 그대로 죽습니다.

## 고친 것
- `company/mapper.ts`의 `toDepartmentNode`: `team.roles ?? []`
- `member/manage-server.ts`의 `getManagedMember`: `detail.roleId !== null` → `!= null`(같은 이유로 `undefined`도 처리)
- 회귀 테스트 추가(BE PR #489 배포 전 응답 모양으로 재현)

BE가 실제로 배포하면 이 방어 코드는 그냥 no-op입니다 — 되돌릴 필요 없습니다.

## 확인법
1. `npx tsc --noEmit` · `npx jest`(133 suites/1414 tests) 통과
2. 배포 후 https://www.z-groupware.site/manage/members · /owner/setting 정상 로드 확인

Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**, 그리고 **서버에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [ ] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시
- [ ] 🎨 디자인 토큰 사용 · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화
- [ ] ♿ a11y
- [ ] ♻️ 재사용 확인
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API 사용 시 미지원 · 권한거부 안내 있음

---

## 🔗 연관 이슈

Closes #505

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

-

---

## 📝 추가 메모
