### PR TITLE
[FIX] 공지 화면 목 actor 권한 판정 수정 #518

### DIFF
--- a/src/app/(shell)/app/notice/[id]/page.tsx
+++ b/src/app/(shell)/app/notice/[id]/page.tsx
@@ -5,8 +5,10 @@ import { NoticeCreateDialog } from "@/features/notice/components/notice-create-d
 import { NoticeDetail } from "@/features/notice/components/notice-detail";
 import { NoticeList } from "@/features/notice/components/notice-list";
 import { getNoticeById, getNotices } from "@/features/notice/server";
+import { getViewer } from "@/features/shell/viewer";
 import { getMockActor } from "@/lib/mock-actor";
 import { canManageNotice } from "@/lib/permission";
+import { isMock } from "@/mocks/config";
 
 interface AppNoticeDetailPageProps {
   params: Promise<{ id: string }>;
@@ -25,7 +27,8 @@ export default async function AppNoticeDetailPage({ params }: AppNoticeDetailPag
   // 없는 공지 id로 들어오면 404 — 링크로 닿는 화면이라 조용히 빈 화면을 보이지 않는다(§정직성).
   if (!notice) notFound();
 
-  const canManage = canManageNotice(getMockActor());
+  const actor = isMock ? getMockActor() : await getViewer();
+  const canManage = canManageNotice(actor);
 
   return (
     <main className="min-h-0 flex-1 overflow-y-auto px-8 py-7">

--- a/src/app/(shell)/app/notice/page.tsx
+++ b/src/app/(shell)/app/notice/page.tsx
@@ -5,8 +5,10 @@ import { FlashToast } from "@/components/common/flash-toast";
 import { NoticeCreateDialog } from "@/features/notice/components/notice-create-dialog";
 import { NoticeList } from "@/features/notice/components/notice-list";
 import { getNotices } from "@/features/notice/server";
+import { getViewer } from "@/features/shell/viewer";
 import { getMockActor } from "@/lib/mock-actor";
 import { canManageNotice } from "@/lib/permission";
+import { isMock } from "@/mocks/config";
 
 export const metadata: Metadata = {
   title: "공지",
@@ -15,7 +17,8 @@ export const metadata: Metadata = {
 export default async function AppNoticePage() {
   const notices = await getNotices();
   // 작성 권한이 있을 때만 "새 공지"를 보인다 — 서버 재검사는 createNoticeAction이 다시 한다(§권한).
-  const canManage = canManageNotice(getMockActor());
+  const actor = isMock ? getMockActor() : await getViewer();
+  const canManage = canManageNotice(actor);
 
   return (
     <main className="min-h-0 flex-1 overflow-y-auto px-8 py-7">

--- a/src/features/notice/actions.real.test.ts
+++ b/src/features/notice/actions.real.test.ts
@@ -1,0 +1,131 @@
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("next/navigation", () => ({ redirect: jest.fn() }));
+jest.mock("@/mocks/config", () => ({ isMock: false }));
+jest.mock("@/features/auth/session", () => ({ requireAccessToken: jest.fn() }));
+jest.mock("@/features/shell/viewer", () => ({ getViewer: jest.fn() }));
+jest.mock("@/lib/api", () => ({
+  ApiError: class ApiError extends Error {
+    status: number;
+    code?: string;
+    constructor(status: number, message: string, code?: string) {
+      super(message);
+      this.status = status;
+      this.code = code;
+    }
+  },
+  serverApi: jest.fn(),
+}));
+
+import { AUTHORITY } from "@/constants/authority";
+import { requireAccessToken } from "@/features/auth/session";
+import { getViewer } from "@/features/shell/viewer";
+import { serverApi } from "@/lib/api";
+
+import { createNoticeAction, deleteNoticeAction, updateNoticeAction } from "./actions";
+
+/**
+ * 공지 작성·수정·삭제 — **실서버 권한 판정**.
+ *
+ * ⚠️ `getMockActor()`(고정 OWNER)를 무조건 쓰던 버그를 고친 회귀 테스트 — 실서버에서는
+ *    `getViewer()`(실제 로그인 세션)를 봐야 OWNER가 아닌 사람이 공지를 작성·수정·삭제하지
+ *    못한다(`canManageNotice`는 OWNER 전용, rooms의 `actions.real.test.ts`와 같은 패턴).
+ */
+
+const requireAccessTokenMock = requireAccessToken as unknown as jest.Mock;
+const getViewerMock = getViewer as unknown as jest.Mock;
+const serverApiMock = serverApi as unknown as jest.Mock;
+
+const OWNER = { id: 1, name: "대표", role: AUTHORITY.OWNER };
+const MEMBER = { id: 3, name: "이하윤", role: AUTHORITY.MEMBER, teamName: "개발팀" };
+
+function form(entries: Record<string, string>): FormData {
+  const data = new FormData();
+  for (const [key, value] of Object.entries(entries)) data.append(key, value);
+  return data;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  requireAccessTokenMock.mockResolvedValue("token");
+});
+
+describe("createNoticeAction — 실서버 권한 판정", () => {
+  it("OWNER 로그인 세션이면 통과한다", async () => {
+    getViewerMock.mockResolvedValue(OWNER);
+    serverApiMock.mockResolvedValueOnce({ noticeId: 10 });
+
+    const result = await createNoticeAction(
+      { errors: {} },
+      form({ title: "공지 제목", body: "본문" }),
+    );
+
+    expect(result.errors).toEqual({});
+    expect(result.notice).toBeDefined();
+    expect(serverApiMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("MEMBER 로그인 세션이면 BE를 부르지 않고 막는다", async () => {
+    getViewerMock.mockResolvedValue(MEMBER);
+
+    const result = await createNoticeAction(
+      { errors: {} },
+      form({ title: "공지 제목", body: "본문" }),
+    );
+
+    expect(result.errors.title).toBe("공지를 작성할 권한이 없습니다");
+    expect(result.notice).toBeUndefined();
+    expect(serverApiMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("updateNoticeAction — 실서버 권한 판정", () => {
+  it("OWNER 로그인 세션이면 통과한다", async () => {
+    getViewerMock.mockResolvedValue(OWNER);
+    serverApiMock.mockResolvedValueOnce({
+      noticeId: 10,
+      title: "수정된 제목",
+      body: "본문",
+      publishedAt: "2026-08-16",
+    });
+
+    const result = await updateNoticeAction(
+      { errors: {} },
+      form({ id: "10", title: "수정된 제목", body: "본문" }),
+    );
+
+    expect(result.errors).toEqual({});
+    expect(serverApiMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("MEMBER 로그인 세션이면 BE를 부르지 않고 막는다", async () => {
+    getViewerMock.mockResolvedValue(MEMBER);
+
+    const result = await updateNoticeAction(
+      { errors: {} },
+      form({ id: "10", title: "수정된 제목", body: "본문" }),
+    );
+
+    expect(result.errors.title).toBe("공지를 수정할 권한이 없습니다");
+    expect(serverApiMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("deleteNoticeAction — 실서버 권한 판정", () => {
+  it("OWNER 로그인 세션이면 통과한다", async () => {
+    getViewerMock.mockResolvedValue(OWNER);
+    serverApiMock.mockResolvedValueOnce(null);
+
+    await deleteNoticeAction(form({ id: "10" }));
+
+    expect(serverApiMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("MEMBER 로그인 세션이면 BE를 부르지 않고 막는다", async () => {
+    getViewerMock.mockResolvedValue(MEMBER);
+
+    await expect(deleteNoticeAction(form({ id: "10" }))).rejects.toThrow(
+      "공지를 삭제할 권한이 없습니다",
+    );
+    expect(serverApiMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/notice/actions.ts
+++ b/src/features/notice/actions.ts
@@ -5,6 +5,7 @@ import { redirect } from "next/navigation";
 
 import { FLASH_TOAST_PARAM } from "@/constants/flash-toast";
 import { requireAccessToken } from "@/features/auth/session";
+import { getViewer } from "@/features/shell/viewer";
 import { ApiError, serverApi } from "@/lib/api";
 import { ep } from "@/lib/endpoints";
 import { getMockActor } from "@/lib/mock-actor";
@@ -92,8 +93,8 @@ export async function createNoticeAction(
   _prev: NoticeFormState,
   formData: FormData,
 ): Promise<NoticeFormState> {
-  if (!canManageNotice(getMockActor()))
-    return { errors: { title: "공지를 작성할 권한이 없습니다" } };
+  const actor = isMock ? getMockActor() : await getViewer();
+  if (!canManageNotice(actor)) return { errors: { title: "공지를 작성할 권한이 없습니다" } };
 
   const draft = readDraft(formData);
   const errors = validateNoticeDraft(draft);
@@ -128,8 +129,8 @@ export async function updateNoticeAction(
   _prev: NoticeFormState,
   formData: FormData,
 ): Promise<NoticeFormState> {
-  if (!canManageNotice(getMockActor()))
-    return { errors: { title: "공지를 수정할 권한이 없습니다" } };
+  const actor = isMock ? getMockActor() : await getViewer();
+  if (!canManageNotice(actor)) return { errors: { title: "공지를 수정할 권한이 없습니다" } };
 
   const id = String(formData.get("id") ?? "");
   const draft = readDraft(formData);
@@ -171,7 +172,8 @@ export async function updateNoticeAction(
  *    없어(파괴적 삭제라 재시도 UI가 필요 없다고 판단, ROOM-05와 다른 지점) 이 방식이 맞다.
  */
 export async function deleteNoticeAction(formData: FormData): Promise<void> {
-  if (!canManageNotice(getMockActor())) {
+  const actor = isMock ? getMockActor() : await getViewer();
+  if (!canManageNotice(actor)) {
     throw new Error("공지를 삭제할 권한이 없습니다");
   }
 


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

- `notice/actions.ts`의 `createNoticeAction`/`updateNoticeAction`/`deleteNoticeAction`과 `app/notice/page.tsx`, `app/notice/[id]/page.tsx`가 실서버 모드에서도 `canManageNotice(getMockActor())`로 고정 OWNER 목 액터를 넘겨 권한을 판정하던 문제를 고쳤다.
- `isMock ? getMockActor() : await getViewer()` 패턴(rooms/actions.ts와 동일)으로 전부 통일.
- BE(`NoticeController`)가 이미 `@PreAuthorize("hasRole('OWNER')")`로 막고 있어 서버는 안전했지만, 화면이 로그인한 사람의 실제 역할과 무관하게 항상 OWNER처럼 UI를 그리고 있었다(§정직성 위반).

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`fix/notice-real-session-permission#518`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 역할 가드(OWNER), 서버 액션에서 재검사(기존에도 BE가 방어하고 있었음)
- [x] 🧬 **zod** — 기존 계약 재사용, 신규 파싱 없음
- [x] 🕵️ **정직성** — 실제 역할과 다른 UI가 보이던 문제를 고쳤다

**품질**

- [x] ♻️ 재사용 확인 (`isMock ? getMockActor() : await getViewer()` — rooms/actions.ts와 같은 패턴 재사용)
- [x] 🧪 관련 유닛 테스트 추가/통과 (`notice/actions.real.test.ts` 6건: OWNER 통과 / MEMBER 차단 × 작성·수정·삭제)

---

## 🔗 연관 이슈

Closes #518

---

## 💬 리뷰 포인트

- rooms 도메인에서 같은 패턴으로 이미 고친 적 있어(PR #510) 그 컨벤션을 그대로 따랐다.
- BE가 이미 서버에서 막고 있어 보안 취약점은 아니었고, 화면 정직성 문제로 분류했다.

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |


---

## 📝 추가 메모
