### PR TITLE
[FIX] 구독 차단 창 로그아웃 연동 #520

### DIFF
--- a/src/features/billing/components/subscription-blocked-dialog.test.tsx
+++ b/src/features/billing/components/subscription-blocked-dialog.test.tsx
@@ -1,0 +1,41 @@
+jest.mock("@/features/auth/actions", () => ({ logoutAction: jest.fn() }));
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { logoutAction } from "@/features/auth/actions";
+
+import { SUBSCRIPTION_STATUS } from "../subscription";
+import { SubscriptionBlockedDialog } from "./subscription-blocked-dialog";
+
+/**
+ * 구독 차단 창 — **나가는 길이 로그아웃으로 바뀐 뒤 회귀 테스트.**
+ *
+ * ⚠️ 예전엔 `/login`으로 보내는 `<Link>`였는데, 세션 쿠키가 살아있는 채로 로그인 화면에
+ *    가면 그대로 이 회사로 되돌아온다 — `logoutAction`(쿠키를 지우고 `/login`으로
+ *    리다이렉트)을 실제로 부르는지 확인한다.
+ */
+
+const logoutActionMock = logoutAction as unknown as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+it("UNPAID 상태에서 버튼을 누르면 logoutAction을 부른다", async () => {
+  const user = userEvent.setup();
+  render(<SubscriptionBlockedDialog status={SUBSCRIPTION_STATUS.UNPAID} />);
+
+  await user.click(screen.getByRole("button", { name: "로그인 화면으로" }));
+
+  expect(logoutActionMock).toHaveBeenCalledTimes(1);
+});
+
+it("EXPIRED 상태에서도 같은 버튼으로 로그아웃한다", async () => {
+  const user = userEvent.setup();
+  render(<SubscriptionBlockedDialog status={SUBSCRIPTION_STATUS.EXPIRED} />);
+
+  await user.click(screen.getByRole("button", { name: "로그인 화면으로" }));
+
+  expect(logoutActionMock).toHaveBeenCalledTimes(1);
+});

--- a/src/features/billing/components/subscription-blocked-dialog.tsx
+++ b/src/features/billing/components/subscription-blocked-dialog.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import Link from "next/link";
+import { useFormStatus } from "react-dom";
 
 import { ResultDialog } from "@/components/common/result-dialog";
 import { buttonVariants } from "@/components/ui/button";
+import { logoutAction } from "@/features/auth/actions";
 import { cn } from "@/lib/utils";
 
 import { SUBSCRIPTION_STATUS, type SubscriptionStatus } from "../subscription";
@@ -17,10 +18,9 @@ import { SUBSCRIPTION_STATUS, type SubscriptionStatus } from "../subscription";
  *    돈 때문에 막히는 자리가 화면마다 다르게 생기면 같은 서비스로 안 읽힌다(§컴포넌트 위생).
  * ⚠️ **닫을 수 없다.** X도 없고 바깥을 눌러도 안 닫힌다 — 닫으면 뒤에 아무것도 없는
  *    빈 화면만 남아서, 막힌 게 아니라 고장 난 것처럼 보인다.
- * ⚠️ 나가는 길은 **로그인 화면**뿐이다. 지금은 세션이 없어 링크로 보내지만,
- *    세션이 붙으면 여기서 로그아웃을 부른다.
- *    TODO(BE 연동): `logoutAction`으로 쿠키를 지우고 `/login`으로 보낸다
- *    (경로는 `lib/endpoints.ts`의 `auth.logout`).
+ * ⚠️ 나가는 길은 **로그아웃**뿐이다 — 세션 쿠키가 살아 있는 채로 `/login`에 링크만
+ *    걸면 로그인 화면에서 다시 이 회사로 돌아와 버린다. `logoutAction`(`LogoutButton`과
+ *    같은 액션)으로 쿠키를 지우고 나서 `/login`으로 보낸다.
  */
 export function SubscriptionBlockedDialog({ status }: { status: SubscriptionStatus }) {
   const isUnpaid = status === SUBSCRIPTION_STATUS.UNPAID;
@@ -49,13 +49,27 @@ export function SubscriptionBlockedDialog({ status }: { status: SubscriptionStat
         </>
       }
       action={
-        <Link
-          href="/login"
-          className={cn(buttonVariants({ variant: "ink" }), "h-11 w-full text-[13px] leading-none")}
-        >
-          로그인 화면으로
-        </Link>
+        <form action={logoutAction} className="w-full">
+          <LogoutSubmitButton />
+        </form>
       }
     />
+  );
+}
+
+function LogoutSubmitButton() {
+  const { pending } = useFormStatus();
+
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      className={cn(
+        buttonVariants({ variant: "ink" }),
+        "h-11 w-full text-[13px] leading-none disabled:opacity-60",
+      )}
+    >
+      {pending ? "로그아웃하는 중" : "로그인 화면으로"}
+    </button>
   );
 }


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

- `SubscriptionBlockedDialog`의 유일한 탈출구가 세션 쿠키를 안 지우는 `/login` `<Link>`라, 로그인된 채로는 같은 회사(같은 차단 상태)로 되돌아와 사실상 나갈 수 없던 문제를 고쳤다.
- 이미 구현돼 있던 `logoutAction`(쿠키 삭제 + `/login` 리다이렉트, `LogoutButton`이 쓰는 것과 동일)을 `<form action={logoutAction}>`으로 연결.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`fix/subscription-blocked-logout#520`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 권한 2축 검사 — 해당 없음(로그아웃 자체엔 권한 판정이 없음)
- [x] 🧬 zod — 해당 없음
- [x] 🕵️ **정직성** — "나가는 길"이 실제로 나가지는지가 핵심 수정 지점

**품질**

- [x] ♻️ 재사용 확인 (`logoutAction`, `LogoutButton`과 같은 액션 재사용 — 새로 만들지 않음)
- [x] 🧪 관련 유닛 테스트 추가/통과 (`subscription-blocked-dialog.test.tsx` 2건: UNPAID/EXPIRED 각각 클릭 시 `logoutAction` 호출 확인)

---

## 🔗 연관 이슈

Closes #520

---

## 💬 리뷰 포인트

- `logoutAction`은 서버 액션이라 실패해도 쿠키는 무조건 지운다(기존 구현) — 이 화면에서 별도 에러 처리를 안 해도 되는 이유.

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |


---

## 📝 추가 메모
