### PR TITLE
[FIX] SSE 알림·자막 스트림 토큰 재발급 누락 수정 #587

### DIFF
--- a/src/app/api/meetings/[meetingId]/captions/stream/route.ts
+++ b/src/app/api/meetings/[meetingId]/captions/stream/route.ts
@@ -1,6 +1,6 @@
 import type { NextRequest } from "next/server";
 
-import { getAccessToken } from "@/features/auth/session";
+import { ensureAccessToken } from "@/features/auth/session";
 import { ep } from "@/lib/endpoints";
 
 /**
@@ -27,7 +27,12 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ meetingId: string }> },
 ) {
-  const accessToken = await getAccessToken();
+  /*
+    ⚠️ **`getAccessToken()`이 아니라 `ensureAccessToken()`이다.** 이 경로는 `proxy.ts`
+       매처에서 제외돼 있어 미들웨어의 자동 재발급을 못 받는다 — 회의가 30분 넘게 길어지면
+       재연결마다 401을 맞는다(알림 스트림과 같은 원인, `session.ts` 주석 참고).
+  */
+  const accessToken = await ensureAccessToken();
   if (!accessToken) {
     return new Response("인증이 필요합니다.", { status: 401 });
   }

--- a/src/app/api/notifications/stream/route.ts
+++ b/src/app/api/notifications/stream/route.ts
@@ -1,6 +1,6 @@
 import type { NextRequest } from "next/server";
 
-import { getAccessToken } from "@/features/auth/session";
+import { ensureAccessToken } from "@/features/auth/session";
 import { ep } from "@/lib/endpoints";
 
 /**
@@ -29,7 +29,13 @@ export const dynamic = "force-dynamic";
 const BASE_URL = process.env.BACKEND_API_URL ?? "http://localhost:8080";
 
 export async function GET(request: NextRequest) {
-  const accessToken = await getAccessToken();
+  /*
+    ⚠️ **`getAccessToken()`이 아니라 `ensureAccessToken()`이다.** 이 경로는 `proxy.ts`
+       매처에서 제외돼 있어(§matcher) 미들웨어의 자동 재발급을 못 받는다 — SSE는 페이지
+       이동 없이 30분 넘게 열려 있을 수 있어, 그냥 읽기만 하면 액세스 토큰 만료 후
+       재연결마다 401을 맞는다(2026-08-16 실제 장애).
+  */
+  const accessToken = await ensureAccessToken();
   if (!accessToken) {
     /*
       ⚠️ **401을 그대로 돌려준다.** 응답이 온 실패라 `EventSource`가 연결을 닫고, 훅은 그

--- a/src/features/auth/session.ts
+++ b/src/features/auth/session.ts
@@ -2,6 +2,8 @@ import "server-only";
 
 import { cookies, headers } from "next/headers";
 
+import { ep } from "@/lib/endpoints";
+
 import {
   ACCESS_TOKEN_COOKIE,
   ACCESS_TOKEN_MAX_AGE,
@@ -11,6 +13,8 @@ import {
   REFRESH_TOKEN_MAX_AGE,
   tokenCookieOptions,
 } from "./cookie";
+
+const BASE_URL = process.env.BACKEND_API_URL ?? "http://localhost:8080";
 
 /**
  * 세션 — **httpOnly 쿠키 한 곳**(CLAUDE.md §렌더링·데이터: `localStorage` 토큰 금지).
@@ -84,4 +88,65 @@ export async function requireAccessToken(): Promise<string> {
   const token = await getAccessToken();
   if (!token) throw new Error("로그인이 필요합니다.");
   return token;
+}
+
+/**
+ * 갱신표로 새 토큰 한 벌 — `proxy.ts`의 `reissue()`와 같은 호출이다.
+ *
+ * ⚠️ **`proxy.ts`와 코드를 공유하지 않는다.** `proxy.ts`는 Edge 미들웨어라 `server-only`인
+ *    이 파일을 import할 수 없다(파일 위 주석 참고) — 그래서 같은 호출을 각자 갖고 있다.
+ * ⚠️ 갱신표도 함께 교체된다(로테이션). 실패는 조용히 `null`이다.
+ */
+async function reissueTokens(
+  refreshToken: string,
+  keepSignedIn: boolean,
+): Promise<SessionTokens | null> {
+  try {
+    const response = await fetch(`${BASE_URL}${ep.refresh()}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refreshToken, keepSignedIn }),
+      cache: "no-store",
+    });
+    if (!response.ok) return null;
+
+    const envelope: unknown = await response.json();
+    const data = (envelope as { data?: { accessToken?: unknown; refreshToken?: unknown } })?.data;
+    if (typeof data?.accessToken !== "string" || typeof data?.refreshToken !== "string")
+      return null;
+
+    return { accessToken: data.accessToken, refreshToken: data.refreshToken };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 액세스 토큰을 꺼내되, 없으면 **여기서 한 번 재발급을 시도한다**.
+ *
+ * ⚠️ **Route Handler 전용이다.** `proxy.ts`(미들웨어)를 안 거치는 경로 — SSE 중계
+ *    (`/api/notifications/stream`·`/api/meetings/[id]/captions/stream`)가 이걸 써야 한다.
+ *    미들웨어 매처가 `/api/*`를 제외하고 있어(`proxy.ts` §matcher), 이 경로들은 액세스
+ *    쿠키가 30분 만에 사라져도 미들웨어의 자동 재발급을 못 받는다 — 페이지 이동 없이
+ *    오래 열려 있는 SSE 연결이 30분을 넘기면 재연결마다 401을 맞던 원인이 이것이다.
+ * ⚠️ 서버 컴포넌트에서는 쓰지 않는다 — `cookies().set()`은 Server Action·Route Handler·
+ *    미들웨어에서만 허용된다(Next 제약, 위 파일 주석 참고).
+ */
+export async function ensureAccessToken(): Promise<string | null> {
+  const existing = await getAccessToken();
+  if (existing) return existing;
+
+  const jar = await cookies();
+  const refreshToken = jar.get(REFRESH_TOKEN_COOKIE)?.value;
+  if (!refreshToken) return null;
+
+  const keepSignedIn = jar.get(KEEP_SIGNED_IN_COOKIE)?.value === "1";
+  const reissued = await reissueTokens(refreshToken, keepSignedIn);
+  if (!reissued) {
+    await clearSession();
+    return null;
+  }
+
+  await setSession(reissued, keepSignedIn);
+  return reissued.accessToken;
 }


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

- `session.ts`에 `ensureAccessToken()` 신규 — 액세스 토큰이 없으면 리프레시 토큰으로
  재발급을 한 번 시도(성공 시 새 쿠키를 굽고 반환, 실패 시 세션 정리 후 `null`)
- `/api/notifications/stream`, `/api/meetings/[meetingId]/captions/stream` 두 Route
  Handler를 `getAccessToken()`(단순 읽기) → `ensureAccessToken()`(재발급 포함)으로 교체
- 원인: `proxy.ts`(미들웨어)의 `config.matcher`가 `/api/*`를 전부 제외하고 있어, 두 SSE
  중계 경로는 미들웨어의 자동 토큰 재발급을 못 받았음. 페이지 이동 없이 30분 넘게 열려
  있는 SSE 연결에서만 재연결 시 401이 재현되던 이유

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`fix/sse-token-refresh#587`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 권한 2축 검사 — 해당 없음(인증 인프라 수정, 권한 로직 변경 없음)
- [ ] 🧬 zod — 해당 없음(BE 응답 shape 변경 없음)
- [x] 🕵️ 정직성 — 해당 없음(목/미구현 아님)
- [ ] 🎨 디자인 토큰 — 해당 없음(UI 변경 없음)

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [ ] ♿ a11y — 해당 없음
- [x] ♻️ 재사용 확인 — `proxy.ts`의 재발급 로직과 같은 동작이나, Edge/Node 런타임 제약으로
  코드 공유 대신 같은 패턴을 `session.ts`에 별도 구현(파일 내 주석에 이유 명시)
- [ ] 🧪 loading/error/empty 3상태 — 해당 없음(API 라우트)
- [ ] 브라우저 전용 API 안내 — 해당 없음

---

## 🔗 연관 이슈

Closes #587

---

## 💬 리뷰 포인트

- `ensureAccessToken()`을 Route Handler 전용으로 제한한 이유(서버 컴포넌트에서 쓰면 안 되는
  이유)가 주석으로 충분히 설명됐는지
- 캡션 스트림 라우트도 같은 버그·같은 수정이 맞는지

## 📝 추가 메모

타입체크 0에러, 전체 테스트 140 suites / 1470개 통과 확인.

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |
