### PR TITLE
[FIX] 구성원 조직도가 BE 응답 구조를 잘못 가정해 항상 0명으로 그려지던 문제를 고친다 #534

### DIFF
--- a/src/features/member/manage-mapper.ts
+++ b/src/features/member/manage-mapper.ts
@@ -87,7 +87,7 @@ export function toBeFilter(filter: MemberFilter): string {
  * ⚠️ **모르는 값이 오면 가장 낮은 권한으로 떨어뜨린다.** BE가 역할을 하나 늘렸을 때
  *    화면이 터지는 것보다, 덜 보이는 쪽이 안전하다 — 권한은 넘겨짚으면 안 되는 값이다(§권한).
  */
-function toAuthority(role: string): Authority {
+export function toAuthority(role: string): Authority {
   switch (role) {
     case AUTHORITY.OWNER:
       return AUTHORITY.OWNER;
@@ -96,6 +96,15 @@ function toAuthority(role: string): Authority {
     default:
       return AUTHORITY.MEMBER;
   }
+}
+
+/**
+ * 역할 라벨 정규화 — **`toManagedMember`와 조직도(`manage-server.ts`의 org-chart 조회)가
+ * 같은 규칙을 쓴다.** 값이 뭘 근거로 오든(목록·조직도) BE의 "없음" 시스템 값·빈 문자열은
+ * 전부 `null`로 되돌린다(2026-08-14 재발견 — 아래 상세 사유는 `toManagedMember` 안 주석 참고).
+ */
+export function toRoleLabel(raw: string | null): string | null {
+  return raw?.trim() && raw.trim() !== ROLE_NONE_LABEL ? raw : null;
 }
 
 /**
@@ -137,8 +146,7 @@ export function toManagedMember(item: BeMemberListItem | BeMemberDetail): Manage
          실패로 막힌 적이 있다 — 매퍼 한 곳에서 정규화해 두면 그 자리를 다시 만들어도
          같은 함정에 안 걸린다.
     */
-    roleLabel:
-      item.roleLabel?.trim() && item.roleLabel.trim() !== ROLE_NONE_LABEL ? item.roleLabel : null,
+    roleLabel: toRoleLabel(item.roleLabel),
     status: toMemberStatus(item.workStatus),
     joinedAt: item.joinedOn ?? "",
     /*

--- a/src/features/member/manage-server.test.ts
+++ b/src/features/member/manage-server.test.ts
@@ -8,12 +8,19 @@ import { serverApi } from "@/lib/api";
 import { getManagedMember, listAllManagedMembersForOrgChart } from "./manage-server";
 
 /**
- * 조직도 전체 명부 — 2026-08-14 프로덕션 장애 수정.
- * `GET /api/members`를 페이지 순회하던 이전 구현은 `size` 상한(`@Max(100)`)과
- * OWNER·ADMIN 전용 가드 때문에 `/app/people`(전 구성원용 화면)에서 깨졌다 — BE 조직도
- * 전용 응답(`GET /api/members/org-chart`) 한 번 호출로 바꿨다. 그 응답은 **팀 단위로
- * 이미 묶여 온다**(`List<OrgChartTeamResponse>`, 담당자 확인 2026-08-14) — 이 테스트는
- * 그 팀 구조를 평평한 명부로 올바르게 펴는지를 잠근다.
+ * 조직도 전체 명부 — 2026-08-14, 두 번째 사고.
+ *
+ * 1차 수정(같은 날 앞선 커밋)은 `GET /api/members` 페이지 순회를 조직도 전용 응답
+ * (`GET /api/members/org-chart`) 한 번 호출로 바꿨는데, 그때 응답 shape을 "팀 → 사람"
+ * 2단계로 잘못 가정했다. BE 실코드 대조 결과(`OrgChartTeamResponse` 등) 실제로는
+ * **팀 → 역할(`subTeams`) → 사람 3단계**다 — 그 가정 때문에 `team.members`가 매번
+ * `undefined`였고, 방어 코드(`?? []`)가 조용히 빈 배열로 접어 **조직도가 항상 0명으로
+ * 그려지고 있었다**(안현님 FE 보고 → BE PR #511). 이 테스트는 3단계 구조를 평평한
+ * 명부로 올바르게 펴는지를 잠근다.
+ *
+ * ⚠️ **여기엔 근무상태 필터가 없다.** 이 응답에는 `workStatus` 자체가 없다(BE 주석:
+ *    "조직도 응답에는 이름·직급·권한만 들어간다") — 삭제된 사람을 빼는 일은 BE가
+ *    쿼리 단(`findActiveByCompany`)에서 이미 하고 있어, FE가 다시 거를 값이 없다.
  */
 describe("listAllManagedMembersForOrgChart — 실서버", () => {
   const requireAccessTokenMock = requireAccessToken as unknown as jest.Mock;
@@ -30,10 +37,6 @@ describe("listAllManagedMembersForOrgChart — 실서버", () => {
       name: `사원${id}`,
       positionName: null,
       role: "MEMBER",
-      isAdmin: false,
-      roleLabel: null,
-      workStatus: "ACTIVE",
-      joinedOn: null,
       ...overrides,
     };
   }
@@ -47,28 +50,60 @@ describe("listAllManagedMembersForOrgChart — 실서버", () => {
     expect(serverApiMock.mock.calls[0][0]).toBe("/api/members/org-chart");
   });
 
-  it("팀 단위로 묶인 응답을 평평한 명부로 편다 — 순서를 그대로 유지한다", async () => {
+  it("팀 → 역할 → 사람 3단계 응답을 평평한 명부로 편다 — 순서를 그대로 유지한다", async () => {
     serverApiMock.mockResolvedValueOnce([
-      { teamName: null, members: [member(1, { role: "OWNER" })] },
-      { teamName: "개발팀", members: [member(2), member(3)] },
-      { teamName: "디자인팀", members: [member(4)] },
+      {
+        teamId: null,
+        name: "미배정",
+        subTeams: [{ roleLabel: null, members: [member(1, { role: "OWNER" })] }],
+      },
+      {
+        teamId: 10,
+        name: "개발팀",
+        subTeams: [
+          { roleLabel: "프론트엔드", members: [member(2)] },
+          { roleLabel: "백엔드", members: [member(3)] },
+        ],
+      },
+      { teamId: 20, name: "디자인팀", subTeams: [{ roleLabel: null, members: [member(4)] }] },
     ]);
 
     const roster = await listAllManagedMembersForOrgChart();
 
     expect(roster.map((m) => m.id)).toEqual([1, 2, 3, 4]);
-    expect(roster.map((m) => m.teamName)).toEqual([null, "개발팀", "개발팀", "디자인팀"]);
+    expect(roster.map((m) => m.teamName)).toEqual(["미배정", "개발팀", "개발팀", "디자인팀"]);
+    expect(roster.map((m) => m.roleLabel)).toEqual([null, "프론트엔드", "백엔드", null]);
   });
 
   /*
-    ⚠️ **`members` 필드가 없는 팀도 있을 수 있다**(2026-08-14 프로덕션 재현) — 이 shape은
-       [가정 shape·미검증]이라 사람이 없는 팀에서 BE가 `members`를 빈 배열이 아니라
-       필드째 빼고 줄 가능성을 배제할 수 없다. 그때 죽지 않고 그 팀만 빈 것으로 본다.
+    ⚠️ **팀 미배정 인원이 응답에서 통째로 빠지던 사고**(BE PR #511)가 다시 나면 여기가 잡는다.
+       "미배정" 칸도 그냥 팀처럼 평평하게 펴야 한다 — `buildOrgChart`가 `teamName`이 아니라
+       `authority`로 대표를 뽑아내므로, 이 칸의 이름이 뭐든 대표는 항상 챙겨진다.
   */
-  it("members 필드가 없는 팀이 와도 죽지 않는다", async () => {
+  it("팀 미배정(대표) 칸도 명부에 포함된다", async () => {
     serverApiMock.mockResolvedValueOnce([
-      { teamName: "개발팀", members: [member(1)] },
-      { teamName: "신규팀" },
+      {
+        teamId: null,
+        name: "미배정",
+        subTeams: [{ roleLabel: null, members: [member(1, { role: "OWNER" })] }],
+      },
+    ]);
+
+    const roster = await listAllManagedMembersForOrgChart();
+
+    expect(roster).toHaveLength(1);
+    expect(roster[0]?.authority).toBe("OWNER");
+  });
+
+  /*
+    ⚠️ **`subTeams`·`members` 필드가 없는 칸도 있을 수 있다**(사람·역할이 없는 팀) — 필드째
+       빠지면 `.flatMap`이 `undefined`에서 터진다. 그때 죽지 않고 그 칸만 빈 것으로 본다.
+  */
+  it("subTeams·members 필드가 없어도 죽지 않는다", async () => {
+    serverApiMock.mockResolvedValueOnce([
+      { teamId: 10, name: "개발팀", subTeams: [{ roleLabel: null, members: [member(1)] }] },
+      { teamId: 30, name: "신규팀" },
+      { teamId: 40, name: "빈팀", subTeams: [{ roleLabel: "백엔드" }] },
     ]);
 
     const roster = await listAllManagedMembersForOrgChart();
@@ -76,21 +111,18 @@ describe("listAllManagedMembersForOrgChart — 실서버", () => {
     expect(roster.map((m) => m.id)).toEqual([1]);
   });
 
-  it("삭제된 사람은 뺀다 — 퇴사자는 남는다", async () => {
+  /*
+    ⚠️ **BE의 시스템 값 `"없음"`도 `null`로 되돌린다**(사원 관리 목록과 같은 규칙,
+       `toRoleLabel` — 매퍼 한 곳을 공유한다).
+  */
+  it("역할 라벨의 '없음' 시스템 값을 null로 되돌린다", async () => {
     serverApiMock.mockResolvedValueOnce([
-      {
-        teamName: "개발팀",
-        members: [
-          member(1),
-          member(2, { workStatus: "DELETED" }),
-          member(3, { workStatus: "RESIGNED" }),
-        ],
-      },
+      { teamId: 10, name: "개발팀", subTeams: [{ roleLabel: "없음", members: [member(1)] }] },
     ]);
 
     const roster = await listAllManagedMembersForOrgChart();
 
-    expect(roster.map((m) => m.id)).toEqual([1, 3]);
+    expect(roster[0]?.roleLabel).toBeNull();
   });
 });
 

--- a/src/features/member/manage-server.ts
+++ b/src/features/member/manage-server.ts
@@ -17,9 +17,11 @@ import {
   type BeCompanyAction,
   type BeMemberDetail,
   type BeMemberListItem,
+  toAuthority,
   toBeFilter,
   toManagedMember,
   toManagedMemberAction,
+  toRoleLabel,
 } from "./manage-mapper";
 import {
   type ManagedMember,
@@ -33,6 +35,7 @@ import {
   listMockManagedMembers,
   listMockMemberEmails,
 } from "./mock/managed";
+import type { OrgRosterMember } from "./org-types";
 import { buildTeamRoles, roleIdOf } from "./team-roles";
 
 /** [확인] BE `HandoverSummaryResponse` — `team-handover/mapper.ts`와 같은 응답. */
@@ -128,21 +131,40 @@ export async function listManagedMembers(): Promise<ManagedMember[]> {
 export const MEMBER_PAGE_SIZE = 20;
 
 /**
- * 조직도 전용 응답 한 팀 — `GET /api/members/org-chart`가 **팀 단위로 이미 묶어서** 준다.
+ * 조직도 전용 응답 — `GET /api/members/org-chart`, **팀 → 역할 → 사람 3단계**다.
  *
- * [가정 shape·미검증] BE 실코드를 아직 대조하지 못했다(§연동 검증) — 담당자가 전해 준 것은
- * "`List<OrgChartTeamResponse>`, 팀 → 소속 구성원 구조"뿐이라, 팀 한 칸은 `GET /api/members`
- * 목록 한 줄(`BeMemberListItem`)과 같은 사람 정보에 `teamName`만 팀 쪽으로 옮겨졌다고 가정한다.
- * 다르면 이 인터페이스와 바로 아래 매핑만 고치면 된다(§Mock 격리막).
+ * [확인] BE 실코드 대조(2026-08-14) — `OrgChartTeamResponse`·`OrgChartSubTeamResponse`·
+ * `OrgChartMemberResponse`(`MemberController.orgChart`). **이전엔 "팀 → 사람" 2단계로
+ * 잘못 가정해 뒀었다** — 그 가정으로는 실제 응답의 `subTeams`를 아예 안 읽어서
+ * `team.members`가 매번 `undefined`였고, 방어 코드(`?? []`)가 그걸 조용히 빈 배열로 접어
+ * **조직도가 팀마다 항상 0명으로 그려지고 있었다.** BE(안현님 보고 · PR #511)가 대표를
+ * 아예 응답에서 빼던 것도 이 자리를 함께 고쳤다 — `teamId: null`·`name: "미배정"`인 팀 칸을
+ * 응답 맨 뒤에 추가로 보낸다. 그 칸도 그냥 팀처럼 평평하게 펴면 된다 — `buildOrgChart`는
+ * `teamName`이 아니라 `authority === OWNER`로 대표를 뽑아내므로 이 칸의 이름이 뭐든 상관없다.
  *
- * ⚠️ **대표(팀이 없는 사람)를 담을 자리가 있어야 한다.** 팀은 계층 없는 플랫 목록이라
- *    (CLAUDE.md §권한 ③) 대표는 어느 팀에도 안 속한다 — `teamName: null`인 칸으로 온다고
- *    가정한다. BE가 대표를 아예 응답에서 빼면 `buildOrgChart`가 대표 없이 팀만 그린다
- *    (`org-types.ts`가 이미 그 경우를 `owner: null`로 다룬다).
+ * ⚠️ **이메일·겸직·근무상태·입사일이 없다.** 전 구성원이 보는 화면이라 인사 정보를 안
+ *    싣는다(BE 주석: "조직도 응답에는 이름·직급·권한만 들어간다"). `OrgRosterMember`가
+ *    이 화면이 실제로 쓰는 값만 계약으로 남기는 이유다(`org-types.ts`) — `ManagedMember`로
+ *    억지로 채우면 없는 값을 지어내게 된다(§정직성).
  */
 interface BeOrgChartTeam {
-  teamName: string | null;
-  members: BeMemberListItem[];
+  teamId: number | null;
+  name: string;
+  subTeams: BeOrgChartSubTeam[];
+}
+
+/** 팀 안의 역할 묶음 — `roleLabel`이 사원 관리 목록의 그것과 같은 값이다 */
+interface BeOrgChartSubTeam {
+  roleLabel: string | null;
+  members: BeOrgChartMember[];
+}
+
+/** 조직도 응답의 사람 한 칸 — 목록·상세보다 훨씬 적다(위 주석 참고) */
+interface BeOrgChartMember {
+  memberId: number;
+  name: string;
+  positionName: string | null;
+  role: string;
 }
 
 /**
@@ -154,30 +176,36 @@ interface BeOrgChartTeam {
  *    BE가 조직도 전용 응답(`GET /api/members/org-chart`)을 이미 열어 두고 있어 — 페이지
  *    단위가 아니라 명부 전체를 한 번에 주고, 권한도 전 구성원에게 열려 있다 — 그걸 그대로
  *    쓴다.
- * ⚠️ **팀 단위로 온 것을 도로 평평하게 편다.** `buildOrgChart`(`org-chart.ts`)는 원래
- *    평평한 `ManagedMember[]`를 받아 자기가 팀별로 다시 묶고 리더를 앞으로 당긴다 — BE가
- *    이미 팀별로 준다고 그 로직을 새로 짤 필요는 없다. 팀이 나온 순서, 팀 안 사람 순서를
+ * ⚠️ **3단계로 온 것을 도로 평평하게 편다.** `buildOrgChart`(`org-chart.ts`)는 원래
+ *    평평한 `OrgRosterMember[]`를 받아 자기가 팀별로 다시 묶고 리더를 앞으로 당긴다 — BE가
+ *    이미 팀·역할별로 준다고 그 로직을 새로 짤 필요는 없다. 팀이 나온 순서, 팀 안 사람 순서를
  *    그대로 유지해서 펴면 `buildOrgChart`가 같은 순서로 다시 묶는다(§목록: 순서는 회사가
  *    정한 것이라 프론트가 안 바꾼다).
  */
-export async function listAllManagedMembersForOrgChart(): Promise<ManagedMember[]> {
+export async function listAllManagedMembersForOrgChart(): Promise<OrgRosterMember[]> {
   if (isMock) return listManagedMembers();
 
   const accessToken = await requireAccessToken();
   const teams = await serverApi<BeOrgChartTeam[]>(ep.memberOrgChart(), { accessToken });
 
   /*
-    ⚠️ **`members`가 없는 팀을 방어한다**(2026-08-14 프로덕션 재현). 이 shape은 위
-       [가정 shape·미검증]대로 아직 BE 실코드로 대조 못 했다 — 사람이 없는 팀에서
-       `members`가 빈 배열이 아니라 필드째 빠져 오면 `team.members.map(...)`이
-       `undefined`에 `.map`을 호출해 `/app/people` 전체가 죽는다.
+    ⚠️ **`subTeams`·`members`가 없는 칸을 방어한다**(2026-08-14, 앞선 2단계 가정이 겪었던
+       것과 같은 종류의 사고 — 사람·역할이 없는 팀에서 그 필드가 빈 배열이 아니라 필드째
+       빠져 오면 `.flatMap`이 `undefined`에서 터진다).
   */
-  return teams
-    .flatMap((team) =>
-      (team.members ?? []).map((member) => ({ ...member, teamName: team.teamName })),
-    )
-    .map(toManagedMember)
-    .filter((member) => isVisibleMemberStatus(member.status));
+  return teams.flatMap((team) =>
+    (team.subTeams ?? []).flatMap((subTeam) =>
+      (subTeam.members ?? []).map((member): OrgRosterMember => ({
+        id: member.memberId,
+        name: member.name,
+        teamName: team.name?.trim() ? team.name : null,
+        position: member.positionName ?? "",
+        authority: toAuthority(member.role),
+        roleLabel: toRoleLabel(subTeam.roleLabel),
+        // 이 응답엔 근무상태가 없다 — 지어내지 않는다(`OrgRosterMember.status` 주석)
+      })),
+    ),
+  );
 }
 
 /**

--- a/src/features/member/org-chart.ts
+++ b/src/features/member/org-chart.ts
@@ -1,11 +1,11 @@
 import { AUTHORITY } from "@/constants/authority";
 import { MEMBER_STATUS, ROLE_NONE_LABEL } from "@/constants/member";
 
-import type { ManagedMember } from "./manage-types";
 import {
   NO_TEAM_LABEL,
   type OrgChart,
   type OrgMember,
+  type OrgRosterMember,
   type OrgSummary,
   type OrgTeam,
 } from "./org-types";
@@ -25,7 +25,7 @@ import {
  *    "팀장이 누구지"로 찾는 자리라 역할·직급이 열쇠다.
  * ⚠️ 그래서 저 함수를 그대로 못 쓴다. 억지로 합치면 한쪽 화면의 검색이 조용히 나빠진다.
  */
-export function searchOrgMembers(members: ManagedMember[], keyword: string): ManagedMember[] {
+export function searchOrgMembers(members: OrgRosterMember[], keyword: string): OrgRosterMember[] {
   const needle = keyword.trim().toLowerCase();
   if (!needle) return members;
 
@@ -37,7 +37,7 @@ export function searchOrgMembers(members: ManagedMember[], keyword: string): Man
 }
 
 /** 화면 맨 위 요약 — **검색 전 명부**를 넘겨야 한다(§org-types) */
-export function summarizeOrg(members: ManagedMember[]): OrgSummary {
+export function summarizeOrg(members: OrgRosterMember[]): OrgSummary {
   const teams = new Set(
     members
       .filter((member) => member.authority !== AUTHORITY.OWNER)
@@ -52,7 +52,7 @@ export function summarizeOrg(members: ManagedMember[]): OrgSummary {
 }
 
 /** 목록 한 줄에서 조직도가 쓰는 것만 꺼낸다 — 이메일·입사일은 안 싣는다(§org-types) */
-function toOrgMember(member: ManagedMember): OrgMember {
+function toOrgMember(member: OrgRosterMember): OrgMember {
   return {
     id: member.id,
     name: member.name,
@@ -78,7 +78,7 @@ function toOrgMember(member: ManagedMember): OrgMember {
  *    둘째부터는 명부가 이상한 것인데, 조용히 버리면 전체 인원과 화면이 어긋난다 —
  *    팀이 없으니 `소속 없음`으로 내려가 눈에 띈다.
  */
-export function buildOrgChart(members: ManagedMember[]): OrgChart {
+export function buildOrgChart(members: OrgRosterMember[]): OrgChart {
   let owner: OrgMember | null = null;
 
   /*

--- a/src/features/member/org-types.ts
+++ b/src/features/member/org-types.ts
@@ -9,9 +9,31 @@ import type { MemberStatus } from "@/constants/member";
  *    사람을 **고치러** 오는 곳이고, 여기는 전 구성원이 조직을 **보러** 오는 곳이다.
  * ⚠️ 그래서 여기 담기는 값이 더 적다. 이메일·입사일·겸직 여부는 안 싣는다 —
  *    조직 구조를 보는 데 필요 없고, 전원이 보는 화면이라 덜 내보내는 편이 맞다.
- * ⚠️ 명부 자체는 **사원 관리와 같은 것**을 읽는다(`mock/managed.ts`). 두 벌로 들고 있으면
- *    같은 회사가 화면마다 달라 보인다.
+ * ⚠️ 목일 때는 명부를 **사원 관리와 같은 것**을 읽는다(`mock/managed.ts`) — 두 벌로 들고
+ *    있으면 같은 회사가 화면마다 달라 보인다. 실서버는 다르다 — BE가 조직도 전용의
+ *    더 얇은 응답(`GET /api/members/org-chart`)을 따로 준다(아래 `OrgRosterMember`).
  */
+
+/**
+ * 조직도 조립(`org-chart.ts`)이 **실제로 필요로 하는 최소 인원 정보** — 사원 관리
+ * (`ManagedMember`)의 부분집합이다.
+ *
+ * ⚠️ **`ManagedMember`를 그대로 쓰지 않는다.** 목 경로는 사원 관리와 같은 명부를 읽어서
+ *    `ManagedMember[]`를 그대로 넘겨도 되지만(구조적으로 이 타입의 상위집합이라 그대로
+ *    맞는다), 실서버 조직도 응답엔 이메일·겸직·근무상태·입사일이 없다 — 그 값들을
+ *    `ManagedMember`에 억지로 채우면 지어낸 값이 된다(§정직성). 이 화면이 실제로 쓰는
+ *    값만 계약으로 남긴다.
+ */
+export interface OrgRosterMember {
+  id: number;
+  name: string;
+  teamName: string | null;
+  position: string;
+  authority: Authority;
+  roleLabel: string | null;
+  /** 실서버 조직도 응답엔 없다 — 있을 때만 넘긴다(아래 `OrgMember.status` 주석 참고) */
+  status?: MemberStatus;
+}
 
 /** 조직도에 서는 사람 한 명 */
 export interface OrgMember {
@@ -37,7 +59,15 @@ export interface OrgMember {
    *    조직 구조와 무관하다).
    */
   authority: Authority;
-  status: MemberStatus;
+  /**
+   * ⚠️⚠️ **없을 수 있다**(2026-08-14). BE 조직도 응답(`GET /api/members/org-chart`)엔
+   *    근무상태가 안 온다 — 전 구성원이 보는 화면이라 인사 정보를 안 싣는다(BE
+   *    `MemberController` 주석: "조직도 응답에는 이름·직급·권한만 들어간다"). 없으면
+   *    `StatusMark`가 아무 뱃지도 안 단다 — **재직으로 지어내지 않는다**(§정직성). BE가
+   *    이 응답에 근무상태를 더하기 전까지, 이 화면의 휴직 배지·집계(`OrgSummary.
+   *    vacationCount`)는 실제로는 항상 비어 있다.
+   */
+  status?: MemberStatus;
 }
 
 /**

--- a/src/features/onboarding/actions.ts
+++ b/src/features/onboarding/actions.ts
@@ -3,12 +3,20 @@
 import { revalidatePath } from "next/cache";
 
 import { requireAccessToken } from "@/features/auth/session";
-import { serverApi, toUserMessage } from "@/lib/api";
+import { ApiError, serverApi, toUserMessage } from "@/lib/api";
 import { ep } from "@/lib/endpoints";
 import { isMock } from "@/mocks/config";
 
 import { findPayloadProblem, toOnboardingPayload } from "./mapper";
 import type { DepartmentNode, Invite, Position } from "./types";
+
+/**
+ * [확인] `AU-035` — 이미 온보딩을 끝낸 회사가 커밋을 다시 시도했다(BE
+ * `AuthErrorCode.ALREADY_ONBOARDED`, 409). 응답이 끊긴 뒤 재시도했을 때 실제로 나는 코드다 —
+ * 이 시도가 잘못된 게 아니라 **앞선 시도가 서버에서는 이미 성공**했다는 뜻이라 일반 실패와
+ * 다르게 다룬다(`use-invite-commit.ts` 참고).
+ */
+const ALREADY_ONBOARDED = "AU-035";
 
 /**
  * 온보딩 커밋 창구 — 격리막(§Mock 격리막).
@@ -20,12 +28,22 @@ import type { DepartmentNode, Invite, Position } from "./types";
  * ⚠️ **한 번뿐이다.** 재호출은 409(`ALREADY_ONBOARDED`)다 — 되돌리는 경로가 없다.
  * ⚠️ 이메일이 겹치면 400이 아니라 `skipped`로 돌아온다. 조용히 버리지 말고 화면에 띄운다
  *    (§정직성) — 오너는 누가 빠졌는지 알아야 계정 발급 화면에서 다시 만든다.
+ * ⚠️⚠️ **응답이 끊기면 재시도가 이 409를 실제로 밟는다**(2026-08-14 프로덕션에서 겪었다).
+ *    Next↔BE 구간이 오래 걸리거나 끊기면 브라우저는 실패로 보는데 BE는 이미 처리를
+ *    끝냈을 수 있다 — 그 상태에서 다시 누르면 여기로 떨어진다. `alreadyOnboarded`로
+ *    구분해서 일반 실패와 다르게 다룬다(부르는 쪽 참고).
  */
 
 export interface OnboardingCommitResult {
   ok: boolean;
-  /** 실패했을 때 화면에 그대로 띄울 한 줄 */
+  /** 실패했을 때 화면에 그대로 띄울 한 줄. `alreadyOnboarded`면 안 쓴다 */
   error?: string;
+  /**
+   * ⚠️ **이 회사는 이미 온보딩이 끝났다는 뜻이다** — 이번 시도가 잘못된 게 아니라, 앞선
+   *    시도가 응답만 못 받고 서버에서는 이미 성공했을 뿐이다. 화면은 이걸 오류로 세우지
+   *    않고 결제 단계로 그냥 넘긴다(`use-invite-commit.ts`).
+   */
+  alreadyOnboarded?: boolean;
   /** 실제로 계정이 나간 주소 — 이 줄에만 `isSent` 도장을 찍는다 */
   issuedEmails: string[];
   /** 빠진 주소와 사유 — 확인 창이 아니라 완료 화면에서 알린다 */
@@ -89,9 +107,12 @@ export async function commitOnboardingAction(input: {
       skipped: data.skipped,
     };
   } catch (error) {
+    const alreadyOnboarded = error instanceof ApiError && error.code === ALREADY_ONBOARDED;
     return {
       ok: false,
-      error: toUserMessage(error),
+      // ⚠️ 이미 끝난 회사면 문구를 안 쓴다 — 부르는 쪽이 오류로 세우지 않고 넘긴다
+      error: alreadyOnboarded ? undefined : toUserMessage(error),
+      alreadyOnboarded,
       issuedEmails: [],
       skipped: [],
     };

--- a/src/features/onboarding/use-invite-commit.test.ts
+++ b/src/features/onboarding/use-invite-commit.test.ts
@@ -1,4 +1,5 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { toast } from "sonner";
 
 import { AUTHORITY } from "@/constants/domain";
 
@@ -10,7 +11,12 @@ jest.mock("./actions", () => ({
   commitOnboardingAction: (...args: unknown[]) => commitOnboardingAction(...args),
 }));
 
-jest.mock("next/navigation", () => ({ useRouter: () => ({ replace: jest.fn() }) }));
+const replaceMock = jest.fn();
+jest.mock("next/navigation", () => ({ useRouter: () => ({ replace: replaceMock }) }));
+
+jest.mock("sonner", () => ({
+  toast: { success: jest.fn(), error: jest.fn(), warning: jest.fn() },
+}));
 
 const DEPARTMENTS: DepartmentNode[] = [{ id: "d1", name: "개발팀", children: [] }];
 const POSITIONS: Position[] = [{ id: "p1", name: "팀장", role: AUTHORITY.LEADER }];
@@ -38,7 +44,7 @@ function setup() {
 }
 
 beforeEach(() => {
-  commitOnboardingAction.mockReset();
+  jest.clearAllMocks();
 });
 
 describe("useInviteCommit — 실패했을 때 버튼을 되살린다", () => {
@@ -71,5 +77,34 @@ describe("useInviteCommit — 실패했을 때 버튼을 되살린다", () => {
 
     await waitFor(() => expect(result.current.isCommitting).toBe(false));
     expect(result.current.error).toBe("서버에 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.");
+  });
+});
+
+/**
+ * `alreadyOnboarded` — 2026-08-14 프로덕션 사고. 1차 시도가 응답만 못 받고 서버에서는
+ * 이미 성공한 뒤 재시도하면 BE가 `AU-035`를 돌려준다 — 이걸 오류로 세우지 않고
+ * 결제 단계로 그냥 넘기는지 잠근다.
+ */
+describe("useInviteCommit — 이미 온보딩이 끝난 회사(AU-035)", () => {
+  it("오류를 세우지 않고 결제 단계로 넘긴다", async () => {
+    commitOnboardingAction.mockResolvedValue({
+      ok: false,
+      alreadyOnboarded: true,
+      issuedEmails: [],
+      skipped: [],
+    });
+
+    const { result } = setup();
+    act(() => result.current.setConfirmOpen(true));
+    await act(async () => result.current.commit());
+
+    await waitFor(() => expect(result.current.isCommitting).toBe(false));
+    expect(result.current.error).toBeNull();
+    // ⚠️ 확인 창을 닫는다 — 성공한 것처럼 다음 화면으로 넘어간다
+    expect(result.current.isConfirmOpen).toBe(false);
+    expect(toast.success).toHaveBeenCalledWith(
+      "이미 등록이 완료되어 있습니다. 결제 단계로 이동합니다.",
+    );
+    expect(replaceMock).toHaveBeenCalledWith("/onboarding/payment");
   });
 });

--- a/src/features/onboarding/use-invite-commit.ts
+++ b/src/features/onboarding/use-invite-commit.ts
@@ -105,6 +105,23 @@ export function useInviteCommit({
 
     if (!result.ok) {
       setCommitting(false);
+
+      /*
+        ⚠️ **오류로 세우지 않는다**(2026-08-14, 프로덕션 사고). 이 코드(`AU-035`)는 지금 이
+           시도가 잘못된 게 아니라 **앞선 시도가 응답만 못 받고 서버에서는 이미 성공**했다는
+           뜻이다 — 타임아웃·네트워크 단절 뒤 재시도가 실제로 이 자리를 밟는다. 창에 오류를
+           띄우고 멈추면 사용자는 "등록이 안 됐다"고 오해해 계속 다시 누르게 된다. 이미 끝난
+           일이니 그대로 다음 단계로 넘긴다 — 4단계(결제)는 어차피 막지 않는 자리다
+           (`guard.ts`: "4단계·완료 화면은 막지 않는다").
+      */
+      if (result.alreadyOnboarded) {
+        markDraftCommitted();
+        setConfirmOpen(false);
+        toast.success("이미 등록이 완료되어 있습니다. 결제 단계로 이동합니다.");
+        router.replace("/onboarding/payment");
+        return;
+      }
+
       setError(result.error ?? "등록하지 못했습니다. 잠시 후 다시 시도해 주세요.");
       return;
     }


### PR DESCRIPTION
## 📋 PR 타입

- [ ] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [x] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

## 무엇
`/app/people`(구성원 조직도) 인원 수가 `/manage/members`(사원 관리)와 다르다는 보고를 조사하다가, 앞서 짚었던 "오너가 빠진다"보다 큰 문제를 발견했다 — FE가 `GET /api/members/org-chart` 응답 구조 자체를 잘못 가정하고 있었다.

## 왜
BE 실코드(`OrgChartTeamResponse`·`OrgChartSubTeamResponse`·`OrgChartMemberResponse`) 대조 결과, 실제 응답은 **팀 → 역할(subTeams) → 사람 3단계**인데 FE는 **팀 → 사람 2단계**로 가정하고 있었다. 존재하지 않는 `team.members`를 읽어 매번 `undefined`였고, 방어 코드(`?? []`)가 조용히 빈 배열로 접어 **조직도가 팀마다 항상 0명으로 그려지고 있었다.**

## 어떻게
- `manage-server.ts`: 실제 3단계 구조에 맞게 `listAllManagedMembersForOrgChart`를 다시 짰다.
- `org-types.ts`: 조직도가 실제로 쓰는 값만 담는 `OrgRosterMember` 계약을 새로 두었다(`ManagedMember`의 부분집합) — 이 응답엔 이메일·겸직·근무상태·입사일이 없어서 억지로 채우지 않는다(§정직성). `OrgMember.status`도 optional로 바꿨다 — 휴직 배지는 이 응답으로는 원래부터 켜질 수 없었다(타입만 정직하게 맞췄다, 동작 변화 없음).
- `manage-mapper.ts`: `toAuthority`·`toRoleLabel`을 export해 사원 관리·조직도가 같은 정규화 규칙을 공유한다.
- `org-chart.ts`는 시그니처만 `OrgRosterMember`로 바꿨다 — `ManagedMember`가 구조적으로 상위집합이라 `org-chart.test.ts`는 수정 없이 그대로 통과한다.

BE PR #511(팀 미배정 인원 묶음 추가)과는 별개의, FE 쪽 shape 불일치 버그다 — 둘 다 배포돼야 조직도가 사원 관리와 인원 수가 맞는다.

## 확인법
`npx jest src/features/member`(140개) · `npx tsc --noEmit` 통과.

Closes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**, 그리고 **서버에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [ ] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시
- [ ] 🎨 디자인 토큰 사용 · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화
- [ ] ♿ a11y
- [ ] ♻️ 재사용 확인
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API 사용 시 미지원 · 권한거부 안내 있음

---

## 🔗 연관 이슈

Closes #534

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

-

---

## 📝 추가 메모
