### PR TITLE
[FIX] 참석자 명부 조회 실패로도 페이지 전체가 죽던 버그 수정 #556

### DIFF
--- a/src/features/rooms/actions.real.test.ts
+++ b/src/features/rooms/actions.real.test.ts
@@ -141,6 +141,17 @@ describe("createRoomReservationAction — 실서버 참석자 재검증", () => 
     expect(result.created).toBeUndefined();
     expect(serverApiMock).not.toHaveBeenCalled();
   });
+
+  /* ⚠️ 회귀 테스트다(2026-08-15, #556) — getMeetingRooms()와 같은 사고가 여기도 있었다. */
+  it("참석자 명부 조회가 실패해도 페이지를 죽이지 않고 폼 오류로 돌려준다", async () => {
+    getReservableMembersMock.mockRejectedValue(new Error("network down"));
+
+    const result = await createRoomReservationAction({ errors: {} }, form([3, 4]));
+
+    expect(result.errors.attendeeIds).toBeDefined();
+    expect(result.created).toBeUndefined();
+    expect(serverApiMock).not.toHaveBeenCalled();
+  });
 });
 
 /**

--- a/src/features/rooms/actions.ts
+++ b/src/features/rooms/actions.ts
@@ -33,6 +33,7 @@ import type {
   MeetingRoomDraft,
   MeetingRoomFormErrors,
   MeetingTopicInput,
+  RoomMember,
   RoomReservation,
   RoomReservationDraft,
   RoomReservationFormErrors,
@@ -193,8 +194,18 @@ export async function createRoomReservationAction(
       ⚠️ **최종 방어는 여전히 BE(`POST /api/meetings`)다.** 여기서 걸러도 폼을 안 거치고
          API를 직접 호출하면 이 검사 자체가 안 돈다 — BE `MeetingAttendeeCommandService`가
          스스로 다시 봐야 한다(아직 BE 요청 문서에 못 올렸다, 다음 라운드에 올릴 것).
+      ⚠️ **이 호출도 실패를 잡는다**(2026-08-15, `getMeetingRooms()`와 같은 사고 — #553/#554).
+         실서버 분기는 BE를 한 번 더 부르는데(`getTeamLeaders()` 또는 `GET /api/members/my-team`),
+         감싸지 않으면 이 액션 전체가 예외를 던져 `/app/rooms` 페이지 전체가 500으로 죽는다.
     */
-    const roster = await getReservableMembers(actor);
+    let roster: RoomMember[];
+    try {
+      roster = await getReservableMembers(actor);
+    } catch {
+      return {
+        errors: { attendeeIds: "참석자 명부를 불러오지 못했습니다 — 잠시 후 다시 시도해 주세요" },
+      };
+    }
     const rosterIds = new Set(roster.map((member) => member.id));
     if (draft.attendeeIds.some((id) => id !== actor.id && !rosterIds.has(id))) {
       return { errors: { attendeeIds: "지정할 수 없는 참석자가 있습니다" } };


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

- PR #554(#553)로 `getMeetingRooms()` 미보호 호출을 고쳤는데도 실서버에서 같은 증상(`/app/rooms` 500)이 계속 재현되어 재조사함.
- 같은 함수(`createRoomReservationAction`) 안에 **같은 패턴의 구멍이 하나 더** 있었습니다 — `getReservableMembers(actor)` 호출에 try/catch가 없었습니다. 이 줄은 2026-08-13부터 있던 기존 코드입니다.
- `getMeetingRooms()`와 동일한 방식으로 감싸서, 실패 시 폼 필드 오류(`attendeeIds`)로 돌려주도록 고쳤습니다.
- 회귀 테스트 추가.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (base `develop`)
- [x] 커밋 컨벤션 준수
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**품질**

- [x] 🧪 회귀 테스트 추가 — 타입체크·린트·전체 테스트 통과 확인

---

## 🔗 연관 이슈

Closes #556

---

## 💬 리뷰 포인트

- 같은 클래스의 버그가 이 파일 다른 곳/다른 파일에도 더 있는지 별도로 전체 스캔 중입니다 — 나오면 후속 PR로 올리겠습니다.

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |


---

## 📝 추가 메모
