### PR TITLE
[FIX] 기업 설정에서 저장되지 않는 팀·직급 순서 조작을 없앤다 #544

### DIFF
--- a/src/features/company/components/company-position-card.tsx
+++ b/src/features/company/components/company-position-card.tsx
@@ -68,6 +68,12 @@ export function CompanyPositionCard({ initial }: { initial: Position[] }) {
     onEditingChange: list.setEditingId,
     draggingId,
     onDraggingChange: setDraggingId,
+    /*
+      ⚠️ **순서를 저장할 API가 없다**(§연동 검증). 직급 저장은 이름·권한만 비교해 보내서,
+         순서를 바꾸고 [저장]을 누르면 "저장했습니다"가 뜨지만 실제로는 조용히 사라진다
+         (2026-08-14 적발). `PositionRowHandlers.canReorder` 참고.
+    */
+    canReorder: false,
   };
 
   const isDirty = JSON.stringify(list.positions) !== JSON.stringify(saved);

--- a/src/features/company/components/company-team-card.test.tsx
+++ b/src/features/company/components/company-team-card.test.tsx
@@ -117,33 +117,14 @@ describe("사원이 딸린 팀", () => {
   });
 
   /*
-    ⚠️ **강등도 막는다.** 남의 팀 아래로 내리면 그 사원들의 소속이 역할이 되어 버려
-       지우는 것과 같은 결과다. 화면이 안 막으면 서버만 거절해서, 지운 적도 없는데
-       "사원이 남아 있습니다"를 보고 무엇을 되돌릴지 모른다.
+    ⚠️ **위치 이동 손잡이를 이 화면만 껐다**(2026-08-14). 순서를 저장할 API가 없어서
+       바꾸고 [저장]을 누르면 성공했다고 뜨고 실제로는 조용히 사라졌다(`canReorder`,
+       `department-node.tsx` 주석) — 그래서 드래그·Alt+방향키 전부가 이 화면에서는
+       사라졌다. 강등이 막히는지(사원이 딸린 팀)를 확인하던 아래 두 테스트는 그 조작을
+       시작할 손잡이 자체가 없어져서 지웠다 — `blockIfStaffed`는 이 화면 전용 규칙이라
+       (온보딩엔 사원이 없어 같은 개념이 없다) 다른 자리에도 없다. 손잡이를 되살릴 때
+       (`canReorder: true`) 함께 되살릴 자리다.
   */
-  it("Alt+→로 남의 팀 아래로 내리려 하면 막고 이유를 말한다", async () => {
-    const user = userEvent.setup();
-    renderCard();
-
-    await user.click(screen.getByRole("button", { name: /개발팀 위치 이동/ }));
-    await user.keyboard("{Alt>}{ArrowRight}{/Alt}");
-
-    expect(toastErrorMock).toHaveBeenCalledWith(expect.stringContaining("옮길 수 없습니다"));
-    // 여전히 팀 자리에 있다 — 삭제 버튼이 그대로다
-    expect(screen.getByRole("button", { name: "개발팀 삭제" })).toBeInTheDocument();
-  });
-
-  it("빈 팀은 내려도 막지 않는다", async () => {
-    const user = userEvent.setup();
-    renderCard();
-
-    // 빈팀이 첫 줄이라 내려갈 곳이 없다 — 대신 개발팀을 올려 순서를 바꾼 뒤 내린다
-    await user.click(screen.getByRole("button", { name: /빈팀 위치 이동/ }));
-    await user.keyboard("{Alt>}{ArrowDown}{/Alt}");
-    await user.keyboard("{Alt>}{ArrowRight}{/Alt}");
-
-    expect(toastErrorMock).not.toHaveBeenCalled();
-  });
 });
 
 describe("역할(트리 아랫단)", () => {

--- a/src/features/company/components/company-team-card.tsx
+++ b/src/features/company/components/company-team-card.tsx
@@ -106,6 +106,13 @@ export function CompanyTeamCard({ initial, memberCounts }: CompanyTeamCardProps)
     onEditingChange: tree.setEditingId,
     dragging,
     onDraggingChange: setDragging,
+    /*
+      ⚠️ **순서를 저장할 API가 없다**(§연동 검증). 손잡이를 그대로 두면 순서를 바꾸고
+         [저장]을 눌렀을 때 "저장했습니다"가 뜨지만 실제로는 조용히 사라진다(2026-08-14
+         적발) — 계층 변경(승격·강등)은 이미 "역할 안 저장" 안내로 막혀 있는데 순서만
+         그 경로를 안 타서 몰래 새고 있었다. `DepartmentNodeHandlers.canReorder` 참고.
+    */
+    canReorder: false,
   };
 
   /*

--- a/src/features/onboarding/components/department-node.tsx
+++ b/src/features/onboarding/components/department-node.tsx
@@ -29,6 +29,17 @@ export interface DepartmentNodeHandlers {
   onEditingChange: (id: string | null) => void;
   dragging: DraggingInfo | null;
   onDraggingChange: (info: DraggingInfo | null) => void;
+  /**
+   * 드래그 손잡이·Alt+방향키 전부를 끈다. **기본은 켜짐**(온보딩) — 저장 한 번에 트리
+   * 전체가 새로 만들어져서 순서·계층 변경이 그대로 반영된다.
+   *
+   * ⚠️ **기업 설정만 끈다.** 그 화면은 저장이 팀 단위 API(`POST`·`PATCH`·`DELETE`)로
+   *    나뉘는데, 순서를 저장할 API 자체가 없고(§연동 검증), 계층 변경(승격·강등)은
+   *    이미 다른 경로(`역할 안 저장` 안내)로 막혀 있다 — 그런데 **순서만** 그 경로를
+   *    안 타서, 바꾸고 [저장]을 누르면 성공했다고 뜨고 실제로는 조용히 사라진다
+   *    (2026-08-14 적발). 손잡이를 아예 안 주는 게 거짓 성공보다 정직하다(§정직성).
+   */
+  canReorder?: boolean;
 }
 
 interface DepartmentNodeProps extends DepartmentNodeHandlers {
@@ -40,6 +51,7 @@ interface DepartmentNodeProps extends DepartmentNodeHandlers {
 export function DepartmentNode({ node, depth, parentId, ...handlers }: DepartmentNodeProps) {
   const { onRename, onAddChild, onRemove, onShift, onPromote, onDemote } = handlers;
   const { editingId, onEditingChange } = handlers;
+  const canReorder = handlers.canReorder ?? true;
 
   const [isExpanded, setIsExpanded] = useState(true);
 
@@ -92,15 +104,20 @@ export function DepartmentNode({ node, depth, parentId, ...handlers }: Departmen
           dropZone === "inside" && "bg-secondary outline-ring outline-2 outline-dashed",
         )}
       >
-        <button
-          {...handleProps}
-          type="button"
-          aria-label={`${node.name} 위치 이동 — Alt와 방향키로도 옮길 수 있습니다(위아래: 순서, 왼쪽: 팀으로 빼기, 오른쪽: 바로 위 팀의 역할로)`}
-          onKeyDown={handleKeyMove}
-          className="text-muted-foreground/40 hover:text-muted-foreground focus-visible:ring-ring shrink-0 cursor-grab rounded opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-hidden active:cursor-grabbing"
-        >
-          <GripVertical className="size-3.5" />
-        </button>
+        {canReorder ? (
+          <button
+            {...handleProps}
+            type="button"
+            aria-label={`${node.name} 위치 이동 — Alt와 방향키로도 옮길 수 있습니다(위아래: 순서, 왼쪽: 팀으로 빼기, 오른쪽: 바로 위 팀의 역할로)`}
+            onKeyDown={handleKeyMove}
+            className="text-muted-foreground/40 hover:text-muted-foreground focus-visible:ring-ring shrink-0 cursor-grab rounded opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-hidden active:cursor-grabbing"
+          >
+            <GripVertical className="size-3.5" />
+          </button>
+        ) : (
+          // ⚠️ 자리만 지킨다 — 없으면 옆 아이콘들이 한 칸씩 밀린다(위 `canReorder` 주석 참고)
+          <span className="size-3.5 shrink-0" aria-hidden />
+        )}
 
         {hasChildren ? (
           <button

--- a/src/features/onboarding/components/position-row.tsx
+++ b/src/features/onboarding/components/position-row.tsx
@@ -26,6 +26,16 @@ export interface PositionRowHandlers {
   onEditingChange: (id: string | null) => void;
   draggingId: DraggingPositionId;
   onDraggingChange: (id: DraggingPositionId) => void;
+  /**
+   * 드래그 손잡이·Alt+↑↓를 끈다. **기본은 켜짐**(온보딩) — 저장 한 번에 목록 전체가
+   * 새로 만들어져서 순서가 그대로 반영된다.
+   *
+   * ⚠️ **기업 설정만 끈다.** 직급 저장은 이름·권한만 비교해 보내는 부분 수정이라 순서를
+   *    담을 API가 없다(§연동 검증) — 순서를 바꾸고 [저장]을 누르면 성공했다고 뜨지만
+   *    실제로는 조용히 사라진다(2026-08-14 적발). 손잡이를 아예 안 주는 게 거짓 성공보다
+   *    정직하다(§정직성).
+   */
+  canReorder?: boolean;
 }
 
 interface PositionRowProps extends PositionRowHandlers {
@@ -47,6 +57,7 @@ export function PositionRow({
   ...handlers
 }: PositionRowProps) {
   const { onRename, onChangeRole, onRemove, onShift, editingId, onEditingChange } = handlers;
+  const canReorder = handlers.canReorder ?? true;
 
   const isEditing = editingId === position.id;
 
@@ -87,28 +98,36 @@ export function PositionRow({
       <span
         className={cn(POSITION_COLUMN.INDEX, "relative flex shrink-0 items-center justify-center")}
       >
-        <span className="text-muted-foreground/40 text-[11px] leading-none tabular-nums transition-opacity group-focus-within:opacity-0 group-hover:opacity-0">
+        <span
+          className={cn(
+            "text-muted-foreground/40 text-[11px] leading-none tabular-nums",
+            // 손잡이가 없으면 굳이 숨겼다 보여줄 이유가 없다 — 번호가 늘 보인다
+            canReorder && "transition-opacity group-focus-within:opacity-0 group-hover:opacity-0",
+          )}
+        >
           {index + 1}
         </span>
-        <button
-          {...handleProps}
-          type="button"
-          aria-label={`${position.name} 순서 이동 — Alt와 위아래 방향키로도 옮길 수 있습니다`}
-          onKeyDown={(event) => {
-            if (!event.altKey) return;
-            if (event.key === "ArrowUp") {
-              event.preventDefault();
-              onShift(position.id, -1);
-            }
-            if (event.key === "ArrowDown") {
-              event.preventDefault();
-              onShift(position.id, 1);
-            }
-          }}
-          className="text-muted-foreground/50 hover:text-muted-foreground focus-visible:ring-ring absolute inset-0 flex cursor-grab items-center justify-center rounded opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-hidden active:cursor-grabbing"
-        >
-          <GripVertical className="size-3.5" />
-        </button>
+        {canReorder && (
+          <button
+            {...handleProps}
+            type="button"
+            aria-label={`${position.name} 순서 이동 — Alt와 위아래 방향키로도 옮길 수 있습니다`}
+            onKeyDown={(event) => {
+              if (!event.altKey) return;
+              if (event.key === "ArrowUp") {
+                event.preventDefault();
+                onShift(position.id, -1);
+              }
+              if (event.key === "ArrowDown") {
+                event.preventDefault();
+                onShift(position.id, 1);
+              }
+            }}
+            className="text-muted-foreground/50 hover:text-muted-foreground focus-visible:ring-ring absolute inset-0 flex cursor-grab items-center justify-center rounded opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-hidden active:cursor-grabbing"
+          >
+            <GripVertical className="size-3.5" />
+          </button>
+        )}
       </span>
 
       {isEditing ? (


### PR DESCRIPTION
## 📋 PR 타입

- [ ] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [x] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [x] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

## 무엇
기업 설정(`/owner/setting`)의 팀 체계·직급 카드에서 드래그·Alt+↑↓로 순서를 바꿔도 [저장]은 성공했다고 뜨지만 실제로는 저장되지 않는다.

## 왜
저장 액션이 순서를 비교 대상에 안 넣고(`id→name` Map 비교), BE `GET/POST/PATCH /api/teams`·`/api/job-positions`에도 순서 필드가 없다 — 저장할 API 자체가 없다. 성공 토스트를 띄우면서 실제로는 조용히 버려지는 정직성 위반이다.

## 어떻게
순서 API가 생기기 전까지 이 두 화면에서만 드래그 손잡이·Alt+↑↓를 껐다(`canReorder` prop 추가, 기본값 켜짐 — 온보딩은 그대로 동작). 이 손잡이로만 확인하던 강등 차단 테스트 2개도 정리했다(온보딩엔 그 규칙 자체가 없다 — 사원이 없으니까).

## 확인법
`npx jest`(1451개) · `npx tsc --noEmit` 통과.

Closes #544

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**, 그리고 **서버에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [ ] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시
- [ ] 🎨 디자인 토큰 사용 · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화
- [ ] ♿ a11y
- [ ] ♻️ 재사용 확인
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API 사용 시 미지원 · 권한거부 안내 있음

---

## 🔗 연관 이슈

Closes #544

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

-

---

## 📝 추가 메모
