### PR TITLE
[FEAT] 사이드바 명칭·구성 개편 및 비대면 회의 진입점 이관 #507

### DIFF
--- a/src/app/(shell)/app/meeting/page.tsx
+++ b/src/app/(shell)/app/meeting/page.tsx
@@ -6,13 +6,7 @@ import {
   type MeetingTab,
 } from "@/features/meeting/components/meeting-list-view";
 import { getMeetingDirectory } from "@/features/meeting/server";
-import {
-  getReservableMembers,
-  getReservableProjects,
-  getReservableTeamActions,
-} from "@/features/rooms/server";
 import { getViewer } from "@/features/shell/viewer";
-import { requiresParentTeamAction } from "@/lib/permission";
 
 /*
   ⚠️ 정적으로 굳히지 않는다 — 예약이 회의를 만들고 상태가 시각으로 변하는 화면이라
@@ -21,7 +15,7 @@ import { requiresParentTeamAction } from "@/lib/permission";
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-  title: "회의",
+  title: "내 회의",
 };
 
 /** 주소에서 온 탭 값 — 모르는 값이면 첫 탭으로 되돌린다 */
@@ -30,13 +24,11 @@ function parseTab(value: string | string[] | undefined): MeetingTab {
 }
 
 /**
- * 회의 목록(WORKFLOW §3-2) — 조회뿐이라 Server Component 하나로 끝난다.
+ * 내 회의 목록(WORKFLOW §3-2) — 조회뿐이라 Server Component 하나로 끝난다.
  *
  * ⚠️ **목록은 전 구성원 공개**다(§3-2-1) — 권한 가드가 없다. 막는 건 상세다.
- * ⚠️ **대면 회의 생성 진입점은 여전히 `/app/rooms` 예약 모달 하나뿐이다**(§3-1) — 회의실
- *    예약이 곧 회의 개설이라 이 화면에 따로 만들지 않는다. 다만 **비대면 회의는 회의실·시간이
- *    없어 예약이 필요 없다**(이슈 #473) — 그래서 이 목록 화면에 자기 진입점(비대면 회의
- *    다이얼로그)을 하나 더 둔다.
+ * ⚠️ **회의 개설(대면·비대면 모두) 진입점은 `/app/rooms`(회의 예약) 하나뿐이다**
+ *    (2026-08-14 사이드바 개편) — 이 화면에는 그리로 가는 이동 링크만 둔다.
  */
 export default async function AppMeetingPage({
   searchParams,
@@ -45,25 +37,12 @@ export default async function AppMeetingPage({
 }) {
   const tab = parseTab((await searchParams).tab);
   const viewer = await getViewer();
-  const [directory, members, projects, teamActions] = await Promise.all([
-    getMeetingDirectory(viewer.id),
-    getReservableMembers(viewer),
-    getReservableProjects(),
-    getReservableTeamActions(viewer),
-  ]);
+  const directory = await getMeetingDirectory(viewer.id);
 
   return (
     <main className="min-h-0 flex-1 overflow-y-auto px-8 py-7">
       <div className="mx-auto w-full max-w-[1440px]">
-        <MeetingListView
-          directory={directory}
-          tab={tab}
-          members={members}
-          projects={projects}
-          showParentTeamAction={requiresParentTeamAction(viewer)}
-          teamActions={teamActions}
-          viewer={{ id: viewer.id, role: viewer.role, teamName: viewer.teamName ?? null }}
-        />
+        <MeetingListView directory={directory} tab={tab} />
       </div>
     </main>
   );

--- a/src/app/(shell)/app/rooms/layout.tsx
+++ b/src/app/(shell)/app/rooms/layout.tsx
@@ -9,13 +9,13 @@ interface RoomsLayoutProps {
 
 /**
  * 사이드바에서 바로 닿는 화면이라 뒤로가기를 두지 않는다(`calendar`·`notice` 목록과 같은 규칙).
- * ⚠️ 아이콘은 사이드바의 "회의실" 항목(`sidebar-item.tsx`의 `room: CalendarRange`)과 같은 걸 쓴다 —
+ * ⚠️ 아이콘은 사이드바의 "회의 예약" 항목(`sidebar-item.tsx`의 `room: CalendarRange`)과 같은 걸 쓴다 —
  *    메뉴에서 본 아이콘과 화면 머리의 아이콘이 다르면 같은 화면으로 안 읽힌다.
  */
 export default function RoomsLayout({ children }: RoomsLayoutProps) {
   return (
     <>
-      <PageHeader title="회의실" icon={CalendarRange} />
+      <PageHeader title="회의 예약" icon={CalendarRange} />
       {children}
     </>
   );

--- a/src/app/(shell)/app/rooms/page.tsx
+++ b/src/app/(shell)/app/rooms/page.tsx
@@ -14,7 +14,7 @@ import { getViewer } from "@/features/shell/viewer";
 import { requiresParentTeamAction } from "@/lib/permission";
 
 export const metadata: Metadata = {
-  title: "회의실",
+  title: "회의 예약",
 };
 
 const DATE_PARAM_PATTERN = /^\d{4}-\d{2}-\d{2}$/;

--- a/src/features/meeting/components/meeting-header.tsx
+++ b/src/features/meeting/components/meeting-header.tsx
@@ -36,9 +36,9 @@ export function MeetingHeader() {
 
   return (
     <PageHeader
-      title="회의"
+      title="내 회의"
       icon={Video}
-      backTo={isList ? undefined : { href: MEETING_LIST_PATH, label: "회의" }}
+      backTo={isList ? undefined : { href: MEETING_LIST_PATH, label: "내 회의" }}
     />
   );
 }

--- a/src/features/meeting/components/meeting-list-view.tsx
+++ b/src/features/meeting/components/meeting-list-view.tsx
@@ -1,21 +1,19 @@
-import { Video } from "lucide-react";
+import { CalendarPlus, Video } from "lucide-react";
 import Link from "next/link";
 
 import { EmptyState } from "@/components/common/empty-state";
-import type { AttendeeScopeViewer } from "@/features/rooms/attendee-scope";
-import type { RoomMember, RoomProjectOption, RoomTeamActionOption } from "@/features/rooms/types";
+import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 import type { MeetingDirectory, MeetingListItem } from "../view-types";
 import { MeetingCard } from "./meeting-card";
-import { OnlineMeetingDialog } from "./online-meeting-dialog";
 
 /**
- * 회의 목록 — 탭 두 개 + 비대면 회의 진입점(WORKFLOW §3-2, 이슈 #473).
+ * 회의 목록 — 탭 두 개 + 회의 예약으로 이동하는 링크(WORKFLOW §3-2).
  *
- * ⚠️ **대면 회의는 여기 만드는 버튼이 없다.** 생성 진입점은 `/app/rooms` 예약 모달 하나뿐이다
- *    (§3-1) — 여기 또 두면 진입점이 두 개가 된다. 다만 **비대면 회의는 회의실·시간이 없어
- *    예약이 필요 없다**(이슈 #473)라 이 목록 화면이 그 하나뿐인 진입점이다.
+ * ⚠️ **대면·비대면 회의를 여는 진입점이 여기 없다.** 회의 개설(대면·비대면 모두)은
+ *    `/app/rooms`(회의 예약) 화면 하나로 모였다(2026-08-14 사이드바 개편) — 여기는
+ *    이동 링크만 두고 목록만 보여준다.
  * ⚠️ 탭은 **주소로** 오간다(`?tab=`). 화면 상태로 두면 새로고침·뒤로 가기에서 탭이 날아간다.
  *    서버 컴포넌트라 클릭은 `Link`다 — 프로젝트 목록의 `?status=`와 같은 패턴.
  */
@@ -83,32 +81,18 @@ function MeetingEmptyState({ tab }: { tab: MeetingTab }) {
 interface MeetingListViewProps {
   directory: MeetingDirectory;
   tab: MeetingTab;
-  /** 비대면 회의 다이얼로그로 그대로 흘려보낸다(`/app/rooms/page.tsx`와 같은 데이터 원천). */
-  members: RoomMember[];
-  projects: RoomProjectOption[];
-  showParentTeamAction: boolean;
-  teamActions: RoomTeamActionOption[];
-  viewer: AttendeeScopeViewer;
 }
 
-export function MeetingListView({
-  directory,
-  tab,
-  members,
-  projects,
-  showParentTeamAction,
-  teamActions,
-  viewer,
-}: MeetingListViewProps) {
+export function MeetingListView({ directory, tab }: MeetingListViewProps) {
   const items: MeetingListItem[] =
     tab === MEETING_TAB.HOSTED ? directory.hosted : directory.invited;
 
   return (
     <div className="flex flex-col gap-6">
       {/*
-        ⚠️ 선(`border-b`)을 **이 바깥 줄**에 건다(2026-08-14, 비대면 회의 버튼을 더하며 옮김).
-           탭 두 개만 있을 때는 탭 상자에 걸어도 됐지만, 오른쪽에 버튼을 나란히 두면 탭 상자
-           너비만큼만 선이 그어져 버튼 아래는 선이 끊긴다 — 줄 전체 폭으로 선을 그어야
+        ⚠️ 선(`border-b`)을 **이 바깥 줄**에 건다(2026-08-14, 회의 예약 이동 링크를 더하며 옮김).
+           탭 두 개만 있을 때는 탭 상자에 걸어도 됐지만, 오른쪽에 링크를 나란히 두면 탭 상자
+           너비만큼만 선이 그어져 링크 아래는 선이 끊긴다 — 줄 전체 폭으로 선을 그어야
            헤더 한 줄로 읽힌다. `TabLink`의 `-mb-px`는 가장 가까운 `border-b` 조상을 기준으로
            겹치므로 옮겨도 밑줄 탭 모양은 그대로다.
       */}
@@ -125,13 +109,11 @@ export function MeetingListView({
             count={directory.invited.length}
           />
         </div>
-        <OnlineMeetingDialog
-          members={members}
-          projects={projects}
-          showParentTeamAction={showParentTeamAction}
-          teamActions={teamActions}
-          viewer={viewer}
-        />
+        {/* 회의 개설(대면·비대면)은 회의 예약 화면 하나로 모였다 — 여기는 이동 링크만 둔다 */}
+        <Link href="/app/rooms" className={cn(buttonVariants({ variant: "outline" }))}>
+          <CalendarPlus aria-hidden />
+          회의 예약으로 이동
+        </Link>
       </div>
 
       {items.length === 0 ? (

--- a/src/features/meeting/components/online-meeting-dialog.tsx
+++ b/src/features/meeting/components/online-meeting-dialog.tsx
@@ -31,6 +31,8 @@ interface OnlineMeetingDialogProps {
   showParentTeamAction: boolean;
   teamActions: RoomTeamActionOption[];
   viewer: AttendeeScopeViewer;
+  /** 트리거 버튼에 얹을 클래스 — 회의실 패널(280px)에서는 폭을 꽉 채운다(`room-list-panel.tsx`). */
+  triggerClassName?: string;
 }
 
 /**
@@ -162,6 +164,7 @@ export function OnlineMeetingDialog({
   showParentTeamAction,
   teamActions,
   viewer,
+  triggerClassName,
 }: OnlineMeetingDialogProps) {
   const [open, setOpen] = useState(false);
   const [createdMeetingId, setCreatedMeetingId] = useState<string | null>(null);
@@ -184,7 +187,9 @@ export function OnlineMeetingDialog({
         setOpen(next);
       }}
     >
-      <DialogTrigger render={<Button type="button" variant="outline" />}>
+      <DialogTrigger
+        render={<Button type="button" variant="outline" size="sm" className={triggerClassName} />}
+      >
         <Video aria-hidden />
         비대면 회의
       </DialogTrigger>

--- a/src/features/rooms/components/room-list-panel.tsx
+++ b/src/features/rooms/components/room-list-panel.tsx
@@ -1,22 +1,40 @@
 import { Plus } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { OnlineMeetingDialog } from "@/features/meeting/components/online-meeting-dialog";
 
+import type { AttendeeScopeViewer } from "../attendee-scope";
 import { ROOM_LIST_PANEL_LABEL, ROOMS_CALENDAR_TOOLBAR_LABEL } from "../constants";
-import type { MeetingRoom } from "../types";
+import type { MeetingRoom, RoomMember, RoomProjectOption, RoomTeamActionOption } from "../types";
 
 interface RoomListPanelProps {
   rooms: MeetingRoom[];
   /** "회의 추가"(2026-08-11 이전엔 캘린더 툴바 안) — 예약 도입부가 회의실 목록 옆이 더 맞다. */
   onAddClick: () => void;
+  /** 비대면 회의 다이얼로그로 그대로 흘려보낸다(2026-08-14, `/app/meeting`에서 이관). */
+  members: RoomMember[];
+  projects: RoomProjectOption[];
+  showParentTeamAction: boolean;
+  teamActions: RoomTeamActionOption[];
+  viewer: AttendeeScopeViewer;
 }
 
 /**
  * 회의실 목록 — 캘린더 우측 사이드바(2026-08-10, 캘린더 하단에서 이동). 예약은 왼쪽
  * 캘린더에서 하고, 여기는 운영 시간만 빠르게 확인하는 자리.
+ * ⚠️ **비대면 회의 진입점도 여기 있다**(2026-08-14, 사이드바 개편으로 `/app/meeting`에서
+ *    이관). 회의실·시간이 없어 예약이 필요 없는 회의라 대면 예약([회의 추가])과 나란히 둔다.
  * 주의: `lg` 미만에서는 캘린더 아래로 쌓인다(`rooms-board.tsx`) — `CalendarDayDetailPanel`과 같은 패턴.
  */
-export function RoomListPanel({ rooms, onAddClick }: RoomListPanelProps) {
+export function RoomListPanel({
+  rooms,
+  onAddClick,
+  members,
+  projects,
+  showParentTeamAction,
+  teamActions,
+  viewer,
+}: RoomListPanelProps) {
   return (
     <aside className="border-border bg-card flex w-full shrink-0 flex-col overflow-hidden rounded-2xl border lg:h-full lg:w-[280px] lg:max-w-[280px]">
       {/*
@@ -53,6 +71,16 @@ export function RoomListPanel({ rooms, onAddClick }: RoomListPanelProps) {
           <Plus aria-hidden />
           {ROOMS_CALENDAR_TOOLBAR_LABEL.addMeeting}
         </Button>
+
+        {/* 비대면 회의는 회의실·시간이 없어 예약이 아니라 등록이다 — 대면 예약과 나란히, 별도 진입점 */}
+        <OnlineMeetingDialog
+          members={members}
+          projects={projects}
+          showParentTeamAction={showParentTeamAction}
+          teamActions={teamActions}
+          viewer={viewer}
+          triggerClassName="w-full"
+        />
       </div>
 
       <ul className="min-h-0 flex-1 overflow-y-auto">

--- a/src/features/rooms/components/rooms-board.tsx
+++ b/src/features/rooms/components/rooms-board.tsx
@@ -77,6 +77,11 @@ export function RoomsBoard({
       <RoomListPanel
         rooms={rooms}
         onAddClick={() => setSlotStart(getNextAvailableSlot(new Date()))}
+        members={members}
+        projects={projects}
+        showParentTeamAction={showParentTeamAction}
+        teamActions={teamActions}
+        viewer={viewer}
       />
 
       <RoomReservationDialog

--- a/src/features/shell/nav-config.test.ts
+++ b/src/features/shell/nav-config.test.ts
@@ -67,9 +67,9 @@ describe("Owner", () => {
 describe("Leader", () => {
   it("팀 관리가 붙는다", () => {
     expect(labels(navFor(actor(AUTHORITY.LEADER)), "팀 관리")).toEqual([
-      "팀원",
-      "팀 액션",
-      "인수인계 승인",
+      "팀원 관리",
+      "팀 액션 관리",
+      "인수인계서 관리",
     ]);
   });
 
@@ -197,11 +197,11 @@ describe("화면이 있으면 자동으로 이어진다", () => {
     ["/app/calendar", "캘린더"],
     ["/app/notice", "공지"],
     ["/app/me", "마이페이지"],
-    ["/manage/billing", "구독"],
+    ["/manage/billing", "구독 관리"],
     ["/manage/storage", "녹음 용량"],
     ["/owner/setting", "기업 설정"],
     ["/manage/members", "사원 관리"],
-    ["/app/meeting", "회의"],
+    ["/app/meeting", "내 회의"],
   ])("만들어진 화면 `%s`(%s)는 링크가 된다", (href) => {
     const item = everyItem.find((candidate) => candidate.href === href);
 

--- a/src/features/shell/nav-config.ts
+++ b/src/features/shell/nav-config.ts
@@ -19,33 +19,41 @@ import { hasRoute } from "./routes";
  * ⚠️ 화면이 아직 없으면 눌러도 404 대신 "준비 중"이 뜬다(§정직성).
  */
 
-/** 로그인한 전원이 같이 쓰는 워크벤치 — 역할에 따라 **빠지는 항목만** 있다 */
+/** 로그인한 전원이 같이 쓰는 상단 항목 — 역할에 따라 **빠지는 항목만** 있다 */
 const COMMON_TOP: NavItem[] = [
-  { href: "/app/projects", label: "프로젝트", icon: "project" },
-  { href: "/app/search", label: "검색", icon: "search" },
-  { href: "/app/calendar", label: "캘린더", icon: "calendar" },
-  { href: "/app/notice", label: "공지", icon: "notice" },
+  { href: "/app/meeting", label: "내 회의", icon: "meeting" },
+  { href: "/app/board", label: "보드", icon: "board" },
 ];
 
+const COMMON_TOP_TAIL: NavItem[] = [
+  { href: "/app/calendar", label: "캘린더", icon: "calendar" },
+  { href: "/app/me", label: "마이페이지", icon: "me" },
+];
+
+/**
+ * Owner에게는 **없는** 상단 항목.
+ *
+ * ⚠️ `/app/my/actions`는 OWNER 접근 불가다(CLAUDE.md §라우트 그룹).
+ *    Owner는 액션을 받는 자리가 아니다.
+ */
+const MEMBER_TOP: NavItem[] = [{ href: "/app/my/actions", label: "내 액션", icon: "board" }];
+
 const COMMON_WORKBENCH: NavItem[] = [
-  { href: "/app/meeting", label: "회의", icon: "meeting" },
-  { href: "/app/rooms", label: "회의실", icon: "room" },
-  { href: "/app/board", label: "보드", icon: "board" },
+  { href: "/app/projects", label: "프로젝트", icon: "project" },
+  { href: "/app/rooms", label: "회의 예약", icon: "room" },
+  { href: "/app/search", label: "검색", icon: "search" },
+  { href: "/app/notice", label: "공지", icon: "notice" },
   { href: "/app/people", label: "구성원", icon: "people" },
 ];
 
 /**
  * Owner에게는 **없는** 워크벤치 항목.
  *
- * ⚠️ `/app/my/actions`는 OWNER 접근 불가, `/app/handover`는 OWNER 제외다
- *    (CLAUDE.md §라우트 그룹). Owner는 액션을 받는 자리가 아니고, 인수인계를 쓰는 쪽도 아니다.
+ * ⚠️ `/app/handover`는 OWNER 제외다(CLAUDE.md §라우트 그룹). Owner는 인수인계를 쓰는 쪽이 아니다.
  */
 const MEMBER_WORKBENCH: NavItem[] = [
-  { href: "/app/my/actions", label: "내 액션", icon: "board" },
-  { href: "/app/handover", label: "인수인계", icon: "approval" },
+  { href: "/app/handover", label: "인수인계서 작성", icon: "approval" },
 ];
-
-const MY_PAGE: NavItem = { href: "/app/me", label: "마이페이지", icon: "me" };
 
 /**
  * 회사 운영 — **Owner와 Admin 겸직자가 보는 것이 다르다.**
@@ -61,7 +69,7 @@ const MY_PAGE: NavItem = { href: "/app/me", label: "마이페이지", icon: "me"
 const MANAGE_MEMBERS: NavItem = { href: "/manage/members", label: "사원 관리", icon: "members" };
 
 const MANAGE_MONEY: NavItem[] = [
-  { href: "/manage/billing", label: "구독", icon: "billing" },
+  { href: "/manage/billing", label: "구독 관리", icon: "billing" },
   { href: "/manage/storage", label: "저장소 관리", icon: "storage" },
 ];
 
@@ -85,9 +93,9 @@ const OWNER_ONLY: NavItem[] = [
 const TEAM_SECTION: NavSection = {
   title: "팀 관리",
   items: [
-    { href: "/team/members", label: "팀원", icon: "members" },
-    { href: "/team/action", label: "팀 액션", icon: "board" },
-    { href: "/team/handover", label: "인수인계 승인", icon: "approval" },
+    { href: "/team/members", label: "팀원 관리", icon: "members" },
+    { href: "/team/action", label: "팀 액션 관리", icon: "board" },
+    { href: "/team/handover", label: "인수인계서 관리", icon: "approval" },
   ],
 };
 
@@ -133,14 +141,13 @@ function withReadiness(items: NavItem[]): NavItem[] {
 export function navFor(viewer: Actor): NavSection[] {
   const isOwner = viewer.role === AUTHORITY.OWNER;
 
-  const workbench = isOwner
-    ? [...COMMON_WORKBENCH, MY_PAGE]
-    : [...COMMON_WORKBENCH, ...MEMBER_WORKBENCH, MY_PAGE];
+  const top = isOwner
+    ? [DASHBOARD[viewer.role], ...COMMON_TOP, ...COMMON_TOP_TAIL]
+    : [DASHBOARD[viewer.role], ...COMMON_TOP, ...MEMBER_TOP, ...COMMON_TOP_TAIL];
 
-  const sections: NavSection[] = [
-    { items: [DASHBOARD[viewer.role], ...COMMON_TOP] },
-    { title: "워크벤치", items: workbench },
-  ];
+  const workbench = isOwner ? COMMON_WORKBENCH : [...COMMON_WORKBENCH, ...MEMBER_WORKBENCH];
+
+  const sections: NavSection[] = [{ items: top }, { title: "워크벤치", items: workbench }];
 
   if (viewer.role === AUTHORITY.LEADER) sections.push(TEAM_SECTION);
 


### PR DESCRIPTION
## 📋 PR 타입

> 해당하는 타입을 선택해 주세요 (복수 선택 가능)

- [x] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [x] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [x] OWNER (대표)
- [x] ADMIN (관리자)
- [x] LEADER (팀장)
- [x] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- 사이드바 라벨을 팀 확정안대로 변경했습니다 — 회의→내 회의, 회의실→회의 예약, 인수인계→인수인계서 작성,
  구독→구독 관리, 팀원→팀원 관리, 팀 액션→팀 액션 관리, 인수인계 승인→인수인계서 관리
- 사이드바 항목 순서를 재구성했습니다 — 대시보드 섹션(대시보드·내 회의·보드·내 액션·캘린더·마이페이지)과
  워크벤치 섹션(프로젝트·회의 예약·검색·공지·구성원·인수인계서 작성)으로 재배치
- 비대면 회의 만들기 진입점을 `/app/meeting`에서 `/app/rooms`(회의 예약)로 옮기고, `/app/meeting`에는
  회의 예약 화면으로 이동하는 링크를 새로 달았습니다

---

## ✅ 작업 체크리스트

**기본**

- [ ] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [ ] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 이번 변경은 라벨·순서만 바꿨고, 기존 표시 조건(`canManageBilling`·
  `canManageRooms`·역할 비교)과 각 화면의 서버 재검사는 그대로 둠(신규 서버 로직 없음)
- [ ] 🧬 **zod** — 이번 변경에 새 스키마 없음(내비 구성·컴포넌트 이관뿐)
- [x] 🕵️ **정직성** — 목·미구현·폴백 해당 없음(순수 UI 재구성)
- [x] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨 — 기존 컴포넌트 재사용, 신규 색상 없음

**품질**

- [x] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그) — 해당 없음(변경 범위 내 신규 자산 없음)
- [x] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로 — 기존 버튼·링크 컴포넌트 재사용
- [x] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인) — `Button`/`buttonVariants` 재사용, `OnlineMeetingDialog`는 이관 없이 import 경로만 재사용
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 기존 상태 로직 변경 없음
- [x] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음 — 해당 없음

---

## 🔗 연관 이슈

Closes #507 

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

- 회의실 관리(admin 전용)와 인수인계서 관리(owner 전용, admin 겸직 불가) 노출 조건은 이번 명세에
  명시가 없어 **기존 정책을 그대로 유지**했습니다 — 의도와 다르면 알려주세요.
- 비대면 회의 다이얼로그를 `features/meeting/components`에서 그대로 import해 `RoomListPanel`에
  꽂았습니다(파일 이동 없이 import 경로만 교차) — 추후 `rooms` 도메인으로 완전히 옮길지는 별도 논의로 남겨뒀습니다.
- 목(mock) 로그인 모드라 실제 로그인 화면으로 브라우저 검증은 못 했고, 타입체크·린트·관련 jest
  스위트(197개)로만 확인했습니다.

---

## 📝 추가 메모