### PR TITLE
[FIX] 인수인계 팀 스코프 권한 검사 + 데모 미리보기 UI 제거 #514

### DIFF
--- a/src/app/(shell)/app/handover/page.tsx
+++ b/src/app/(shell)/app/handover/page.tsx
@@ -5,7 +5,7 @@ import { HANDOVER_TYPE } from "@/constants/domain";
 import { HandoverControls } from "@/features/handover/components/handover-controls";
 import { OffboardingForm } from "@/features/handover/components/offboarding-form";
 import { VacationForm } from "@/features/handover/components/vacation-form";
-import { parseHandoverPreview, parseHandoverType } from "@/features/handover/lib";
+import { parseHandoverType } from "@/features/handover/lib";
 import { getHandoverContext } from "@/features/handover/server";
 import { roleHome } from "@/features/shell/home";
 import { getViewer } from "@/features/shell/viewer";
@@ -16,15 +16,14 @@ export const metadata: Metadata = {
 };
 
 interface HandoverPageProps {
-  searchParams: Promise<{ as?: string; type?: string }>;
+  searchParams: Promise<{ type?: string }>;
 }
 
 /**
  * 인수인계서 신청 — 휴직/오프보딩(WORKFLOW.md §7).
- * ⚠️ Owner는 이 화면에 안 온다 — `canWriteHandover`로 실제 가드를 건다(2026-08-15,
- *    "로그인 세션이 없어 미리보기 토글로 대신한다"던 이전 상태를 벗어남).
- *    미리보기 토글(`?as=`)은 mock 모드에서만 의미가 있고, 실서버에서는
- *    `getHandoverContext`가 그 값을 무시하고 실제 로그인 세션(`getViewer`)만 본다.
+ * ⚠️ Owner는 이 화면에 안 온다 — `canWriteHandover`로 실제 가드를 건다.
+ *    `getHandoverContext`는 실제 로그인 세션(`getViewer`)만 본다 — 미리보기 토글은
+ *    데모용이라 걷어냈다(2026-08-16).
  */
 export default async function HandoverPage({ searchParams }: HandoverPageProps) {
   const viewer = await getViewer();
@@ -33,9 +32,8 @@ export default async function HandoverPage({ searchParams }: HandoverPageProps) 
   }
 
   const params = await searchParams;
-  const preview = parseHandoverPreview(params.as);
   const type = parseHandoverType(params.type);
-  const context = await getHandoverContext(preview);
+  const context = await getHandoverContext();
 
   return (
     <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
@@ -47,7 +45,7 @@ export default async function HandoverPage({ searchParams }: HandoverPageProps) 
            1400px로 늘리면 라벨과 커서가 멀어져 읽고 쓰기가 나빠진다(기업 설정과 같은 판단).
       */}
       <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-5">
-        <HandoverControls activePreview={preview} activeType={type} />
+        <HandoverControls activeType={type} />
 
         {type === HANDOVER_TYPE.VACATION ? (
           <VacationForm context={context} />

--- a/src/features/handover/components/handover-controls.tsx
+++ b/src/features/handover/components/handover-controls.tsx
@@ -2,88 +2,36 @@ import Link from "next/link";
 
 import type { HandoverType } from "@/constants/domain";
 import { cn } from "@/lib/utils";
-import { isMock } from "@/mocks/config";
 
-import {
-  DEFAULT_HANDOVER_PREVIEW,
-  DEFAULT_HANDOVER_TYPE,
-  HANDOVER_PREVIEW_TABS,
-  HANDOVER_TYPE_TABS,
-  type HandoverPreview,
-} from "../lib";
+import { DEFAULT_HANDOVER_TYPE, HANDOVER_TYPE_TABS } from "../lib";
 
 interface HandoverControlsProps {
-  activePreview: HandoverPreview;
   activeType: HandoverType;
 }
 
-function buildHref(preview: HandoverPreview, type: HandoverType): string {
-  const params = new URLSearchParams();
-  if (preview !== DEFAULT_HANDOVER_PREVIEW) params.set("as", preview);
-  if (type !== DEFAULT_HANDOVER_TYPE) params.set("type", type);
-  const query = params.toString();
-  return query ? `/app/handover?${query}` : "/app/handover";
+function buildHref(type: HandoverType): string {
+  return type !== DEFAULT_HANDOVER_TYPE ? `/app/handover?type=${type}` : "/app/handover";
 }
 
-/**
- * 미리보기 토글 + 휴직/오프보딩 탭 — 둘 다 **서버우선 `<Link>`**(team/members 컨트롤과
- * 같은 결). 한쪽을 바꿀 때 다른 쪽 값은 유지해야 해서 항상 같이 넘긴다.
- */
-export function HandoverControls({ activePreview, activeType }: HandoverControlsProps) {
+/** 휴직/오프보딩 탭 — **서버우선 `<Link>`**(team/members 컨트롤과 같은 결). */
+export function HandoverControls({ activeType }: HandoverControlsProps) {
   return (
-    <div className="flex flex-col gap-3">
-      {/*
-        ⚠️ **무채색이다**(2026-08-11). 주황 테두리·바탕이었는데, 이건 연동 전 임시 도구이지
-           경고가 아니다 — 색으로 알리는 건 에러(빨강)뿐이다(DESIGN §5).
-        ⚠️ **mock 모드에서만 보인다**(2026-08-15). 실서버에서는 `getViewer()`가 실제 로그인
-           본인을 이미 정해서 바꿔 볼 "인물"이라는 개념 자체가 없다 — 실서버인데 이 토글이
-           남아 있으면 실제 신청 화면에 아직 로그인 전 임시 도구가 뜨는 것처럼 보인다.
-      */}
-      {isMock && (
-        <div className="border-border bg-secondary/50 flex items-center gap-3 rounded-lg border px-3 py-2">
-          <span className="text-muted-foreground shrink-0 text-[12px] leading-4 font-medium">
-            임시 미리보기
-          </span>
-          <div role="group" aria-label="미리보기 인물" className="flex items-center gap-1">
-            {HANDOVER_PREVIEW_TABS.map((tab) => (
-              <Link
-                key={tab.preview}
-                href={buildHref(tab.preview, activeType)}
-                aria-pressed={activePreview === tab.preview}
-                className={cn(
-                  "rounded-md px-2 py-1 text-[12px] leading-4 transition-colors",
-                  activePreview === tab.preview
-                    ? "bg-foreground text-background font-medium"
-                    : "text-muted-foreground hover:bg-muted",
-                )}
-              >
-                {tab.label}
-              </Link>
-            ))}
-          </div>
-          <span className="text-muted-foreground text-[11px] leading-4">
-            — 로그인 연동 전까지만 쓰는 화면 확인용입니다.
-          </span>
-        </div>
-      )}
-
-      <nav aria-label="인수인계 종류" className="border-border flex gap-4 border-b">
-        {HANDOVER_TYPE_TABS.map((tab) => (
-          <Link
-            key={tab.type}
-            href={buildHref(activePreview, tab.type)}
-            aria-current={activeType === tab.type ? "page" : undefined}
-            className={cn(
-              "-mb-px border-b-2 px-1 pb-2 text-[13px] leading-5 font-medium transition-colors",
-              activeType === tab.type
-                ? "border-foreground text-foreground"
-                : "text-muted-foreground hover:text-foreground border-transparent",
-            )}
-          >
-            {tab.label}
-          </Link>
-        ))}
-      </nav>
-    </div>
+    <nav aria-label="인수인계 종류" className="border-border flex gap-4 border-b">
+      {HANDOVER_TYPE_TABS.map((tab) => (
+        <Link
+          key={tab.type}
+          href={buildHref(tab.type)}
+          aria-current={activeType === tab.type ? "page" : undefined}
+          className={cn(
+            "-mb-px border-b-2 px-1 pb-2 text-[13px] leading-5 font-medium transition-colors",
+            activeType === tab.type
+              ? "border-foreground text-foreground"
+              : "text-muted-foreground hover:text-foreground border-transparent",
+          )}
+        >
+          {tab.label}
+        </Link>
+      ))}
+    </nav>
   );
 }

--- a/src/features/handover/lib.ts
+++ b/src/features/handover/lib.ts
@@ -53,35 +53,6 @@ export function toHandoverCreateRequestBody(payload: SubmitHandoverPayload) {
   };
 }
 
-/**
- * ⚠️ **임시 미리보기 토글**(사용자 요청, 2026-08-08) — 로그인이 아직 없어 "지금 보고
- *    있는 사람"을 화면에서 바로 바꿔볼 수 있게 둔 것. 실제 세션이 붙으면 이 토글과
- *    `?as=`는 걷어내고 `getViewer()`가 그 자리를 대신한다.
- */
-export const HANDOVER_PREVIEW = {
-  MEMBER: "member",
-  LEADER: "leader",
-} as const;
-export type HandoverPreview = (typeof HANDOVER_PREVIEW)[keyof typeof HANDOVER_PREVIEW];
-
-export const HANDOVER_PREVIEW_LABEL: Record<HandoverPreview, string> = {
-  member: "팀원(이하윤)",
-  leader: "팀장(김서준)",
-};
-
-export const HANDOVER_PREVIEW_TABS: { preview: HandoverPreview; label: string }[] = [
-  HANDOVER_PREVIEW.MEMBER,
-  HANDOVER_PREVIEW.LEADER,
-].map((preview) => ({ preview, label: HANDOVER_PREVIEW_LABEL[preview] }));
-
-export const DEFAULT_HANDOVER_PREVIEW: HandoverPreview = HANDOVER_PREVIEW.MEMBER;
-
-export function parseHandoverPreview(value: string | undefined): HandoverPreview {
-  return (
-    HANDOVER_PREVIEW_TABS.find((t) => t.preview === value)?.preview ?? DEFAULT_HANDOVER_PREVIEW
-  );
-}
-
 export const HANDOVER_TYPE_TABS: { type: HandoverType; label: string }[] = [
   HANDOVER_TYPE.VACATION,
   HANDOVER_TYPE.OFFBOARDING,

--- a/src/features/handover/server.test.ts
+++ b/src/features/handover/server.test.ts
@@ -11,7 +11,6 @@ import { requireAccessToken } from "@/features/auth/session";
 import { getViewer } from "@/features/shell/viewer";
 import { serverApi } from "@/lib/api";
 
-import { HANDOVER_PREVIEW } from "./lib";
 import { getHandoverContext } from "./server";
 
 /**
@@ -71,7 +70,7 @@ describe("getHandoverContext — 실서버", () => {
       ],
     });
 
-    const context = await getHandoverContext(HANDOVER_PREVIEW.MEMBER);
+    const context = await getHandoverContext();
 
     expect(context.applicant).toEqual({
       id: 3,
@@ -112,7 +111,7 @@ describe("getHandoverContext — 실서버", () => {
       },
     ]);
 
-    const context = await getHandoverContext(HANDOVER_PREVIEW.LEADER);
+    const context = await getHandoverContext();
 
     // ⚠️ 본인(memberId 2)은 후보에서 빠져야 한다 — 자기 자신에게 재배정할 수 없다.
     expect(context.teammates).toEqual([

--- a/src/features/handover/server.ts
+++ b/src/features/handover/server.ts
@@ -15,7 +15,6 @@ import { serverApi } from "@/lib/api";
 import { ep } from "@/lib/endpoints";
 import { isMock } from "@/mocks/config";
 
-import { HANDOVER_PREVIEW, type HandoverPreview } from "./lib";
 import type {
   HandoverActionItem,
   HandoverApplicant,
@@ -29,10 +28,7 @@ import type {
  * `TEAM_MEMBER_ROSTER_MOCK`(team/members 피처)을 그대로 쓴다. 두 벌을 따로 두면
  * 화면마다 같은 사람의 액션·명단이 어긋난다.
  */
-const APPLICANT_NAME_BY_PREVIEW: Record<HandoverPreview, string> = {
-  member: "이하윤",
-  leader: "김서준",
-};
+const MOCK_APPLICANT_NAME = "이하윤";
 
 function buildActions(memberName: string): HandoverActionItem[] {
   const actions: HandoverActionItem[] = [];
@@ -114,7 +110,7 @@ async function fetchTeammatesForSelfReassign(
     }));
 }
 
-export async function getHandoverContext(preview: HandoverPreview): Promise<HandoverContext> {
+export async function getHandoverContext(): Promise<HandoverContext> {
   if (!isMock) {
     const viewer = await getViewer();
     const accessToken = await requireAccessToken();
@@ -136,36 +132,17 @@ export async function getHandoverContext(preview: HandoverPreview): Promise<Hand
     return { applicant, actions, teammates };
   }
 
-  const applicantName = APPLICANT_NAME_BY_PREVIEW[preview];
-  const roster = TEAM_MEMBER_ROSTER_MOCK.find((member) => member.name === applicantName);
-  if (!roster) throw new Error("mock 데이터 오류 — 로스터에 없는 미리보기 인물입니다.");
+  const roster = TEAM_MEMBER_ROSTER_MOCK.find((member) => member.name === MOCK_APPLICANT_NAME);
+  if (!roster) throw new Error("mock 데이터 오류 — 로스터에 없는 인물입니다.");
 
   const applicant: HandoverApplicant = {
     id: roster.id,
     name: roster.name,
-    role: preview === HANDOVER_PREVIEW.LEADER ? AUTHORITY.LEADER : AUTHORITY.MEMBER,
+    role: AUTHORITY.MEMBER,
     teamName: roster.teamName,
   };
 
   const actions = buildActions(applicant.name);
 
-  /*
-    ⚠️ 팀장 본인 휴직의 자가 재할당 대상 — **같은 팀** 소속(본인 제외)만(WORKFLOW.md §7
-       "팀장 본인 휴직", 2026-08-09 재확인). 지금은 로스터 mock이 개발팀 한 팀뿐이라
-       `teamName` 필터가 없어도 우연히 같은 팀만 나왔었다 — 다른 팀이 로스터에 추가되는
-       순간 타 팀원이 조용히 새어 들어갈 수 있어 명시적으로 건다.
-  */
-  const teammates =
-    applicant.role === AUTHORITY.LEADER
-      ? TEAM_MEMBER_ROSTER_MOCK.filter(
-          (member) => member.teamName === applicant.teamName && member.name !== applicant.name,
-        ).map((member) => ({
-          id: member.id,
-          name: member.name,
-          position: member.position,
-          role: member.role,
-        }))
-      : [];
-
-  return { applicant, actions, teammates };
+  return { applicant, actions, teammates: [] };
 }

--- a/src/features/team-handover/actions.real.test.ts
+++ b/src/features/team-handover/actions.real.test.ts
@@ -1,0 +1,116 @@
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/mocks/config", () => ({ isMock: false }));
+jest.mock("@/features/auth/session", () => ({ requireAccessToken: jest.fn() }));
+jest.mock("@/features/shell/viewer", () => ({ getViewer: jest.fn() }));
+jest.mock("./server", () => ({
+  FIXED_LEADER_NAME: "김서준",
+  getTeamHandoverDetail: jest.fn(),
+}));
+jest.mock("@/lib/api", () => ({
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+  serverApi: jest.fn(),
+}));
+
+import { AUTHORITY } from "@/constants/authority";
+import { requireAccessToken } from "@/features/auth/session";
+import { getViewer } from "@/features/shell/viewer";
+import { serverApi } from "@/lib/api";
+
+import { completeTeamHandoverAction, rejectTeamHandoverAction } from "./actions";
+import { getTeamHandoverDetail } from "./server";
+
+/**
+ * 팀장 중간승인 확정·반려 — **실서버 팀 스코프 권한 판정**.
+ *
+ * ⚠️ 회귀 테스트다 — 두 액션 다 `getTeamHandoverDetail`만 부르고 승인자가 그 팀 소속인지는
+ *    전혀 안 봐서, 다른 팀 LEADER도 이 팀의 인수인계서를 승인·반려할 수 있던 구멍이 있었다.
+ *    `canApproveMid(viewer, { teamId: handover.teamId })`로 막았다.
+ * ⚠️ **BE도 같은 구멍이 있다**(`HandoverService.complete/reject`가 companyId·teamId를
+ *    전혀 안 봄) — 이건 FE 1차 가드일 뿐, 진짜 방어선은 BE 수정이다.
+ */
+
+const requireAccessTokenMock = requireAccessToken as unknown as jest.Mock;
+const getViewerMock = getViewer as unknown as jest.Mock;
+const getTeamHandoverDetailMock = getTeamHandoverDetail as unknown as jest.Mock;
+const serverApiMock = serverApi as unknown as jest.Mock;
+
+const HANDOVER = {
+  handoverId: 55,
+  memberId: 3,
+  memberName: "이하윤",
+  teamId: 10,
+  type: "VACATION",
+  period: { from: "2026-09-01", to: "2026-09-15" },
+  actionCount: 1,
+  actions: [
+    {
+      id: 101,
+      projectTag: "GOODS",
+      parentTeamActionName: "앱 개발 착수",
+      title: "온보딩 플로우 와이어프레임 검토",
+      status: "IN_PROGRESS",
+      startDate: "2026-08-01",
+      dueDate: "2026-09-10",
+    },
+  ],
+  teammates: [{ id: 4, name: "박도현", position: "사원", role: "프론트엔드" }],
+};
+
+const SAME_TEAM_LEADER = { id: 2, role: AUTHORITY.LEADER, teamId: 10, teamName: "개발팀" };
+const OTHER_TEAM_LEADER = { id: 6, role: AUTHORITY.LEADER, teamId: 20, teamName: "마케팅팀" };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  requireAccessTokenMock.mockResolvedValue("token");
+  getTeamHandoverDetailMock.mockResolvedValue(HANDOVER);
+});
+
+describe("completeTeamHandoverAction — 실서버 팀 스코프 권한 판정", () => {
+  it("같은 팀 LEADER면 통과해 BE를 부른다", async () => {
+    getViewerMock.mockResolvedValue(SAME_TEAM_LEADER);
+    serverApiMock.mockResolvedValue({});
+
+    const result = await completeTeamHandoverAction(55, [{ actionId: 101, assigneeId: 4 }]);
+
+    expect(result.isSuccess).toBe(true);
+    expect(serverApiMock).toHaveBeenCalled();
+  });
+
+  it("다른 팀 LEADER면 BE를 부르지 않고 막는다", async () => {
+    getViewerMock.mockResolvedValue(OTHER_TEAM_LEADER);
+
+    const result = await completeTeamHandoverAction(55, [{ actionId: 101, assigneeId: 4 }]);
+
+    expect(result.isSuccess).toBe(false);
+    expect(result.message).toBe("이 인수인계서를 승인할 권한이 없습니다");
+    expect(serverApiMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("rejectTeamHandoverAction — 실서버 팀 스코프 권한 판정", () => {
+  it("같은 팀 LEADER면 통과해 BE를 부른다", async () => {
+    getViewerMock.mockResolvedValue(SAME_TEAM_LEADER);
+    serverApiMock.mockResolvedValue({});
+
+    const result = await rejectTeamHandoverAction(55, "기간이 부적절합니다");
+
+    expect(result.isSuccess).toBe(true);
+    expect(serverApiMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("다른 팀 LEADER면 BE를 부르지 않고 막는다", async () => {
+    getViewerMock.mockResolvedValue(OTHER_TEAM_LEADER);
+
+    const result = await rejectTeamHandoverAction(55, "기간이 부적절합니다");
+
+    expect(result.isSuccess).toBe(false);
+    expect(result.message).toBe("이 인수인계서를 반려할 권한이 없습니다");
+    expect(serverApiMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/team-handover/actions.ts
+++ b/src/features/team-handover/actions.ts
@@ -8,9 +8,11 @@ import {
   rejectMockHandover,
 } from "@/features/member/mock/managed";
 import { TEAM_ACTION_PERSONAL_ITEMS_MOCK } from "@/features/project/mock/team-action-detail";
+import { getViewer } from "@/features/shell/viewer";
 import { ApiError, serverApi } from "@/lib/api";
 import { todayIso } from "@/lib/date";
 import { ep } from "@/lib/endpoints";
+import { canApproveMid } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
 import { FIXED_LEADER_NAME, getTeamHandoverDetail } from "./server";
@@ -86,9 +88,10 @@ export async function commitHandoverReassignments(
  * (WORKFLOW.md §7·§13-4).
  * ⚠️ **재배정 반영은 `board/actions.ts`와 같은 방식**이다(mock) — `TEAM_ACTION_PERSONAL_ITEMS_MOCK`
  *    항목을 직접 mutate한다(별도 격리 저장소를 새로 두지 않는다).
- * ⚠️ 세션이 아직 없어(`getViewer()`가 항상 OWNER) 이 화면·액션은 `/team/(dashboard)`와 같이
- *    권한 게이트 없이 고정 스코프(김서준 · 개발팀)로 동작한다. 세션이 붙으면 첫 줄에서
- *    `assertPermission(canApproveMid(viewer, { teamId }))`를 넣는다.
+ * ⚠️ **실서버 분기만 팀 스코프를 검사한다**(2026-08-15) — mock 로스터엔 숫자 팀 id가 없어
+ *    (`server.ts`의 `teamId: 0` 참고) mock 분기는 종전처럼 `/team/(dashboard)`와 같은
+ *    고정 스코프(김서준 · 개발팀)로 그대로 둔다. **진짜 방어선은 BE다**(§권한: 화면 숨김은
+ *    UX일 뿐) — 이건 그 앞에 세우는 1차 가드일 뿐이라 BE 쪽 스코프 검증과 별개로 먼저 넣는다.
  */
 export async function completeTeamHandoverAction(
   handoverId: number,
@@ -96,6 +99,13 @@ export async function completeTeamHandoverAction(
 ): Promise<{ isSuccess: boolean; message?: string }> {
   const handover = await getTeamHandoverDetail(handoverId);
   if (!handover) return { isSuccess: false, message: "이미 처리됐거나 없는 인수인계서입니다" };
+
+  if (!isMock) {
+    const viewer = await getViewer();
+    if (!canApproveMid(viewer, { teamId: handover.teamId })) {
+      return { isSuccess: false, message: "이 인수인계서를 승인할 권한이 없습니다" };
+    }
+  }
 
   /*
     ⚠️ 화면의 "전부 배정" 제약은 UX일 뿐이다 — 여기서도 다시 본다(§권한: 화면 숨김은
@@ -160,6 +170,13 @@ export async function rejectTeamHandoverAction(
 
   const handover = await getTeamHandoverDetail(handoverId);
   if (!handover) return { isSuccess: false, message: "이미 처리됐거나 없는 인수인계서입니다" };
+
+  if (!isMock) {
+    const viewer = await getViewer();
+    if (!canApproveMid(viewer, { teamId: handover.teamId })) {
+      return { isSuccess: false, message: "이 인수인계서를 반려할 권한이 없습니다" };
+    }
+  }
 
   if (isMock) {
     /*

--- a/src/features/team-handover/mapper.ts
+++ b/src/features/team-handover/mapper.ts
@@ -81,6 +81,7 @@ export interface HandoverDetailFromBe {
   handoverId: number;
   memberId: number;
   memberName: string;
+  teamId: number;
   type: HandoverType;
   status: HandoverStatus;
   period: { from: string; to: string } | null;
@@ -118,6 +119,7 @@ export function toTeamHandoverListItem(be: BeHandoverSummaryResponse): TeamHando
     handoverId: be.id,
     memberId: be.writerMemberId,
     memberName: be.writerName,
+    teamId: be.teamId,
     type,
     period,
     actionCount: be.itemCount,
@@ -136,6 +138,7 @@ export function toHandoverDetailFromBe(be: BeHandoverResponse): HandoverDetailFr
     handoverId: be.id,
     memberId: be.writerMemberId,
     memberName: be.writerNameSnap,
+    teamId: be.teamId,
     type,
     status: mapHandoverStatusFromBe(be.status as HandoverStatusBe),
     period,

--- a/src/features/team-handover/server.ts
+++ b/src/features/team-handover/server.ts
@@ -105,6 +105,10 @@ export async function listTeamHandovers(): Promise<TeamHandoverListItem[]> {
           handoverId: member.id,
           memberId: member.id,
           memberName: member.name,
+          // ⚠️ 목 로스터엔 숫자 팀 id가 없다 — `canApproveMid` 팀 스코프 검사는 실서버
+          //    분기에서만 돈다(§목 단계 권한 검사 범위, 이 파일 하단 `completeTeamHandoverAction`
+          //    주석 참고)라 이 값은 목에서 실제로 쓰이지 않는다.
+          teamId: 0,
           type: handover.type,
           period: handover.period,
           actionCount: handover.actionCount,
@@ -141,6 +145,8 @@ export async function getTeamHandoverDetail(
       handoverId: memberId,
       memberId,
       memberName: detail.member.name,
+      // ⚠️ 목 전용 — 위 목록 분기와 같은 이유로 실제로 쓰이지 않는다.
+      teamId: 0,
       type: handover.type,
       period: handover.period,
       actionCount: handover.actionCount,

--- a/src/features/team-handover/types.ts
+++ b/src/features/team-handover/types.ts
@@ -24,6 +24,8 @@ export interface TeamHandoverListItem {
   handoverId: number;
   memberId: number;
   memberName: string;
+  /** 이 인수인계서가 속한 팀 — 권한 판정(`canApproveMid`)이 이 값과 승인자의 팀을 대조한다. */
+  teamId: number;
   type: HandoverType;
   /** 휴직 기간 `YYYY-MM-DD`. 오프보딩이면 `null`(돌아오지 않는다) */
   period: { from: string; to: string } | null;


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계

---

## 🙋 관련 역할

- [x] LEADER (팀장)
- [x] 공통

---

## 📝 작업 내용

- `completeTeamHandoverAction`/`rejectTeamHandoverAction`(team-handover, 실서버 분기)에 `canApproveMid`로 팀 스코프 권한 검사 추가 — 역할(LEADER)만 확인하고 리소스 소유권(같은 팀인지)은 검사하지 않아 다른 팀 인수인계서를 승인/반려할 수 있던 문제. BE `HandoverService`도 동일한 검증 공백이 있어 별도로 전달했고, 이건 FE 1차 방어선.
- 인수인계 신청 화면(`/app/handover`)의 데모용 "임시 미리보기" 인물 전환 토글(`?as=`) 제거 — 실서버 분기는 이미 `getViewer()`만 보고 이 값을 무시해 기능상 죽어있었는데 UI만 남아 있었다. mock 분기도 전환 없이 고정 인물로 단순화.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`fix/handover-team-scope-permission#514`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**(팀 스코프), 서버 액션에서 재검사
- [x] 🧬 **zod** — 기존 계약 재사용, 신규 파싱 없음
- [x] 🕵️ **정직성** — 데모용 코드는 걷어냈고, 남은 mock 분기는 주석으로 명시
- [x] 🎨 디자인 토큰 — UI 삭제만 있음, 신규 스타일 없음

**품질**

- [x] ♻️ 재사용 확인 (`lib/permission.ts`의 `canApproveMid` 재사용)
- [x] 🧪 관련 유닛 테스트 추가/통과 (`team-handover/actions.real.test.ts` 4건, `handover/server.test.ts` 2건)

---

## 🔗 연관 이슈

Closes #514
Closes #515

---

## 💬 리뷰 포인트

- `team-handover/actions.ts`의 팀 스코프 검사가 `handover.teamId`를 신뢰하는데, 그 값은 `mapper.ts`에서 BE 응답의 `teamId`를 그대로 흡수한 것 — BE 필드명이 이후 바뀌면 매퍼만 고치면 된다.
- 인수인계 신청 화면의 미리보기 제거로 mock 모드는 항상 고정 인물(이하윤/MEMBER)로만 확인 가능 — LEADER 화면을 mock으로 보고 싶으면 `TEAM_MEMBER_ROSTER_MOCK`에서 이름을 바꿔야 한다.

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |


---

## 📝 추가 메모
