### PR TITLE
[FIX] 회의실 운영시간 개념 제거(BE PR #523 대응) #561

### DIFF
--- a/src/features/rooms/actions.real.test.ts
+++ b/src/features/rooms/actions.real.test.ts
@@ -2,7 +2,7 @@ jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
 jest.mock("@/mocks/config", () => ({ isMock: false }));
 jest.mock("@/features/auth/session", () => ({ requireAccessToken: jest.fn() }));
 jest.mock("@/features/shell/viewer", () => ({ getViewer: jest.fn() }));
-jest.mock("./server", () => ({ getReservableMembers: jest.fn(), getMeetingRooms: jest.fn() }));
+jest.mock("./server", () => ({ getReservableMembers: jest.fn() }));
 jest.mock("@/lib/api", () => ({
   ApiError: class ApiError extends Error {
     status: number;
@@ -27,7 +27,7 @@ import {
   deleteMeetingRoomAction,
   updateMeetingRoomAction,
 } from "./actions";
-import { getMeetingRooms, getReservableMembers } from "./server";
+import { getReservableMembers } from "./server";
 
 /**
  * 회의실 예약 생성 — **실서버 참석자 재검증**.
@@ -39,7 +39,6 @@ import { getMeetingRooms, getReservableMembers } from "./server";
 const requireAccessTokenMock = requireAccessToken as unknown as jest.Mock;
 const getViewerMock = getViewer as unknown as jest.Mock;
 const getReservableMembersMock = getReservableMembers as unknown as jest.Mock;
-const getMeetingRoomsMock = getMeetingRooms as unknown as jest.Mock;
 const serverApiMock = serverApi as unknown as jest.Mock;
 
 const LEADER = { id: 2, name: "김서준", role: AUTHORITY.LEADER, teamName: "개발팀" };
@@ -75,15 +74,6 @@ beforeEach(() => {
   getReservableMembersMock.mockResolvedValue([
     { id: 3, name: "박도현", teamName: "개발팀", authority: AUTHORITY.MEMBER },
     { id: 4, name: "이서연", teamName: "개발팀", authority: AUTHORITY.MEMBER },
-  ]);
-  getMeetingRoomsMock.mockResolvedValue([
-    {
-      id: "room-small-b",
-      name: "소회의실 B",
-      location: "3층",
-      openTime: "09:00",
-      closeTime: "18:00",
-    },
   ]);
   serverApiMock.mockResolvedValue({
     meetingId: 10,
@@ -127,22 +117,7 @@ describe("createRoomReservationAction — 실서버 참석자 재검증", () => 
     expect(serverApiMock).toHaveBeenCalledTimes(1);
   });
 
-  /*
-    ⚠️ 회귀 테스트다(2026-08-15 실서버 500 사고) — `getMeetingRooms()`에 try/catch가 없어서
-       BE가 잠깐 흔들리면 이 액션 전체가 예외를 던졌고, Next.js가 `/app/rooms` 페이지 전체를
-       500으로 날렸다. 폼 필드 오류로 곱게 돌아와야 한다 — 페이지가 죽으면 안 된다.
-  */
-  it("회의실 목록 조회가 실패해도 페이지를 죽이지 않고 폼 오류로 돌려준다", async () => {
-    getMeetingRoomsMock.mockRejectedValue(new Error("network down"));
-
-    const result = await createRoomReservationAction({ errors: {} }, form([3, 4]));
-
-    expect(result.errors.roomId).toBeDefined();
-    expect(result.created).toBeUndefined();
-    expect(serverApiMock).not.toHaveBeenCalled();
-  });
-
-  /* ⚠️ 회귀 테스트다(2026-08-15, #556) — getMeetingRooms()와 같은 사고가 여기도 있었다. */
+  /* ⚠️ 회귀 테스트다(2026-08-15, #556) — 이전 `getMeetingRooms()`와 같은 사고가 여기도 있었다. */
   it("참석자 명부 조회가 실패해도 페이지를 죽이지 않고 폼 오류로 돌려준다", async () => {
     getReservableMembersMock.mockRejectedValue(new Error("network down"));
 
@@ -165,8 +140,6 @@ function roomForm(): FormData {
   const data = new FormData();
   data.append("name", "박애관 302호");
   data.append("location", "박애관 302호");
-  data.append("openTime", "00:00");
-  data.append("closeTime", "23:30");
   return data;
 }
 
@@ -199,8 +172,6 @@ describe("회의실 추가·수정·삭제 — 실서버 권한 판정", () => {
       meetingRoomId: 1,
       name: "박애관 302호",
       location: "박애관 302호",
-      availableFrom: "00:00",
-      availableTo: "23:30",
     });
     const data = roomForm();
     data.append("id", "1");

--- a/src/features/rooms/actions.test.ts
+++ b/src/features/rooms/actions.test.ts
@@ -68,8 +68,6 @@ const roomForm = (entries: Record<string, string>) => {
 const VALID_ROOM_ENTRIES: Record<string, string> = {
   name: "신관 세미나실",
   location: "4층 C동",
-  openTime: "10:00",
-  closeTime: "17:00",
 };
 
 describe("회의실 추가·수정", () => {

--- a/src/features/rooms/actions.ts
+++ b/src/features/rooms/actions.ts
@@ -27,7 +27,7 @@ import {
 import { findMockMember } from "./mock/members";
 import { addMockReservation, listMockReservationsByRoom } from "./mock/reservations";
 import { addMockRoom, deleteMockRoom, findMockRoom, updateMockRoom } from "./mock/rooms";
-import { getMeetingRooms, getReservableMembers } from "./server";
+import { getReservableMembers } from "./server";
 import type {
   MeetingRoom,
   MeetingRoomDraft,
@@ -46,11 +46,12 @@ const ROOM_NOT_FOUND_MESSAGE = "수정할 회의실을 찾을 수 없습니다";
 
 /**
  * 회의실 추가·수정 API 실패를 폼 필드 오류로 바꾼다(ROOM-03·04 공통).
- * ⚠️ `MR-002`(이름 중복)는 `name` 칸에, `MR-003`(시간 역전)·`MR-006`(좁힌 시간 밖에 이미
- *    예약된 슬롯 있음)은 `closeTime` 칸에 붙인다 — 이 폼엔 "회의실 전체" 오류를 보여줄 자리가
+ * ⚠️ `MR-002`(이름 중복)는 `name` 칸에 붙인다 — 이 폼엔 "회의실 전체" 오류를 보여줄 자리가
  *    따로 없어서, 화면 가드가 이미 막아 준 `MR-004`(권한)를 포함해 나머지는 전부 `name` 칸에
  *    얹는다(기존 권한 오류와 같은 자리). `MR-001`(존재하지 않는 회의실, 수정 전용)은 mock
  *    분기의 "수정할 회의실을 찾을 수 없습니다"와 문구를 맞춘다.
+ * ⚠️ **`MR-003`(시간 역전)·`MR-006`(운영시간 밖 예약)은 더는 없다**(2026-08-15, BE PR #523 —
+ *    운영시간 개념 자체를 없애 그 오류 코드도 같이 사라졌다).
  */
 function toMeetingRoomFormErrors(error: unknown): MeetingRoomFormErrors {
   if (!(error instanceof ApiError)) throw error;
@@ -60,9 +61,6 @@ function toMeetingRoomFormErrors(error: unknown): MeetingRoomFormErrors {
       return { name: ROOM_NOT_FOUND_MESSAGE };
     case "MR-002":
       return { name: ROOM_NAME_CONFLICT_MESSAGE };
-    case "MR-003":
-    case "MR-006":
-      return { closeTime: error.message };
     default:
       return { name: error.message };
   }
@@ -160,25 +158,13 @@ export async function createRoomReservationAction(
   const actor = isMock ? getMockActor() : await getViewer();
 
   /*
-    ⚠️ **회의실마다 이용 가능 시간이 다르다**(2026-08-14, BE 24시간 운영 협의) — 전역 상수 하나로
-       모든 회의실을 같이 막던 걸 걷어내고, 지금 고른 회의실의 실제 `openTime`/`closeTime`으로
-       검증한다. 못 찾으면(폼 조작 등) `null`을 넘겨 시간대 검사만 건너뛴다 — 없는 `roomId` 자체는
-       존재하지 않는 회의실이라 서버 호출 단계에서 어차피 막힌다.
-    ⚠️ **`getMeetingRooms()` 실패를 여기서 잡는다**(2026-08-15 실서버 500 사고 수정 — 이 호출에
-       try/catch가 없어서 BE가 잠깐이라도 흔들리면 이 액션 전체가 예외를 던졌고, Next.js가
-       `/app/rooms` 페이지 전체를 500으로 날려 버렸다). 아래 `POST /api/meetings`와 같은 자리다 —
-       BE 호출 실패는 **이 액션의 실패**지 페이지 전체의 실패가 아니다, 폼 필드 오류로 곱게
-       돌려준다.
+    ⚠️ **회의실별 이용 가능 시간 검증은 없다**(2026-08-15, BE PR #523 — 회의실 운영시간
+       개념 자체를 없앴다, 항상 이용 가능). 예전엔 여기서 `getMeetingRooms()`로 고른
+       회의실을 찾아 `openTime`/`closeTime`을 봤는데, 그 값 자체가 더는 안 와서 그 호출
+       자체가 필요 없어졌다 — 존재하지 않는 `roomId`는 `POST /api/meetings` 단계에서
+       BE가 어차피 막는다(위 §정직성과 같은 결).
   */
-  let rooms: MeetingRoom[];
-  try {
-    rooms = await getMeetingRooms();
-  } catch {
-    return { errors: { roomId: "회의실 정보를 불러오지 못했습니다 — 잠시 후 다시 시도해 주세요" } };
-  }
-  const room = rooms.find((candidate) => candidate.id === draft.roomId) ?? null;
-
-  const errors = validateRoomReservationDraft(draft, { role: actor.role }, room);
+  const errors = validateRoomReservationDraft(draft, { role: actor.role });
   if (Object.keys(errors).length > 0) return { errors };
 
   if (!isMock) {
@@ -288,8 +274,6 @@ function readRoomDraft(formData: FormData): MeetingRoomDraft {
   return {
     name: String(formData.get("name") ?? ""),
     location: String(formData.get("location") ?? ""),
-    openTime: String(formData.get("openTime") ?? ""),
-    closeTime: String(formData.get("closeTime") ?? ""),
   };
 }
 

--- a/src/features/rooms/components/room-delete-dialog.test.tsx
+++ b/src/features/rooms/components/room-delete-dialog.test.tsx
@@ -22,8 +22,6 @@ const ROOM: MeetingRoom = {
   id: "r1",
   name: "대회의실",
   location: "3층 A동",
-  openTime: "09:00",
-  closeTime: "18:00",
 };
 
 function renderDialog() {

--- a/src/features/rooms/components/room-form.tsx
+++ b/src/features/rooms/components/room-form.tsx
@@ -3,7 +3,6 @@
 import { useActionState, useEffect, useRef, useState } from "react";
 
 import { FieldError } from "@/components/common/field-error";
-import { TimePickerField } from "@/components/common/time-picker-field";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 
@@ -29,15 +28,13 @@ interface RoomFormProps {
 
 /**
  * 회의실 추가·수정 폼 — `notice-form.tsx`와 같은 골격(실제 `<form action={formAction}>`).
- * 이용 시작·종료는 `TimePickerField`(shadcn Popover 기반)로 고른다 — 네이티브
- * `<input type="time">` 대신 서비스 톤에 맞춘 팝오버 목록을 쓴다(2026-08-10 변경).
+ * ⚠️ **이용 시작·종료 입력이 없다**(2026-08-15, BE PR #523 — 운영시간 개념 자체를 없앴다,
+ *    회의실은 이제 항상 이용 가능). 예전엔 여기 `TimePickerField` 두 칸이 있었다.
  */
 export function RoomForm({ action, room, onSuccess, onPendingChange, formRef }: RoomFormProps) {
   const [state, formAction, isPending] = useActionState(action, { errors: {} });
   const [name, setName] = useState(room?.name ?? "");
   const [location, setLocation] = useState(room?.location ?? "");
-  const [openTime, setOpenTime] = useState(room?.openTime ?? "");
-  const [closeTime, setCloseTime] = useState(room?.closeTime ?? "");
   const handledRoomId = useRef<string | null>(null);
 
   useEffect(() => {
@@ -79,34 +76,6 @@ export function RoomForm({ action, room, onSuccess, onPendingChange, formRef }: 
           aria-invalid={Boolean(state.errors.location)}
         />
         <FieldError reserveSpace message={state.errors.location} />
-      </div>
-
-      <div className="grid grid-cols-2 gap-3">
-        <div className="flex flex-col gap-1.5">
-          <Label htmlFor="room-open-time">이용 시작</Label>
-          <TimePickerField
-            id="room-open-time"
-            name="openTime"
-            value={openTime}
-            onChange={setOpenTime}
-            aria-invalid={Boolean(state.errors.openTime)}
-            className="w-full"
-          />
-          <FieldError reserveSpace message={state.errors.openTime} />
-        </div>
-
-        <div className="flex flex-col gap-1.5">
-          <Label htmlFor="room-close-time">이용 종료</Label>
-          <TimePickerField
-            id="room-close-time"
-            name="closeTime"
-            value={closeTime}
-            onChange={setCloseTime}
-            aria-invalid={Boolean(state.errors.closeTime)}
-            className="w-full"
-          />
-          <FieldError reserveSpace message={state.errors.closeTime} />
-        </div>
       </div>
     </form>
   );

--- a/src/features/rooms/components/room-list-panel.tsx
+++ b/src/features/rooms/components/room-list-panel.tsx
@@ -90,9 +90,7 @@ export function RoomListPanel({
             className="border-border hover:bg-foreground/[0.03] flex items-center justify-between gap-3 border-t px-5 py-3.5 transition-colors"
           >
             <span className="text-foreground text-[13px] leading-5">{room.name}</span>
-            <span className="text-muted-foreground text-[12px] leading-4 tabular-nums">
-              {room.openTime} - {room.closeTime}
-            </span>
+            <span className="text-muted-foreground text-[12px] leading-4">{room.location}</span>
           </li>
         ))}
       </ul>

--- a/src/features/rooms/components/room-reservation-dialog.test.tsx
+++ b/src/features/rooms/components/room-reservation-dialog.test.tsx
@@ -16,8 +16,6 @@ const ROOMS: MeetingRoom[] = [
     id: "room-large",
     name: "대회의실",
     location: "3층 A동",
-    openTime: "09:00",
-    closeTime: "18:00",
   },
 ];
 /* ⚠️ Owner가 여는 폼이라 후보는 **팀장뿐**이다(2026-08-13, `attendee-scope.ts`) — 예전의

--- a/src/features/rooms/components/rooms-board.test.tsx
+++ b/src/features/rooms/components/rooms-board.test.tsx
@@ -30,8 +30,6 @@ const ROOMS: MeetingRoom[] = [
     id: "room-large",
     name: "대회의실",
     location: "3층 A동",
-    openTime: "09:00",
-    closeTime: "18:00",
   },
 ];
 const MEMBERS = [{ id: 2, name: "김서준", teamName: "개발팀", authority: AUTHORITY.LEADER }];

--- a/src/features/rooms/components/rooms-manage-table.tsx
+++ b/src/features/rooms/components/rooms-manage-table.tsx
@@ -1,4 +1,4 @@
-import { CalendarRange, Clock, MapPin } from "lucide-react";
+import { CalendarRange, MapPin } from "lucide-react";
 
 import { EmptyState } from "@/components/common/empty-state";
 
@@ -51,16 +51,14 @@ export function RoomsManageTable({ rooms, canManage }: RoomsManageTableProps) {
         <div className="border-border overflow-x-auto border-t">
           <table className="w-full min-w-[560px] table-fixed text-[13px]">
             <colgroup>
-              <col className="w-[30%]" />
-              <col className="w-[28%]" />
-              <col className="w-[26%]" />
-              <col className="w-[16%]" />
+              <col className="w-[40%]" />
+              <col className="w-[38%]" />
+              <col className="w-[22%]" />
             </colgroup>
             <thead>
               <tr className="text-muted-foreground bg-secondary/50 border-border border-b text-[12px] leading-4">
                 <th className="px-7 py-3 text-left font-normal">이름</th>
                 <th className="px-4 py-3 text-center font-normal">위치</th>
-                <th className="px-4 py-3 text-center font-normal">이용 가능 시간</th>
                 <th className="px-4 py-3 text-center font-normal">
                   <span className="sr-only">관리</span>
                 </th>
@@ -78,12 +76,6 @@ export function RoomsManageTable({ rooms, canManage }: RoomsManageTableProps) {
                     <span className="text-muted-foreground inline-flex items-center gap-1.5">
                       <MapPin className="size-3.5 shrink-0" aria-hidden />
                       {room.location}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3.5 text-center tabular-nums">
-                    <span className="text-muted-foreground inline-flex items-center gap-1.5">
-                      <Clock className="size-3.5 shrink-0" aria-hidden />
-                      {room.openTime} - {room.closeTime}
                     </span>
                   </td>
                   <td className="px-4 py-3.5 text-center">

--- a/src/features/rooms/components/weekly-room-calendar.test.tsx
+++ b/src/features/rooms/components/weekly-room-calendar.test.tsx
@@ -63,8 +63,8 @@ import type { MeetingRoom, RoomCalendarEvent, RoomMember } from "../types";
 import { WeeklyRoomCalendar } from "./weekly-room-calendar";
 
 const ROOMS: MeetingRoom[] = [
-  { id: "room-a", name: "대회의실", location: "3층 A동", openTime: "09:00", closeTime: "18:00" },
-  { id: "room-b", name: "소회의실", location: "3층 B동", openTime: "09:00", closeTime: "18:00" },
+  { id: "room-a", name: "대회의실", location: "3층 A동" },
+  { id: "room-b", name: "소회의실", location: "3층 B동" },
 ];
 const MEMBERS: RoomMember[] = [
   { id: 1, name: "박대표", teamName: null, authority: AUTHORITY.OWNER },

--- a/src/features/rooms/constants.ts
+++ b/src/features/rooms/constants.ts
@@ -8,18 +8,6 @@
 /** 예약 길이 — 팀 확정: 30분 한 타임, 연장하지 않는다(CLAUDE.md §브라우저 API). */
 export const RESERVATION_DURATION_MINUTES = 30;
 
-/**
- * "회의 추가" 버튼이 여는 기본 슬롯 계산(`next-available-slot.ts`)만 쓰는 넉넉한 기본값
- * (분 단위, 09:00~18:00) — 어느 회의실을 고를지 아직 모르는 시점이라 실제 제약이 아니라
- * **그럴듯한 시작값**일 뿐이다.
- * ⚠️ **실제 예약 가능 여부는 이 값이 안 막는다**(2026-08-14, BE 회의실 24시간 운영 협의 이후
- *    정정 — 예전엔 이 상수가 모든 회의실의 실제 운영시간 제약이었다). 진짜 제약은
- *    `validate.ts`가 고른 회의실의 `openTime`/`closeTime`으로 따로 본다 — 회의실마다
- *    운영시간이 다를 수 있어 전역 상수로는 표현이 안 된다.
- */
-export const ROOM_OPERATING_START_MINUTES = 9 * 60;
-export const ROOM_OPERATING_END_MINUTES = 18 * 60;
-
 /*
   ⚠️ **참석자 피커 필터 상수(`ROOM_ATTENDEE_FILTER`·`ROOM_ATTENDEE_FILTER_LABEL`)는 지웠다**
      (2026-08-13 — 2026-08-12에 넣었던 "전체 · 팀장급만"/"전체 · 내 부서만" 토글을 뒤집었다).
@@ -39,8 +27,10 @@ export const ROOMS_CALENDAR_TOOLBAR_LABEL = {
 export const ROOM_LIST_PANEL_LABEL = {
   title: "회의실 목록",
   /* ⚠️ 명령이 아니라 **설명**이다 — `~하세요`는 §카피(명령은 `~해 주세요`) 밖이고, 이 줄은
-     시키는 말이 아니라 이 목록이 무엇인지 알리는 말이다. */
-  guidance: "회의실별 예약 가능 시간입니다.",
+     시키는 말이 아니라 이 목록이 무엇인지 알리는 말이다.
+     ⚠️ "예약 가능 시간"이 아니라 "위치"다(2026-08-15, BE PR #523 — 운영시간 개념이 없어져
+     회의실은 이제 항상 이용 가능하다, 목록에 남는 부가 정보는 위치뿐이다). */
+  guidance: "회의실별 위치입니다.",
   countSuffix: "개",
 } as const;
 

--- a/src/features/rooms/mapper/availability.ts
+++ b/src/features/rooms/mapper/availability.ts
@@ -14,12 +14,11 @@ import type {
 /**
  * 주간 예약 현황(`GET /api/meeting-rooms/availability`, ROOM-02) 안의 회의실 사본 — `location`이
  * 없다(BE가 이 엔드포인트에서는 안 내려준다).
+ * ⚠️ `availableFrom`/`availableTo`도 없다(2026-08-15, BE PR #523 — 운영시간 개념 자체를 없앴다).
  */
 export interface BeRoomAvailabilityMeetingRoom {
   meetingRoomId: number;
   name: string;
-  availableFrom: string;
-  availableTo: string;
 }
 
 export interface BeRoomAvailabilitySlot {
@@ -51,8 +50,6 @@ export function toRoomWeekAvailability(be: BeRoomWeekAvailability): RoomWeekAvai
       id: String(be.meetingRoom.meetingRoomId),
       name: be.meetingRoom.name,
       location: "",
-      openTime: be.meetingRoom.availableFrom,
-      closeTime: be.meetingRoom.availableTo,
     },
     days: be.days.map((day) => ({
       date: day.date,

--- a/src/features/rooms/mapper/rooms.ts
+++ b/src/features/rooms/mapper/rooms.ts
@@ -6,14 +6,16 @@
 
 import type { MeetingRoom, MeetingRoomDraft } from "../types";
 
-/** `GET /api/meeting-rooms` 배열 원소, `POST`·`PATCH` 성공 응답의 회의실 부분과 같은 모양. */
+/**
+ * `GET /api/meeting-rooms` 배열 원소, `POST`·`PATCH` 성공 응답의 회의실 부분과 같은 모양.
+ * ⚠️ **`availableFrom`/`availableTo`는 없다**(2026-08-15, BE PR #523 — 운영시간 개념 자체를
+ *    DB 컬럼째 삭제했다). 예전엔 여기 있었다 — 실서버가 그 필드를 더는 안 준다.
+ */
 export interface BeMeetingRoom {
   meetingRoomId: number;
   name: string;
   /** nullable — 위치 미등록 회의실은 `null`. */
   location: string | null;
-  availableFrom: string;
-  availableTo: string;
 }
 
 export function toMeetingRoom(be: BeMeetingRoom): MeetingRoom {
@@ -21,17 +23,13 @@ export function toMeetingRoom(be: BeMeetingRoom): MeetingRoom {
     id: String(be.meetingRoomId),
     name: be.name,
     location: be.location ?? "",
-    openTime: be.availableFrom,
-    closeTime: be.availableTo,
   };
 }
 
-/** `POST /api/meeting-rooms`(ROOM-03) 요청 본문 — 폼 입력(`openTime`·`closeTime`)을 BE 필드명으로 바꾼다. */
+/** `POST /api/meeting-rooms`(ROOM-03) 요청 본문. */
 export interface BeCreateMeetingRoomPayload {
   name: string;
   location: string | null;
-  availableFrom: string;
-  availableTo: string;
 }
 
 export function toCreateMeetingRoomPayload(draft: MeetingRoomDraft): BeCreateMeetingRoomPayload {
@@ -39,8 +37,6 @@ export function toCreateMeetingRoomPayload(draft: MeetingRoomDraft): BeCreateMee
   return {
     name: draft.name.trim(),
     location: location.length > 0 ? location : null,
-    availableFrom: draft.openTime,
-    availableTo: draft.closeTime,
   };
 }
 
@@ -55,7 +51,5 @@ export function toCreatedMeetingRoom(meetingRoomId: number, draft: MeetingRoomDr
     id: String(meetingRoomId),
     name: draft.name.trim(),
     location: draft.location.trim(),
-    openTime: draft.openTime,
-    closeTime: draft.closeTime,
   };
 }

--- a/src/features/rooms/mock/rooms.test.ts
+++ b/src/features/rooms/mock/rooms.test.ts
@@ -3,8 +3,6 @@ import { addMockRoom, deleteMockRoom, findMockRoom, listMockRooms, updateMockRoo
 const DRAFT = {
   name: "  신관 세미나실  ",
   location: "  4층 C동  ",
-  openTime: "10:00",
-  closeTime: "17:00",
 };
 
 describe("회의실 mock 스토어", () => {

--- a/src/features/rooms/mock/rooms.ts
+++ b/src/features/rooms/mock/rooms.ts
@@ -11,34 +11,10 @@ interface RoomStore {
 }
 
 const INITIAL: MeetingRoom[] = [
-  {
-    id: "room-large",
-    name: "대회의실",
-    location: "3층 A동",
-    openTime: "09:00",
-    closeTime: "18:00",
-  },
-  {
-    id: "room-small-a",
-    name: "소회의실 A",
-    location: "3층 A동",
-    openTime: "09:00",
-    closeTime: "18:00",
-  },
-  {
-    id: "room-small-b",
-    name: "소회의실 B",
-    location: "3층 B동",
-    openTime: "09:00",
-    closeTime: "18:00",
-  },
-  {
-    id: "room-video",
-    name: "화상회의실",
-    location: "본관 5층",
-    openTime: "09:00",
-    closeTime: "18:00",
-  },
+  { id: "room-large", name: "대회의실", location: "3층 A동" },
+  { id: "room-small-a", name: "소회의실 A", location: "3층 A동" },
+  { id: "room-small-b", name: "소회의실 B", location: "3층 B동" },
+  { id: "room-video", name: "화상회의실", location: "본관 5층" },
 ];
 
 const globalStore = globalThis as typeof globalThis & {
@@ -63,8 +39,6 @@ export function addMockRoom(draft: MeetingRoomDraft): MeetingRoom {
     id: `room-${++store.sequence}`,
     name: draft.name.trim(),
     location: draft.location.trim(),
-    openTime: draft.openTime,
-    closeTime: draft.closeTime,
   };
   store.rooms = [...store.rooms, room];
   return room;
@@ -75,13 +49,7 @@ export function updateMockRoom(id: string, draft: MeetingRoomDraft): MeetingRoom
   const index = store.rooms.findIndex((room) => room.id === id);
   if (index === -1) return null;
 
-  const updated: MeetingRoom = {
-    id,
-    name: draft.name.trim(),
-    location: draft.location.trim(),
-    openTime: draft.openTime,
-    closeTime: draft.closeTime,
-  };
+  const updated: MeetingRoom = { id, name: draft.name.trim(), location: draft.location.trim() };
   store.rooms = [...store.rooms.slice(0, index), updated, ...store.rooms.slice(index + 1)];
   return updated;
 }

--- a/src/features/rooms/next-available-slot.test.ts
+++ b/src/features/rooms/next-available-slot.test.ts
@@ -11,24 +11,9 @@ describe("getNextAvailableSlot", () => {
     expect(slot).toEqual(new Date("2026-08-11T10:30:00"));
   });
 
-  it("운영 시간 전이면 같은 날 09:00으로 당긴다", () => {
-    const slot = getNextAvailableSlot(new Date("2026-08-11T07:40:00"));
-    expect(slot).toEqual(new Date("2026-08-11T09:00:00"));
-  });
-
-  it("마감 30분을 못 채우면 다음 날 09:00으로 넘긴다", () => {
-    const slot = getNextAvailableSlot(new Date("2026-08-11T17:45:00"));
-    expect(slot).toEqual(new Date("2026-08-12T09:00:00"));
-  });
-
-  it("운영 종료 시각이면 다음 날로 넘긴다", () => {
-    const slot = getNextAvailableSlot(new Date("2026-08-11T18:00:00"));
-    expect(slot).toEqual(new Date("2026-08-12T09:00:00"));
-  });
-
-  /* 2026-08-14는 금요일 — 주말은 막지 않는다(2026-08-15 재확정), 다음 날은 그대로 토요일이다. */
-  it("금요일 마감 뒤엔 다음 날(토요일) 09:00으로 넘긴다", () => {
-    const slot = getNextAvailableSlot(new Date("2026-08-14T17:45:00"));
-    expect(slot).toEqual(new Date("2026-08-15T09:00:00"));
+  /* ⚠️ 회의실 운영시간 개념이 없어져서(2026-08-15, BE PR #523) 심야 시각도 그대로 반올림만 한다. */
+  it("운영 시간 밖(새벽)이어도 밀어내지 않고 그대로 30분 단위로 올린다", () => {
+    const slot = getNextAvailableSlot(new Date("2026-08-11T02:10:00"));
+    expect(slot).toEqual(new Date("2026-08-11T02:30:00"));
   });
 });

--- a/src/features/rooms/next-available-slot.ts
+++ b/src/features/rooms/next-available-slot.ts
@@ -1,16 +1,13 @@
-import {
-  RESERVATION_DURATION_MINUTES,
-  ROOM_OPERATING_END_MINUTES,
-  ROOM_OPERATING_START_MINUTES,
-} from "./constants";
+import { RESERVATION_DURATION_MINUTES } from "./constants";
 
 /**
  * 우측 상단 "예약하기" 버튼이 여는 기본 슬롯 — 지금 시각을 30분 단위로 올려 잡는다.
  * ⚠️ 회의실·요일별 예약 현황은 안 본다 — 그건 예약 모달을 연 뒤 캘린더에서 이미 확인할 수 있고,
- *    이 계산은 "언제 열지"만 정한다(어느 회의실인지는 모달에서 고른다). 이제 이 값은 **초기
+ *    이 계산은 "언제 열지"만 정한다(어느 회의실인지는 모달에서 고른다). 이 값은 **초기
  *    제안**일 뿐이다 — 모달이 직접 고를 수 있는 날짜·시간 피커를 열어 준다(2026-08-14).
- * ⚠️ 운영 시간(09:00~18:00) 밖이면 다음 날 09:00으로 넘긴다 — `validateRoomReservationDraft`가
- *    막는 값을 미리 열어주지 않는다.
+ * ⚠️ **운영 시간 밖으로 밀어내는 로직은 없다**(2026-08-15, BE PR #523 — 회의실 운영시간
+ *    개념 자체를 없앴다). 예전엔 09:00~18:00 밖이면 다음 날 09:00으로 넘겼는데, 이제 회의실은
+ *    항상 이용 가능이라 그럴 이유가 없다 — 그냥 지금 시각을 30분 단위로 올림한 값을 그대로 쓴다.
  */
 export function getNextAvailableSlot(now: Date): Date {
   const slot = new Date(now);
@@ -21,17 +18,5 @@ export function getNextAvailableSlot(now: Date): Date {
     slot.setMinutes(slot.getMinutes() + (RESERVATION_DURATION_MINUTES - remainder));
   }
 
-  const dayMinutes = slot.getHours() * 60 + slot.getMinutes();
-  if (dayMinutes < ROOM_OPERATING_START_MINUTES) {
-    setTimeOfDay(slot, ROOM_OPERATING_START_MINUTES);
-  } else if (dayMinutes + RESERVATION_DURATION_MINUTES > ROOM_OPERATING_END_MINUTES) {
-    slot.setDate(slot.getDate() + 1);
-    setTimeOfDay(slot, ROOM_OPERATING_START_MINUTES);
-  }
-
   return slot;
-}
-
-function setTimeOfDay(date: Date, minutesFromMidnight: number): void {
-  date.setHours(Math.floor(minutesFromMidnight / 60), minutesFromMidnight % 60, 0, 0);
 }

--- a/src/features/rooms/server.ts
+++ b/src/features/rooms/server.ts
@@ -18,6 +18,7 @@ import { type Actor, requiresParentTeamAction } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
 import { RESERVATION_DURATION_MINUTES } from "./constants";
+import { GRID_END_HOUR, GRID_START_HOUR } from "./grid-slot";
 import {
   type BeMeetingRoom,
   type BeRoomWeekAvailability,
@@ -39,25 +40,28 @@ import type {
 
 const WEEKDAYS_PER_WEEK = 5;
 
-function toMinutesOfDay(hhmm: string): number {
-  const [hours, minutes] = hhmm.split(":").map(Number);
-  return hours! * 60 + minutes!;
-}
-
 function toHHMM(minutesOfDay: number): string {
   const hours = Math.floor(minutesOfDay / 60);
   const minutes = minutesOfDay % 60;
   return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
 }
 
-/** 목 데이터로 하루치 슬롯을 만든다 — 회의실 운영 시간을 30분 단위로 나누고 겹치는 예약이 있으면 RESERVED로 채운다. */
+/*
+  ⚠️ **회의실 운영시간이 아니라 하루 전체 범위다**(2026-08-15, BE PR #523 — 운영시간 개념 자체를
+     없앴다. 회의실은 이제 항상 이용 가능). 캘린더 그리드(`grid-slot.ts`)와 같은 00:00~24:00
+     범위를 그대로 쓴다 — 목 슬롯이 실제 그리드보다 좁으면 그리드 하단이 빈 칸처럼 보인다.
+*/
+const DAY_START_MINUTES = GRID_START_HOUR * 60;
+const DAY_END_MINUTES = GRID_END_HOUR * 60;
+
+/** 목 데이터로 하루치 슬롯을 만든다 — 하루 전체를 30분 단위로 나누고 겹치는 예약이 있으면 RESERVED로 채운다. */
 function buildMockDaySlots(date: Date, room: MeetingRoom): RoomDayAvailability {
   const reservations = listMockReservationsByRoom(room.id);
   const slots: RoomAvailabilitySlot[] = [];
 
   for (
-    let minutesOfDay = toMinutesOfDay(room.openTime);
-    minutesOfDay < toMinutesOfDay(room.closeTime);
+    let minutesOfDay = DAY_START_MINUTES;
+    minutesOfDay < DAY_END_MINUTES;
     minutesOfDay += RESERVATION_DURATION_MINUTES
   ) {
     const startTime = toHHMM(minutesOfDay);

--- a/src/features/rooms/types.ts
+++ b/src/features/rooms/types.ts
@@ -9,16 +9,15 @@ import type { Authority } from "@/constants/authority";
  * 회의실 한 곳.
  * ⚠️ **"수용 인원" 필드는 없다**(WORKFLOW.md §10-A 확정 — 전면 폐기). 화면·모달·데이터 구조
  *    어디에도 안 둔다. 대신 "위치"가 있다.
+ * ⚠️ **운영시간(`openTime`/`closeTime`) 필드도 없다**(2026-08-15, BE PR #523 — DB 컬럼째 삭제,
+ *    회의실은 이제 도메인상 항상 이용 가능하다). 예전엔 여기 있었다 — BE가 안 주는 값을
+ *    화면이 지어내면 안 되고(§정직성), 시간대 검증도 더는 할 대상이 없다.
  */
 export interface MeetingRoom {
   id: string;
   name: string;
   /** 자유 텍스트 — "3층 A동"처럼(WORKFLOW.md §10-A) */
   location: string;
-  /** "HH:mm" */
-  openTime: string;
-  /** "HH:mm" */
-  closeTime: string;
 }
 
 /**
@@ -28,10 +27,6 @@ export interface MeetingRoom {
 export interface MeetingRoomDraft {
   name: string;
   location: string;
-  /** "HH:mm" */
-  openTime: string;
-  /** "HH:mm" */
-  closeTime: string;
 }
 
 export type MeetingRoomFormErrors = Partial<Record<keyof MeetingRoomDraft, string>>;

--- a/src/features/rooms/validate.test.ts
+++ b/src/features/rooms/validate.test.ts
@@ -4,7 +4,6 @@ import { validateMeetingRoomDraft, validateRoomReservationDraft } from "./valida
 
 const OWNER_HOST = { role: AUTHORITY.OWNER };
 const LEADER_HOST = { role: AUTHORITY.LEADER };
-const ROOM = { openTime: "09:00", closeTime: "18:00" };
 
 /** 2026-08-10은 월요일이다 — 평일 검사 테스트는 이 값을 흔들면 같이 깨진다. */
 const VALID_DRAFT = {
@@ -19,112 +18,48 @@ const VALID_DRAFT = {
 
 describe("회의실 예약 검증", () => {
   it("전부 채우면 통과한다", () => {
-    expect(validateRoomReservationDraft(VALID_DRAFT, OWNER_HOST, ROOM)).toEqual({});
+    expect(validateRoomReservationDraft(VALID_DRAFT, OWNER_HOST)).toEqual({});
   });
 
   it("제목이 비면 막는다", () => {
-    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, title: "   " }, OWNER_HOST, ROOM);
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, title: "   " }, OWNER_HOST);
     expect(errors.title).toBe("회의 제목을 입력해 주세요");
   });
 
   it("회의실을 안 고르면 막는다", () => {
-    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, roomId: "" }, OWNER_HOST, ROOM);
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, roomId: "" }, OWNER_HOST);
     expect(errors.roomId).toBeDefined();
   });
 
   it("날짜 형식이 아니면 막는다", () => {
-    const errors = validateRoomReservationDraft(
-      { ...VALID_DRAFT, date: "2026/08/10" },
-      OWNER_HOST,
-      ROOM,
-    );
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, date: "2026/08/10" }, OWNER_HOST);
     expect(errors.date).toBe("올바른 날짜가 아니에요");
   });
 
   it("존재하지 않는 날짜는 막는다", () => {
-    const errors = validateRoomReservationDraft(
-      { ...VALID_DRAFT, date: "2026-02-30" },
-      OWNER_HOST,
-      ROOM,
-    );
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, date: "2026-02-30" }, OWNER_HOST);
     expect(errors.date).toBe("올바른 날짜가 아니에요");
   });
 
   /* 주말도 막지 않는다(2026-08-15 재확정) — BE에 요일 제약이 없어(§연동 검증) 막을 이유가 없다. */
   it("주말도 통과한다 — 2026-08-15는 토요일", () => {
-    const errors = validateRoomReservationDraft(
-      { ...VALID_DRAFT, date: "2026-08-15" },
-      OWNER_HOST,
-      ROOM,
-    );
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, date: "2026-08-15" }, OWNER_HOST);
     expect(errors.date).toBeUndefined();
   });
 
   it("30분 단위가 아닌 시작 시각은 막는다", () => {
-    const errors = validateRoomReservationDraft(
-      { ...VALID_DRAFT, startTime: "10:15" },
-      OWNER_HOST,
-      ROOM,
-    );
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, startTime: "10:15" }, OWNER_HOST);
     expect(errors.startTime).toBe("예약은 30분 단위로만 가능합니다");
   });
 
-  it("운영 시작(09:00) 이전은 막는다", () => {
-    const errors = validateRoomReservationDraft(
-      { ...VALID_DRAFT, startTime: "08:30" },
-      OWNER_HOST,
-      ROOM,
-    );
-    expect(errors.startTime).toBe("회의실 이용 시간(09:00~18:00) 안에서 선택해 주세요");
-  });
-
-  it("30분을 더하면 운영 종료(18:00)를 넘는 시작 시각은 막는다", () => {
-    const errors = validateRoomReservationDraft(
-      { ...VALID_DRAFT, startTime: "17:45" },
-      OWNER_HOST,
-      ROOM,
-    );
-    expect(errors.startTime).toBeDefined();
-  });
-
-  it("운영 종료 딱 맞춰 끝나는 17:30 시작은 통과한다", () => {
-    const errors = validateRoomReservationDraft(
-      { ...VALID_DRAFT, startTime: "17:30" },
-      OWNER_HOST,
-      ROOM,
-    );
-    expect(errors.startTime).toBeUndefined();
-  });
-
-  /*
-    ⚠️ 회의실마다 운영시간이 다를 수 있다(2026-08-14, BE 24시간 운영 협의) — 같은 09:00
-       시작이라도 회의실에 따라 통과/차단이 갈려야 그 취지가 실제로 반영된 것이다.
-  */
-  it("회의실이 더 이르게 열면 그 시간부터 통과한다", () => {
-    const roomOpen24h = { openTime: "00:00", closeTime: "23:30" };
-    const errors = validateRoomReservationDraft(
-      { ...VALID_DRAFT, startTime: "01:00" },
-      OWNER_HOST,
-      roomOpen24h,
-    );
-    expect(errors.startTime).toBeUndefined();
-  });
-
-  it("회의실을 못 찾으면(room=null) 시간대 검사를 건너뛴다", () => {
-    const errors = validateRoomReservationDraft(
-      { ...VALID_DRAFT, startTime: "23:00" },
-      OWNER_HOST,
-      null,
-    );
+  /* ⚠️ 회의실 이용 시간 검사는 없다(2026-08-15, BE PR #523 — 운영시간 개념 자체를 없앴다). */
+  it("운영 시간 밖(새벽)이어도 30분 단위이기만 하면 통과한다", () => {
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, startTime: "01:00" }, OWNER_HOST);
     expect(errors.startTime).toBeUndefined();
   });
 
   it("프로젝트를 안 고르면 막는다(WORKFLOW.md §3-1: 항상 필수)", () => {
-    const errors = validateRoomReservationDraft(
-      { ...VALID_DRAFT, projectId: "" },
-      OWNER_HOST,
-      ROOM,
-    );
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, projectId: "" }, OWNER_HOST);
     expect(errors.projectId).toBe("프로젝트를 선택해 주세요");
   });
 
@@ -132,7 +67,6 @@ describe("회의실 예약 검증", () => {
     const errors = validateRoomReservationDraft(
       { ...VALID_DRAFT, topics: [{ main: "", sub: "" }] },
       OWNER_HOST,
-      ROOM,
     );
     expect(errors.topics).toBe("회의 안건(대주제·소주제)을 한 쌍 이상 입력해 주세요");
   });
@@ -141,7 +75,6 @@ describe("회의실 예약 검증", () => {
     const errors = validateRoomReservationDraft(
       { ...VALID_DRAFT, topics: [{ main: "제품", sub: "" }] },
       OWNER_HOST,
-      ROOM,
     );
     expect(errors.topics).toBeDefined();
   });
@@ -156,7 +89,6 @@ describe("회의실 예약 검증", () => {
         ],
       },
       OWNER_HOST,
-      ROOM,
     );
     expect(errors.topics).toBe("빈 안건 칸을 채우거나 삭제해 주세요");
   });
@@ -171,18 +103,17 @@ describe("회의실 예약 검증", () => {
         ],
       },
       OWNER_HOST,
-      ROOM,
     );
     expect(errors.topics).toBeUndefined();
   });
 
   it("Host가 Owner면 상위 팀 액션 없이도 통과한다", () => {
-    const errors = validateRoomReservationDraft(VALID_DRAFT, OWNER_HOST, ROOM);
+    const errors = validateRoomReservationDraft(VALID_DRAFT, OWNER_HOST);
     expect(errors.parentTeamActionId).toBeUndefined();
   });
 
   it("Host가 Leader면 상위 팀 액션이 없으면 막는다", () => {
-    const errors = validateRoomReservationDraft(VALID_DRAFT, LEADER_HOST, ROOM);
+    const errors = validateRoomReservationDraft(VALID_DRAFT, LEADER_HOST);
     expect(errors.parentTeamActionId).toBe("상위 팀 액션을 선택해 주세요");
   });
 
@@ -190,7 +121,6 @@ describe("회의실 예약 검증", () => {
     const errors = validateRoomReservationDraft(
       { ...VALID_DRAFT, parentTeamActionId: 1 },
       LEADER_HOST,
-      ROOM,
     );
     expect(errors.parentTeamActionId).toBeUndefined();
   });
@@ -199,7 +129,6 @@ describe("회의실 예약 검증", () => {
     const errors = validateRoomReservationDraft(
       { ...VALID_DRAFT, parentTeamActionId: 1 },
       OWNER_HOST,
-      ROOM,
     );
     expect(errors.parentTeamActionId).toBe(
       "Owner가 개설하는 회의에는 상위 팀 액션을 지정할 수 없습니다",
@@ -207,11 +136,7 @@ describe("회의실 예약 검증", () => {
   });
 
   it("참석자가 한 명도 없으면 막는다", () => {
-    const errors = validateRoomReservationDraft(
-      { ...VALID_DRAFT, attendeeIds: [] },
-      OWNER_HOST,
-      ROOM,
-    );
+    const errors = validateRoomReservationDraft({ ...VALID_DRAFT, attendeeIds: [] }, OWNER_HOST);
     expect(errors.attendeeIds).toBe("참석자를 한 명 이상 선택해 주세요");
   });
 
@@ -219,7 +144,6 @@ describe("회의실 예약 검증", () => {
     const errors = validateRoomReservationDraft(
       { ...VALID_DRAFT, attendeeIds: [Number.NaN] },
       OWNER_HOST,
-      ROOM,
     );
     expect(errors.attendeeIds).toBe("참석자 값이 올바르지 않습니다");
   });
@@ -228,8 +152,6 @@ describe("회의실 예약 검증", () => {
 const VALID_ROOM_DRAFT = {
   name: "대회의실",
   location: "3층 A동",
-  openTime: "09:00",
-  closeTime: "18:00",
 };
 
 describe("회의실 추가·수정 검증", () => {
@@ -245,38 +167,5 @@ describe("회의실 추가·수정 검증", () => {
   it("위치가 비면 막는다", () => {
     const errors = validateMeetingRoomDraft({ ...VALID_ROOM_DRAFT, location: "" });
     expect(errors.location).toBe("위치를 입력해 주세요");
-  });
-
-  it("시간 형식이 아니면 막는다", () => {
-    const errors = validateMeetingRoomDraft({ ...VALID_ROOM_DRAFT, openTime: "9:00" });
-    expect(errors.openTime).toBe("30분 단위로 입력해 주세요 (예: 09:00, 09:30)");
-  });
-
-  /*
-    ⚠️ 뒤집힌 계약이다(2026-08-12) — 전에는 "30분 단위 제약 없음"이 FE 설계였지만, BE
-       `@Pattern`([확인] CreateMeetingRoomRequest)이 30분 단위만 받아 09:15는 FE를 통과하고
-       BE 400으로 튕겼다. 검증 규칙은 BE와 한 벌이어야 한다.
-  */
-  it("30분 단위가 아니면 막는다 — BE @Pattern과 같은 규칙", () => {
-    const errors = validateMeetingRoomDraft({ ...VALID_ROOM_DRAFT, openTime: "09:15" });
-    expect(errors.openTime).toBe("30분 단위로 입력해 주세요 (예: 09:00, 09:30)");
-  });
-
-  it("종료 시간이 시작 시간보다 이르면 막는다", () => {
-    const errors = validateMeetingRoomDraft({
-      ...VALID_ROOM_DRAFT,
-      openTime: "18:00",
-      closeTime: "09:00",
-    });
-    expect(errors.closeTime).toBe("종료 시간은 시작 시간보다 늦어야 합니다");
-  });
-
-  it("시작과 종료가 같으면 막는다", () => {
-    const errors = validateMeetingRoomDraft({
-      ...VALID_ROOM_DRAFT,
-      openTime: "09:00",
-      closeTime: "09:00",
-    });
-    expect(errors.closeTime).toBe("종료 시간은 시작 시간보다 늦어야 합니다");
   });
 });

--- a/src/features/rooms/validate.ts
+++ b/src/features/rooms/validate.ts
@@ -3,7 +3,6 @@ import { isValid, parse } from "date-fns";
 import type { Authority } from "@/constants/authority";
 import { requiresParentTeamAction } from "@/lib/permission";
 
-import { RESERVATION_DURATION_MINUTES } from "./constants";
 import type {
   MeetingRoomDraft,
   MeetingRoomFormErrors,
@@ -13,22 +12,10 @@ import type {
 
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 const TIME_PATTERN = /^([01]\d|2[0-3]):(00|30)$/;
-/**
- * 회의실 운영 시작·종료 시각용 — **예약 슬롯과 똑같이 30분 단위다**(2026-08-12 고침).
- * ⚠️ 전에는 임의 분(09:15)을 허용했는데 BE `@Pattern`([확인] `CreateMeetingRoomRequest`)이
- *    30분 단위만 받아, FE 검증을 통과한 값이 400으로 튕기고 그 오류가 매핑 default 분기라
- *    **엉뚱한 이름 칸에** 붙었다 — 검증 규칙은 BE와 한 벌이어야 한다.
- */
-const GENERAL_TIME_PATTERN = /^([01]\d|2[0-3]):(00|30)$/;
 
 function isValidCalendarDate(value: string): boolean {
   if (!DATE_PATTERN.test(value)) return false;
   return isValid(parse(value, "yyyy-MM-dd", new Date()));
-}
-
-function toMinutes(time: string): number {
-  const [hour, minute] = time.split(":");
-  return Number(hour) * 60 + Number(minute);
 }
 
 /**
@@ -38,18 +25,16 @@ function toMinutes(time: string): number {
  * ⚠️ **참조 무결성도 여기서 안 본다** — `roomId`·`projectId`가 실제로 존재하는지, 골라 낸
  *    `parentTeamActionId`가 진짜 그 프로젝트·그 팀의 것인지는 `actions.ts`가 목/실서버 조회
  *    뒤에 따로 확인한다(§권한: 화면 숨김은 UX일 뿐 보안이 아니다). 여기는 **형식**만 본다.
+ * ⚠️ **회의실 이용 시간 검사는 없다**(2026-08-15, BE PR #523 — 운영시간 개념 자체를 없앴다,
+ *    회의실은 이제 항상 이용 가능이 도메인 모델). 예전엔 여기서 회의실의 `openTime`/`closeTime`을
+ *    받아 시작 시각이 그 안에 드는지 봤는데, 그 값 자체가 더는 안 온다 — 지운 게 아니라
+ *    검사할 대상이 사라졌다.
  * @param host "상위 팀 액션" 필수 여부는 회의를 여는 사람의 권한에 달렸다(`requiresParentTeamAction`,
  *   WORKFLOW.md §3-1) — Owner면 이 필드가 없어도 되고, Leader/Member면 반드시 있어야 한다.
- * @param room 이 예약이 실제로 겨냥한 회의실의 이용 가능 시간 — **회의실마다 다르다**(2026-08-14,
- *   BE 24시간 운영 협의). 예전엔 전역 09:00~18:00 상수 하나로 모든 회의실을 같이 막았는데,
- *   그러면 회의실별로 다르게 늘린 운영시간이 의미가 없어진다. `roomId`가 가리키는 회의실을
- *   못 찾았으면(폼 조작 등) `null`을 넘긴다 — 그때는 시간대 검사를 건너뛴다, 존재하지 않는
- *   `roomId` 자체는 `actions.ts`가 참조 무결성으로 따로 막는다(위 주석 참고).
  */
 export function validateRoomReservationDraft(
   draft: RoomReservationDraft,
   host: { role: Authority },
-  room: { openTime: string; closeTime: string } | null,
 ): RoomReservationFormErrors {
   const errors: RoomReservationFormErrors = {};
 
@@ -66,13 +51,6 @@ export function validateRoomReservationDraft(
     errors.startTime = "시작 시간을 선택해 주세요";
   } else if (!TIME_PATTERN.test(draft.startTime)) {
     errors.startTime = "예약은 30분 단위로만 가능합니다";
-  } else if (room) {
-    const startMinutes = toMinutes(draft.startTime);
-    const openMinutes = toMinutes(room.openTime);
-    const closeMinutes = toMinutes(room.closeTime);
-    if (startMinutes < openMinutes || startMinutes + RESERVATION_DURATION_MINUTES > closeMinutes) {
-      errors.startTime = `회의실 이용 시간(${room.openTime}~${room.closeTime}) 안에서 선택해 주세요`;
-    }
   }
 
   // ⚠️ 프로젝트는 이제 항상 필수다(WORKFLOW.md §3-1 확정) — 프로젝트에 안 묶인 예약은 없다.
@@ -105,34 +83,14 @@ export function validateRoomReservationDraft(
 
 /**
  * 회의실 추가·수정 폼 검증(`/manage/rooms`) — 화면과 서버(Server Action)가 이 함수 하나로 본다.
- * ⚠️ 이용 가능 시간도 **예약 슬롯과 같은 30분 단위**다(2026-08-13 정정 — 전에는 "제약이 없다"고
- *    적혀 있었으나 BE `@Pattern`이 30분 단위만 받는다). 검증 규칙은 BE와 한 벌이어야 한다.
+ * ⚠️ **이용 가능 시간 입력은 없다**(2026-08-15, BE PR #523 — 운영시간 개념 자체를 없앴다).
+ *    예전엔 여기서 `openTime`/`closeTime` 형식·순서를 봤는데, 그 필드 자체가 폼에서 빠졌다.
  */
 export function validateMeetingRoomDraft(draft: MeetingRoomDraft): MeetingRoomFormErrors {
   const errors: MeetingRoomFormErrors = {};
 
   if (!draft.name.trim()) errors.name = "회의실 이름을 입력해 주세요";
   if (!draft.location.trim()) errors.location = "위치를 입력해 주세요";
-
-  if (!draft.openTime.trim()) {
-    errors.openTime = "이용 시작 시간을 입력해 주세요";
-  } else if (!GENERAL_TIME_PATTERN.test(draft.openTime)) {
-    errors.openTime = "30분 단위로 입력해 주세요 (예: 09:00, 09:30)";
-  }
-
-  if (!draft.closeTime.trim()) {
-    errors.closeTime = "이용 종료 시간을 입력해 주세요";
-  } else if (!GENERAL_TIME_PATTERN.test(draft.closeTime)) {
-    errors.closeTime = "30분 단위로 입력해 주세요 (예: 18:00, 18:30)";
-  }
-
-  if (
-    !errors.openTime &&
-    !errors.closeTime &&
-    toMinutes(draft.openTime) >= toMinutes(draft.closeTime)
-  ) {
-    errors.closeTime = "종료 시간은 시작 시간보다 늦어야 합니다";
-  }
 
   return errors;
 }


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

- BE가 PR #523에서 회의실 `openTime`/`closeTime`(운영시간) 개념 자체를 DB 컬럼째 삭제했다 — 회의실은 이제 도메인상 항상 이용 가능하다.
- FE는 아직 그 필드를 받아 쓰고 있었다. `createRoomReservationAction`이 회의실 시간 검증에 쓰던 `toMinutes(room.openTime)`가 `undefined.split(":")`를 호출해 **동기 TypeError**를 던졌고, `/app/rooms` 예약 시도가 페이지 전체를 500으로 크래시시켰다.
- `types.ts`(UI계약) → `mapper/rooms.ts`·`mapper/availability.ts`(BE shape 흡수) → `mock/rooms.ts`·`server.ts`(목 데이터·슬롯 생성) → `validate.ts`·`actions.ts`(검증·Server Action) → `room-form.tsx`·`room-list-panel.tsx`·`rooms-manage-table.tsx`(UI) 순으로 운영시간 개념을 전부 걷어냈다.
- 목 슬롯 생성 범위는 회의실별 운영시간 대신 캘린더 그리드(`grid-slot.ts`)와 같은 00:00~24:00을 그대로 쓴다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수
- [x] `Closes #561` 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [x] 🔐 권한 2축 검사 — 이번 변경은 검증 로직 축소일 뿐 권한 판정 경로는 그대로다(`canManageRooms`/`getViewer` 미변경)
- [x] 🕵️ 정직성 — 제거 사유를 각 파일 주석에 남김(BE PR #523)
- [x] 🎨 디자인 토큰 — 표 컬럼 폭만 3열로 재분배, 새 하드코딩 없음

**품질**

- [x] ♻️ 재사용 확인 — 신규 컴포넌트 없음, 기존 컴포넌트 축소만
- [x] 🧪 `loading` / `error` / `empty` — 변경 없음(기존 3상태 유지)

---

## 🔗 연관 이슈

Closes #561

---

## 💬 리뷰 포인트

- `validate.ts`의 `validateRoomReservationDraft`가 `room` 파라미터 없이 2-인자로 바뀌었다 — 회의실 존재 여부는 여전히 `POST /api/meetings` 단계에서 BE가 최종 검사한다.
- `actions.ts`의 `createRoomReservationAction`에서 `getMeetingRooms()` 호출 자체를 제거했다(검증 대상이 사라져서) — 이전 PR #554의 try/catch 가드가 통째로 없어진 것처럼 보일 수 있는데, 그 호출이 더는 필요 없어 지운 것이다.
- 테스트 145개(rooms 피처) + 전체 스위트 1468개 통과, `tsc --noEmit`/`eslint` 클린.

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |


---

## 📝 추가 메모
