### PR TITLE
[FIX] 기업 설정에서 회사 위치를 지울 수 있게 한다 #542

### DIFF
--- a/src/features/auth/components/address-picker.tsx
+++ b/src/features/auth/components/address-picker.tsx
@@ -28,6 +28,15 @@ interface AddressPickerProps {
   /** 이미 고른 곳. 아직 안 골랐으면 `null` */
   picked: PickedPlace | null;
   onPick: (place: PickedPlace) => void;
+  /**
+   * 고른 곳을 지운다 — **없으면 지우기 버튼 자체가 안 뜬다.**
+   *
+   * ⚠️ 신청 화면은 이 prop을 안 넘긴다. 위치는 신청을 끝내는 데 반드시 있어야 하는 값이라
+   *    (`registerSchema.shape.place`가 `null`을 거절한다) 지울 수 있으면 안 된다 — 기업 설정
+   *    (이미 회사가 있고, 위치는 선택 값)에서만 넘긴다(§연동 검증: BE `UpdateCompanyRequest`
+   *    가 빈 주소로 지우기를 지원한다).
+   */
+  onClear?: () => void;
   hasError: boolean;
   /**
    * 지도 상자 크기.
@@ -40,6 +49,7 @@ interface AddressPickerProps {
 export function AddressPicker({
   picked,
   onPick,
+  onClear,
   hasError,
   mapClassName = "h-[160px]",
 }: AddressPickerProps) {
@@ -281,7 +291,17 @@ export function AddressPicker({
           <p className="text-muted-foreground flex items-center gap-1.5 text-[12px] leading-4">
             {/* ⚠️ 초록은 규칙에 없는 색이다 — 골랐다는 건 체크 표시가 이미 말한다(DESIGN §5) */}
             <Check className="text-foreground size-3.5 shrink-0" aria-hidden />
-            <span>{picked.address}</span>
+            <span className="flex-1">{picked.address}</span>
+            {/* ⚠️ `onClear`가 없으면(신청 화면) 안 그린다 — 위치는 신청을 끝내는 데 반드시 있어야 한다 */}
+            {onClear && (
+              <button
+                type="button"
+                onClick={onClear}
+                className="text-muted-foreground hover:text-foreground focus-visible:ring-ring shrink-0 rounded px-1 underline-offset-2 hover:underline focus-visible:ring-2 focus-visible:outline-hidden"
+              >
+                지우기
+              </button>
+            )}
           </p>
           {/*
             ⚠️ `key`에 **SDK 상태를 함께 넣는다.** 이미 고른 곳을 들고 시작하는 화면

--- a/src/features/company/components/company-profile-card.tsx
+++ b/src/features/company/components/company-profile-card.tsx
@@ -162,6 +162,15 @@ export function CompanyProfileCard({ profile }: { profile: CompanyProfile }) {
                 setPlace(next);
                 markFixed("place");
               }}
+              /*
+                ⚠️ **여기서만 넘긴다.** 신청 화면은 위치가 신청을 끝내는 데 반드시 있어야 하는
+                   값이라 지울 수 없다 — 이미 회사가 있는 이 화면만 위치를 선택 값으로 다룬다
+                   (BE `UpdateCompanyRequest`가 빈 주소로 지우기를 지원한다).
+              */
+              onClear={() => {
+                setPlace(null);
+                markFixed("place");
+              }}
               hasError={Boolean(errorOf("place"))}
               mapClassName="h-[232px]"
             />

--- a/src/features/company/mapper.test.ts
+++ b/src/features/company/mapper.test.ts
@@ -80,11 +80,17 @@ describe("toCompanyUpdateBody — 좌표 저장", () => {
     expect(body).not.toHaveProperty("longitude");
   });
 
-  /* ⚠️ 빈 주소는 BE `@Pattern`이 400으로 거절한다 — 필드째 생략한다(PR #423). 좌표도 따라간다 */
-  it("주소가 없으면 주소도 좌표도 생략한다 — place는 한 몸이다", () => {
+  /*
+    ⚠️ **2026-08-14, BE 실코드 재대조로 뒤집었다.** 예전엔 빈 주소를 `@Pattern`이 400으로
+       거절해서 필드째 생략했는데(PR #423), 지금 BE `UpdateCompanyRequest`는 주소만 그
+       규칙에서 빼고 **빈 문자열을 "지운다"는 신호로 읽는다** — 그래서 지금은 생략이 아니라
+       빈 문자열을 그대로 보낸다. 좌표는 여전히 생략한다(주소 없는 요청에 좌표만 실으면
+       반쪽 위치가 저장된다).
+  */
+  it("주소가 없으면 빈 문자열로 보낸다 — BE가 이걸 지우기 신호로 읽는다", () => {
     const body = toCompanyUpdateBody({ ...DRAFT, place: null });
 
-    expect(body).toEqual({ name: "새이름", businessNumber: "999-88-77777" });
+    expect(body).toEqual({ name: "새이름", businessNumber: "999-88-77777", address: "" });
   });
 });
 

--- a/src/features/company/mapper.ts
+++ b/src/features/company/mapper.ts
@@ -92,7 +92,14 @@ export function toCompanyProfile(profile: BeCompanyProfile): CompanyProfile {
 export interface BeCompanyUpdateBody {
   name: string;
   businessNumber: string;
-  address?: string;
+  /**
+   * ⚠️ **다른 칸과 달리 항상 보낸다.** 나머지 필드는 없으면 "건드리지 말라"는 뜻인데, 주소는
+   *    BE가 **빈 문자열을 "지운다"는 신호로 따로 읽는다**([확인] `UpdateCompanyRequest` 주석 —
+   *    "빈 문자열을 보내면 주소와 좌표를 함께 지운다", 2026-08-14 develop 대조. 예전엔
+   *    `@Pattern`이 빈 값을 거절했지만(PR #423), 이후 주소만 그 규칙에서 빠졌다). 필드째
+   *    생략하면 지우기 신호 자체를 낼 수 없다.
+   */
+  address: string;
   latitude?: number;
   longitude?: number;
 }
@@ -100,14 +107,14 @@ export interface BeCompanyUpdateBody {
 /**
  * 저장 본문.
  *
- * ⚠️ **부분 수정 계약이다** — 필드가 없으면 "건드리지 말라"다. 빈 문자열은 BE `@Pattern`
- *    (NOT_BLANK_IF_PRESENT)이 400으로 거절하므로 주소가 비면 **필드째 생략**한다(PR #423).
- * ⚠️ **좌표는 주소를 따라간다**(2026-08-13 결정). `place`는 주소+좌표 한 몸이라 주소를
- *    생략하면 좌표도 생략한다 — BE는 좌표 단독 수정도 받지만, 주소 없는 요청에 좌표만 실으면
- *    옛 주소 글자에 새 핀이 붙는 반쪽 위치가 저장된다.
+ * ⚠️ **주소는 지우기가 가능하다**(2026-08-14, BE 실코드 재대조로 뒤집음). 위 `address` 주석
+ *    참고 — 고른 위치가 없으면 빈 문자열을 그대로 보낸다.
+ * ⚠️ **좌표는 주소를 따라간다**(2026-08-13 결정). `place`는 주소+좌표 한 몸이라 주소가 없으면
+ *    좌표도 생략한다 — BE는 좌표 단독 수정도 받지만, 주소 없는 요청에 좌표만 실으면 옛 주소
+ *    글자에 새 핀이 붙는 반쪽 위치가 저장된다. (주소를 지우는 요청이면 어차피 BE가 좌표도
+ *    함께 지운다 — 위 `UpdateCompanyRequest` 주석.)
  * ⚠️ **`0,0`은 좌표가 아니라 "지도를 못 썼다"는 표기다**(`register-draft`의 `PickedPlace`
- *    규칙 — 키 없음·SDK 차단). 그대로 보내면 기니만 바다에 핀이 저장되므로 생략한다 —
- *    없는 값은 안 보내는 게 부분 수정 계약과도 맞는다.
+ *    규칙 — 키 없음·SDK 차단). 그대로 보내면 기니만 바다에 핀이 저장되므로 생략한다.
  *    [확인] BE `UpdateCompanyRequest.latitude/longitude` 2026-08-13 develop(`30952c10`).
  */
 export function toCompanyUpdateBody(draft: CompanyProfileDraft): BeCompanyUpdateBody {
@@ -117,7 +124,8 @@ export function toCompanyUpdateBody(draft: CompanyProfileDraft): BeCompanyUpdate
   return {
     name: draft.name,
     businessNumber: draft.businessNumber,
-    ...(place ? { address: place.address } : {}),
+    // 없으면 빈 문자열 — BE가 이걸 "지운다"로 읽는다(위 `BeCompanyUpdateBody.address` 주석)
+    address: place?.address ?? "",
     ...(hasPin ? { latitude: place.lat, longitude: place.lng } : {}),
   };
 }

--- a/src/features/company/validate.test.ts
+++ b/src/features/company/validate.test.ts
@@ -43,8 +43,14 @@ describe("validateCompanyProfile", () => {
     },
   );
 
-  it("위치를 안 고르면 막는다 — 세금계산서가 나가는 주소다", () => {
-    expect(validateCompanyProfile({ ...VALID, place: null }).place).toBeTruthy();
+  /*
+    ⚠️ **2026-08-14, BE 실코드 재대조로 뒤집었다.** 신청(`registerSchema`)에서는 위치가
+       필수라 `null`을 막지만, 여기(기업 설정)는 **이미 등록한 위치를 지울 수 있어야** 한다
+       (BE `UpdateCompanyRequest` — 빈 주소로 지우기를 지원한다). 그래서 신청 스키마를
+       그대로 안 쓰고 `place`만 따로 둔다(`validate.ts` 주석).
+  */
+  it("위치를 지워도(null) 막지 않는다 — 등록한 위치를 나중에 지울 수 있어야 한다", () => {
+    expect(validateCompanyProfile({ ...VALID, place: null })).toEqual({});
   });
 
   it("주소가 비어 있으면 좌표가 있어도 막는다", () => {
@@ -79,11 +85,11 @@ describe("validateCompanyProfile", () => {
     expect(errors.businessNumber).toBe("사업자등록번호를 입력해 주세요");
   });
 
-  it("신청 화면과 같은 문구로 알린다", () => {
+  it("신청 화면과 같은 문구로 알린다 — 위치만 예외다(위 테스트 참고)", () => {
     const errors = validateCompanyProfile({ name: "", businessNumber: "", place: null });
 
     expect(errors.name).toBe("기업명을 입력해 주세요");
-    expect(errors.place).toBe("회사 위치를 찾아 골라 주세요");
+    expect(errors.place).toBeUndefined();
   });
 });
 

--- a/src/features/company/validate.ts
+++ b/src/features/company/validate.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import { AUTHORITY, POSITION_AUTHORITIES } from "@/constants/domain";
-import { registerSchema } from "@/features/auth/register-draft";
+import { placeSchema, registerSchema } from "@/features/auth/register-draft";
 import { MAX_DEPARTMENT_DEPTH, MAX_ORG_NAME_LENGTH } from "@/features/onboarding/types";
 
 import type { CompanyProfileDraft, CompanyProfileErrors, DepartmentNode, Position } from "./types";
@@ -12,15 +12,19 @@ import type { CompanyProfileDraft, CompanyProfileErrors, DepartmentNode, Positio
  */
 
 /**
- * 기본 정보 규칙은 **기업 등록 신청과 같은 것**을 쓴다.
+ * 기본 정보 규칙은 **기업 등록 신청과 같은 것**을 쓴다 — 단, 위치는 다르다.
  *
  * ⚠️ 여기서 규칙을 새로 적으면 신청 때는 통과한 값이 설정에서 막히거나 그 반대가 된다 —
  *    같은 회사의 같은 값이다. 신청 스키마의 칸을 그대로 꺼내 쓴다(칸 이름만 우리 것).
+ * ⚠️ **`place`만 신청 스키마를 그대로 못 쓴다**(2026-08-14). 신청은 위치를 **반드시 골라야**
+ *    끝나는 자리라 `registerSchema.shape.place`가 `null`을 거절하는데, 설정은 **이미 고른
+ *    위치를 지울 수 있어야** 한다(BE `UpdateCompanyRequest` — 빈 주소로 지우기를 지원한다).
+ *    그래서 여기만 `refine` 없는 `placeSchema.nullable()`을 직접 쓴다.
  */
 const companyProfileSchema = z.object({
   name: registerSchema.shape.companyName,
   businessNumber: registerSchema.shape.businessNumber,
-  place: registerSchema.shape.place,
+  place: placeSchema.nullable(),
 });
 
 export function validateCompanyProfile(draft: CompanyProfileDraft): CompanyProfileErrors {


### PR DESCRIPTION
## 📋 PR 타입

- [ ] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [x] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

## 무엇
기업 설정(`/owner/setting`)에서 한 번 고른 회사 위치(주소·좌표)를 지울 방법이 없었다.

## 왜
BE 실코드 재대조(`UpdateCompanyRequest.java`) — 주소만 `NOT_BLANK_IF_PRESENT` 제약에서 빠져 있고 **빈 문자열을 보내면 주소·좌표를 함께 지운다**고 명시돼 있다. 그런데 FE는 검증 스키마가 기업 등록 신청 스키마(위치 필수)를 그대로 재사용해 `null`을 막고 있었고, 매퍼도 옛 BE 제약(PR #423) 기준으로 위치가 없으면 `address` 필드째 생략했다. 화면에 지우는 버튼도 없었다.

## 어떻게
- `address-picker.tsx`: 선택적 `onClear` prop 추가 — 넘기면 "지우기" 버튼이 뜬다. 신청 화면은 안 넘긴다(위치가 신청 필수값).
- `company-profile-card.tsx`: `onClear`로 위치를 `null`로 만든다.
- `validate.ts`: 기업 설정만 `placeSchema.nullable()`(refine 없음)을 써서 `null`을 허용한다.
- `mapper.ts`: `address`를 항상 보낸다(없으면 빈 문자열) — BE가 지우기 신호로 읽는다.

## 확인법
`npx jest src/features/company`(75개 포함) · `npx tsc --noEmit` 통과.

Closes #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 회사 프로필에서 선택한 주소를 지울 수 있는 버튼을 추가했습니다.
  * 주소 삭제 시 관련 입력 오류가 자동으로 숨겨집니다.

* **버그 수정**
  * 주소를 삭제한 상태에서도 회사 프로필을 정상적으로 저장할 수 있도록 개선했습니다.
  * 주소가 없을 때 빈 주소로 처리하고, 유효한 경우에만 좌표를 전송합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**, 그리고 **서버에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [ ] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시
- [ ] 🎨 디자인 토큰 사용 · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화
- [ ] ♿ a11y
- [ ] ♻️ 재사용 확인
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API 사용 시 미지원 · 권한거부 안내 있음

---

## 🔗 연관 이슈

Closes #542

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

-

---

## 📝 추가 메모
