### PR TITLE
[FEAT] 저장소 관리 조회 실연동 — GET /api/companies/me/storage #511

### DIFF
--- a/src/features/storage/actions.ts
+++ b/src/features/storage/actions.ts
@@ -14,7 +14,8 @@ import { canDeleteRecordings } from "./storage";
  * ⚠️ **되돌릴 수 없는 일이다.** 지운 음성은 복구되지 않는다 — 그래서 권한도, 지울 수 있는
  *    줄인지도 **서버에서 다시 본다**. 화면에서 버튼을 감춘 건 UX일 뿐이고, 액션은 주소만
  *    알면 직접 부를 수 있다(§권한: 화면 숨김은 보안이 아니다).
- * ⚠️ 아직 목이다. BE 스펙이 확정되면 본문만 채운다 — 부르는 쪽은 그대로다.
+ * ⚠️ **조회(`getStorageOverview`)는 실연동됐다**(2026-08-14 BE PR #494). 삭제만 아직
+ *    목이다 — BE에 `DELETE .../projects/{tag}`가 없다(아래 `deleteRecordingsAction` 참고).
  */
 
 /** 액션의 공통 결과 — 실패를 예외로 던지지 않고 값으로 돌려준다(화면이 문구를 고른다) */
@@ -77,6 +78,12 @@ export async function deleteRecordingsAction(tag: string): Promise<StorageAction
     return { isSuccess: true };
   }
 
-  // TODO(BE 협의): `DELETE /companies/me/storage/projects/{tag}`
-  return { isSuccess: false, message: "삭제하지 못했습니다" };
+  /*
+    ⚠️ **BE에 아직 이 경로가 없다**(2026-08-14 확인 — `CompanyStorageController`는
+       조회(`GET /companies/me/storage`)만 있고 삭제 라우트가 없다). 조회는 이미 실연동
+       됐으니 되는 척하지 않는다(§정직성) — 없는 API를 부르는 대신 여기서 명시적으로 막는다.
+       BE가 `DELETE /companies/me/storage/projects/{tag}`를 열면 그 자리에 `serverApi`
+       호출과 `revalidatePath("/manage/storage")`를 넣는다.
+  */
+  return { isSuccess: false, message: "삭제하지 못했습니다 — 아직 지원하지 않는 기능입니다" };
 }

--- a/src/features/storage/server.test.ts
+++ b/src/features/storage/server.test.ts
@@ -1,0 +1,72 @@
+jest.mock("@/mocks/config", () => ({ isMock: false }));
+jest.mock("@/features/auth/session", () => ({ requireAccessToken: jest.fn() }));
+jest.mock("@/lib/api", () => ({ serverApi: jest.fn() }));
+
+import { PROJECT_STATUS } from "@/constants/project";
+import { requireAccessToken } from "@/features/auth/session";
+import { serverApi } from "@/lib/api";
+
+import { getStorageOverview } from "./server";
+
+/**
+ * 저장소 현황 조회 — 실서버 연동(2026-08-14 BE PR #494).
+ *
+ * ⚠️ BE `StorageOverviewResponse`가 이 화면의 UI 계약과 필드명을 그대로 맞췄다고
+ *    명시했지만, 매퍼를 거치는지·`serverApi`가 봉투를 벗기는지는 실행으로 잠가 둔다 —
+ *    "이름이 같다"와 "실제로 그대로 통과한다"는 다른 확인이다.
+ */
+describe("getStorageOverview — 실서버", () => {
+  const requireAccessTokenMock = requireAccessToken as unknown as jest.Mock;
+  const serverApiMock = serverApi as unknown as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    requireAccessTokenMock.mockResolvedValue("token");
+  });
+
+  it("저장소 엔드포인트를 한 번 불러 그대로 옮긴다", async () => {
+    serverApiMock.mockResolvedValueOnce({
+      voiceGb: 34.9,
+      sttGb: 6.8,
+      projects: [
+        {
+          tag: "product-v2",
+          name: "제품 v2.0",
+          meetingCount: 24,
+          voiceGb: 9.1,
+          sttGb: 1.4,
+          lastRecordedAt: "2026-08-07",
+          status: PROJECT_STATUS.IN_PROGRESS,
+        },
+      ],
+    });
+
+    const overview = await getStorageOverview();
+
+    expect(serverApiMock.mock.calls[0][0]).toBe("/api/companies/me/storage");
+    expect(overview).toEqual({
+      voiceGb: 34.9,
+      sttGb: 6.8,
+      projects: [
+        {
+          tag: "product-v2",
+          name: "제품 v2.0",
+          meetingCount: 24,
+          voiceGb: 9.1,
+          sttGb: 1.4,
+          lastRecordedAt: "2026-08-07",
+          status: PROJECT_STATUS.IN_PROGRESS,
+        },
+      ],
+    });
+  });
+
+  /* ⚠️ 빈 회사는 에러가 아니라 0.0GB·빈 배열이다(BE PR #494 본문 — "그 외 도메인 예외는 없다") */
+  it("녹음이 하나도 없는 회사는 0GB·빈 목록이다", async () => {
+    serverApiMock.mockResolvedValueOnce({ voiceGb: 0, sttGb: 0, projects: [] });
+
+    const overview = await getStorageOverview();
+
+    expect(overview).toEqual({ voiceGb: 0, sttGb: 0, projects: [] });
+  });
+});

--- a/src/features/storage/server.test.ts
+++ b/src/features/storage/server.test.ts
@@ -69,4 +69,31 @@ describe("getStorageOverview — 실서버", () => {
 
     expect(overview).toEqual({ voiceGb: 0, sttGb: 0, projects: [] });
   });
+
+  /*
+    ⚠️ **`projects`가 `[]`가 아니라 필드째 빠지거나 `null`로 올 수도 있다**(2026-08-14
+       재발견 — `team.roles`·조직도 `members`에서 실제로 겪은 것과 같은 종류의 위험이다).
+       BE가 진짜 빈 리스트를 `[]`로 직렬화한다는 보장은 이 코드만 보고는 확신할 수 없다 —
+       `.map()`이 죽는 대신 빈 배열로 접힌다.
+  */
+  it("projects 필드가 없거나 null이어도 죽지 않고 빈 배열이다", async () => {
+    serverApiMock.mockResolvedValueOnce({ voiceGb: 0, sttGb: 0, projects: undefined });
+    expect((await getStorageOverview()).projects).toEqual([]);
+
+    serverApiMock.mockResolvedValueOnce({ voiceGb: 0, sttGb: 0, projects: null });
+    expect((await getStorageOverview()).projects).toEqual([]);
+  });
+
+  /*
+    ⚠️ **실패는 그대로 던진다 — 삼키지 않는다.** 이 함수는 일부러 try/catch가 없다
+       (BE 403은 화면 가드가 이미 걸러서 이 함수까지 안 온다고 보고, 여기서 또 잡아
+       조용히 목 값으로 대신하면 실제 사용자에게 옛 값을 보여주는 거짓 화면이 된다).
+       나중에 "UX 개선" 명목으로 try/catch를 씌워도 이 테스트가 잡는다.
+  */
+  it("serverApi가 실패하면 삼키지 않고 그대로 던진다", async () => {
+    const boom = new Error("500");
+    serverApiMock.mockRejectedValueOnce(boom);
+
+    await expect(getStorageOverview()).rejects.toBe(boom);
+  });
 });

--- a/src/features/storage/server.ts
+++ b/src/features/storage/server.ts
@@ -1,16 +1,18 @@
 import "server-only";
 
-import { PROJECT_STATUS } from "@/constants/project";
+import { PROJECT_STATUS, type ProjectStatus } from "@/constants/project";
+import { requireAccessToken } from "@/features/auth/session";
+import { serverApi } from "@/lib/api";
+import { ep } from "@/lib/endpoints";
 import { isMock } from "@/mocks/config";
 
-import type { StorageOverview } from "./types";
+import type { ProjectStorage, StorageOverview } from "./types";
 
 /**
  * 녹음 용량 조회 — **격리막**.
  *
  * ⚠️ 컴포넌트는 반환 타입(`StorageOverview`)만 본다. 연동되면 여기서 `isMock` 분기만
  *    실서버 호출로 바꾸고 매퍼가 shape을 흡수한다 — 화면은 안 바뀐다.
- * ⚠️ ERD·API가 아직 없다(BE 협의 전). 아래 값은 "그럴듯한 예시"가 아니라 **가정한 shape**이다.
  */
 
 /**
@@ -76,9 +78,69 @@ const MOCK: StorageOverview = {
   ],
 };
 
+/**
+ * BE shape → UI 계약 (§Mock 격리막).
+ *
+ * [확인] BE `StorageOverviewResponse`(`metering` 패키지, 2026-08-14 BE PR #494) —
+ * BE가 이 화면의 UI 계약(`StorageOverview`)에 필드명을 그대로 맞춰서 냈다(BE 코드 주석에
+ * "FE storage/types.ts의 StorageOverview 계약과 필드명을 그대로 맞춘다"라고 명시). 그래도
+ * 매퍼를 거친다 — BE 응답 모양이 바뀌어도 고칠 곳이 여기 한 곳이어야 한다.
+ *
+ * ⚠️ **`sttGb`는 지금 캡션 몫만 반영된다**(BE PR #494 본문 명시) — transcript·요약 리포트는
+ *    capture 도메인 연동이 아직 안 붙어서, 실제보다 적게 보일 수 있다. FE가 고칠 수 있는
+ *    값이 아니다 — BE가 그 리포트를 붙이면 이 값도 저절로 올라온다.
+ * ⚠️ `voiceGb`·`sttGb`는 BE가 이미 소수점 첫째 자리로 반올림해서 준다 — 여기서 다시
+ *    반올림하지 않는다.
+ */
+interface BeProjectStorage {
+  tag: string;
+  name: string;
+  meetingCount: number;
+  voiceGb: number;
+  sttGb: number;
+  /** `2020-01-02` — Jackson이 `LocalDate`를 ISO 문자열로 내린다 */
+  lastRecordedAt: string;
+  status: ProjectStatus;
+}
+
+interface BeStorageOverview {
+  voiceGb: number;
+  sttGb: number;
+  projects: BeProjectStorage[];
+}
+
+function toProjectStorage(item: BeProjectStorage): ProjectStorage {
+  return {
+    tag: item.tag,
+    name: item.name,
+    meetingCount: item.meetingCount,
+    voiceGb: item.voiceGb,
+    sttGb: item.sttGb,
+    lastRecordedAt: item.lastRecordedAt,
+    status: item.status,
+  };
+}
+
+function toStorageOverview(be: BeStorageOverview): StorageOverview {
+  return {
+    voiceGb: be.voiceGb,
+    sttGb: be.sttGb,
+    projects: be.projects.map(toProjectStorage),
+  };
+}
+
+/**
+ * [확인] BE `CompanyStorageController.getStorage` — `GET /api/companies/me/storage`,
+ * `@PreAuthorize("hasAnyRole('OWNER', 'ADMIN')")`(`canManageStorage`와 같은 문).
+ *
+ * ⚠️ 이 엔드포인트 자체가 던지는 도메인 예외는 없다(BE PR #494 본문) — 빈 회사는
+ *    0.0GB·빈 배열로 정상 응답한다. 인증 없음·OWNER·ADMIN 아님만 403이고, 그건 화면
+ *    가드(`canManageStorage`)가 이미 걸러 이 함수를 부르기 전에 막는다.
+ */
 export async function getStorageOverview(): Promise<StorageOverview> {
   if (isMock) return MOCK;
 
-  // TODO(BE 협의): `GET /companies/me/storage` → { voiceGb, sttGb, projects[] }
-  throw new Error("저장소 정보를 불러오지 못했습니다");
+  const accessToken = await requireAccessToken();
+  const overview = await serverApi<BeStorageOverview>(ep.companyStorage(), { accessToken });
+  return toStorageOverview(overview);
 }

--- a/src/features/storage/server.ts
+++ b/src/features/storage/server.ts
@@ -106,7 +106,8 @@ interface BeProjectStorage {
 interface BeStorageOverview {
   voiceGb: number;
   sttGb: number;
-  projects: BeProjectStorage[];
+  /** ⚠️ 없을 수도 있다고 정직하게 적는다 — `toStorageOverview`의 `?? []` 방어 근거다 */
+  projects?: BeProjectStorage[];
 }
 
 function toProjectStorage(item: BeProjectStorage): ProjectStorage {
@@ -122,10 +123,17 @@ function toProjectStorage(item: BeProjectStorage): ProjectStorage {
 }
 
 function toStorageOverview(be: BeStorageOverview): StorageOverview {
+  /*
+    ⚠️ **빈 회사가 정상이라는 약속을 여기서도 지킨다**(BE PR #494 본문 — "빈 회사는
+       0.0GB·빈 배열로 정상 응답"). `projects`가 진짜 `[]`로 온다는 보장은 Jackson
+       직렬화 설정에 달려 있어 코드만 보고 100% 확신할 수 없다 — `null`로 와도
+       `.map()`이 죽지 않고 똑같이 빈 배열로 접히게 방어한다(§company/mapper.ts의
+       `team.roles ?? []`와 같은 이유).
+  */
   return {
     voiceGb: be.voiceGb,
     sttGb: be.sttGb,
-    projects: be.projects.map(toProjectStorage),
+    projects: (be.projects ?? []).map(toProjectStorage),
   };
 }
 

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -132,6 +132,12 @@ export const ep = {
   companyRegistrations: () => "/api/companies/registrations",
   companyMe: () => "/api/companies/me",
   companyOnboarding: () => "/api/companies/me/onboarding",
+  /*
+   * 저장소 관리(`/manage/storage`). [확인] BE `CompanyStorageController`
+   * (`metering` 패키지, 2026-08-14 BE PR #494) — `GET`만 있다. 프로젝트별 저장 기록
+   * 삭제(`DELETE .../projects/{tag}`)는 BE에 아직 없다(`deleteRecordingsAction` 참고).
+   */
+  companyStorage: () => "/api/companies/me/storage",
 
   /*
    * 회의 — [확인] BE 실코드 대조(2026-08-12, 커밋 `51b5482f` "회의·회의실·공지사항 API 경로 통일" 리팩터 반영)


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [x] OWNER (대표)
- [x] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

## 무엇
BE PR #494(Z-Groupware/BACKEND)가 연 `GET /api/companies/me/storage`를 `getStorageOverview`에 연결했습니다.

## 확인 (BE 실코드 대조 — 완벽하게 맞는지 검증)
- 필드명 1:1 일치(BE가 FE 계약에 맞춰 설계 — BE 코드 주석에 명시)
- 권한 문(`OWNER`·`ADMIN`) 일치
- `ProjectStatus` enum 값 일치
- 도메인 예외 없음 — 빈 회사도 정상 응답(0.0GB·빈 배열)

## BE 쪽 남은 제약 (FE 이슈 아님, #511 본문에 기록)
- `sttGb`는 캡션 몫만(transcript·요약 연동 별도 진행 중)
- 삭제 엔드포인트 없음 — `deleteRecordingsAction`은 계속 미구현으로 남김(메시지 정정)

## 확인법
`npx tsc --noEmit` · `npx jest`(134 suites/1415 tests) 통과.

Closes #511

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**, 그리고 **서버에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [ ] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시
- [ ] 🎨 디자인 토큰 사용 · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화
- [ ] ♿ a11y
- [ ] ♻️ 재사용 확인
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API 사용 시 미지원 · 권한거부 안내 있음

---

## 🔗 연관 이슈

Closes #511

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

-

---

## 📝 추가 메모
