### PR TITLE
[FIX] 비대면 회의 상세 조회 시 meetingRoom·startAt null로 죽던 것을 고친다 #564

### DIFF
--- a/src/features/meeting/mapper.ts
+++ b/src/features/meeting/mapper.ts
@@ -404,9 +404,12 @@ export interface BeMeetingDetail {
    * ⚠️ 오프셋 없는 문자열은 JS가 **그 프로세스의 시간대**로 읽는다. 우리 서버는
    *    `next.config.ts`가 `TZ=Asia/Seoul`을 박아 두어 맞아떨어진다 — 배포에서 TZ를
    *    덮어쓰면 회의 시각이 통째로 밀린다(배포 전달사항).
+   * ⚠️ **비대면 회의는 `null`이다**(2026-08-15, MEET-18 — WORKFLOW.md §3-1-A. 이 필드는
+   *    DB에도 안 저장된다). `MeetingDetailResponse.formatDateTime`이 `null`을 그대로 통과시킨다
+   *    (BE 실코드 대조) — 여기서 문자열로만 받으면 비대면 회의 상세가 파싱 단계에서 죽는다.
    */
-  startAt: string;
-  endAt: string;
+  startAt: string | null;
+  endAt: string | null;
   /**
    * 확정 전 AI 액션 초안 건수 — 종료되지 않은 회의는 서버가 조회 없이 `0`으로 확정한다
    * (BE `MeetingDetailQueryService.resolvePendingActionCount`).
@@ -435,7 +438,15 @@ export interface BeMeetingDetail {
    */
   agenda?: { mainTopic: string | null; subTopics: string[] } | null;
   project: { projectId: number; tag: string };
-  meetingRoom: { meetingRoomId: number; name: string };
+  /**
+   * ⚠️ **비대면 회의는 `null`이다**(2026-08-15, MEET-18 — 회의실·시간대 예약 자체가 없는
+   *    회의라 회의실이 없다, WORKFLOW.md §3-1-A). `MeetingDetailResponse.from`이
+   *    `result.meetingRoom() == null ? null : ...`로 실제로 `null`을 보낸다(BE 실코드 대조,
+   *    `AnalysisController`가 아니라 `MeetingDetailResponse.java`) — **이 화면이 온라인
+   *    회의인지 판별하는 유일한 신호이기도 하다**(`toMeetingDetailView`의 `isOnline` 참고,
+   *    응답에 별도 `isOnline` 필드는 없다).
+   */
+  meetingRoom: { meetingRoomId: number; name: string } | null;
   host: { memberId: number; name: string };
   attendees: BeMeetingAttendee[];
 }
@@ -482,8 +493,9 @@ function isBeMeetingDetail(value: unknown): value is BeMeetingDetail {
     typeof detail.meetingId === "number" &&
     typeof detail.title === "string" &&
     typeof detail.status === "string" &&
-    typeof detail.startAt === "string" &&
-    typeof detail.endAt === "string" &&
+    /* ⚠️ 비대면 회의는 `null`이다(MEET-18, WORKFLOW.md §3-1-A) — `BeMeetingDetail.startAt` 주석 참고 */
+    isOptionalNullableString(detail.startAt) &&
+    isOptionalNullableString(detail.endAt) &&
     typeof detail.pendingActionCount === "number" &&
     (detail.summaryStatus === null || typeof detail.summaryStatus === "string") &&
     /* ⚠️ #461/#472 확장 필드 — 없어도 통과한다(배포 전 응답에는 이 필드들이 없다) */
@@ -491,7 +503,8 @@ function isBeMeetingDetail(value: unknown): value is BeMeetingDetail {
     isOptionalAgenda(detail.agenda) &&
     typeof detail.project?.projectId === "number" &&
     typeof detail.project?.tag === "string" &&
-    typeof detail.meetingRoom?.name === "string" &&
+    /* ⚠️ 비대면 회의는 `null`이다(MEET-18) — `BeMeetingDetail.meetingRoom` 주석 참고 */
+    (detail.meetingRoom === null || typeof detail.meetingRoom?.name === "string") &&
     typeof detail.host?.memberId === "number" &&
     Array.isArray(detail.attendees) &&
     detail.attendees.every(isBeMeetingAttendee)
@@ -572,14 +585,20 @@ export function hostIdOf(detail: Pick<BeMeetingDetail, "host">): number {
  *    직접 포맷하면 목·실서버가 서로 다른 문자열을 그린다.
  * ⚠️ 소속·직급은 가운뎃점으로 잇되 **빈 조각은 버린다** — 팀이 없는 대표에게 ` · 대표`처럼
  *    앞이 빈 줄이 남으면 명단이 어긋나 보인다(목 경로와 같은 규칙).
+ * ⚠️ **비대면 회의는 이 화면에 올 일이 없다**(WORKFLOW.md §3-1-A — 제출 즉시 `DONE`이라
+ *    `/capture`로 갈 이유가 없다). 그래도 `parseMeetingDetail`은 공용이라 `startAt`·`meetingRoom`이
+ *    `null`이어도 여기서 죽지 않게만 방어한다(빈 문자열, `BeMeetingDetail`과 같은 규칙).
  */
 export function toMeetingCaptureInfo(detail: BeMeetingDetail): MeetingCaptureInfo {
   return {
     id: String(detail.meetingId),
     title: detail.title,
     projectTag: detail.project.tag,
-    schedule: formatMeetingSchedule(new Date(detail.startAt), new Date(detail.endAt)),
-    roomName: detail.meetingRoom.name,
+    schedule:
+      detail.startAt && detail.endAt
+        ? formatMeetingSchedule(new Date(detail.startAt), new Date(detail.endAt))
+        : "",
+    roomName: detail.meetingRoom?.name ?? "",
     attendees: detail.attendees.map((attendee) =>
       toCaptureAttendee(attendee, detail.host.memberId),
     ),
@@ -662,8 +681,9 @@ export function toMeetingDetailView(
     originLabel: originLabelFromTeamId(be.teamId),
     parentTeamActionHref: null,
     agenda: toMeetingAgenda(be.agenda),
-    schedule: formatMeetingSchedule(new Date(be.startAt), new Date(be.endAt)),
-    roomName: be.meetingRoom.name,
+    schedule:
+      be.startAt && be.endAt ? formatMeetingSchedule(new Date(be.startAt), new Date(be.endAt)) : "",
+    roomName: be.meetingRoom?.name ?? "",
     attendees: be.attendees.map((attendee) => ({ id: attendee.memberId, name: attendee.name })),
     outputKindLabel: outputKindLabelOf(be.teamId),
     outputs: null,
@@ -672,8 +692,12 @@ export function toMeetingDetailView(
     pendingActionCount: be.pendingActionCount,
     isStalled: be.summaryStatus === BE_SUMMARY_STATUS.STALLED,
     isHost: options.isHost,
-    // 실서버는 아직 비대면 회의를 모른다 — BE가 필드를 주면 그때 매퍼가 읽는다(이슈 #473).
-    isOnline: false,
+    /*
+     * ⚠️ **`meetingRoom`이 이제 실제 신호다**(2026-08-15, MEET-18 배포 확인). 응답에 별도
+     *    `isOnline` 필드는 없다 — 회의실이 없다는 것 자체가 비대면 회의라는 뜻이라
+     *    (`BeMeetingDetail.meetingRoom` 주석) 이 값 하나로 가른다.
+     */
+    isOnline: be.meetingRoom === null,
   };
 }
 

--- a/src/features/meeting/review/mapper.ts
+++ b/src/features/meeting/review/mapper.ts
@@ -215,7 +215,16 @@ export function toMeetingReviewInfo(params: {
     meetingTitle: detail.title,
     hostId: hostIdOf(detail),
     projectTag: detail.project.tag,
-    scheduleLabel: formatMeetingSchedule(new Date(detail.startAt), new Date(detail.endAt)),
+    /*
+     * ⚠️ **비대면 회의는 `startAt`·`endAt`이 `null`이다**(MEET-18, WORKFLOW.md §3-1-A — 시간대
+     *    예약 자체가 없는 회의라 저장하지 않는다). `new Date(null)`은 "Invalid Date"가 되어
+     *    `formatMeetingSchedule`이 깨진 문자열을 돌려주므로, 그 경우 WORKFLOW가 정한 문구로
+     *    대신한다("온라인으로 진행된 회의입니다").
+     */
+    scheduleLabel:
+      detail.startAt && detail.endAt
+        ? formatMeetingSchedule(new Date(detail.startAt), new Date(detail.endAt))
+        : "온라인으로 진행된 회의입니다",
     assigneeOptions: toAssigneeOptions(detail),
     /* ⚠️ Owner 개설 회의만 teamId가 null이다(PR #461/#472 대조) — 이 하나로 화면 모드가 갈린다 */
     isOwnerMeeting: detail.teamId === null,

--- a/src/features/meeting/server.ts
+++ b/src/features/meeting/server.ts
@@ -423,8 +423,11 @@ async function getLiveMeetingDetail(id: string, viewer: Actor): Promise<MeetingD
     ⚠️ **`pendingReason`이 있으면 발화 기록을 안 물어본다.** 화면이 그 칸을 안 그리는데
        (`meeting-detail-view.tsx` — 안내 카드만 뜬다) 조회부터 하면 헛수고다. 회의가 아직
        안 끝났으면 발화 자체가 없을 수도 있다.
+    ⚠️ **비대면 회의도 안 물어본다**(WORKFLOW.md §3-1-A — 실시간 캡처가 아니라 화자 귀속 근거인
+       자막 청크 자체가 없다, "온라인으로 진행된 회의입니다" 문구로 그 자리를 대신한다).
+       `detail.startAt`도 `null`이라 `toScriptChunks`의 기준 시각을 만들 수 없다.
   */
-  if (view.pendingReason !== null) {
+  if (view.pendingReason !== null || detail.startAt === null) {
     return { kind: "ok", detail: view };
   }
 


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

- BE가 MEET-18(비대면 회의)을 배포하면서 `MeetingDetailResponse`가 `meetingRoom`·`startAt`·`endAt`을
  `null`로 보내기 시작했다(회의실·시간대 예약이 없는 회의라서, WORKFLOW.md §3-1-A) — BE 실코드
  (`MeetingDetailResponse.from`)로 직접 확인했다.
- FE `mapper.ts`의 `isBeMeetingDetail`(응답 모양 검사)은 이 셋을 전부 필수 문자열로 요구하고 있어서,
  비대면 회의 상세를 여는 순간 검사가 실패해 `parseMeetingDetail`이 던졌다. 회의 상세·캡처·검토
  화면이 전부 이 함수를 공유해서 세 화면이 같이 죽는 버그였다.
- `BeMeetingDetail.meetingRoom`/`startAt`/`endAt`을 null 허용으로 바꾸고 검사 함수를 맞췄다.
- `toMeetingCaptureInfo`·`toMeetingDetailView`·`review/mapper.ts`의 `toMeetingReviewInfo`가 null이면
  빈 문자열 또는 WORKFLOW가 정한 안내 문구("온라인으로 진행된 회의입니다")로 대체하도록 방어했다.
- `toMeetingDetailView`의 `isOnline`을 하드코딩값(`false`)에서 `meetingRoom === null` 기준으로
  바꿨다 — 응답에 별도 `isOnline` 필드가 없어 이게 유일한 신호다.
- `getLiveMeetingDetail`은 `startAt`이 `null`(비대면)이면 발화 기록 조회 자체를 건너뛰게 했다 —
  애초에 자막 청크가 없는 회의라 물어볼 이유가 없다(WORKFLOW.md §3-1-A).

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수
- [x] `Closes #564` 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [x] 🕵️ 정직성 — 비대면 회의의 빈 시간·회의실은 WORKFLOW.md §3-1-A가 정한 안내 문구로 대체, 지어낸 값 없음

**품질**

- [x] ♻️ 재사용 확인 — 신규 컴포넌트 없음, `view-types.ts`의 기존 `isOnline`/빈 문자열 계약을 그대로 채웠다(그 계약은 이슈 #473 때부터 이미 있었는데 매퍼가 못 따라갔었다)

---

## 🔗 연관 이슈

Closes #564

---

## 💬 리뷰 포인트

- 목록·대시보드(MEET-02·03·17)는 건드리지 않았다 — "BE가 비대면 회의를 걸러 준다"는 팀 합의(2026-08-14, `getMeetingDirectory` 주석)가 있어서다. 다만 BE `MeetingListResponse.toMeetingResponse`를 직접 봤을 때 `meeting.meetingRoom()`·`startAt()`을 null 검사 없이 그대로 쓰고 있어서, 그 필터가 실제로 항상 지켜지는지는 BE 쪽에서 한 번 확인해 주면 좋겠다(별도 이슈로 낼지는 리뷰어 판단에 맡긴다).
- 타입체크·`eslint`·`jest`(회의 피처 247개 + 전체 1480개) 전부 통과.

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |


---

## 📝 추가 메모
