### PR TITLE
[FIX] 회의실 예약 제출 시 getMeetingRooms 실패로 페이지 전체가 죽던 버그 수정 #553

### DIFF
--- a/src/features/rooms/actions.real.test.ts
+++ b/src/features/rooms/actions.real.test.ts
@@ -126,6 +126,21 @@ describe("createRoomReservationAction — 실서버 참석자 재검증", () => 
     expect(result.errors).toEqual({});
     expect(serverApiMock).toHaveBeenCalledTimes(1);
   });
+
+  /*
+    ⚠️ 회귀 테스트다(2026-08-15 실서버 500 사고) — `getMeetingRooms()`에 try/catch가 없어서
+       BE가 잠깐 흔들리면 이 액션 전체가 예외를 던졌고, Next.js가 `/app/rooms` 페이지 전체를
+       500으로 날렸다. 폼 필드 오류로 곱게 돌아와야 한다 — 페이지가 죽으면 안 된다.
+  */
+  it("회의실 목록 조회가 실패해도 페이지를 죽이지 않고 폼 오류로 돌려준다", async () => {
+    getMeetingRoomsMock.mockRejectedValue(new Error("network down"));
+
+    const result = await createRoomReservationAction({ errors: {} }, form([3, 4]));
+
+    expect(result.errors.roomId).toBeDefined();
+    expect(result.created).toBeUndefined();
+    expect(serverApiMock).not.toHaveBeenCalled();
+  });
 });
 
 /**

--- a/src/features/rooms/actions.ts
+++ b/src/features/rooms/actions.ts
@@ -163,8 +163,18 @@ export async function createRoomReservationAction(
        모든 회의실을 같이 막던 걸 걷어내고, 지금 고른 회의실의 실제 `openTime`/`closeTime`으로
        검증한다. 못 찾으면(폼 조작 등) `null`을 넘겨 시간대 검사만 건너뛴다 — 없는 `roomId` 자체는
        존재하지 않는 회의실이라 서버 호출 단계에서 어차피 막힌다.
+    ⚠️ **`getMeetingRooms()` 실패를 여기서 잡는다**(2026-08-15 실서버 500 사고 수정 — 이 호출에
+       try/catch가 없어서 BE가 잠깐이라도 흔들리면 이 액션 전체가 예외를 던졌고, Next.js가
+       `/app/rooms` 페이지 전체를 500으로 날려 버렸다). 아래 `POST /api/meetings`와 같은 자리다 —
+       BE 호출 실패는 **이 액션의 실패**지 페이지 전체의 실패가 아니다, 폼 필드 오류로 곱게
+       돌려준다.
   */
-  const rooms = await getMeetingRooms();
+  let rooms: MeetingRoom[];
+  try {
+    rooms = await getMeetingRooms();
+  } catch {
+    return { errors: { roomId: "회의실 정보를 불러오지 못했습니다 — 잠시 후 다시 시도해 주세요" } };
+  }
   const room = rooms.find((candidate) => candidate.id === draft.roomId) ?? null;
 
   const errors = validateRoomReservationDraft(draft, { role: actor.role }, room);


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

- **실서버(z-groupware.site)에서 재현된 프로덕션 버그**입니다 — 회의실 예약 제출 시 `/app/rooms` 페이지 전체가 500 에러로 죽었습니다(콘솔 `digest: "2710907828"`).
- `createRoomReservationAction`(`src/features/rooms/actions.ts`)이 회의실별 운영시간 검증(2026-08-14, PR #547)을 위해 함수 맨 앞에서 `getMeetingRooms()`를 부르는데, 이 호출에 **try/catch가 없었습니다.** BE가 잠깐이라도 흔들리면 이 액션 전체가 예외를 던지고, Next.js가 페이지 전체를 500으로 처리했습니다.
- 같은 함수 안의 다른 BE 호출들(`getReservableMembers`, `POST /api/meetings`)은 전부 try/catch로 감싸 폼 필드 오류로 돌려주는데, 이 호출만 그 패턴을 놓쳤습니다 — 이번 PR로 같은 패턴에 맞춥니다.
- 회귀 테스트 추가: `getMeetingRooms()`가 실패해도 페이지가 죽지 않고 폼 오류(`roomId`)로 돌아오는지 확인.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (base `develop`)
- [x] 커밋 컨벤션 준수
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**품질**

- [x] 🧪 회귀 테스트 추가(`actions.real.test.ts`) — 타입체크·린트·테스트 전부 통과 확인

---

## 🔗 연관 이슈

Closes #553

---

## 💬 리뷰 포인트

- 실서버 재현 버그라 빠른 리뷰·머지 부탁드립니다. 머지 후 `main` 병합도 이어서 요청드릴 예정입니다.

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |


---

## 📝 추가 메모
