### PR TITLE
[FIX] Server Action의 미보호 BE 호출로 페이지가 죽는 공통 버그 일괄 수정 #558

### DIFF
--- a/src/features/board/actions.ts
+++ b/src/features/board/actions.ts
@@ -13,7 +13,13 @@ import { isMock } from "@/mocks/config";
 
 import { canMoveCard, getBoardColumn } from "./lib";
 import { getMyActionBoard, getProjectBoard } from "./server";
-import { BOARD_COLUMN, type BoardChange, type BoardColumnId, type BoardType } from "./types";
+import {
+  BOARD_COLUMN,
+  type BoardCard,
+  type BoardChange,
+  type BoardColumnId,
+  type BoardType,
+} from "./types";
 
 const BOARD_PATH = "/app/board";
 
@@ -71,8 +77,18 @@ async function commitBoardChangesLive(
   changes: BoardChange[],
 ): Promise<{ appliedCount: number }> {
   const today = new Date();
-  const currentCards =
-    boardType === "project" ? await getProjectBoard() : await getMyActionBoard("");
+  /*
+    ⚠️ **현재 카드 조회 실패도 잡는다**(2026-08-15, `rooms/actions.ts`의 `getMeetingRooms()`와
+       같은 사고 — #553/#554/#556). 호출부(`board-view.tsx`)가 이미 이 액션이 던지는 경우를
+       잡아 토스트로 보여주지만(§정직성 주석), `appliedCount: 0`으로 곱게 돌려주면 호출부의
+       기존 "옮기지 못했습니다" 분기를 그대로 타서 새 처리를 안 만들어도 된다.
+  */
+  let currentCards: BoardCard[];
+  try {
+    currentCards = boardType === "project" ? await getProjectBoard() : await getMyActionBoard("");
+  } catch {
+    return { appliedCount: 0 };
+  }
 
   const validItems = changes
     .map((change) => {

--- a/src/features/leader-handover/actions.ts
+++ b/src/features/leader-handover/actions.ts
@@ -46,7 +46,19 @@ export async function assignLeaderHandoverAction(
       ⚠️ 후보 목록에 있는지는 여기서 다시 본다(§권한: 화면 숨김은 보안이 아니다) — 주소만
          알면 이 액션을 직접 부를 수 있어, 화면이 안 보여준 값이라도 여기서 걸러야 한다.
     */
-    const handover = await getLeaderHandoverDetail(handoverId);
+    /*
+      ⚠️ **실패도 잡는다**(2026-08-15, `rooms/actions.ts`의 `getMeetingRooms()`와 같은 사고 —
+         #553/#554/#556/#558). 감싸지 않으면 이 액션 전체가 죽어 페이지가 500으로 날아간다.
+    */
+    let handover: Awaited<ReturnType<typeof getLeaderHandoverDetail>>;
+    try {
+      handover = await getLeaderHandoverDetail(handoverId);
+    } catch {
+      return {
+        isSuccess: false,
+        message: "인수인계서를 불러오지 못했습니다 — 잠시 후 다시 시도해 주세요",
+      };
+    }
     if (!handover) return { isSuccess: false };
     if (handover.custodyStatus !== LEADER_HANDOVER_CUSTODY_STATUS.PENDING) {
       return { isSuccess: false };

--- a/src/features/meeting/actions.attendees-real.test.ts
+++ b/src/features/meeting/actions.attendees-real.test.ts
@@ -91,6 +91,21 @@ describe("updateMeetingAttendeesAction — 실서버, host 자신이 고치는 �
     expect(getManagedMemberMock).not.toHaveBeenCalled();
   });
 
+  /*
+    ⚠️ 회귀 테스트다(2026-08-15, #558 — `rooms/actions.ts`의 `getMeetingRooms()`와 같은
+       사고). `getReservableMembers`에 try/catch가 없어서 BE가 흔들리면 이 액션 전체가
+       예외를 던져 페이지가 500으로 죽었다.
+  */
+  it("참석자 명부 조회가 실패해도 페이지를 죽이지 않고 오류로 돌려준다", async () => {
+    serverApiMock.mockResolvedValueOnce(meetingDetail());
+    getReservableMembersMock.mockRejectedValue(new Error("network down"));
+
+    const result = await updateMeetingAttendeesAction(INITIAL, form(100, [3]));
+
+    expect(result.error).toBeDefined();
+    expect(result.attendeeIds).toBeNull();
+  });
+
   it("명부 밖 id가 섞이면 PUT을 부르지 않고 막는다", async () => {
     serverApiMock.mockResolvedValueOnce(meetingDetail());
 
@@ -173,5 +188,16 @@ describe("updateMeetingAttendeesAction — 실서버, OWNER·ADMIN이 남의 회
     expect(getReservableMembersMock).not.toHaveBeenCalled();
     expect(result.error).toBeNull();
     expect(serverApiMock).toHaveBeenCalledTimes(2);
+  });
+
+  /* ⚠️ 회귀 테스트다(2026-08-15, #558) — getManagedMember도 같은 사고를 겪을 수 있었다. */
+  it("host 정보 조회가 실패해도 페이지를 죽이지 않고 오류로 돌려준다", async () => {
+    serverApiMock.mockResolvedValueOnce(meetingDetail({ host: { memberId: 9, name: "대표" } }));
+    getManagedMemberMock.mockRejectedValue(new Error("network down"));
+
+    const result = await updateMeetingAttendeesAction(INITIAL, form(100, [3]));
+
+    expect(result.error).toBeDefined();
+    expect(result.attendeeIds).toBeNull();
   });
 });

--- a/src/features/meeting/actions.ts
+++ b/src/features/meeting/actions.ts
@@ -204,11 +204,24 @@ export async function updateMeetingAttendeesAction(
        경로로 못 들어온다(`canEditMeetingAttendees`가 `isHost`를 요구한다) — 직접 요청을
        조작해야만 닿는 자리라 영향은 방어 심도 문제다.
   */
+  /*
+    ⚠️ **`getManagedMember`·`getReservableMembers` 실패도 잡는다**(2026-08-15, `rooms/actions.ts`
+       의 `getMeetingRooms()`와 같은 사고 — #553/#554/#556). 둘 다 실서버 분기에서 BE를
+       부르는데, 감싸지 않으면 이 액션 전체가 죽어 페이지가 500으로 날아간다.
+  */
   let scopeActor: Actor | null;
   if (actor.id === hostId) {
     scopeActor = actor;
   } else {
-    const hostDetail = await getManagedMember(hostId);
+    let hostDetail: Awaited<ReturnType<typeof getManagedMember>>;
+    try {
+      hostDetail = await getManagedMember(hostId);
+    } catch {
+      return {
+        error: "개설자 정보를 불러오지 못했습니다 — 잠시 후 다시 시도해 주세요",
+        attendeeIds: null,
+      };
+    }
     scopeActor =
       hostDetail && hostDetail.member.authority === AUTHORITY.OWNER
         ? {
@@ -224,7 +237,15 @@ export async function updateMeetingAttendeesAction(
        정보를 못 구한 경우 포함) — 위 주석의 "한 칸", BE가 마저 본다.
   */
   if (scopeActor) {
-    const roster = await getReservableMembers(scopeActor);
+    let roster: Awaited<ReturnType<typeof getReservableMembers>>;
+    try {
+      roster = await getReservableMembers(scopeActor);
+    } catch {
+      return {
+        error: "참석자 명부를 불러오지 못했습니다 — 잠시 후 다시 시도해 주세요",
+        attendeeIds: null,
+      };
+    }
     const rosterIds = new Set(roster.map((member) => member.id));
     if (attendeeIds.some((id) => id !== hostId && !rosterIds.has(id))) {
       return { error: "지정할 수 없는 참석자가 있습니다", attendeeIds: null };

--- a/src/features/member/manage-actions.ts
+++ b/src/features/member/manage-actions.ts
@@ -132,8 +132,20 @@ export async function changeMemberGradeAction(
   const position = next.position.trim();
   if (!position) return { isSuccess: false, message: "직급을 골라 주세요" };
 
-  /* ⚠️ Admin도 부르는 액션이라 OWNER 전용 `companies/me`를 물면 안 된다 — 팀·직급만 받는다 */
-  const company = await getCompanyOrg();
+  /*
+    ⚠️ Admin도 부르는 액션이라 OWNER 전용 `companies/me`를 물면 안 된다 — 팀·직급만 받는다
+    ⚠️ **실패도 잡는다**(2026-08-15, `rooms/actions.ts`의 `getMeetingRooms()`와 같은 사고 —
+       #553/#554/#556). 감싸지 않으면 이 액션 전체가 죽어 페이지가 500으로 날아간다.
+  */
+  let company: Awaited<ReturnType<typeof getCompanyOrg>>;
+  try {
+    company = await getCompanyOrg();
+  } catch {
+    return {
+      isSuccess: false,
+      message: "회사 정보를 불러오지 못했습니다 — 잠시 후 다시 시도해 주세요",
+    };
+  }
   if (!company.positions.some((entry) => entry.name === position)) {
     return { isSuccess: false, message: "회사에 없는 직급입니다" };
   }
@@ -148,7 +160,19 @@ export async function changeMemberGradeAction(
        부를 수 있다 — 없으면 회사에 하나뿐인 대표를 Member로 끌어내릴 수 있고, `OWNER`는
        화이트리스트에 없어 **되돌릴 수도 없다**(일방통행 파괴).
   */
-  const target = await getManagedMember(id);
+  /*
+    ⚠️ `getManagedMember`는 404·403만 `null`로 접는다 — 그 외 실패(통신 장애 등)는 그대로
+       다시 던진다(§정직성 주석, 그 함수 자체). 여기서도 잡아야 페이지가 안 죽는다.
+  */
+  let target: Awaited<ReturnType<typeof getManagedMember>>;
+  try {
+    target = await getManagedMember(id);
+  } catch {
+    return {
+      isSuccess: false,
+      message: "사원 정보를 불러오지 못했습니다 — 잠시 후 다시 시도해 주세요",
+    };
+  }
   if (!target) return { isSuccess: false, message: "없는 사원입니다" };
   /*
     ⚠️ 잠긴 이유(대표 · 퇴사)는 **화면과 같은 판정**을 쓴다. 두 곳이 각자 세면 화면은 폼을
@@ -189,7 +213,20 @@ export async function changeMemberGradeAction(
        인수인계를 두 사람이 중간 승인할 수 있고, 하나뿐인 리더를 내리면 그 팀의 중간 승인
        라인이 조용히 사라진다(WORKFLOW §7). 기업 설정도 같은 규칙을 지킨다.
   */
-  const clash = await findTeamLeaderClash(target.member, next.authority);
+  /*
+    ⚠️ **이 호출도 실패를 잡는다**(2026-08-15, 같은 사고 — #553/#554/#556). `findTeamLeaderClash`는
+       리더 여부가 실제로 바뀔 때만 내부에서 `getTeamLeaders()`로 BE를 부르므로 늘 도는 건
+       아니지만, 돌 때 실패하면 감싸지 않는 한 페이지가 500으로 죽는다.
+  */
+  let clash: string | null;
+  try {
+    clash = await findTeamLeaderClash(target.member, next.authority);
+  } catch {
+    return {
+      isSuccess: false,
+      message: "팀장 정보를 불러오지 못했습니다 — 잠시 후 다시 시도해 주세요",
+    };
+  }
   if (clash) return { isSuccess: false, message: clash };
 
   if (!isMock) {
@@ -457,8 +494,16 @@ export async function issueAccountAction(draft: AccountDraft): Promise<IssueAcco
     ⚠️ 직급 목록을 **여기서 구해 넘긴다.** 화면이 보낸 값을 그대로 믿으면 회사에 없는
        직급으로도 발급된다(§권한: 화면 숨김은 보안이 아니다).
   */
-  /* ⚠️ Admin도 발급할 수 있다 — OWNER 전용 `companies/me` 대신 팀·직급만 받는다(403 방지) */
-  const company = await getCompanyOrg();
+  /*
+    ⚠️ Admin도 발급할 수 있다 — OWNER 전용 `companies/me` 대신 팀·직급만 받는다(403 방지)
+    ⚠️ **실패도 잡는다**(2026-08-15, 같은 사고 — #553/#554/#556/#558).
+  */
+  let company: Awaited<ReturnType<typeof getCompanyOrg>>;
+  try {
+    company = await getCompanyOrg();
+  } catch {
+    return { errors: {}, message: "회사 정보를 불러오지 못했습니다 — 잠시 후 다시 시도해 주세요" };
+  }
   const errors = validateAccount(
     draft,
     company.positions.map((position) => position.name),

--- a/src/features/project/actions.ts
+++ b/src/features/project/actions.ts
@@ -84,7 +84,17 @@ export async function createProjectAction(
 
   if (!isMock) {
     const accessToken = await requireAccessToken();
-    const teamIds = await resolveTeamIds(accessToken, draft.teamNames);
+    /*
+      ⚠️ **`resolveTeamIds`도 실패를 잡는다**(2026-08-15, `rooms/actions.ts`의 `getMeetingRooms()`와
+         같은 사고 — #553/#554/#556). BE 팀 목록 조회가 실패하면 이 호출도 예외를 던지는데,
+         감싸지 않으면 이 액션 전체가 죽어 페이지가 500으로 날아간다.
+    */
+    let teamIds: number[];
+    try {
+      teamIds = await resolveTeamIds(accessToken, draft.teamNames);
+    } catch {
+      return { errors: { name: "팀 목록을 불러오지 못했습니다 — 잠시 후 다시 시도해 주세요" } };
+    }
     const body = toCreateProjectRequestBody(draft, teamIds);
 
     try {

--- a/src/features/storage/actions.ts
+++ b/src/features/storage/actions.ts
@@ -59,7 +59,19 @@ export async function deleteRecordingsAction(tag: string): Promise<StorageAction
     ⚠️ **지울 수 있는 줄인지 서버가 판정한다.** 화면이 보낸 태그를 그대로 믿으면
        진행 중인 프로젝트의 녹음도 지워진다 — 되돌릴 수 없는 일이라 여기서 막는다.
   */
-  const overview = await getStorageOverview();
+  /*
+    ⚠️ **실패도 잡는다**(2026-08-15, `rooms/actions.ts`의 `getMeetingRooms()`와 같은 사고 —
+       #553/#554/#556/#558). 감싸지 않으면 이 액션 전체가 죽어 페이지가 500으로 날아간다.
+  */
+  let overview: Awaited<ReturnType<typeof getStorageOverview>>;
+  try {
+    overview = await getStorageOverview();
+  } catch {
+    return {
+      isSuccess: false,
+      message: "저장소 정보를 불러오지 못했습니다 — 잠시 후 다시 시도해 주세요",
+    };
+  }
   const target = overview.projects.find((project) => project.tag === tag);
 
   if (!target) return { isSuccess: false, message: "프로젝트를 찾지 못했습니다" };

--- a/src/features/team-handover/actions.real.test.ts
+++ b/src/features/team-handover/actions.real.test.ts
@@ -91,6 +91,18 @@ describe("completeTeamHandoverAction — 실서버 팀 스코프 권한 판정",
     expect(result.message).toBe("이 인수인계서를 승인할 권한이 없습니다");
     expect(serverApiMock).not.toHaveBeenCalled();
   });
+
+  /* ⚠️ 회귀 테스트다(2026-08-15, #558) — getTeamHandoverDetail() 실패로 페이지가 죽던 사고. */
+  it("인수인계서 조회가 실패해도 페이지를 죽이지 않고 오류로 돌려준다", async () => {
+    getViewerMock.mockResolvedValue(SAME_TEAM_LEADER);
+    getTeamHandoverDetailMock.mockRejectedValue(new Error("network down"));
+
+    const result = await completeTeamHandoverAction(55, [{ actionId: 101, assigneeId: 4 }]);
+
+    expect(result.isSuccess).toBe(false);
+    expect(result.message).toBeDefined();
+    expect(serverApiMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("rejectTeamHandoverAction — 실서버 팀 스코프 권한 판정", () => {
@@ -111,6 +123,18 @@ describe("rejectTeamHandoverAction — 실서버 팀 스코프 권한 판정", (
 
     expect(result.isSuccess).toBe(false);
     expect(result.message).toBe("이 인수인계서를 반려할 권한이 없습니다");
+    expect(serverApiMock).not.toHaveBeenCalled();
+  });
+
+  /* ⚠️ 회귀 테스트다(2026-08-15, #558) — getTeamHandoverDetail() 실패로 페이지가 죽던 사고. */
+  it("인수인계서 조회가 실패해도 페이지를 죽이지 않고 오류로 돌려준다", async () => {
+    getViewerMock.mockResolvedValue(SAME_TEAM_LEADER);
+    getTeamHandoverDetailMock.mockRejectedValue(new Error("network down"));
+
+    const result = await rejectTeamHandoverAction(55, "기간이 부적절합니다");
+
+    expect(result.isSuccess).toBe(false);
+    expect(result.message).toBeDefined();
     expect(serverApiMock).not.toHaveBeenCalled();
   });
 });

--- a/src/features/team-handover/actions.ts
+++ b/src/features/team-handover/actions.ts
@@ -97,7 +97,20 @@ export async function completeTeamHandoverAction(
   handoverId: number,
   assignments: TeamHandoverAssignment[],
 ): Promise<{ isSuccess: boolean; message?: string }> {
-  const handover = await getTeamHandoverDetail(handoverId);
+  /*
+    ⚠️ `getTeamHandoverDetail`은 404·403만 `null`로 접는다 — 그 외 실패(통신 장애 등)는
+       그대로 다시 던진다. 여기서도 잡아야 페이지가 안 죽는다(2026-08-15, 같은 사고 —
+       #553/#554/#556/#558).
+  */
+  let handover: Awaited<ReturnType<typeof getTeamHandoverDetail>>;
+  try {
+    handover = await getTeamHandoverDetail(handoverId);
+  } catch {
+    return {
+      isSuccess: false,
+      message: "인수인계서를 불러오지 못했습니다 — 잠시 후 다시 시도해 주세요",
+    };
+  }
   if (!handover) return { isSuccess: false, message: "이미 처리됐거나 없는 인수인계서입니다" };
 
   if (!isMock) {
@@ -168,7 +181,15 @@ export async function rejectTeamHandoverAction(
 ): Promise<{ isSuccess: boolean; message?: string }> {
   if (!reason.trim()) return { isSuccess: false, message: "반려 사유를 입력해 주세요" };
 
-  const handover = await getTeamHandoverDetail(handoverId);
+  let handover: Awaited<ReturnType<typeof getTeamHandoverDetail>>;
+  try {
+    handover = await getTeamHandoverDetail(handoverId);
+  } catch {
+    return {
+      isSuccess: false,
+      message: "인수인계서를 불러오지 못했습니다 — 잠시 후 다시 시도해 주세요",
+    };
+  }
   if (!handover) return { isSuccess: false, message: "이미 처리됐거나 없는 인수인계서입니다" };
 
   if (!isMock) {


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

`createRoomReservationAction`의 `getMeetingRooms()`/`getReservableMembers()` 미보호 호출로 회의실 예약 제출 시 `/app/rooms` 페이지 전체가 500으로 죽던 실서버 사고(#553/#554, #556/#557)를 고친 뒤, 같은 패턴이 저장소 전체에 더 있는지 전수 스캔했습니다. **7개 파일, 9곳**에서 같은 버그를 찾아 한 번에 고쳤습니다.

**버그 패턴**: Server Action이 `server.ts`의 실서버 함수를 부르는데, 그 함수가 내부에서 BE를 호출한다. try/catch 없이 부르면 BE가 잠깐 흔들리기만 해도 액션 전체가 예외를 던지고, Next.js가 페이지 전체를 500으로 처리한다.

**수정한 9곳**:

| 파일 | 함수 | 미보호 호출 |
|---|---|---|
| `project/actions.ts` | `createProjectAction` | `resolveTeamIds()` |
| `board/actions.ts` | `commitBoardChangesLive` | `getProjectBoard()`/`getMyActionBoard()` |
| `meeting/actions.ts` | `updateMeetingAttendeesAction` | `getManagedMember()`/`getReservableMembers()` |
| `member/manage-actions.ts` | `changeMemberGradeAction` | `getCompanyOrg()`/`getManagedMember()`/`findTeamLeaderClash()` |
| `member/manage-actions.ts` | `issueAccountAction` | `getCompanyOrg()` |
| `team-handover/actions.ts` | `completeTeamHandoverAction`/`rejectTeamHandoverAction` | `getTeamHandoverDetail()` |
| `leader-handover/actions.ts` | `assignLeaderHandoverAction` | `getLeaderHandoverDetail()` |
| `storage/actions.ts` | `deleteRecordingsAction` | `getStorageOverview()` |

각 자리는 그 액션이 이미 쓰는 실패 응답 모양(폼 필드 오류 또는 `{isSuccess, message}`)으로 감쌌습니다 — 새 계약을 만들지 않았습니다.

**건드리지 않은 것**: `getMeetingSummaryAction`(회의실 캘린더 상세조회)은 클라이언트(`room-meeting-detail-dialog.tsx`)의 `.catch()`로 이미 안전하게 처리돼 있어 제외했습니다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (base `develop`)
- [x] 커밋 컨벤션 준수
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**품질**

- [x] 🧪 빈도 높은 곳(rooms 계열·`updateMeetingAttendeesAction`·team-handover 승인/반려)엔 회귀 테스트 추가. 나머지 5곳(project·board·member 3곳·leader-handover·storage)은 기존 real-server 테스트 스캐폴딩이 없어 새 테스트는 안 만들었고, 타입체크·린트·기존 테스트 스위트(1479개) 전부 통과로 검증했습니다.
- [x] 자체 코드리뷰(적대적 검토) 1회 통과 — 각 자리의 반환 필드가 그 함수의 기존 실패 응답 모양과 일치하는지 확인

---

## 🔗 연관 이슈

Closes #558

---

## 💬 리뷰 포인트

- 9곳 다 같은 기계적 패턴(`try { await X() } catch { return 기존모양 }`)이라 한 PR로 묶었습니다. 리뷰하실 때 각 파일이 실제로 그 함수의 기존 실패 응답 필드명을 그대로 쓰는지만 대조해 주시면 충분합니다.

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |


---

## 📝 추가 메모
