### PR TITLE
[FIX] 마이페이지 소속 표시가 권한별로 분기되지 않는다 #513

### DIFF
--- a/src/features/profile/components/profile-header.test.tsx
+++ b/src/features/profile/components/profile-header.test.tsx
@@ -1,21 +1,67 @@
 import { render, screen } from "@testing-library/react";
 
-import { AUTHORITY_LABEL } from "@/constants/authority";
+import { AUTHORITY, AUTHORITY_LABEL } from "@/constants/authority";
 
 import { MY_PROFILE_MOCK } from "../mock/profile";
+import type { MyProfile } from "../types";
 import { ProfileHeader } from "./profile-header";
 
 describe("ProfileHeader", () => {
-  it("이름·이메일·역할 라벨·소속을 보여준다", () => {
+  it("이름·이메일·역할 라벨을 보여준다", () => {
     render(<ProfileHeader profile={MY_PROFILE_MOCK} />);
 
     expect(screen.getByText(MY_PROFILE_MOCK.name)).toBeInTheDocument();
     expect(screen.getByText(MY_PROFILE_MOCK.email)).toBeInTheDocument();
     expect(screen.getByText(AUTHORITY_LABEL[MY_PROFILE_MOCK.role])).toBeInTheDocument();
+  });
+
+  it("OWNER는 회사명 · 대표로 소속을 보여준다", () => {
+    render(<ProfileHeader profile={MY_PROFILE_MOCK} />);
+
+    expect(screen.getByText(`${MY_PROFILE_MOCK.companyName} · 대표`)).toBeInTheDocument();
+  });
+
+  it("LEADER는 회사명 · 팀 · 직책으로 소속을 보여준다(팀 안 역할 라벨은 안 붙는다)", () => {
+    const leader: MyProfile = {
+      ...MY_PROFILE_MOCK,
+      role: AUTHORITY.LEADER,
+      roleLabel: "리더",
+      position: "팀장",
+    };
+    render(<ProfileHeader profile={leader} />);
+
+    expect(
+      screen.getByText(`${leader.companyName} · ${leader.teamName} · ${leader.position}`),
+    ).toBeInTheDocument();
+  });
+
+  it("MEMBER는 팀 안 역할이 있으면 회사명 · 팀 · 역할 · 직책으로 보여준다", () => {
+    const member: MyProfile = {
+      ...MY_PROFILE_MOCK,
+      role: AUTHORITY.MEMBER,
+      roleLabel: "프론트엔드",
+      position: "사원",
+    };
+    render(<ProfileHeader profile={member} />);
+
     expect(
       screen.getByText(
-        `${MY_PROFILE_MOCK.companyName} · ${MY_PROFILE_MOCK.teamName} · ${MY_PROFILE_MOCK.position}`,
+        `${member.companyName} · ${member.teamName} · ${member.roleLabel} · ${member.position}`,
       ),
+    ).toBeInTheDocument();
+  });
+
+  it("MEMBER는 팀 안 역할이 없으면 회사명 · 팀 · 직책으로 보여준다", () => {
+    const member: MyProfile = {
+      ...MY_PROFILE_MOCK,
+      role: AUTHORITY.MEMBER,
+      roleLabel: null,
+      position: "사원",
+    };
+    render(<ProfileHeader profile={member} />);
+
+    expect(
+      screen.getByText(`${member.companyName} · ${member.teamName} · ${member.position}`),
     ).toBeInTheDocument();
   });
 });

--- a/src/features/profile/components/profile-header.tsx
+++ b/src/features/profile/components/profile-header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AUTHORITY_BADGE_CLASS, AUTHORITY_LABEL } from "@/constants/authority";
+import { AUTHORITY, AUTHORITY_BADGE_CLASS, AUTHORITY_LABEL } from "@/constants/authority";
 import { LogoutButton } from "@/features/auth/components/logout-button";
 import { useProfileAvatar } from "@/hooks/use-profile-avatar";
 import { cn } from "@/lib/utils";
@@ -10,6 +10,21 @@ import { ChangePasswordDialog } from "./change-password-dialog";
 
 interface ProfileHeaderProps {
   profile: MyProfile;
+}
+
+/**
+ * 권한별로 소속 표기가 다르다(§권한 — 축이 2개다).
+ * OWNER=회사·대표 / LEADER=회사·팀·직책 / MEMBER=회사·팀·(역할 있으면)·직책.
+ */
+function formatAffiliation(profile: MyProfile): string {
+  const { companyName, teamName, roleLabel, position, role } = profile;
+
+  if (role === AUTHORITY.OWNER) return `${companyName} · 대표`;
+  if (role === AUTHORITY.LEADER) return `${companyName} · ${teamName} · ${position}`;
+
+  return roleLabel
+    ? `${companyName} · ${teamName} · ${roleLabel} · ${position}`
+    : `${companyName} · ${teamName} · ${position}`;
 }
 
 /**
@@ -42,9 +57,7 @@ export function ProfileHeader({ profile }: ProfileHeaderProps) {
           >
             {AUTHORITY_LABEL[profile.role]}
           </span>
-          <span className="text-muted-foreground/70 text-[11px]">
-            {profile.companyName} · {profile.teamName} · {profile.position}
-          </span>
+          <span className="text-muted-foreground/70 text-[11px]">{formatAffiliation(profile)}</span>
         </div>
       </div>
 

--- a/src/features/profile/mock/profile.ts
+++ b/src/features/profile/mock/profile.ts
@@ -12,6 +12,8 @@ export const MY_PROFILE_MOCK: MyProfile = {
   role: AUTHORITY.OWNER,
   companyName: "(주)테크스타트",
   teamName: "제품개발팀",
+  // ⚠️ OWNER는 소속 표시에 팀 안 세부 역할을 쓰지 않는다("대표"로 고정 표시).
+  roleLabel: null,
   position: "수석",
   joinedAt: "2021-03-02",
 };

--- a/src/features/profile/server.ts
+++ b/src/features/profile/server.ts
@@ -41,6 +41,7 @@ export async function getMyProfile(): Promise<MyProfile> {
     role: me.authority,
     companyName: me.companyName,
     teamName: me.teamName ?? "-",
+    roleLabel: me.roleLabel,
     position: me.positionName ?? "-",
     joinedAt: me.joinedOn ?? "-",
   };

--- a/src/features/profile/types.ts
+++ b/src/features/profile/types.ts
@@ -13,6 +13,8 @@ export interface MyProfile {
   role: Authority;
   companyName: string;
   teamName: string;
+  /** 팀 안의 세부 역할 라벨(프론트엔드·백엔드 등) — 없는 팀도 있어 `null` 가능(§조직 계층). */
+  roleLabel: string | null;
   /** 직급 라벨 — 영문 워딩 규칙(§카피)과 별개로, 직급은 팀에서 한글로 쓴다(예: "수석"). */
   position: string;
   /** "YYYY-MM-DD" */


### PR DESCRIPTION
## 📋 PR 타입

> 해당하는 타입을 선택해 주세요 (복수 선택 가능)

- [ ] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [x] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [x] OWNER (대표)
- [ ] ADMIN (관리자)
- [x] LEADER (팀장)
- [x] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- 마이페이지 소속 표시를 권한별로 분기하는 `formatAffiliation`을 `ProfileHeader`에 추가했다.
  - OWNER → `회사명 · 대표`
  - LEADER → `회사명 · 팀 · 직책`
  - MEMBER → 팀 안 세부 역할(`roleLabel`)이 있으면 `회사명 · 팀 · 역할 · 직책`, 없으면 `회사명 · 팀 · 직책`
- `MyProfile` UI계약에 `roleLabel: string | null`을 추가하고, `profile/server.ts`가 부트스트랩(`Me.roleLabel`)에서
  그대로 흘려주도록 했다. 목 데이터(`MY_PROFILE_MOCK`)도 맞춰 갱신.
- `ProfileHeader` 테스트를 OWNER/LEADER/MEMBER(역할 있음·없음) 4가지 분기로 나눠 다시 작성했다.

---

## ✅ 작업 체크리스트

**기본**

- [ ] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [ ] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 표시 전용 변경이라 권한 가드·소유권 검사 대상 아님(읽기 전용 마이페이지)
- [ ] 🧬 **zod** — 해당 없음 (BFF 응답 매핑 구조 변경 없음, 기존 `Me.roleLabel` 필드를 그대로 흘림)
- [x] 🕵️ **정직성** — 목 데이터도 실제 계약과 동일한 필드로 갱신, 되는 척 없음
- [x] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨 — 기존 클래스 재사용, 변경 없음

**품질**

- [x] ⚡ 최적화 — 해당 없음 (순수 표시 로직)
- [x] ♿ a11y — 변경 없음 (기존 마크업 유지)
- [x] ♻️ 재사용 확인 — 기존 `AUTHORITY` 상수·컴포넌트 재사용, 신규 컴포넌트 없음
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 해당 없음 (표시 포맷 분기만 추가, 상태 없음)
- [x] 브라우저 전용 API 사용 — 해당 없음

---

## 🔗 연관 이슈

Closes #513

---

## 📸 스크린샷 (선택)

| Before                              | After                     |
| ------------------------------------ | ------------------------- |
| `(주)테크스타트 · 제품개발팀 · 수석`(OWNER에게도 팀·직책 표시) | `(주)테크스타트 · 대표` |

---

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

- LEADER 포맷에는 팀 안 세부 역할(`roleLabel`)을 의도적으로 안 붙였다(리더는 직책만 표시) — 명세와 일치하는지 확인 부탁드립니다.
- SYSTEM 권한은 별도 분기 없이 MEMBER와 동일 경로(역할 있으면 붙이고 없으면 생략)를 타는데, 맞는 처리인지 확인 부탁드립니다.

---

## 📝 추가 메모

`ProfileInfoCard`(아래 "기본 정보" 카드)는 이번 변경 대상이 아닙니다 — 요청 범위가 상단 소속 줄(`ProfileHeader`)에
한정돼 있어 그대로 두었습니다.