### PR TITLE
[FIX] 회의실 캘린더 상세 모달에 회의 취소(삭제) 버튼을 연결한다 #569

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -141,15 +141,18 @@
   --card-foreground: #1c1917;
   --popover: #ffffff;
   --popover-foreground: #1c1917;
-  --primary: #3b82f6; /* 액센트 */
+  --primary: #3b82f6;
+  /* 액센트 */
   --primary-foreground: #ffffff;
-  --secondary: #fafaf9; /* 섹션 띠 */
+  --secondary: #fafaf9;
+  /* 섹션 띠 */
   --secondary-foreground: #1c1917;
   --muted: #fafaf9;
   --muted-foreground: #78716c;
   --accent: #fafaf9;
   --accent-foreground: #1c1917;
-  --destructive: #ef4444; /* 에러 */
+  --destructive: #ef4444;
+  /* 에러 */
   /*
     에러 면 **위에** 얹는 글자·아이콘. 두 모드 모두 흰색이다 — 뒤집지 않는다.
     ⚠️ 이 짝이 있어야 실패 토스트가 성립한다. 빨강을 글자에 쓰면 알약 배경이 모드마다
@@ -428,9 +431,11 @@
       transform: translate3d(-34px, 10px, 0) scale(0.94);
       filter: blur(10px);
     }
+
     55% {
       filter: blur(0);
     }
+
     100% {
       opacity: 1;
       transform: translate3d(0, 0, 0) scale(1);
@@ -444,9 +449,11 @@
       transform: translate3d(34px, 10px, 0) scale(0.94);
       filter: blur(10px);
     }
+
     55% {
       filter: blur(0);
     }
+
     100% {
       opacity: 1;
       transform: translate3d(0, 0, 0) scale(1);
@@ -463,6 +470,7 @@
       opacity: 0.4;
       transform: perspective(1200px) rotateX(6deg) translateY(10px);
     }
+
     100% {
       opacity: 1;
       transform: perspective(1200px) rotateX(0deg) translateY(0);
@@ -774,6 +782,7 @@
     100% {
       transform: translateY(0);
     }
+
     50% {
       transform: translateY(-6px);
     }
@@ -794,6 +803,7 @@
       transform: scale(1);
       opacity: 0.04;
     }
+
     50% {
       transform: scale(1.05);
       opacity: 0.07;
@@ -810,6 +820,7 @@
     100% {
       transform: translate(0, 0);
     }
+
     50% {
       transform: translate(24px, -20px);
     }
@@ -888,11 +899,13 @@
       opacity: 0;
       transform: translateY(5px);
     }
+
     8%,
     88% {
       opacity: 1;
       transform: none;
     }
+
     100% {
       opacity: 0;
       transform: translateY(-3px);
@@ -916,6 +929,7 @@
         transform: translateY(120px) scale(0.92);
         filter: blur(10px);
       }
+
       to {
         opacity: 1;
         transform: none;
@@ -954,6 +968,7 @@
         transform: translateX(-110px) scale(0.94);
         filter: blur(10px);
       }
+
       to {
         opacity: 1;
         transform: none;
@@ -967,6 +982,7 @@
         transform: translateX(110px) scale(0.94);
         filter: blur(10px);
       }
+
       to {
         opacity: 1;
         transform: none;
@@ -1009,6 +1025,7 @@
       from {
         transform: scaleX(0);
       }
+
       to {
         transform: scaleX(1);
       }
@@ -1196,21 +1213,26 @@
       transform: translateX(-140%) skewX(-20deg);
       opacity: 0;
     }
+
     47% {
       opacity: 1;
     }
+
     54% {
       transform: translateX(360%) skewX(-20deg);
       opacity: 0;
     }
+
     /* 두 번째 섬광 — 한 번보다 두 번이 "빠·라밤"으로 읽힌다 */
     58% {
       transform: translateX(-140%) skewX(-20deg);
       opacity: 0;
     }
+
     60% {
       opacity: 0.8;
     }
+
     68%,
     100% {
       transform: translateX(360%) skewX(-20deg);
@@ -1228,6 +1250,7 @@
     45% {
       box-shadow: 0 0 0 0 rgba(124, 58, 237, 0);
     }
+
     /* 첫 박 — 흰빛이 터진다 */
     50% {
       box-shadow:
@@ -1235,11 +1258,13 @@
         0 0 60px 16px rgba(255, 255, 255, 0.6),
         0 0 110px 34px rgba(124, 58, 237, 0.55);
     }
+
     56% {
       box-shadow:
         0 0 0 0 rgba(255, 255, 255, 0),
         0 0 30px 5px rgba(124, 58, 237, 0.35);
     }
+
     /* 둘째 박 — 조금 작게 한 번 더 */
     61% {
       box-shadow:
@@ -1247,6 +1272,7 @@
         0 0 44px 10px rgba(255, 255, 255, 0.35),
         0 0 80px 22px rgba(59, 130, 246, 0.4);
     }
+
     75%,
     100% {
       box-shadow: 0 0 22px 3px rgba(124, 58, 237, 0.2);
@@ -1289,11 +1315,13 @@
       opacity: 0;
       transform: translate(-30px, -24px) rotate(-9deg);
     }
+
     25%,
     82% {
       opacity: 1;
       transform: none;
     }
+
     94%,
     100% {
       opacity: 0;
@@ -1306,11 +1334,13 @@
       opacity: 0;
       transform: translate(26px, 28px) rotate(7deg);
     }
+
     25%,
     82% {
       opacity: 1;
       transform: none;
     }
+
     94%,
     100% {
       opacity: 0;
@@ -1323,11 +1353,13 @@
       opacity: 0;
       transform: translate(30px, -20px) rotate(9deg);
     }
+
     25%,
     82% {
       opacity: 1;
       transform: none;
     }
+
     94%,
     100% {
       opacity: 0;
@@ -1358,6 +1390,7 @@
       opacity: 0;
       transform: translate(-14px, -10px) rotate(-8deg);
     }
+
     to {
       opacity: 1;
       transform: none;
@@ -1369,6 +1402,7 @@
       opacity: 0;
       transform: translate(10px, 12px) rotate(6deg);
     }
+
     to {
       opacity: 1;
       transform: none;
@@ -1380,6 +1414,7 @@
       opacity: 0;
       transform: translate(12px, -8px) rotate(8deg);
     }
+
     to {
       opacity: 1;
       transform: none;
@@ -1410,6 +1445,7 @@
     100% {
       transform: scaleY(0.3);
     }
+
     50% {
       transform: scaleY(1);
     }
@@ -1436,10 +1472,12 @@
     0% {
       transform: scaleX(0);
     }
+
     45%,
     88% {
       transform: scaleX(1);
     }
+
     100% {
       transform: scaleX(0);
     }
@@ -1455,6 +1493,7 @@
     from {
       transform: scale(0);
     }
+
     to {
       transform: scale(1);
     }
@@ -1470,6 +1509,7 @@
       opacity: 0;
       transform: scale(0.4);
     }
+
     to {
       opacity: 1;
       transform: scale(1);
@@ -1486,6 +1526,7 @@
     49% {
       opacity: 1;
     }
+
     50%,
     100% {
       opacity: 0;
@@ -1512,29 +1553,35 @@
       left: 2%;
       transform: translateY(-50%) rotate(45deg);
     }
+
     8% {
       opacity: 1;
       transform: translateY(-70%) rotate(36deg);
     }
+
     35% {
       left: 32%;
       transform: translateY(-95%) rotate(40deg);
     }
+
     55% {
       left: 50%;
       transform: translateY(-72%) rotate(48deg);
     }
+
     /* 힘이 빠진다 — 기수가 꺾이고 고도를 잃는다 */
     75% {
       opacity: 1;
       left: 66%;
       transform: translateY(-46%) rotate(64deg);
     }
+
     88% {
       opacity: 0;
       left: 76%;
       transform: translateY(10%) rotate(96deg);
     }
+
     100% {
       opacity: 0;
       left: 76%;
@@ -1556,17 +1603,21 @@
       opacity: 0;
       transform: scale(1.8) translateY(-10px);
     }
+
     12% {
       opacity: 1;
       transform: scale(0.92) translateY(0);
     }
+
     18% {
       transform: scale(1.06);
     }
+
     24%,
     88% {
       transform: scale(1);
     }
+
     100% {
       opacity: 0;
       transform: scale(1);
@@ -1584,6 +1635,7 @@
       opacity: 0.5;
       transform: scale(0.6);
     }
+
     30%,
     100% {
       opacity: 0;
@@ -1608,11 +1660,13 @@
       opacity: 0;
       visibility: hidden;
     }
+
     45%,
     88% {
       opacity: 1;
       visibility: visible;
     }
+
     100% {
       opacity: 0;
       visibility: hidden;
@@ -1635,11 +1689,13 @@
       opacity: 0;
       transform: translate3d(-26px, -20px, 0) rotateY(-45deg) rotate(-14deg);
     }
+
     54%,
     92% {
       opacity: 1;
       transform: none;
     }
+
     100% {
       opacity: 0;
       transform: none;
@@ -1652,11 +1708,13 @@
       opacity: 0;
       transform: translate3d(22px, 26px, 0) rotateY(45deg) rotate(12deg);
     }
+
     60%,
     92% {
       opacity: 1;
       transform: none;
     }
+
     100% {
       opacity: 0;
       transform: none;
@@ -1669,11 +1727,13 @@
       opacity: 0;
       transform: translate3d(26px, -18px, 0) rotateY(-40deg) rotate(14deg);
     }
+
     64%,
     92% {
       opacity: 1;
       transform: none;
     }
+
     100% {
       opacity: 0;
       transform: none;
@@ -1728,9 +1788,11 @@
       transform: translate3d(0, 26px, 0) scale(0.94);
       filter: blur(10px);
     }
+
     55% {
       filter: blur(0);
     }
+
     100% {
       opacity: 1;
       transform: translate3d(0, 0, 0) scale(1);
@@ -1747,9 +1809,11 @@
       transform: translateX(-120%);
       opacity: 0;
     }
+
     35% {
       opacity: 0.9;
     }
+
     100% {
       transform: translateX(220%);
       opacity: 0;
@@ -1809,6 +1873,7 @@
     animation-name: assemble-in-left;
     animation-delay: 0.22s;
   }
+
   .assemble > * > *:nth-child(2) {
     animation-name: assemble-in-right;
     animation-delay: 0.38s;
@@ -1818,21 +1883,27 @@
   .assemble > * > * > * {
     animation: assemble-in 0.55s cubic-bezier(0.16, 1.1, 0.3, 1) both;
   }
+
   .assemble > * > * > *:nth-child(1) {
     animation-delay: 0.3s;
   }
+
   .assemble > * > * > *:nth-child(2) {
     animation-delay: 0.42s;
   }
+
   .assemble > * > * > *:nth-child(3) {
     animation-delay: 0.54s;
   }
+
   .assemble > * > * > *:nth-child(4) {
     animation-delay: 0.66s;
   }
+
   .assemble > * > * > *:nth-child(5) {
     animation-delay: 0.78s;
   }
+
   .assemble > * > * > *:nth-child(6) {
     animation-delay: 0.9s;
   }
@@ -1982,6 +2053,7 @@
   * {
     @apply border-border outline-ring/50;
   }
+
   /*
    * 화면 배율 — **`body`를 키워 놓고 `transform`으로 줄인다.**
    *
@@ -2008,6 +2080,7 @@
     height: 100%;
     overflow: hidden;
   }
+
   body {
     @apply bg-background text-foreground;
 
@@ -2047,9 +2120,11 @@
       0 1px 2px color-mix(in oklch, var(--foreground) 4%, transparent),
       0 1px 3px color-mix(in oklch, var(--foreground) 3%, transparent);
   }
+
   .dark .app-shell .bg-card {
     box-shadow: none;
   }
+
   html {
     @apply font-sans;
   }
@@ -2090,6 +2165,7 @@
   .recharts-surface:focus {
     outline: none;
   }
+
   .recharts-surface:focus-visible {
     outline: 2px solid var(--ring);
     outline-offset: 2px;

--- a/src/features/meeting/components/meeting-cancel-dialog.tsx
+++ b/src/features/meeting/components/meeting-cancel-dialog.tsx
@@ -11,17 +11,23 @@ import { cancelMeetingAction } from "../actions";
 
 interface MeetingCancelDialogProps {
   meetingId: string;
+  /**
+   * 취소 성공 뒤 처리를 호출자가 대신하고 싶을 때 쓴다(예: 회의실 캘린더 모달 — 지금 보이는
+   * 막대를 로컬 state에서 바로 지운다, §최적화: action 리턴값으로 화면 반영). 안 주면 기존
+   * 그대로 `router.refresh()`로 상세 페이지를 다시 그린다.
+   */
+  onCancelled?: () => void;
 }
 
 /**
  * 회의 취소(MEET-06) — 상세 머리글의 [회의 취소] 버튼이 연다.
- * ⚠️ 트리거·노출 조건(host·SCHEDULED만)은 `MeetingDetailView`가 정한다 — 여기는 확인 흐름만.
+ * ⚠️ 트리거·노출 조건(host·SCHEDULED만)은 호출자가 `canCancelMeeting`으로 정한다 — 여기는 확인 흐름만.
  * ⚠️ **소프트 취소다** — 회의 자체는 삭제되지 않는다(BE `V3.3.3`처럼 `status`+`canceled_at`으로
  *    남는다). `RoomDeleteDialog`와 같은 골격(`useTransition` + 서버 액션 직접 호출)이되,
  *    실패(이미 시작된 회의 등)는 창을 닫지 않고 `ConfirmDialog`의 `error` 자리에 띄운다 —
  *    되돌릴 수 없는 일이 막혔을 때 토스트만 쓰면 몇 초 뒤엔 아무 일도 없던 것처럼 보인다.
  */
-export function MeetingCancelDialog({ meetingId }: MeetingCancelDialogProps) {
+export function MeetingCancelDialog({ meetingId, onCancelled }: MeetingCancelDialogProps) {
   const [open, setOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
@@ -35,7 +41,8 @@ export function MeetingCancelDialog({ meetingId }: MeetingCancelDialogProps) {
         return;
       }
       setOpen(false);
-      router.refresh();
+      if (onCancelled) onCancelled();
+      else router.refresh();
       toast.success("회의를 취소했습니다");
     });
   }

--- a/src/features/rooms/components/room-meeting-detail-dialog.test.tsx
+++ b/src/features/rooms/components/room-meeting-detail-dialog.test.tsx
@@ -1,0 +1,80 @@
+jest.mock("@/features/meeting/actions", () => ({
+  getMeetingSummaryAction: jest.fn(),
+  updateMeetingAction: jest.fn(),
+  cancelMeetingAction: jest.fn(),
+}));
+jest.mock("next/navigation", () => ({ useRouter: () => ({ refresh: jest.fn() }) }));
+
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import {
+  cancelMeetingAction,
+  getMeetingSummaryAction,
+  type MeetingSummary,
+} from "@/features/meeting/actions";
+
+import { RoomMeetingDetailDialog } from "./room-meeting-detail-dialog";
+
+const SUMMARY: MeetingSummary = {
+  id: "meeting-1",
+  title: "주간 스크럼",
+  schedule: "8월 15일(토) 10:00~10:30",
+  roomName: "대회의실",
+  attendees: [{ id: 1, name: "김서준" }],
+  agenda: null,
+  isHost: true,
+  pendingReason: "SCHEDULED",
+};
+
+describe("RoomMeetingDetailDialog", () => {
+  beforeEach(() => {
+    jest.mocked(getMeetingSummaryAction).mockResolvedValue({ kind: "ok", summary: SUMMARY });
+  });
+
+  // ⚠️ 개설자(host)가 시작 전(SCHEDULED) 회의를 열면 [수정]뿐 아니라 [회의 취소]도 나와야 한다
+  //    (회의실 개설 모달과 같은 수정/삭제 흐름, 2026-08-15).
+  it("개설자가 열면 [회의 취소]를 눌러 회의를 취소할 수 있고, 성공하면 onCancelled가 불린다", async () => {
+    jest.mocked(cancelMeetingAction).mockResolvedValue({ error: null });
+    const onCancelled = jest.fn();
+    const onOpenChange = jest.fn();
+    const user = userEvent.setup();
+
+    render(
+      <RoomMeetingDetailDialog
+        meetingId="meeting-1"
+        onOpenChange={onOpenChange}
+        onTitleUpdated={jest.fn()}
+        onCancelled={onCancelled}
+      />,
+    );
+
+    const cancelButton = await screen.findByRole("button", { name: "회의 취소" });
+    await user.click(cancelButton);
+
+    const confirmDialog = await screen.findByRole("dialog", { name: "이 회의를 취소할까요?" });
+    await user.click(within(confirmDialog).getByRole("button", { name: "회의 취소" }));
+
+    await waitFor(() => expect(onCancelled).toHaveBeenCalledWith("meeting-1"));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("개설자가 아니면 [회의 취소] 버튼이 없다", async () => {
+    jest.mocked(getMeetingSummaryAction).mockResolvedValue({
+      kind: "ok",
+      summary: { ...SUMMARY, isHost: false },
+    });
+
+    render(
+      <RoomMeetingDetailDialog
+        meetingId="meeting-1"
+        onOpenChange={jest.fn()}
+        onTitleUpdated={jest.fn()}
+        onCancelled={jest.fn()}
+      />,
+    );
+
+    await screen.findByText(SUMMARY.title);
+    expect(screen.queryByRole("button", { name: "회의 취소" })).not.toBeInTheDocument();
+  });
+});

--- a/src/features/rooms/components/room-meeting-detail-dialog.tsx
+++ b/src/features/rooms/components/room-meeting-detail-dialog.tsx
@@ -14,8 +14,9 @@ import {
   updateMeetingAction,
   type UpdateMeetingState,
 } from "@/features/meeting/actions";
+import { MeetingCancelDialog } from "@/features/meeting/components/meeting-cancel-dialog";
 import { MEETING_TITLE_MAX_LENGTH } from "@/features/meeting/lib";
-import { canEditMeeting } from "@/features/meeting/status";
+import { canCancelMeeting, canEditMeeting } from "@/features/meeting/status";
 
 const INITIAL_STATE: UpdateMeetingState = { error: null, saved: null };
 
@@ -32,6 +33,8 @@ interface RoomMeetingDetailDialogProps {
   onOpenChange: (open: boolean) => void;
   /** 제목 수정이 저장되면 캘린더 막대도 같이 바꾸라고 올려보낸다(재조회 없이 비관적 갱신). */
   onTitleUpdated: (meetingId: string, title: string) => void;
+  /** 회의 취소가 성공하면 캘린더 막대를 지우라고 올려보낸다(§최적화: action 리턴값으로 화면 반영). */
+  onCancelled: (meetingId: string) => void;
 }
 
 /**
@@ -53,6 +56,7 @@ export function RoomMeetingDetailDialog({
   meetingId,
   onOpenChange,
   onTitleUpdated,
+  onCancelled,
 }: RoomMeetingDetailDialogProps) {
   return (
     <Dialog open={meetingId !== null} onOpenChange={(next) => !next && onOpenChange(false)}>
@@ -67,6 +71,7 @@ export function RoomMeetingDetailDialog({
             meetingId={meetingId}
             onClose={() => onOpenChange(false)}
             onTitleUpdated={onTitleUpdated}
+            onCancelled={onCancelled}
           />
         )}
       </DialogContent>
@@ -78,9 +83,15 @@ interface MeetingSummaryPanelProps {
   meetingId: string;
   onClose: () => void;
   onTitleUpdated: (meetingId: string, title: string) => void;
+  onCancelled: (meetingId: string) => void;
 }
 
-function MeetingSummaryPanel({ meetingId, onClose, onTitleUpdated }: MeetingSummaryPanelProps) {
+function MeetingSummaryPanel({
+  meetingId,
+  onClose,
+  onTitleUpdated,
+  onCancelled,
+}: MeetingSummaryPanelProps) {
   const [load, setLoad] = useState<LoadState>({ status: "loading" });
   const [editing, setEditing] = useState(false);
   const [state, formAction, isPending] = useActionState(updateMeetingAction, INITIAL_STATE);
@@ -230,6 +241,18 @@ function MeetingSummaryPanel({ meetingId, onClose, onTitleUpdated }: MeetingSumm
       </div>
 
       <div className="border-border flex items-center justify-end gap-2 border-t px-6 py-4">
+        {canCancelMeeting({
+          isHost: load.summary.isHost,
+          pendingReason: load.summary.pendingReason,
+        }) && (
+          <MeetingCancelDialog
+            meetingId={meetingId}
+            onCancelled={() => {
+              onCancelled(meetingId);
+              onClose();
+            }}
+          />
+        )}
         {canEditMeeting({
           isHost: load.summary.isHost,
           pendingReason: load.summary.pendingReason,

--- a/src/features/rooms/components/rooms-board.tsx
+++ b/src/features/rooms/components/rooms-board.tsx
@@ -112,6 +112,9 @@ export function RoomsBoard({
             prev.map((event) => (event.meetingId === meetingId ? { ...event, title } : event)),
           );
         }}
+        onCancelled={(meetingId) => {
+          setEvents((prev) => prev.filter((event) => event.meetingId !== meetingId));
+        }}
       />
     </div>
   );


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정
- [ ] feature — 새로운 기능 추가
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

- 회의실 캘린더 상세 모달(`RoomMeetingDetailDialog`)에 개설자용 [회의 취소] 버튼을 연결한다 — 기존엔 [수정]만 있었다
- 기존 `MeetingCancelDialog`(회의 상세 페이지가 쓰던 확인 모달)를 그대로 재사용해 디자인을 새로 만들지 않았다
- 취소 성공 시 캘린더에서 그 예약 막대를 재조회 없이 바로 지운다(`rooms-board.tsx`)

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`fix/rooms-meeting-cancel-dialog#{이슈번호}`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [ ] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — `canCancelMeeting`(개설자·SCHEDULED만), 실제 취소는 기존 서버 액션 `cancelMeetingAction`이 재검사
- [x] 🧬 **zod** — 기존 `cancelMeetingAction`/`MeetingSummary` 타입을 그대로 쓴다(신규 스키마 없음)
- [x] 🕵️ **정직성** — 목 아님, 실 서버 액션 연결
- [x] 🎨 디자인 토큰 사용 — 신규 스타일 없음(`ConfirmDialog`·`Button` 재사용)

**품질**

- [ ] ⚡ 최적화 — 해당 없음(신규 번들·이미지 없음)
- [x] ♿ a11y — 버튼·다이얼로그는 기존 `MeetingCancelDialog`/`ConfirmDialog` 그대로
- [x] ♻️ 재사용 확인 — `MeetingCancelDialog`를 새로 안 만들고 재사용(옵션 콜백만 추가)
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 취소 실패 시 확인 모달 안에 에러 표시(기존 패턴)
- [ ] 브라우저 전용 API — 해당 없음

---

## 🔗 연관 이슈

Closes #569

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- `MeetingCancelDialog`의 `onCancelled` 콜백 방식이 회의 상세 페이지(기존 `router.refresh()` 경로)와
  회의실 캘린더(신규 로컬 state 경로) 양쪽에서 문제없이 동작하는지
- `canCancelMeeting` 조건(host·SCHEDULED)이 회의실 캘린더 문맥에서도 맞는지(회의 상세 페이지와 동일 조건 재사용)

---

## 📝 추가 메모

새 테스트 `room-meeting-detail-dialog.test.tsx` 추가(개설자 취소 성공 플로우, 비개설자는 버튼 없음).
`rooms`/`meeting` 스위트 394건 + `tsc` 통과.