### PR TITLE
[FEAT] 캡처 오디오 조각 S3 업로드 연동 #530

### DIFF
--- a/src/features/meeting/capture/actions.ts
+++ b/src/features/meeting/capture/actions.ts
@@ -5,7 +5,7 @@ import { serverApi, toUserMessage } from "@/lib/api";
 import { ep } from "@/lib/endpoints";
 import { isMock } from "@/mocks/config";
 
-import type { CaptionChunkInput, CaptureSession } from "./types";
+import type { CaptionChunkInput, CapturePart, CaptureSession } from "./types";
 
 /**
  * 캡처 창구 — 격리막(§Mock 격리막).
@@ -65,6 +65,67 @@ export async function startCaptureSessionAction(
         startedAtEpochMs: response.startedAtEpochMs,
       },
     };
+  } catch (error) {
+    return { ok: false, error: toUserMessage(error) };
+  }
+}
+
+/* ────────────────────────── CAP-04 · 07 오디오 조각 업로드 ────────────────────────── */
+
+/** [확인] BE `CaptureUploadController.presign` — `PresignedPartsResponse` */
+interface PresignedPartsApiResponse {
+  segmentSeq: number;
+  parts: { seq: number; presignedUrl: string; expiresIn: number }[];
+}
+
+/**
+ * 조각 업로드용 presigned URL을 배치로 받는다(CAP-04).
+ *
+ * ⚠️ **한 번에 여러 개 받는다**(기본 20개=5분치, `upload.ts`가 정한다). 15초마다 새로
+ *    발급받으면 그 왕복이 매번 녹음 조각 전송을 가로막는다.
+ * ⚠️ 목에서는 **빈 배치를 돌려준다** — 목은 S3가 없어서 업로드를 안 한다(자막만 오간다).
+ */
+export async function presignCaptureUploadAction(
+  meetingId: number,
+  count: number,
+  contentType: string,
+): Promise<CaptureActionResult<{ segmentSeq: number; parts: CapturePart[] }>> {
+  if (isMock) return { ok: true, data: { segmentSeq: 0, parts: [] } };
+
+  try {
+    const accessToken = await requireAccessToken();
+    const response = await serverApi<PresignedPartsApiResponse>(ep.partsPresign(meetingId), {
+      method: "POST",
+      accessToken,
+      json: { count, contentType },
+    });
+    return { ok: true, data: response };
+  } catch (error) {
+    return { ok: false, error: toUserMessage(error) };
+  }
+}
+
+/**
+ * 조각 하나가 S3에 다 올라갔음을 알린다(CAP-07) — 이 호출 자체가 녹음자 하트비트다.
+ *
+ * ⚠️ **BE가 재검증한다.** 여기 실은 `sizeBytes`를 그대로 믿지 않고 S3 HEAD로 실제 업로드
+ *    여부를 다시 본다 — 우리가 보내는 값은 참고일 뿐 신뢰 경계는 서버에 있다.
+ */
+export async function completeCaptureUploadAction(
+  meetingId: number,
+  seq: number,
+  body: { segmentSeq: number; s3Key: string; sizeBytes: number },
+): Promise<CaptureActionResult<void>> {
+  if (isMock) return { ok: true };
+
+  try {
+    const accessToken = await requireAccessToken();
+    await serverApi<unknown>(ep.partComplete(meetingId, seq), {
+      method: "POST",
+      accessToken,
+      json: body,
+    });
+    return { ok: true };
   } catch (error) {
     return { ok: false, error: toUserMessage(error) };
   }

--- a/src/features/meeting/capture/recorder.ts
+++ b/src/features/meeting/capture/recorder.ts
@@ -8,7 +8,13 @@
  *    10분 완결 파일을 만든다(백엔드 확정).
  * ⚠️ **일시정지는 파일을 안 쪼갠다.** `pause/resume`은 하나의 연속 파일로 이어진다 —
  *    조용한 구간만 빠진다.
+ * ⚠️ **MIME 타입을 고정한다**(`upload.ts`의 `RECORDING_CONTENT_TYPE`). BE presign이
+ *    Content-Type을 서명에 실어서(`CapS3ObjectStorageAdapter`), 브라우저 기본값에
+ *    맡기면 `;codecs=opus` 같은 접미사가 실제 녹음과 presign 요청 사이에서 어긋나
+ *    S3가 서명 불일치로 PUT을 거절한다.
  */
+
+import { RECORDING_CONTENT_TYPE } from "./upload";
 
 export interface RecorderHandlers {
   /** 15초마다 나오는 조각 — 서버가 모아서 세그먼트를 만든다 */
@@ -69,7 +75,15 @@ export function createCaptureRecorder(handlers: RecorderHandlers): CaptureRecord
 
   const openSegment = () => {
     if (!stream) return;
-    const instance = new MediaRecorder(stream);
+    /*
+      ⚠️ 지원 여부를 먼저 묻는다 — 지원 안 하는 `mimeType`을 그냥 넘기면 생성자가 던진다.
+         Chrome 계열은 거의 항상 지원하지만, 혹시라도 없으면 브라우저 기본값으로 물러난다
+         (그때는 PUT Content-Type이 실제 녹음과 어긋날 수 있다는 걸 감수한다 — 녹음
+         자체가 아예 안 되는 것보다는 낫다).
+    */
+    const instance = MediaRecorder.isTypeSupported(RECORDING_CONTENT_TYPE)
+      ? new MediaRecorder(stream, { mimeType: RECORDING_CONTENT_TYPE })
+      : new MediaRecorder(stream);
     instance.ondataavailable = (event) => {
       if (event.data.size > 0) handlers.onSlice(event.data);
     };

--- a/src/features/meeting/capture/recorder.ts
+++ b/src/features/meeting/capture/recorder.ts
@@ -36,7 +36,12 @@ export interface CaptureRecorder {
   resume(): void;
   /** 세그먼트를 닫고 다음 구간을 연다 — 10분 경계에서 부른다 */
   rotate(index: number): void;
-  stop(): void;
+  /**
+   * 마이크를 끈다 — **마지막 조각까지 다 받은 뒤에 끝난다.**
+   * ⚠️ `void`로 두면 부르는 쪽이 `stop()` 직후 곧바로 다음 일을 해서, 비동기로 뒤늦게
+   *    오는 마지막 `dataavailable`(=마지막 15초 조각)이 갈 곳을 잃는다(§use-capture `end()`).
+   */
+  stop(): Promise<void>;
   /**
    * 열려 있는 마이크 스트림 — `start()`가 성공한 뒤에만 있다.
    *
@@ -75,15 +80,8 @@ export function createCaptureRecorder(handlers: RecorderHandlers): CaptureRecord
 
   const openSegment = () => {
     if (!stream) return;
-    /*
-      ⚠️ 지원 여부를 먼저 묻는다 — 지원 안 하는 `mimeType`을 그냥 넘기면 생성자가 던진다.
-         Chrome 계열은 거의 항상 지원하지만, 혹시라도 없으면 브라우저 기본값으로 물러난다
-         (그때는 PUT Content-Type이 실제 녹음과 어긋날 수 있다는 걸 감수한다 — 녹음
-         자체가 아예 안 되는 것보다는 낫다).
-    */
-    const instance = MediaRecorder.isTypeSupported(RECORDING_CONTENT_TYPE)
-      ? new MediaRecorder(stream, { mimeType: RECORDING_CONTENT_TYPE })
-      : new MediaRecorder(stream);
+    // ⚠️ 지원 여부는 `start()`가 이미 확인했다 — 여기 오는 시점엔 항상 지원된다.
+    const instance = new MediaRecorder(stream, { mimeType: RECORDING_CONTENT_TYPE });
     instance.ondataavailable = (event) => {
       if (event.data.size > 0) handlers.onSlice(event.data);
     };
@@ -94,6 +92,18 @@ export function createCaptureRecorder(handlers: RecorderHandlers): CaptureRecord
 
   return {
     async start() {
+      /*
+        ⚠️ **지원 안 하면 아예 시작하지 않는다**(CodeRabbit 지적, 2026-08-16). presign
+           요청·PUT 헤더가 항상 `RECORDING_CONTENT_TYPE` 고정이라, 브라우저가 다른 형식으로
+           녹음하면 나중에 S3가 서명 불일치로 PUT을 거절한다 — 마이크만 켜진 채 업로드가
+           전부 실패하는 것보다, 애초에 시작 안 하는 쪽이 낫다. Chrome 계열에서는 사실상
+           항상 지원되는 형식이라 실사용에서 이 분기를 탈 일은 거의 없다.
+      */
+      if (!MediaRecorder.isTypeSupported(RECORDING_CONTENT_TYPE)) {
+        handlers.onFatal("이 브라우저에서는 녹음 형식을 지원하지 않습니다.");
+        return false;
+      }
+
       try {
         /*
           ⚠️ **기본값에 맡기지 않는다.** 회의실 노트북 마이크는 에어컨·타자 소리를 그대로
@@ -143,11 +153,34 @@ export function createCaptureRecorder(handlers: RecorderHandlers): CaptureRecord
       return stream;
     },
     stop() {
-      if (recorder && recorder.state !== "inactive") recorder.stop();
+      const closing = recorder;
       recorder = null;
-      // 마이크 표시등을 끈다 — 트랙을 안 멈추면 회의가 끝나도 계속 켜져 있다
-      stream?.getTracks().forEach((track) => track.stop());
-      stream = null;
+
+      const closeStream = () => {
+        // 마이크 표시등을 끈다 — 트랙을 안 멈추면 회의가 끝나도 계속 켜져 있다
+        stream?.getTracks().forEach((track) => track.stop());
+        stream = null;
+      };
+
+      /*
+        ⚠️ **`onstop` 뒤에 끝난다.** `.stop()`을 부른 직후에도 마지막으로 잡힌 조각은
+           `dataavailable`로 비동기 전달된 뒤에야 `onstop`이 온다 — 스트림을 그 전에 끊으면
+           안전하지만(이미 버퍼링된 조각엔 영향 없다), **부르는 쪽이 "다 끝났다"고 알기엔
+           너무 이르다.** `use-capture.ts`의 `end()`가 이 완료를 기다린 뒤에야 업로드 큐
+           참조를 정리한다 — 그래야 이 마지막 조각의 `onSlice`가 살아있는 업로더를 본다.
+      */
+      return new Promise<void>((resolve) => {
+        if (!closing || closing.state === "inactive") {
+          closeStream();
+          resolve();
+          return;
+        }
+        closing.onstop = () => {
+          closeStream();
+          resolve();
+        };
+        closing.stop();
+      });
     },
   };
 }

--- a/src/features/meeting/capture/stt.ts
+++ b/src/features/meeting/capture/stt.ts
@@ -104,6 +104,21 @@ const FATAL_MESSAGE: Record<string, string> = {
 /** 이만큼 연속으로 빈 세션이면 포기하고 알린다 — 대략 30초어치다 */
 const MAX_EMPTY_RESTARTS = 8;
 
+/**
+ * 한 발화가 확정 없이 이어질 수 있는 최대 시간(ms).
+ *
+ * ⚠️ **`isFinal`은 전적으로 브라우저 엔진이 정한다.** 쉬지 않고 이어 말하면 문장이
+ *    끝나도 다음 말과 합쳐진 채 계속 interim으로만 머무는 경우가 실제로 나온다(QA
+ *    확인, 2026-08-16) — 우리 쪽에 문장 경계를 아는 방법이 없어 완전히 고칠 수는
+ *    없고, **너무 길어지면 끊어서 확정시키는** 정도로 완화한다.
+ * ⚠️ 8초로 잡은 이유 — 화면(§DESIGN)의 발화 단위 감각과 맞춘 값이다. 더 짧으면 정상
+ *    속도로 긴 문장을 말하는 사람의 말까지 억지로 끊는다.
+ */
+const MAX_UTTERANCE_MS = 8_000;
+
+/** 발화가 너무 길어졌는지 이 주기로 살핀다 */
+const UTTERANCE_CHECK_MS = 1_000;
+
 export function createSttEngine(handlers: SttHandlers): SttEngine | null {
   const Ctor = ctorOf();
   if (!Ctor) return null;
@@ -120,6 +135,9 @@ export function createSttEngine(handlers: SttHandlers): SttEngine | null {
    */
   let emptyRestarts = 0;
   let retryTimer: number | null = null;
+  /** 지금 확정 안 된 말이 **언제부터** 이어지고 있는가 — 없으면 `null` */
+  let utteranceOpenAt: number | null = null;
+  let utteranceCheckTimer: number | null = null;
 
   const spawn = () => {
     const instance = new Ctor();
@@ -142,11 +160,16 @@ export function createSttEngine(handlers: SttHandlers): SttEngine | null {
         if (result?.isFinal) {
           // 한 문장이라도 받았으면 정상이다 — 물러설 시간을 되돌린다
           emptyRestarts = 0;
+          utteranceOpenAt = null;
           handlers.onChunk(text);
         } else {
           pending = pending ? `${pending} ${text}` : text;
         }
       }
+
+      // 새로 이어지는 말이 생겼으면 그 시작 시각을 잡는다 — 너무 길어지면 강제로 끊는다
+      if (pending && utteranceOpenAt === null) utteranceOpenAt = Date.now();
+      if (!pending) utteranceOpenAt = null;
 
       // 확정으로 넘어간 순간 흐린 줄을 비운다 — 안 비우면 같은 말이 두 줄로 보인다
       handlers.onPartial(pending);
@@ -204,15 +227,36 @@ export function createSttEngine(handlers: SttHandlers): SttEngine | null {
     }
   };
 
+  /*
+    ⚠️ **`.stop()`으로 끊는다, `.abort()`가 아니다.** `stop()`은 지금까지 들은 걸 확정해서
+       `onresult(isFinal)`로 돌려준 뒤 `onend`를 부른다 — `abort()`는 그 없이 즉시 버린다.
+       여기서 `abort()`를 쓰면 8초 넘게 참은 말이 그대로 통째로 사라진다.
+    ⚠️ **`stopped`는 안 건드린다.** 이건 우리가 의도적으로 끝내는 게 아니라 **길어서
+       강제로 한 번 끊는 것**이다 — `onend`가 정상적으로 다시 여는 경로를 그대로 탄다.
+  */
+  const cutIfTooLong = () => {
+    if (utteranceOpenAt === null) return;
+    if (Date.now() - utteranceOpenAt < MAX_UTTERANCE_MS) return;
+    utteranceOpenAt = null;
+    recognition?.stop();
+  };
+
   return {
     start() {
       if (!stopped) return;
       stopped = false;
       emptyRestarts = 0;
+      utteranceOpenAt = null;
+      utteranceCheckTimer = window.setInterval(cutIfTooLong, UTTERANCE_CHECK_MS);
       spawn();
     },
     stop() {
       stopped = true;
+      utteranceOpenAt = null;
+      if (utteranceCheckTimer !== null) {
+        window.clearInterval(utteranceCheckTimer);
+        utteranceCheckTimer = null;
+      }
       handlers.onPartial("");
       if (retryTimer !== null) {
         window.clearTimeout(retryTimer);

--- a/src/features/meeting/capture/stt.ts
+++ b/src/features/meeting/capture/stt.ts
@@ -109,8 +109,8 @@ const MAX_EMPTY_RESTARTS = 8;
  *
  * ⚠️ **`isFinal`은 전적으로 브라우저 엔진이 정한다.** 쉬지 않고 이어 말하면 문장이
  *    끝나도 다음 말과 합쳐진 채 계속 interim으로만 머무는 경우가 실제로 나온다(QA
- *    확인, 2026-08-16) — 우리 쪽에 문장 경계를 아는 방법이 없어 완전히 고칠 수는
- *    없고, **너무 길어지면 끊어서 확정시키는** 정도로 완화한다.
+ *    확인) — 우리 쪽에 문장 경계를 아는 방법이 없어 완전히 고칠 수는 없고,
+ *    **너무 길어지면 끊어서 확정시키는** 정도로 완화한다.
  * ⚠️ 8초로 잡은 이유 — 화면(§DESIGN)의 발화 단위 감각과 맞춘 값이다. 더 짧으면 정상
  *    속도로 긴 문장을 말하는 사람의 말까지 억지로 끊는다.
  */
@@ -178,6 +178,7 @@ export function createSttEngine(handlers: SttHandlers): SttEngine | null {
     instance.onerror = (event) => {
       if (!isFatalSttError(event.error)) return;
       stopped = true;
+      clearUtteranceTimer();
       // ⚠️ 비추던 문장을 지운다 — 안 지우면 받아쓰기가 죽었는데 점선 줄이 계속 깜빡여
       //    **아직 듣고 있는 것처럼** 보인다(§정직성). 어차피 확정 안 돼 서버로도 안 간다.
       handlers.onPartial("");
@@ -188,6 +189,14 @@ export function createSttEngine(handlers: SttHandlers): SttEngine | null {
       if (stopped) return;
 
       /*
+        ⚠️ **여기서도 지운다.** 확정 없이 interim만 있던 세션이 스스로 닫히면(다음 줄의
+           재시작), 그 발화는 다음 세션으로 안 이어진다 — 지우지 않으면 새 세션의 첫
+           interim이 이 낡은 시각을 물려받아 감시 타이머가 아직 시작도 안 한 발화를
+           너무 일찍 끊는다(CodeRabbit 지적, 2026-08-16).
+      */
+      utteranceOpenAt = null;
+
+      /*
         세션이 스스로 닫혔다 — 다시 연다.
         ⚠️ 연속 실패가 쌓이면 **물러서며** 연다(0.2s → 0.4s → 0.8s …, 최대 5초). 조용해서
            닫힌 정상 상황은 첫 문장이 오는 순간 `emptyRestarts`가 0으로 돌아가 지연이 사라진다.
@@ -196,6 +205,7 @@ export function createSttEngine(handlers: SttHandlers): SttEngine | null {
       emptyRestarts += 1;
       if (emptyRestarts > MAX_EMPTY_RESTARTS) {
         stopped = true;
+        clearUtteranceTimer();
         handlers.onPartial("");
         handlers.onFatal("자막을 계속 받지 못했습니다. 마이크와 네트워크를 확인해 주세요.");
         return;
@@ -241,6 +251,21 @@ export function createSttEngine(handlers: SttHandlers): SttEngine | null {
     recognition?.stop();
   };
 
+  /*
+    ⚠️ **종료로 가는 길이 셋이다** — 공개 `stop()`, 치명 오류(`onerror`), 재시작 포기
+       (`onend`의 `MAX_EMPTY_RESTARTS` 초과) — 셋 다 여기를 거쳐야 한다. 하나라도
+       빠뜨리면 그 길로 끝난 세션의 타이머가 안 멈추고 계속 돌다가, 다음 `start()`가
+       새 타이머 ID로 `utteranceCheckTimer`를 덮어써서 **옛 타이머는 영영 못 지운다**
+       (CodeRabbit 지적, 2026-08-16).
+  */
+  const clearUtteranceTimer = () => {
+    utteranceOpenAt = null;
+    if (utteranceCheckTimer !== null) {
+      window.clearInterval(utteranceCheckTimer);
+      utteranceCheckTimer = null;
+    }
+  };
+
   return {
     start() {
       if (!stopped) return;
@@ -252,11 +277,7 @@ export function createSttEngine(handlers: SttHandlers): SttEngine | null {
     },
     stop() {
       stopped = true;
-      utteranceOpenAt = null;
-      if (utteranceCheckTimer !== null) {
-        window.clearInterval(utteranceCheckTimer);
-        utteranceCheckTimer = null;
-      }
+      clearUtteranceTimer();
       handlers.onPartial("");
       if (retryTimer !== null) {
         window.clearTimeout(retryTimer);

--- a/src/features/meeting/capture/types.ts
+++ b/src/features/meeting/capture/types.ts
@@ -18,6 +18,20 @@ export interface CaptureSession {
 }
 
 /**
+ * presign(CAP-04)이 발급한 업로드 자리 하나 — S3로 직접 PUT할 때 쓴다.
+ *
+ * ⚠️ **오브젝트 키가 따로 없다.** BE는 서명된 URL만 주고 키는 검증용으로만 들고 있어서,
+ *    complete(CAP-07)에 실어 보낼 키는 이 URL 경로에서 직접 뽑아야 한다(`upload.ts`).
+ */
+export interface CapturePart {
+  /** 세그먼트 내 청크 순번 — complete·재개 조회의 키 */
+  seq: number;
+  presignedUrl: string;
+  /** 이 초 안에 PUT까지 끝나야 한다 */
+  expiresIn: number;
+}
+
+/**
  * 서버로 보낼 자막 한 조각 — [확인] BE `SubmitCaptionsRequest.ChunkRequest`.
  *
  * ⚠️ 필드 이름을 바꾸지 않는다. 이 모양 그대로 JSON이 된다.

--- a/src/features/meeting/capture/upload.test.ts
+++ b/src/features/meeting/capture/upload.test.ts
@@ -1,0 +1,117 @@
+jest.mock("./actions", () => ({
+  presignCaptureUploadAction: jest.fn(),
+  completeCaptureUploadAction: jest.fn(),
+}));
+
+import { completeCaptureUploadAction, presignCaptureUploadAction } from "./actions";
+import { createSliceUploader } from "./upload";
+
+/**
+ * 오디오 조각 업로더 — presign 배치 소진·S3 키 파싱·연속 실패 알림만 확인한다.
+ * ⚠️ 실제 S3 PUT은 `fetch`를 목으로 대체한다 — 네트워크 계층은 여기서 안 본다.
+ */
+
+const presignMock = presignCaptureUploadAction as unknown as jest.Mock;
+const completeMock = completeCaptureUploadAction as unknown as jest.Mock;
+
+function batch(segmentSeq: number, seqs: number[]) {
+  return {
+    ok: true,
+    data: {
+      segmentSeq,
+      parts: seqs.map((seq) => ({
+        seq,
+        presignedUrl: `https://bucket.s3.amazonaws.com/companies/1/meetings/9/segments/${segmentSeq}/parts/${seq}.webm?X-Amz-Signature=abc`,
+        expiresIn: 300,
+      })),
+    },
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  global.fetch = jest.fn().mockResolvedValue({ ok: true });
+  completeMock.mockResolvedValue({ ok: true });
+});
+
+it("배치가 바닥나면 다음 배치를 받아 이어서 올린다", async () => {
+  /*
+    ⚠️ threshold(3)보다 작은 배치라 매번 pop할 때마다 배경 refill이 걸린다 — 정확히 몇 번
+       불렸는지는 타이밍에 좌우되는 구현 세부라 안 세고, `mockResolvedValue`로 그 이후
+       호출도 항상 답을 받게만 해 둔다.
+  */
+  presignMock.mockResolvedValueOnce(batch(0, [1, 2])).mockResolvedValue(batch(0, [3, 4, 5]));
+
+  const uploader = createSliceUploader(9, { onFailure: jest.fn() });
+  uploader.enqueue(new Blob(["a"]));
+  uploader.enqueue(new Blob(["b"]));
+  uploader.enqueue(new Blob(["c"]));
+  await uploader.flush();
+
+  expect(presignMock).toHaveBeenCalled();
+  expect(completeMock).toHaveBeenCalledTimes(3);
+  expect(completeMock).toHaveBeenNthCalledWith(1, 9, 1, {
+    segmentSeq: 0,
+    s3Key: "companies/1/meetings/9/segments/0/parts/1.webm",
+    sizeBytes: expect.any(Number),
+  });
+  expect(completeMock).toHaveBeenNthCalledWith(2, 9, 2, {
+    segmentSeq: 0,
+    s3Key: "companies/1/meetings/9/segments/0/parts/2.webm",
+    sizeBytes: expect.any(Number),
+  });
+});
+
+it("presigned URL 경로에서 S3 키를 정확히 뽑아 complete에 실어 보낸다", async () => {
+  presignMock.mockResolvedValue(batch(2, [1, 2, 3]));
+
+  const uploader = createSliceUploader(9, { onFailure: jest.fn() });
+  uploader.enqueue(new Blob(["a"]));
+  await uploader.flush();
+
+  expect(completeMock).toHaveBeenCalledWith(9, 1, {
+    segmentSeq: 2,
+    s3Key: "companies/1/meetings/9/segments/2/parts/1.webm",
+    sizeBytes: expect.any(Number),
+  });
+});
+
+it("S3 PUT이 연속 3번 실패하면 알리고, 성공하면 실패 횟수가 되돌아간다", async () => {
+  presignMock.mockResolvedValue(batch(0, [1, 2, 3, 4]));
+  const onFailure = jest.fn();
+  (global.fetch as jest.Mock)
+    .mockResolvedValueOnce({ ok: false, status: 500 })
+    .mockResolvedValueOnce({ ok: false, status: 500 })
+    .mockResolvedValueOnce({ ok: false, status: 500 })
+    .mockResolvedValueOnce({ ok: true });
+
+  const uploader = createSliceUploader(9, { onFailure });
+  uploader.enqueue(new Blob(["a"]));
+  uploader.enqueue(new Blob(["b"]));
+  uploader.enqueue(new Blob(["c"]));
+  uploader.enqueue(new Blob(["d"]));
+  await uploader.flush();
+
+  expect(onFailure).toHaveBeenCalledTimes(1);
+  expect(completeMock).toHaveBeenCalledTimes(1); // 네 번째만 PUT이 성공해 complete까지 감
+});
+
+it("순서대로, 하나씩 올린다 — 동시에 여러 조각을 PUT하지 않는다", async () => {
+  presignMock.mockResolvedValue(batch(0, [1, 2, 3]));
+  let inFlight = 0;
+  let maxInFlight = 0;
+  (global.fetch as jest.Mock).mockImplementation(async () => {
+    inFlight += 1;
+    maxInFlight = Math.max(maxInFlight, inFlight);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    inFlight -= 1;
+    return { ok: true };
+  });
+
+  const uploader = createSliceUploader(9, { onFailure: jest.fn() });
+  uploader.enqueue(new Blob(["a"]));
+  uploader.enqueue(new Blob(["b"]));
+  await uploader.flush();
+
+  expect(maxInFlight).toBe(1);
+});

--- a/src/features/meeting/capture/upload.test.ts
+++ b/src/features/meeting/capture/upload.test.ts
@@ -76,14 +76,36 @@ it("presigned URL 경로에서 S3 키를 정확히 뽑아 complete에 실어 보
   });
 });
 
-it("S3 PUT이 연속 3번 실패하면 알리고, 성공하면 실패 횟수가 되돌아간다", async () => {
-  presignMock.mockResolvedValue(batch(0, [1, 2, 3, 4]));
+it("PUT이 실패해도 같은 조각을 재시도해서 결국 올린다", async () => {
+  presignMock.mockResolvedValue(batch(0, [1]));
   const onFailure = jest.fn();
   (global.fetch as jest.Mock)
     .mockResolvedValueOnce({ ok: false, status: 500 })
     .mockResolvedValueOnce({ ok: false, status: 500 })
-    .mockResolvedValueOnce({ ok: false, status: 500 })
     .mockResolvedValueOnce({ ok: true });
+
+  const uploader = createSliceUploader(9, { onFailure });
+  uploader.enqueue(new Blob(["a"]));
+  await uploader.flush();
+
+  expect(global.fetch).toHaveBeenCalledTimes(3); // 같은 presignedUrl로 세 번째 만에 성공
+  expect(completeMock).toHaveBeenCalledTimes(1);
+  expect(onFailure).not.toHaveBeenCalled();
+}, 10_000);
+
+it("재시도까지 다 실패한 조각이 연속 3개면 알리고, 그다음 성공하면 실패 횟수가 되돌아간다", async () => {
+  presignMock.mockResolvedValue(batch(0, [1, 2, 3, 4]));
+  const onFailure = jest.fn();
+  /*
+    조각 1·2·3은 매 시도 실패(각 3번씩 재시도 후 포기 = 9번), 조각 4는 그 뒤 첫 시도부터
+    성공한다(10번째 호출) — 호출 순번으로 세는 게 개별 mockResolvedValueOnce를 9개
+    늘어놓는 것보다 개수를 세기 쉽다.
+  */
+  let callCount = 0;
+  (global.fetch as jest.Mock).mockImplementation(async () => {
+    callCount += 1;
+    return { ok: callCount > 9, status: 500 };
+  });
 
   const uploader = createSliceUploader(9, { onFailure });
   uploader.enqueue(new Blob(["a"]));
@@ -92,9 +114,10 @@ it("S3 PUT이 연속 3번 실패하면 알리고, 성공하면 실패 횟수가 
   uploader.enqueue(new Blob(["d"]));
   await uploader.flush();
 
-  expect(onFailure).toHaveBeenCalledTimes(1);
-  expect(completeMock).toHaveBeenCalledTimes(1); // 네 번째만 PUT이 성공해 complete까지 감
-});
+  expect(global.fetch).toHaveBeenCalledTimes(10); // (3+3+3)번 재시도 + 마지막 1번
+  expect(onFailure).toHaveBeenCalledTimes(1); // 조각 3개 연속 포기한 시점에 딱 한 번
+  expect(completeMock).toHaveBeenCalledTimes(1); // 조각 4만 성공해 complete까지 감
+}, 15_000);
 
 it("순서대로, 하나씩 올린다 — 동시에 여러 조각을 PUT하지 않는다", async () => {
   presignMock.mockResolvedValue(batch(0, [1, 2, 3]));

--- a/src/features/meeting/capture/upload.ts
+++ b/src/features/meeting/capture/upload.ts
@@ -40,6 +40,25 @@ export interface SliceUploader {
 /** 연속 실패 이 횟수부터 화면에 알린다 — 한두 번의 튐은 흔하다(§captions와 같은 기준) */
 const MAX_CONSECUTIVE_FAILURES = 3;
 
+/** 조각 하나(PUT+complete)를 이만큼 재시도한다 — 그래도 안 되면 이 조각만 포기한다 */
+const MAX_UPLOAD_ATTEMPTS = 3;
+
+/** 재시도 사이 간격 — S3·네트워크가 순간적으로 튄 경우를 위한 최소한의 여유 */
+const RETRY_DELAY_MS = 500;
+
+/** S3 PUT 하나가 이 시간을 넘기면 멈춰선 것으로 본다 — `fetch`엔 기본 timeout이 없다 */
+const PUT_TIMEOUT_MS = 20_000;
+
+/**
+ * 풀에 든 조각 — **발급 당시의 `segmentSeq`를 같이 들고 다닌다.**
+ * ⚠️ 배치마다 `segmentSeq`가 바뀔 수 있다(녹음자 교체 등, `CaptureUploadService`
+ *    `willChangeSegment`) — 전역 변수 하나로 두면 새 배치가 그 값을 덮어써서, 아직
+ *    풀에 남아 있던 **이전 배치의 조각**이 **새 세그먼트 번호**로 complete될 수 있다.
+ */
+interface PooledPart extends CapturePart {
+  segmentSeq: number;
+}
+
 /**
  * presigned URL 경로에서 오브젝트 키를 뽑는다.
  *
@@ -51,22 +70,40 @@ function keyOf(presignedUrl: string): string {
   return decodeURIComponent(pathname.replace(/^\//, ""));
 }
 
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
 export function createSliceUploader(meetingId: number, handlers: UploadHandlers): SliceUploader {
-  let pool: CapturePart[] = [];
-  let segmentSeq: number | null = null;
+  let pool: PooledPart[] = [];
   let refilling: Promise<void> | null = null;
   let consecutiveFailures = 0;
   /** 순서를 지키는 직렬 큐 — 각 조각은 앞 조각이 끝난 뒤에만 시작한다 */
   let chain: Promise<void> = Promise.resolve();
 
+  const reportFailure = () => {
+    consecutiveFailures += 1;
+    if (consecutiveFailures === MAX_CONSECUTIVE_FAILURES) {
+      handlers.onFailure("녹음 파일을 서버에 올리지 못하고 있습니다. 자막은 계속 기록됩니다.");
+    }
+  };
+
+  /*
+    ⚠️ **여기서 절대 안 던진다.** `presignCaptureUploadAction`은 스스로 값으로 실패를
+       돌려주지만(actions.ts의 규칙), 그래도 예기치 못하게 거부되면 `refilling`이
+       rejected 프라미스로 남는다 — `nextPart`의 `await refill()`이 그걸 그대로 던지면
+       `uploadOne`이 죽고, 그 뒤로는 `chain`의 `.then()`이 하나도 안 돌아 **큐 전체가
+       멈춘다**(CodeRabbit 지적, 2026-08-16). 실패도 "빈 배치"로 흡수한다.
+  */
   const refill = (): Promise<void> => {
     if (refilling) return refilling;
     refilling = presignCaptureUploadAction(meetingId, BATCH_COUNT, RECORDING_CONTENT_TYPE)
       .then((result) => {
         if (result.ok && result.data) {
-          segmentSeq = result.data.segmentSeq;
-          pool = [...pool, ...result.data.parts];
+          const { segmentSeq, parts } = result.data;
+          pool = [...pool, ...parts.map((part) => ({ ...part, segmentSeq }))];
         }
+      })
+      .catch(() => {
+        /* 배치를 못 받았다 — 빈손으로 끝낸다, `nextPart`가 `null`로 받아 실패 처리한다 */
       })
       .finally(() => {
         refilling = null;
@@ -74,7 +111,7 @@ export function createSliceUploader(meetingId: number, handlers: UploadHandlers)
     return refilling;
   };
 
-  const nextPart = async (): Promise<CapturePart | null> => {
+  const nextPart = async (): Promise<PooledPart | null> => {
     // 여유 있게 미리 채운다 — 기다리지 않는다(바닥나기 전이라 급하지 않다)
     if (pool.length > 0 && pool.length <= REFILL_THRESHOLD) void refill();
     // 정말 바닥났으면 이번엔 기다린다 — 줄 새 조각을 그냥 버릴 수는 없다
@@ -85,38 +122,55 @@ export function createSliceUploader(meetingId: number, handlers: UploadHandlers)
     return part;
   };
 
-  const uploadOne = async (blob: Blob) => {
-    const part = await nextPart();
-    if (!part || segmentSeq === null) {
-      consecutiveFailures += 1;
-      if (consecutiveFailures === MAX_CONSECUTIVE_FAILURES) {
-        handlers.onFailure("녹음 파일을 서버에 올리지 못하고 있습니다. 자막은 계속 기록됩니다.");
-      }
-      return;
-    }
-
+  /** 조각 하나를 한 번 PUT+complete한다 — 성공하면 `true` */
+  const attemptOnce = async (part: PooledPart, blob: Blob): Promise<boolean> => {
     try {
       const response = await fetch(part.presignedUrl, {
         method: "PUT",
         headers: { "Content-Type": RECORDING_CONTENT_TYPE },
         body: blob,
+        // ⚠️ 기본 timeout이 없다 — S3가 응답 없이 멈추면 flush()·end()가 영원히 안 끝난다
+        signal: AbortSignal.timeout(PUT_TIMEOUT_MS),
       });
-      if (!response.ok) throw new Error(`S3 PUT ${response.status}`);
+      if (!response.ok) return false;
 
       const completed = await completeCaptureUploadAction(meetingId, part.seq, {
-        segmentSeq,
+        segmentSeq: part.segmentSeq,
         s3Key: keyOf(part.presignedUrl),
         sizeBytes: blob.size,
       });
-      if (!completed.ok) throw new Error(completed.error ?? "complete 실패");
-
-      consecutiveFailures = 0;
+      return completed.ok;
     } catch {
-      consecutiveFailures += 1;
-      if (consecutiveFailures === MAX_CONSECUTIVE_FAILURES) {
-        handlers.onFailure("녹음 파일을 서버에 올리지 못하고 있습니다. 자막은 계속 기록됩니다.");
-      }
+      return false;
     }
+  };
+
+  /*
+    ⚠️ **실패한 조각을 그냥 버리지 않는다.** 전엔 PUT이든 complete든 한 번 실패하면 그
+       조각은 영영 안 올라가고 다음 조각이 더 큰 seq로 complete돼, 서버가 실제로는
+       없는 공백을 결원(`missingSeqs`)으로 본다(CodeRabbit 지적, 2026-08-16). **같은
+       presigned URL로 몇 번 더 시도**한다 — PUT에 실패했든(파일이 안 올라감) 아직
+       S3엔 있는데 complete만 실패했든, URL 자체는 재사용해도 안전하다(성공한 PUT을
+       또 해도 같은 객체를 덮어쓸 뿐이다).
+  */
+  const uploadOne = async (blob: Blob) => {
+    const part = await nextPart();
+    if (!part) {
+      reportFailure();
+      return;
+    }
+
+    for (let attempt = 1; attempt <= MAX_UPLOAD_ATTEMPTS; attempt += 1) {
+      const ok = await attemptOnce(part, blob);
+      if (ok) {
+        consecutiveFailures = 0;
+        return;
+      }
+      if (attempt < MAX_UPLOAD_ATTEMPTS) await sleep(RETRY_DELAY_MS);
+    }
+
+    // 여기까지 왔으면 이 조각은 포기한다 — 그래도 녹음·다음 조각은 계속돼야 한다
+    reportFailure();
   };
 
   return {

--- a/src/features/meeting/capture/upload.ts
+++ b/src/features/meeting/capture/upload.ts
@@ -1,0 +1,130 @@
+/**
+ * 업로드 계층 — 15초 조각(`recorder.ts`)을 모아 서버 presign(CAP-04)으로 받은 URL에
+ * **브라우저가 S3로 직접 PUT**하고, 성공하면 complete(CAP-07)로 알린다(WORKFLOW §3-3).
+ *
+ * ⚠️ presign은 **배치**로 받는다(기본 20개=5분치) — 조각마다 새로 부르면 15초마다
+ *    왕복이 끼어든다. 배치가 바닥나기 전에 다음 배치를 미리 받아 둔다.
+ * ⚠️ **순서대로, 하나씩 올린다.** 동시에 여러 개를 올리면 늦게 끝난 것 때문에 순서가
+ *    뒤집혀 BE의 결원 판정(`missingSeqs`)이 실제로는 안 밀린 조각까지 결원으로 본다.
+ * ⚠️ **실패해도 녹음은 안 멈춘다.** 오디오가 정본이라고 해서 여기서 회의를 막으면 자막·
+ *    녹음을 둘 다 잃는다 — 연속 실패만 화면에 알리고(`onFailure`) 다음 조각은 계속 받는다.
+ * ⚠️ **Content-Type이 서명에 들어간다**(BE `CapS3ObjectStorageAdapter`가 `PutObjectRequest`에
+ *    `contentType`을 실어 presign한다) — PUT 헤더가 여기서 요청한 값과 다르면 S3가
+ *    서명 불일치로 거절한다. presign 요청·PUT 헤더가 항상 같은 상수를 써야 한다.
+ */
+
+import { completeCaptureUploadAction, presignCaptureUploadAction } from "./actions";
+import type { CapturePart } from "./types";
+
+/** 15초 × 20 = 5분치 — 한 배치의 크기 */
+const BATCH_COUNT = 20;
+
+/** 이 개수 이하로 남으면 다음 배치를 미리 받는다(바닥나고서 받으면 그사이 조각이 밀린다) */
+const REFILL_THRESHOLD = 3;
+
+/** presign 요청·PUT 헤더가 공유하는 값 — `recorder.ts`가 이 형식으로 녹음한다 */
+export const RECORDING_CONTENT_TYPE = "audio/webm";
+
+export interface UploadHandlers {
+  /** 연속 실패 — 녹음은 계속되지만 화면에 남긴다(§정직성) */
+  onFailure(message: string): void;
+}
+
+export interface SliceUploader {
+  /** 조각 하나를 큐에 넣는다 — 호출 순서대로 올라간다 */
+  enqueue(blob: Blob): void;
+  /** 큐에 남은 조각을 마저 올릴 때까지 기다린다 — 종료 직전에 부른다 */
+  flush(): Promise<void>;
+}
+
+/** 연속 실패 이 횟수부터 화면에 알린다 — 한두 번의 튐은 흔하다(§captions와 같은 기준) */
+const MAX_CONSECUTIVE_FAILURES = 3;
+
+/**
+ * presigned URL 경로에서 오브젝트 키를 뽑는다.
+ *
+ * ⚠️ presign 응답엔 키가 따로 안 온다 — BE는 서명된 URL만 주고, complete에 실어 보낼 키는
+ *    이 URL 자신에서 읽어야 한다(`CaptureUploadService.buildS3Key`가 서버 안에서만 안다).
+ */
+function keyOf(presignedUrl: string): string {
+  const { pathname } = new URL(presignedUrl);
+  return decodeURIComponent(pathname.replace(/^\//, ""));
+}
+
+export function createSliceUploader(meetingId: number, handlers: UploadHandlers): SliceUploader {
+  let pool: CapturePart[] = [];
+  let segmentSeq: number | null = null;
+  let refilling: Promise<void> | null = null;
+  let consecutiveFailures = 0;
+  /** 순서를 지키는 직렬 큐 — 각 조각은 앞 조각이 끝난 뒤에만 시작한다 */
+  let chain: Promise<void> = Promise.resolve();
+
+  const refill = (): Promise<void> => {
+    if (refilling) return refilling;
+    refilling = presignCaptureUploadAction(meetingId, BATCH_COUNT, RECORDING_CONTENT_TYPE)
+      .then((result) => {
+        if (result.ok && result.data) {
+          segmentSeq = result.data.segmentSeq;
+          pool = [...pool, ...result.data.parts];
+        }
+      })
+      .finally(() => {
+        refilling = null;
+      });
+    return refilling;
+  };
+
+  const nextPart = async (): Promise<CapturePart | null> => {
+    // 여유 있게 미리 채운다 — 기다리지 않는다(바닥나기 전이라 급하지 않다)
+    if (pool.length > 0 && pool.length <= REFILL_THRESHOLD) void refill();
+    // 정말 바닥났으면 이번엔 기다린다 — 줄 새 조각을 그냥 버릴 수는 없다
+    if (pool.length === 0) await refill();
+    const [part, ...rest] = pool;
+    if (!part) return null;
+    pool = rest;
+    return part;
+  };
+
+  const uploadOne = async (blob: Blob) => {
+    const part = await nextPart();
+    if (!part || segmentSeq === null) {
+      consecutiveFailures += 1;
+      if (consecutiveFailures === MAX_CONSECUTIVE_FAILURES) {
+        handlers.onFailure("녹음 파일을 서버에 올리지 못하고 있습니다. 자막은 계속 기록됩니다.");
+      }
+      return;
+    }
+
+    try {
+      const response = await fetch(part.presignedUrl, {
+        method: "PUT",
+        headers: { "Content-Type": RECORDING_CONTENT_TYPE },
+        body: blob,
+      });
+      if (!response.ok) throw new Error(`S3 PUT ${response.status}`);
+
+      const completed = await completeCaptureUploadAction(meetingId, part.seq, {
+        segmentSeq,
+        s3Key: keyOf(part.presignedUrl),
+        sizeBytes: blob.size,
+      });
+      if (!completed.ok) throw new Error(completed.error ?? "complete 실패");
+
+      consecutiveFailures = 0;
+    } catch {
+      consecutiveFailures += 1;
+      if (consecutiveFailures === MAX_CONSECUTIVE_FAILURES) {
+        handlers.onFailure("녹음 파일을 서버에 올리지 못하고 있습니다. 자막은 계속 기록됩니다.");
+      }
+    }
+  };
+
+  return {
+    enqueue(blob) {
+      chain = chain.then(() => uploadOne(blob));
+    },
+    flush() {
+      return chain;
+    },
+  };
+}

--- a/src/features/meeting/capture/use-capture.ts
+++ b/src/features/meeting/capture/use-capture.ts
@@ -25,6 +25,7 @@ import {
 import { type CaptureRecorder, createCaptureRecorder, isRecordingSupported } from "./recorder";
 import { createSttEngine, isSttSupported, type SttEngine, type TranscriptChunk } from "./stt";
 import type { CaptionChunkInput } from "./types";
+import { createSliceUploader, type SliceUploader } from "./upload";
 
 /**
  * 캡처 화면의 손발 — 단계·시간·자막을 한 곳에서 든다.
@@ -116,6 +117,7 @@ export function useCapture(meetingId: string, initialSeq = 0): UseCaptureResult 
 
   const sttRef = useRef<SttEngine | null>(null);
   const recorderRef = useRef<CaptureRecorder | null>(null);
+  const uploaderRef = useRef<SliceUploader | null>(null);
   /** 이미 닫은 세그먼트 수 — 같은 경계에서 두 번 닫지 않으려고 든다 */
   const closedRef = useRef(0);
 
@@ -303,6 +305,12 @@ export function useCapture(meetingId: string, initialSeq = 0): UseCaptureResult 
     levelRef.current = null;
     recorderRef.current?.stop();
     recorderRef.current = null;
+    /*
+      ⚠️ **참조만 지운다 — 큐를 비우지 않는다.** 이미 `enqueue`된 조각은 각자 자기
+         프라미스 체인을 쥐고 계속 올라간다. `end()`가 `uploader.flush()`로 그 체인이
+         끝나길 따로 기다린다 — 여기서 참조를 지워도 진행 중인 업로드는 안 끊긴다.
+    */
+    uploaderRef.current = null;
   }, []);
 
   /**
@@ -355,13 +363,16 @@ export function useCapture(meetingId: string, initialSeq = 0): UseCaptureResult 
 
     const recorder = createCaptureRecorder({
       /*
-        ⚠️ **오디오 업로드는 아직 안 붙었다**(다음 조각). 협의 대기가 아니라 **API는 이미
-           확정**돼 있다 — presign(CAP-04)으로 URL을 받아 브라우저가 **S3에 직접 PUT**하고
-           complete(CAP-07)로 알린다. 우리 서버를 거치는 multipart가 아니다.
-        ⚠️ 그때까지 **녹음 파일은 어디에도 안 남는다.** 자막만 올라간다 —
-           되는 척하지 않으려고 여기 적어 둔다(§정직성).
+        ⚠️ **`uploaderRef`가 아직 없을 수 있다.** CAP-01이 성공하기 전까지는 `null`이라
+           조각을 조용히 버린다 — 마이크가 15초를 채우는 것보다 CAP-01 왕복이 훨씬 빨라
+           실제로는 거의 안 일어나지만, 혹시 그 사이에 조각이 와도 없는 업로더에 넣지
+           않는다(아래에서 CAP-01이 실패하면 마이크 자체를 닫는다).
+        ⚠️ **세그먼트가 닫혀도(10분 경계) BE에 따로 알리지 않는다.** BE는 조각 개수로
+           스스로 10분어치를 끊어 붙인다(`SttBlockCutTrigger`, "10분/40청크") — FE의
+           `rotate()`는 `MediaRecorder` 헤더를 새로 여는 로컬 사정일 뿐, 같은 시간
+           기준(`recordedMs`)을 쓰므로 경계가 자연히 맞아떨어진다.
       */
-      onSlice: () => {},
+      onSlice: (blob) => uploaderRef.current?.enqueue(blob),
       onSegmentClosed: () => {},
       onFatal: setError,
     });
@@ -419,6 +430,13 @@ export function useCapture(meetingId: string, initialSeq = 0): UseCaptureResult 
       recorderRef.current = null;
       return;
     }
+
+    /*
+      ⚠️ **CAP-01 성공 뒤에 만든다.** `onSlice`가 이 값을 읽는 시점(15초 뒤)엔 이미 있어야
+         하고, 위에서 실패하면 여기까지 안 온다 — `null`인 채로 조각을 흘려도 조용히
+         버려질 뿐 잘못된 회의로 잘못 올라가는 일은 없다.
+    */
+    uploaderRef.current = createSliceUploader(Number(meetingId), { onFailure: setError });
 
     utteranceStartRef.current = null;
     const stt = createSttEngine({
@@ -492,6 +510,11 @@ export function useCapture(meetingId: string, initialSeq = 0): UseCaptureResult 
          **회의는 끝났는데 서버만 모르는** 상태가 된다 — 요약도 액션 분배도 영영 안 돈다.
          마이크 표시등은 화면을 떠날 때 정리 효과가 한 번 더 끈다.
     */
+    /*
+      ⚠️ **`teardown()` 전에 붙들어 둔다.** `teardown()`이 `uploaderRef.current`를 지워서,
+         그 뒤에 읽으면 이미 올리는 중인 조각들의 큐를 놓친다.
+    */
+    const uploader = uploaderRef.current;
     try {
       teardown();
     } catch {
@@ -519,7 +542,16 @@ export function useCapture(meetingId: string, initialSeq = 0): UseCaptureResult 
       ⚠️ 전송 자체가 거부되는 경우(브라우저→Next 단절)도 여기서 받는다.
     */
     try {
-      const result = await drainCaptions().then(() => completeMeetingAction(Number(meetingId)));
+      /*
+        ⚠️ **오디오 큐도 같이 기다린다.** 마지막 몇 조각은 종료 버튼을 누른 시점에 아직
+           업로드 중일 수 있다 — 기다리지 않고 바로 종료를 알리면 그 조각들은 큐 안에서는
+           계속 올라가지만, 사람은 이미 "끝났다"고 보고 창을 닫아 버릴 수 있다. 두 큐는
+           서로 무관하니 나란히 기다린다(하나가 느리다고 다른 하나를 막지 않는다).
+      */
+      const [result] = await Promise.all([
+        drainCaptions().then(() => completeMeetingAction(Number(meetingId))),
+        uploader?.flush() ?? Promise.resolve(),
+      ]);
       if (result.ok) return { ok: true };
 
       const message = result.error ?? CAPTURE_FAILURE_MESSAGE.MEETING_END;

--- a/src/features/meeting/capture/use-capture.ts
+++ b/src/features/meeting/capture/use-capture.ts
@@ -297,19 +297,20 @@ export function useCapture(meetingId: string, initialSeq = 0): UseCaptureResult 
     [elapsedNow],
   );
 
+  /*
+    ⚠️ **화면 이탈 전용이다.** 정리 함수는 동기라 `recorder.stop()`의 마지막 조각을
+       기다릴 수 없다 — 여기서는 마이크 표시등을 최대한 빨리 끄는 게 우선이고, 놓치는
+       마지막 조각은 감수한다. `end()`는 이 함수를 안 쓰고 따로 순서를 지켜 기다린다
+       (아래 참고, CodeRabbit 지적 2026-08-16).
+  */
   const teardown = useCallback(() => {
     sttRef.current?.stop();
     sttRef.current = null;
     /* ⚠️ 음량계를 녹음기보다 **먼저** 놓는다 — 스트림이 닫힌 뒤 읽으면 예외가 난다 */
     levelRef.current?.close();
     levelRef.current = null;
-    recorderRef.current?.stop();
+    void recorderRef.current?.stop();
     recorderRef.current = null;
-    /*
-      ⚠️ **참조만 지운다 — 큐를 비우지 않는다.** 이미 `enqueue`된 조각은 각자 자기
-         프라미스 체인을 쥐고 계속 올라간다. `end()`가 `uploader.flush()`로 그 체인이
-         끝나길 따로 기다린다 — 여기서 참조를 지워도 진행 중인 업로드는 안 끊긴다.
-    */
     uploaderRef.current = null;
   }, []);
 
@@ -396,7 +397,7 @@ export function useCapture(meetingId: string, initialSeq = 0): UseCaptureResult 
 
     /* 기다리는 사이에 떠났으면 방금 연 마이크를 바로 닫는다 */
     if (unmountedRef.current) {
-      recorder.stop();
+      void recorder.stop();
       recorderRef.current = null;
       return;
     }
@@ -412,13 +413,13 @@ export function useCapture(meetingId: string, initialSeq = 0): UseCaptureResult 
     try {
       const session = await startCaptureSessionAction(Number(meetingId));
       if (!session.ok) {
-        recorder.stop();
+        void recorder.stop();
         recorderRef.current = null;
         setError(session.error ?? "녹음 시작을 서버에 알리지 못했습니다.");
         return;
       }
     } catch {
-      recorder.stop();
+      void recorder.stop();
       recorderRef.current = null;
       setError("서버에 연결하지 못했습니다. 다시 시도해 주세요.");
       return;
@@ -426,7 +427,7 @@ export function useCapture(meetingId: string, initialSeq = 0): UseCaptureResult 
 
     /* CAP-01 응답을 기다리는 사이에 떠났으면 방금 연 마이크를 바로 닫는다 */
     if (unmountedRef.current) {
-      recorder.stop();
+      void recorder.stop();
       recorderRef.current = null;
       return;
     }
@@ -505,21 +506,33 @@ export function useCapture(meetingId: string, initialSeq = 0): UseCaptureResult 
 
   const end = useCallback(async () => {
     /*
-      ⚠️ **정리가 실패해도 종료 알림은 나간다**(2026-08-12, 코드래빗 지적). `MediaRecorder.stop()`
-         같은 브라우저 API는 상태가 어긋나면 던지는데(`InvalidStateError`), 그걸로 흐름이 멈추면
-         **회의는 끝났는데 서버만 모르는** 상태가 된다 — 요약도 액션 분배도 영영 안 돈다.
-         마이크 표시등은 화면을 떠날 때 정리 효과가 한 번 더 끈다.
+      ⚠️ **`teardown()`을 안 쓴다**(CodeRabbit 지적, 2026-08-16 — 종료 순서를 직렬화하라).
+         `teardown()`은 화면 이탈용이라 `recorder.stop()`을 기다리지 않는데, 여기서 그러면
+         `.stop()` 뒤에 비동기로 오는 **마지막 15초 조각**이 이미 비운 `uploaderRef`를 보고
+         조용히 사라진다. 짧은 회의는 그 마지막 조각이 유일한 오디오일 수도 있다.
+      ⚠️ **오디오를 먼저 다 올린 뒤에만 종료를 알린다.** 전에는 업로드 큐와 종료 알림을
+         `Promise.all`로 나란히 돌렸는데, 그러면 서버가 아직 안 받은 조각이 남은 채로
+         회의가 DONE 처리될 수 있다 — 뒤이은 STT 블록 조립이 그 구간을 놓친다.
     */
-    /*
-      ⚠️ **`teardown()` 전에 붙들어 둔다.** `teardown()`이 `uploaderRef.current`를 지워서,
-         그 뒤에 읽으면 이미 올리는 중인 조각들의 큐를 놓친다.
-    */
+    sttRef.current?.stop();
+    sttRef.current = null;
+    /* ⚠️ 음량계를 녹음기보다 **먼저** 놓는다 — 스트림이 닫힌 뒤 읽으면 예외가 난다 */
+    levelRef.current?.close();
+    levelRef.current = null;
+
     const uploader = uploaderRef.current;
     try {
-      teardown();
+      /*
+        ⚠️ **여기서 기다린다.** `recorder.stop()`이 반환하는 프라미스는 마지막
+           `dataavailable`(→`onSlice`→`uploader.enqueue`)까지 다 받은 뒤에야 풀린다 —
+           그 전에 `uploaderRef`를 비우면 방금 잡힌 마지막 조각이 갈 곳을 잃는다.
+      */
+      await recorderRef.current?.stop();
     } catch {
       /* 로컬 정리 실패는 사용자가 할 수 있는 일이 없다 — 알림을 계속 보내는 게 더 중요하다 */
     }
+    recorderRef.current = null;
+    uploaderRef.current = null;
 
     const at = Date.now();
     /*
@@ -532,7 +545,7 @@ export function useCapture(meetingId: string, initialSeq = 0): UseCaptureResult 
     setPhase(CAPTURE_PHASE.ENDED);
 
     /*
-      MEET-08 — 남은 자막을 마저 보내고 종료를 알린다.
+      MEET-08 — 오디오·자막을 마저 보내고서야 종료를 알린다.
       ⚠️ **AI 분석을 프론트가 부르지 않는다**(§3-3 4번). 서버가 종료 처리 안에서 큐에 걸고
          실패해도 재시도한다 — 사용자가 창을 닫아도 안전하다.
       ⚠️ 되돌릴 수 없다. 확인 창을 거친 뒤에만 여기로 온다(§3-3 종료 정책).
@@ -543,15 +556,13 @@ export function useCapture(meetingId: string, initialSeq = 0): UseCaptureResult 
     */
     try {
       /*
-        ⚠️ **오디오 큐도 같이 기다린다.** 마지막 몇 조각은 종료 버튼을 누른 시점에 아직
-           업로드 중일 수 있다 — 기다리지 않고 바로 종료를 알리면 그 조각들은 큐 안에서는
-           계속 올라가지만, 사람은 이미 "끝났다"고 보고 창을 닫아 버릴 수 있다. 두 큐는
-           서로 무관하니 나란히 기다린다(하나가 느리다고 다른 하나를 막지 않는다).
+        ⚠️ **오디오 큐가 다 끝난 뒤에만 완료를 알린다**(순서 있음, `Promise.all` 아니다).
+           `uploader.flush()` 자체는 개별 조각 실패까지 막지 않는다(연속 실패는
+           `onFailure`로 이미 화면에 알렸다) — 여기서는 "큐가 비었는가"만 기다린다.
       */
-      const [result] = await Promise.all([
-        drainCaptions().then(() => completeMeetingAction(Number(meetingId))),
-        uploader?.flush() ?? Promise.resolve(),
-      ]);
+      await (uploader?.flush() ?? Promise.resolve());
+
+      const result = await drainCaptions().then(() => completeMeetingAction(Number(meetingId)));
       if (result.ok) return { ok: true };
 
       const message = result.error ?? CAPTURE_FAILURE_MESSAGE.MEETING_END;
@@ -562,7 +573,7 @@ export function useCapture(meetingId: string, initialSeq = 0): UseCaptureResult 
       setError(message);
       return { ok: false, error: message };
     }
-  }, [teardown, drainCaptions, meetingId]);
+  }, [drainCaptions, meetingId]);
 
   return { phase, support, recordedMs, chunks, partial, error, enter, start, pause, resume, end };
 }


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가
- [x] fix — 버그 수정(요약이 영원히 안 끝나던 문제의 근본 원인)

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

- `recorder.ts`가 15초마다 만드는 오디오 조각을 `use-capture.ts`의 `onSlice`가 그냥 버리던 것을, 새로 만든 `upload.ts`(`createSliceUploader`)로 연결했다.
  - presign(CAP-04)으로 URL을 배치(20개=5분치) 발급받아 브라우저가 **S3로 직접 PUT**, 성공하면 complete(CAP-07)로 알린다. 순서를 지키려 조각은 직렬 큐로 하나씩 올린다.
  - presign 응답엔 S3 키가 안 내려와서, `presignedUrl` 경로에서 직접 파싱해 complete에 실어 보낸다.
  - `MediaRecorder`의 `mimeType`을 `audio/webm`으로 고정했다 — BE presign이 Content-Type을 서명에 실어서(`CapS3ObjectStorageAdapter`), 브라우저 기본값과 어긋나면 S3가 PUT을 서명 불일치로 거절한다.
  - 업로드 실패는 연속 3회부터만 화면에 알린다(자막과 같은 기준) — 녹음 자체는 안 막는다.
  - `end()`가 종료 직전 남은 업로드 큐(`flush()`)도 자막 큐(`drainCaptions`)와 나란히 기다리게 했다.
- **부수 발견**: BE `SttBlockCutTrigger`(오디오 조각이 있어야 STT 블록을 만든다)가 이 연동이 없어서 한 번도 안 돌고 있었다 — `AnalysisService.getProcessingStatus`가 영원히 `NOT_STARTED`를 돌려줘 요약 카드가 "요약 중"에서 절대 안 바뀌던 현상의 **근본 원인**이었다. 이 PR로 같이 해소된다.
- `stt.ts`에 발화 강제 컷(8초)을 추가했다 — 쉬지 않고 이어 말하면 브라우저 STT가 문장을 안 끊고 계속 interim으로만 이어 붙이는 현상을, `.stop()`(지금까지 들은 걸 확정)으로 강제로 끊어 완화한다.
  - ⚠️ **정정(2026-08-16)**: 처음엔 "발화 기록(ANLZ-05)의 화자 귀속 근거로 이 자막을 쓴다"고 적었는데, 이건 BE에 남아 있던 stale 주석을 그대로 믿은 실수였다. 실제로는 **host만 녹음을 진행**해서 자막의 `personId`는 항상 host ID 하나로만 넘어가고, 화자 구분은 AI팀이 **참석자 명단** 기준으로 한다 — 자막(그리고 이 청크 길이)은 화자 귀속과 무관하다. 그래도 이 완화 자체는 **실시간 자막 가독성**(진행자가 되짚어보는 용도, `SttHandlers.onPartial` 주석 참고)과 STT 실패 시 폴백 텍스트 품질에는 여전히 의미가 있어 남겨 뒀다 — 다만 "화자 귀속을 지킨다"는 근거는 취소한다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feat/capture-audio-upload-pipeline#530`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🕵️ **정직성** — 업로드 실패는 화면에 남기고 조용히 삼키지 않는다
- [x] 🎨 디자인 토큰 — 신규 UI 없음

**품질**

- [x] ♻️ 재사용 확인 — `recorder.ts`/`stt.ts`/`use-capture.ts`의 기존 계층 분리 규칙(WORKFLOW §3-3, "STT 계층만 교체 가능하게 분리")을 그대로 따름
- [x] 🧪 `upload.test.ts` 4건(배치 소진·S3 키 파싱·연속 실패 알림·순서 보장) 추가, 기존 회의 도메인 테스트 243건 전부 통과

---

## 🔗 연관 이슈

Closes #530

---

## 💬 리뷰 포인트

- `upload.ts`의 `keyOf()`가 presigned URL 경로에서 S3 키를 파싱하는 방식이 맞는지 — BE `CaptureUploadService.buildS3Key`가 만드는 실제 키 형식과 맞춰 실기기로 한 번 확인이 필요합니다(로컬에서는 mock URL로만 테스트했습니다).
- `stt.ts`의 8초 발화 컷이 실제 회의에서 자연스러운 문장 흐름을 너무 자주 끊지는 않는지 — 값은 임의로 잡았습니다(팀 확정 아님). 위 정정대로 화자 귀속과는 무관하니, 순수 UX·폴백 텍스트 품질 트레이드오프로만 판단해 주세요.
- BE와의 실연동 확인(presign→PUT→complete가 실제로 S3에 파일을 남기는지, STT 블록이 실제로 생기는지)은 로컬 목이 아니라 배포 환경에서 재확인이 필요합니다.

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |


---

## 📝 추가 메모
