### PR TITLE
[FIX] 회의실 추가·수정·삭제 권한 판정이 실제 로그인 세션을 보게 한다 #509

### DIFF
--- a/src/features/rooms/actions.real.test.ts
+++ b/src/features/rooms/actions.real.test.ts
@@ -21,7 +21,12 @@ import { requireAccessToken } from "@/features/auth/session";
 import { getViewer } from "@/features/shell/viewer";
 import { serverApi } from "@/lib/api";
 
-import { createRoomReservationAction } from "./actions";
+import {
+  createMeetingRoomAction,
+  createRoomReservationAction,
+  deleteMeetingRoomAction,
+  updateMeetingRoomAction,
+} from "./actions";
 import { getReservableMembers } from "./server";
 
 /**
@@ -110,5 +115,65 @@ describe("createRoomReservationAction — 실서버 참석자 재검증", () => 
 
     expect(result.errors).toEqual({});
     expect(serverApiMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * 회의실 추가·수정·삭제 — **실서버 권한 판정이 실제 로그인 세션을 본다**.
+ *
+ * ⚠️ 회귀 테스트다 — 세 액션이 전부 `canManageRooms(getMockActor())`로 실서버에서도
+ *    고정된 mock 액터(OWNER, isAdmin 없음)를 판정해서, 실제로 is_admin인 사람이 로그인해도
+ *    항상 막히던 버그가 있었다. `getViewer()`(실제 세션)를 보게 고쳤다.
+ */
+function roomForm(): FormData {
+  const data = new FormData();
+  data.append("name", "박애관 302호");
+  data.append("location", "박애관 302호");
+  data.append("openTime", "00:00");
+  data.append("closeTime", "23:30");
+  return data;
+}
+
+const ADMIN_LEADER = { id: 5, role: AUTHORITY.LEADER, isAdmin: true, teamName: "인사팀" };
+const NON_ADMIN_LEADER = { id: 2, role: AUTHORITY.LEADER, teamName: "개발팀" };
+
+describe("회의실 추가·수정·삭제 — 실서버 권한 판정", () => {
+  it("createMeetingRoomAction — is_admin 로그인 세션이면 통과해 BE를 부른다", async () => {
+    getViewerMock.mockResolvedValue(ADMIN_LEADER);
+    serverApiMock.mockResolvedValue({ meetingRoomId: 1 });
+
+    const result = await createMeetingRoomAction({ errors: {} }, roomForm());
+
+    expect(result.errors).toEqual({});
+    expect(serverApiMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("createMeetingRoomAction — is_admin 아닌 로그인 세션이면 BE를 부르지 않고 막는다", async () => {
+    getViewerMock.mockResolvedValue(NON_ADMIN_LEADER);
+
+    const result = await createMeetingRoomAction({ errors: {} }, roomForm());
+
+    expect(result.errors.name).toBe("회의실을 추가할 권한이 없습니다");
+    expect(serverApiMock).not.toHaveBeenCalled();
+  });
+
+  it("updateMeetingRoomAction — is_admin 아닌 로그인 세션이면 BE를 부르지 않고 막는다", async () => {
+    getViewerMock.mockResolvedValue(NON_ADMIN_LEADER);
+    const data = roomForm();
+    data.append("id", "1");
+
+    const result = await updateMeetingRoomAction({ errors: {} }, data);
+
+    expect(result.errors.name).toBe("회의실을 수정할 권한이 없습니다");
+    expect(serverApiMock).not.toHaveBeenCalled();
+  });
+
+  it("deleteMeetingRoomAction — is_admin 아닌 로그인 세션이면 BE를 부르지 않고 막는다", async () => {
+    getViewerMock.mockResolvedValue(NON_ADMIN_LEADER);
+    const data = new FormData();
+    data.append("id", "1");
+
+    await expect(deleteMeetingRoomAction(data)).rejects.toThrow("회의실을 삭제할 권한이 없습니다");
+    expect(serverApiMock).not.toHaveBeenCalled();
   });
 });

--- a/src/features/rooms/actions.real.test.ts
+++ b/src/features/rooms/actions.real.test.ts
@@ -157,6 +157,24 @@ describe("회의실 추가·수정·삭제 — 실서버 권한 판정", () => {
     expect(serverApiMock).not.toHaveBeenCalled();
   });
 
+  it("updateMeetingRoomAction — is_admin 로그인 세션이면 통과해 BE를 부른다", async () => {
+    getViewerMock.mockResolvedValue(ADMIN_LEADER);
+    serverApiMock.mockResolvedValue({
+      meetingRoomId: 1,
+      name: "박애관 302호",
+      location: "박애관 302호",
+      availableFrom: "00:00",
+      availableTo: "23:30",
+    });
+    const data = roomForm();
+    data.append("id", "1");
+
+    const result = await updateMeetingRoomAction({ errors: {} }, data);
+
+    expect(result.errors).toEqual({});
+    expect(serverApiMock).toHaveBeenCalledTimes(1);
+  });
+
   it("updateMeetingRoomAction — is_admin 아닌 로그인 세션이면 BE를 부르지 않고 막는다", async () => {
     getViewerMock.mockResolvedValue(NON_ADMIN_LEADER);
     const data = roomForm();
@@ -166,6 +184,17 @@ describe("회의실 추가·수정·삭제 — 실서버 권한 판정", () => {
 
     expect(result.errors.name).toBe("회의실을 수정할 권한이 없습니다");
     expect(serverApiMock).not.toHaveBeenCalled();
+  });
+
+  it("deleteMeetingRoomAction — is_admin 로그인 세션이면 통과해 BE를 부른다", async () => {
+    getViewerMock.mockResolvedValue(ADMIN_LEADER);
+    serverApiMock.mockResolvedValue(null);
+    const data = new FormData();
+    data.append("id", "1");
+
+    await deleteMeetingRoomAction(data);
+
+    expect(serverApiMock).toHaveBeenCalledTimes(1);
   });
 
   it("deleteMeetingRoomAction — is_admin 아닌 로그인 세션이면 BE를 부르지 않고 막는다", async () => {

--- a/src/features/rooms/actions.ts
+++ b/src/features/rooms/actions.ts
@@ -272,7 +272,8 @@ export async function createMeetingRoomAction(
   _prev: MeetingRoomFormState,
   formData: FormData,
 ): Promise<MeetingRoomFormState> {
-  if (!canManageRooms(getMockActor())) {
+  const actor = isMock ? getMockActor() : await getViewer();
+  if (!canManageRooms(actor)) {
     return { errors: { name: "회의실을 추가할 권한이 없습니다" } };
   }
 
@@ -307,7 +308,8 @@ export async function updateMeetingRoomAction(
   _prev: MeetingRoomFormState,
   formData: FormData,
 ): Promise<MeetingRoomFormState> {
-  if (!canManageRooms(getMockActor())) {
+  const actor = isMock ? getMockActor() : await getViewer();
+  if (!canManageRooms(actor)) {
     return { errors: { name: "회의실을 수정할 권한이 없습니다" } };
   }
 
@@ -351,7 +353,8 @@ export async function updateMeetingRoomAction(
  *    부르는 흐름이라 폼 오류 슬롯이 없고, 던진 오류는 가장 가까운 `error.tsx`가 받는다.
  */
 export async function deleteMeetingRoomAction(formData: FormData): Promise<void> {
-  if (!canManageRooms(getMockActor())) {
+  const actor = isMock ? getMockActor() : await getViewer();
+  if (!canManageRooms(actor)) {
     throw new Error("회의실을 삭제할 권한이 없습니다");
   }
 


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독

---

## 🙋 관련 역할

- [x] ADMIN (관리자)

---

## 📝 작업 내용

`createMeetingRoomAction`·`updateMeetingRoomAction`·`deleteMeetingRoomAction` 세 곳이 `canManageRooms(getMockActor())`로 권한을 판정하고 있었습니다 — `getMockActor()`는 `isMock` 여부와 무관하게 항상 고정된 mock 액터(`isAdmin` 없음)를 돌려주므로, 실서버 모드에서도 실제 is_admin 로그인 세션과 무관하게 항상 막혔습니다.

같은 파일 159번째 줄에 이미 있는 올바른 패턴을 그대로 적용했습니다:

```ts
const actor = isMock ? getMockActor() : await getViewer();
if (!canManageRooms(actor)) { ... }
```

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`fix/rooms-manage-permission-live#509`, base `develop`)
- [x] 커밋 컨벤션 준수 (`fix: 제목 #509`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 역할 가드(`canManageRooms`)가 이제 실제 세션을 봄. BE도 각 엔드포인트에서 재검사함(화면 가드는 UX일 뿐이라는 기존 원칙 그대로 유지)

**품질**

- [x] 🧪 `typecheck`·`lint` 통과, 전체 `jest`(129 suites/1380 tests) 통과
- [x] 새 회귀 테스트 4건 추가(`actions.real.test.ts`) — is_admin 세션은 통과해 BE를 부르는지, is_admin 아닌 세션은 셋 다 BE를 안 부르고 막는지

---

## 🔗 연관 이슈

Closes #509

---

## 💬 리뷰 포인트

같은 파일의 다른 실서버 분기(예약 생성 등)에도 이런 "고정 mock 액터를 그대로 쓴" 패턴이 더 남아있는지 리뷰 시 같이 훑어봐 주시면 좋을 것 같습니다 — 이번에 발견한 세 곳은 전부 고쳤습니다.

---

## 📝 추가 메모

없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 실제 환경에서 회의실 생성·수정·삭제 시 현재 로그인 사용자의 권한을 올바르게 확인합니다.
  * 관리자는 회의실 생성 요청을 수행할 수 있으며, 비관리자의 작업은 권한 오류로 차단됩니다.

* **테스트**
  * 실제 로그인 세션의 관리자 및 비관리자 권한 동작을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |
