### PR TITLE
[FIX] 온보딩 3단계 재시도가 AU-035를 오류로 보여주는 문제를 고친다 #532

### DIFF
--- a/src/features/onboarding/actions.ts
+++ b/src/features/onboarding/actions.ts
@@ -3,12 +3,20 @@
 import { revalidatePath } from "next/cache";
 
 import { requireAccessToken } from "@/features/auth/session";
-import { serverApi, toUserMessage } from "@/lib/api";
+import { ApiError, serverApi, toUserMessage } from "@/lib/api";
 import { ep } from "@/lib/endpoints";
 import { isMock } from "@/mocks/config";
 
 import { findPayloadProblem, toOnboardingPayload } from "./mapper";
 import type { DepartmentNode, Invite, Position } from "./types";
+
+/**
+ * [확인] `AU-035` — 이미 온보딩을 끝낸 회사가 커밋을 다시 시도했다(BE
+ * `AuthErrorCode.ALREADY_ONBOARDED`, 409). 응답이 끊긴 뒤 재시도했을 때 실제로 나는 코드다 —
+ * 이 시도가 잘못된 게 아니라 **앞선 시도가 서버에서는 이미 성공**했다는 뜻이라 일반 실패와
+ * 다르게 다룬다(`use-invite-commit.ts` 참고).
+ */
+const ALREADY_ONBOARDED = "AU-035";
 
 /**
  * 온보딩 커밋 창구 — 격리막(§Mock 격리막).
@@ -20,12 +28,22 @@ import type { DepartmentNode, Invite, Position } from "./types";
  * ⚠️ **한 번뿐이다.** 재호출은 409(`ALREADY_ONBOARDED`)다 — 되돌리는 경로가 없다.
  * ⚠️ 이메일이 겹치면 400이 아니라 `skipped`로 돌아온다. 조용히 버리지 말고 화면에 띄운다
  *    (§정직성) — 오너는 누가 빠졌는지 알아야 계정 발급 화면에서 다시 만든다.
+ * ⚠️⚠️ **응답이 끊기면 재시도가 이 409를 실제로 밟는다**(2026-08-14 프로덕션에서 겪었다).
+ *    Next↔BE 구간이 오래 걸리거나 끊기면 브라우저는 실패로 보는데 BE는 이미 처리를
+ *    끝냈을 수 있다 — 그 상태에서 다시 누르면 여기로 떨어진다. `alreadyOnboarded`로
+ *    구분해서 일반 실패와 다르게 다룬다(부르는 쪽 참고).
  */
 
 export interface OnboardingCommitResult {
   ok: boolean;
-  /** 실패했을 때 화면에 그대로 띄울 한 줄 */
+  /** 실패했을 때 화면에 그대로 띄울 한 줄. `alreadyOnboarded`면 안 쓴다 */
   error?: string;
+  /**
+   * ⚠️ **이 회사는 이미 온보딩이 끝났다는 뜻이다** — 이번 시도가 잘못된 게 아니라, 앞선
+   *    시도가 응답만 못 받고 서버에서는 이미 성공했을 뿐이다. 화면은 이걸 오류로 세우지
+   *    않고 결제 단계로 그냥 넘긴다(`use-invite-commit.ts`).
+   */
+  alreadyOnboarded?: boolean;
   /** 실제로 계정이 나간 주소 — 이 줄에만 `isSent` 도장을 찍는다 */
   issuedEmails: string[];
   /** 빠진 주소와 사유 — 확인 창이 아니라 완료 화면에서 알린다 */
@@ -89,9 +107,12 @@ export async function commitOnboardingAction(input: {
       skipped: data.skipped,
     };
   } catch (error) {
+    const alreadyOnboarded = error instanceof ApiError && error.code === ALREADY_ONBOARDED;
     return {
       ok: false,
-      error: toUserMessage(error),
+      // ⚠️ 이미 끝난 회사면 문구를 안 쓴다 — 부르는 쪽이 오류로 세우지 않고 넘긴다
+      error: alreadyOnboarded ? undefined : toUserMessage(error),
+      alreadyOnboarded,
       issuedEmails: [],
       skipped: [],
     };

--- a/src/features/onboarding/actions.ts
+++ b/src/features/onboarding/actions.ts
@@ -44,9 +44,20 @@ export interface OnboardingCommitResult {
    *    않고 결제 단계로 그냥 넘긴다(`use-invite-commit.ts`).
    */
   alreadyOnboarded?: boolean;
-  /** 실제로 계정이 나간 주소 — 이 줄에만 `isSent` 도장을 찍는다 */
+  /**
+   * 실제로 계정이 나간 주소 — 이 줄에만 `isSent` 도장을 찍는다.
+   *
+   * ⚠️ **`alreadyOnboarded`면 빈 배열이지만 "아무도 안 나갔다"는 뜻이 아니다.** 앞선
+   *    시도가 실제로 몇 명을 발급하고 몇 명은 주소 중복으로 건너뛰었을 수 있는데, 그
+   *    응답을 브라우저가 못 받아서 **우리는 그 결과를 영영 모른다**(재검증 API가 없다) —
+   *    "빈 배열=전원 성공"으로 읽으면 안 된다(적대적 검토, 2026-08-14).
+   */
   issuedEmails: string[];
-  /** 빠진 주소와 사유 — 확인 창이 아니라 완료 화면에서 알린다 */
+  /**
+   * 빠진 주소와 사유 — 확인 창이 아니라 완료 화면에서 알린다.
+   * ⚠️ 위 `issuedEmails`와 같은 이유로 `alreadyOnboarded`면 빈 배열이라도 "빠진 사람 없음"을
+   *    보장하지 않는다.
+   */
   skipped: { email: string; reason: string }[];
 }
 

--- a/src/features/onboarding/use-invite-commit.test.ts
+++ b/src/features/onboarding/use-invite-commit.test.ts
@@ -102,9 +102,7 @@ describe("useInviteCommit — 이미 온보딩이 끝난 회사(AU-035)", () => 
     expect(result.current.error).toBeNull();
     // ⚠️ 확인 창을 닫는다 — 성공한 것처럼 다음 화면으로 넘어간다
     expect(result.current.isConfirmOpen).toBe(false);
-    expect(toast.success).toHaveBeenCalledWith(
-      "이미 등록이 완료되어 있습니다. 결제 단계로 이동합니다.",
-    );
+    expect(toast.success).toHaveBeenCalledWith("이미 등록된 회사입니다");
     expect(replaceMock).toHaveBeenCalledWith("/onboarding/payment");
   });
 });

--- a/src/features/onboarding/use-invite-commit.test.ts
+++ b/src/features/onboarding/use-invite-commit.test.ts
@@ -1,4 +1,5 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { toast } from "sonner";
 
 import { AUTHORITY } from "@/constants/domain";
 
@@ -10,7 +11,12 @@ jest.mock("./actions", () => ({
   commitOnboardingAction: (...args: unknown[]) => commitOnboardingAction(...args),
 }));
 
-jest.mock("next/navigation", () => ({ useRouter: () => ({ replace: jest.fn() }) }));
+const replaceMock = jest.fn();
+jest.mock("next/navigation", () => ({ useRouter: () => ({ replace: replaceMock }) }));
+
+jest.mock("sonner", () => ({
+  toast: { success: jest.fn(), error: jest.fn(), warning: jest.fn() },
+}));
 
 const DEPARTMENTS: DepartmentNode[] = [{ id: "d1", name: "개발팀", children: [] }];
 const POSITIONS: Position[] = [{ id: "p1", name: "팀장", role: AUTHORITY.LEADER }];
@@ -38,7 +44,7 @@ function setup() {
 }
 
 beforeEach(() => {
-  commitOnboardingAction.mockReset();
+  jest.clearAllMocks();
 });
 
 describe("useInviteCommit — 실패했을 때 버튼을 되살린다", () => {
@@ -71,5 +77,34 @@ describe("useInviteCommit — 실패했을 때 버튼을 되살린다", () => {
 
     await waitFor(() => expect(result.current.isCommitting).toBe(false));
     expect(result.current.error).toBe("서버에 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.");
+  });
+});
+
+/**
+ * `alreadyOnboarded` — 2026-08-14 프로덕션 사고. 1차 시도가 응답만 못 받고 서버에서는
+ * 이미 성공한 뒤 재시도하면 BE가 `AU-035`를 돌려준다 — 이걸 오류로 세우지 않고
+ * 결제 단계로 그냥 넘기는지 잠근다.
+ */
+describe("useInviteCommit — 이미 온보딩이 끝난 회사(AU-035)", () => {
+  it("오류를 세우지 않고 결제 단계로 넘긴다", async () => {
+    commitOnboardingAction.mockResolvedValue({
+      ok: false,
+      alreadyOnboarded: true,
+      issuedEmails: [],
+      skipped: [],
+    });
+
+    const { result } = setup();
+    act(() => result.current.setConfirmOpen(true));
+    await act(async () => result.current.commit());
+
+    await waitFor(() => expect(result.current.isCommitting).toBe(false));
+    expect(result.current.error).toBeNull();
+    // ⚠️ 확인 창을 닫는다 — 성공한 것처럼 다음 화면으로 넘어간다
+    expect(result.current.isConfirmOpen).toBe(false);
+    expect(toast.success).toHaveBeenCalledWith(
+      "이미 등록이 완료되어 있습니다. 결제 단계로 이동합니다.",
+    );
+    expect(replaceMock).toHaveBeenCalledWith("/onboarding/payment");
   });
 });

--- a/src/features/onboarding/use-invite-commit.ts
+++ b/src/features/onboarding/use-invite-commit.ts
@@ -105,6 +105,23 @@ export function useInviteCommit({
 
     if (!result.ok) {
       setCommitting(false);
+
+      /*
+        ⚠️ **오류로 세우지 않는다**(2026-08-14, 프로덕션 사고). 이 코드(`AU-035`)는 지금 이
+           시도가 잘못된 게 아니라 **앞선 시도가 응답만 못 받고 서버에서는 이미 성공**했다는
+           뜻이다 — 타임아웃·네트워크 단절 뒤 재시도가 실제로 이 자리를 밟는다. 창에 오류를
+           띄우고 멈추면 사용자는 "등록이 안 됐다"고 오해해 계속 다시 누르게 된다. 이미 끝난
+           일이니 그대로 다음 단계로 넘긴다 — 4단계(결제)는 어차피 막지 않는 자리다
+           (`guard.ts`: "4단계·완료 화면은 막지 않는다").
+      */
+      if (result.alreadyOnboarded) {
+        markDraftCommitted();
+        setConfirmOpen(false);
+        toast.success("이미 등록이 완료되어 있습니다. 결제 단계로 이동합니다.");
+        router.replace("/onboarding/payment");
+        return;
+      }
+
       setError(result.error ?? "등록하지 못했습니다. 잠시 후 다시 시도해 주세요.");
       return;
     }

--- a/src/features/onboarding/use-invite-commit.ts
+++ b/src/features/onboarding/use-invite-commit.ts
@@ -117,7 +117,14 @@ export function useInviteCommit({
       if (result.alreadyOnboarded) {
         markDraftCommitted();
         setConfirmOpen(false);
-        toast.success("이미 등록이 완료되어 있습니다. 결제 단계로 이동합니다.");
+        /*
+          ⚠️ **"전원 초대됨"이라고는 말하지 않는다**(적대적 검토, 2026-08-14). 앞선 시도가
+             실제로 몇 명을 발급하고 몇 명은 주소 중복으로 건너뛰었을 수 있는데, 그 결과를
+             우리는 영영 모른다(`actions.ts`의 `issuedEmails`/`skipped` 주석 참고) — 그래도
+             그 불확실함을 여기서 사용자에게 알리지는 않는다(팀 결정). "완료"·"성공"이라고
+             단정하지 않고 사실("이미 등록됨")만 짧게 말한다.
+        */
+        toast.success("이미 등록된 회사입니다");
         router.replace("/onboarding/payment");
         return;
       }


### PR DESCRIPTION
## 📋 PR 타입

- [ ] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

## 무엇
온보딩 3단계 [등록]이 응답을 못 받으면(타임아웃·네트워크 단절) 화면은 실패로 표시하지만, BE는 이미 처리를 끝낸 경우가 있다. 이 상태에서 재시도하면 BE가 409(`AU-035`, `AuthErrorCode.ALREADY_ONBOARDED`)를 돌려주는데, 지금까지는 이걸 일반 오류처럼 그대로 화면에 띄워 사용자가 혼란스러워했다(2026-08-14 실제로 겪음).

## 왜
BE 실코드 확인(`AuthErrorCode.java`, `CompanyOnboardingCommitter.java`) — `AU-035`는 "이번 시도가 잘못됐다"가 아니라 "이 회사는 이미 온보딩이 끝났다"는 뜻이다. 정상적인 다음 행동은 오류를 보여주는 게 아니라 결제 단계로 넘기는 것이다 — 4단계(결제)는 어차피 `guardOnboardingStep`이 막지 않는 자리라 안전하다.

## 어떻게
- `commitOnboardingAction`이 `AU-035`를 `alreadyOnboarded: boolean`으로 구분해 돌려준다(에러 문구는 안 실음).
- `useInviteCommit`은 이 경우 확인창을 닫고, 성공 토스트("이미 등록이 완료되어 있습니다. 결제 단계로 이동합니다")를 띄운 뒤 `/onboarding/payment`로 넘긴다. 다른 실패는 기존 그대로 창 안에 문구가 남는다.

## 확인법
`npx jest src/features/onboarding`(151개) · `npx tsc --noEmit` 통과.

Closes #532

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**, 그리고 **서버에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [ ] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시
- [ ] 🎨 디자인 토큰 사용 · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화
- [ ] ♿ a11y
- [ ] ♻️ 재사용 확인
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API 사용 시 미지원 · 권한거부 안내 있음

---

## 🔗 연관 이슈

Closes #532

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

-

---

## 📝 추가 메모
