### PR TITLE
[FIX] 회의실 캘린더 빈 칸 호버가 예약 컨테이너에 막혀 발화하지 않는다 #571

### DIFF
--- a/src/features/rooms/components/weekly-room-calendar.css
+++ b/src/features/rooms/components/weekly-room-calendar.css
@@ -252,6 +252,19 @@
   right: 0;
   margin-right: 0;
   z-index: 20;
+  /*
+    ⚠️ **컨테이너 자체는 클릭을 안 받는다**(2026-08-15 추가 수정). 이 컨테이너는 그 날 칸
+       전체 높이를 차지하는 하나짜리 `div`다(예약이 몇 개든, 심지어 0개여도) — 위에서
+       z-index만 올렸더니 예약이 없는 빈 시간대까지 이 컨테이너가 뒤덮어서, 빈 칸의
+       `.rbc-time-slot:hover`가 아예 발화하지 않았다(마우스 아래 최상단 요소가 항상 이
+       빈 컨테이너였다 — #571). 컨테이너는 통과시키고, 실제 예약 막대(`.rbc-event`)만
+       도로 받게 한다.
+  */
+  pointer-events: none;
+}
+
+.rbc-day-slot .rbc-events-container .rbc-event {
+  pointer-events: auto;
 }
 
 .rbc-event.rbc-selected {


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정
- [ ] feature — 새로운 기능 추가
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

- `.rbc-day-slot .rbc-events-container`(날짜 칸 전체 높이를 차지하는 예약 래퍼)에
  `pointer-events: none`을 줘서 예약이 없는 빈 시간대까지 이 컨테이너가 마우스를
  가로채던 문제를 고친다
- 실제 예약 막대(`.rbc-event`)에는 `pointer-events: auto`를 다시 줘서 클릭·상세조회
  모달(#550)은 그대로 동작한다
- 결과: 빈 칸 hover(cursor pointer + 배경색, #258)가 정상 발화한다

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`fix/rooms-calendar-hover-pointer-events#{이슈번호}`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [ ] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 해당 없음(순수 스타일 수정, 서버 재검사 대상 아님)
- [x] 🧬 **zod** — 해당 없음
- [x] 🕵️ **정직성** — 해당 없음(목·미구현 아님)
- [x] 🎨 디자인 토큰 사용 — 신규 색상 없음(레이아웃 속성만 추가)

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [x] ♿ a11y — 클릭 가능 영역이 실제 예약 막대로 좁아져 스크린리더·키보드 포커스 대상과 시각적 클릭 영역이 일치함
- [x] ♻️ 재사용 확인 — 기존 CSS 파일 안에서만 수정
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 해당 없음(순수 CSS)
- [ ] 브라우저 전용 API — 해당 없음

---

## 🔗 연관 이슈

Closes #571

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
| 빈 칸 hover 안 뜸 (`.rbc-events-container`가 가로챔) | 빈 칸 hover 정상(cursor pointer + 배경색), 예약 클릭도 그대로 동작 |

---

## 💬 리뷰 포인트

- `pointer-events: none`을 컨테이너에, `auto`를 `.rbc-event`에만 다시 주는 방식이
  다른 화면(개인 캘린더 등)엔 영향 없는지 — 이 파일(`weekly-room-calendar.css`)에만
  스코프돼 있어 영향 범위는 회의실 캘린더 하나뿐임
- 실제 예약 막대 클릭 시 상세조회 모달이 여전히 정상 동작하는지(#550 회귀 여부)

---

## 📝 추가 메모

`rooms` 테스트 스위트 147건 통과(RBC 자체는 mock이라 이 회귀를 직접 못 잡는다 — 이번 버그는
실브라우저 devtools 검사로 잡은 것). CSS만 수정이라 별도 유닛 테스트는 추가하지 않았다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 주간 룸 캘린더의 빈 시간대에서 슬롯 hover 및 클릭이 정상적으로 작동합니다.
  * 기존 예약 이벤트는 계속 클릭할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->