### PR TITLE
[FIX] 비대면 회의 등록 후 요약 진행 카드 연동 #537

### DIFF
--- a/src/features/meeting/components/online-meeting-dialog.test.tsx
+++ b/src/features/meeting/components/online-meeting-dialog.test.tsx
@@ -2,6 +2,9 @@ jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
 jest.mock("@/lib/mock-actor", () => ({
   getMockActor: jest.fn(() => ({ id: 1, role: "OWNER" })),
 }));
+jest.mock("@/features/notification/notification-provider", () => ({
+  useNotificationCenter: jest.fn(() => ({ trackAnalysis: jest.fn() })),
+}));
 
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -150,5 +153,29 @@ describe("OnlineMeetingDialog", () => {
     await waitFor(() => {
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
+  });
+
+  /*
+    ⚠️ 등록 직후부터 요약 진행 카드를 쫓아야 한다 — 서버가 등록 시점에 곧장 STT·AI 분석을
+       시작해서(`MeetingService.createOnlineMeeting`), 실시간 캡처 종료와 같은 이유로
+       `trackAnalysis`를 안 부르면 검토 화면으로 갈 길이 안 생긴다.
+  */
+  it("등록에 성공하면 요약 진행 카드를 쫓기 시작한다", async () => {
+    const { useNotificationCenter } = jest.requireMock(
+      "@/features/notification/notification-provider",
+    ) as { useNotificationCenter: jest.Mock };
+    const trackAnalysis = jest.fn();
+    useNotificationCenter.mockReturnValue({ trackAnalysis });
+
+    const user = userEvent.setup();
+    renderDialog();
+
+    await fillFormFields(user);
+    await confirmSubmit(user);
+
+    await waitFor(() => {
+      expect(trackAnalysis).toHaveBeenCalledTimes(1);
+    });
+    expect(trackAnalysis).toHaveBeenCalledWith(expect.any(String), expect.any(String));
   });
 });

--- a/src/features/meeting/components/online-meeting-dialog.tsx
+++ b/src/features/meeting/components/online-meeting-dialog.tsx
@@ -15,6 +15,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { useNotificationCenter } from "@/features/notification/notification-provider";
 import type { AttendeeScopeViewer } from "@/features/rooms/attendee-scope";
 import { RoomAttendeePicker } from "@/features/rooms/components/room-attendee-picker";
 import type { RoomMember, RoomProjectOption, RoomTeamActionOption } from "@/features/rooms/types";
@@ -63,8 +64,21 @@ export function OnlineMeetingDialog({
   const formRef = useRef<HTMLFormElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  const { trackAnalysis } = useNotificationCenter();
+
+  /*
+    ⚠️ **등록 직후부터 진행 카드를 띄운다.** 비대면 회의는 등록되는 순간 서버가 전체 파일
+       STT·AI 분석을 곧장 시작한다(`MeetingService.createOnlineMeeting` 주석) — 실시간
+       캡처 종료(`capture-view.tsx`)와 같은 이유로, 여기서도 안 쫓으면 회의를 만들고도
+       검토 화면으로 갈 길이 안 생긴다.
+  */
   const { form, setForm, file, fileError, errors, isSubmitting, handleFileChange, handleSubmit } =
-    useOnlineMeetingForm({ onCreated: () => setOpen(false) });
+    useOnlineMeetingForm({
+      onCreated: (meetingId, title) => {
+        trackAnalysis(meetingId, title);
+        setOpen(false);
+      },
+    });
 
   function handleFormSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();

--- a/src/features/meeting/components/use-online-meeting-form.ts
+++ b/src/features/meeting/components/use-online-meeting-form.ts
@@ -26,8 +26,15 @@ const EMPTY_FORM = {
 export type OnlineMeetingFormValues = typeof EMPTY_FORM;
 
 interface UseOnlineMeetingFormOptions {
-  /** 세 단계가 전부 끝나 회의가 만들어지면 다이얼로그를 닫으라고 알린다. */
-  onCreated: () => void;
+  /**
+   * 세 단계가 전부 끝나 회의가 만들어지면 다이얼로그를 닫으라고 알린다.
+   *
+   * ⚠️ **방금 만든 회의의 id·제목을 같이 준다.** 비대면 회의는 등록되는 순간 서버가 전체
+   *    파일 STT·AI 분석을 곧장 시작한다(`MeetingService.createOnlineMeeting` 주석) — 실시간
+   *    캡처 종료(`capture-view.tsx`의 `trackAnalysis`)와 똑같이, 등록 직후부터 진행 상황을
+   *    쫓아야 검토 화면으로 갈 길이 생긴다. 값이 없으면 그 카드를 못 띄운다.
+   */
+  onCreated: (meetingId: string, title: string) => void;
 }
 
 /**
@@ -134,7 +141,8 @@ export function useOnlineMeetingForm({ onCreated }: UseOnlineMeetingFormOptions)
     }
 
     toast.success("비대면 회의를 등록했습니다");
-    onCreated();
+    // ⚠️ 성공 응답엔 항상 `created`가 실린다(`errors`가 비었을 때만 여기 온다) — 없으면 계약 위반이다.
+    if (result.created) onCreated(result.created.id, form.title);
   }
 
   return {


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

- `MeetingService.createOnlineMeeting()`은 등록 시점에 곧장 전체 파일 STT·AI 분석을 시작하는데(BE 주석 확인), FE는 이 사실과 무관하게 토스트 한 줄만 띄우고 끝났다 — 이후 진행 상황을 알 방법도, 완료 후 검토 화면으로 갈 경로도 없었다.
- 실시간 캡처 종료(`capture-view.tsx`)가 쓰는 것과 같은 `trackAnalysis`(`useNotificationCenter`)를 등록 성공 직후 호출하도록 연결했다 — 등록 직후부터 우측 하단 진행 카드가 뜨고, 완료되면 그 카드를 눌러 검토 화면으로 이동할 수 있다.
- `useOnlineMeetingForm`의 `onCreated` 콜백 시그니처를 `() => void`에서 `(meetingId: string, title: string) => void`로 바꿨다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`fix/online-meeting-analysis-tracking#537`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🕵️ **정직성** — 서버가 실제로 처리 중인 일을 화면이 아무 말도 안 하던 것을 고침

**품질**

- [x] ♻️ 재사용 확인 — `capture-view.tsx`가 이미 쓰는 `trackAnalysis` 패턴 그대로 재사용, 새 상태 관리 안 만듦
- [x] 🧪 `online-meeting-dialog.test.tsx`에 등록 성공 시 `trackAnalysis` 호출 확인 테스트 추가, 도메인 전체 240개 통과

---

## 🔗 연관 이슈

Closes #537

---

## 💬 리뷰 포인트

- `onCreated` 콜백 시그니처 변경이 이 다이얼로그 하나에만 쓰여서 다른 호출부 영향은 없습니다.

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |


---

## 📝 추가 메모
