### PR TITLE
[FIX] 비대면 회의 목록 계약과 녹음 파일명을 BE 실코드에 맞춘다 #592

### DIFF
--- a/src/features/meeting/actions.ts
+++ b/src/features/meeting/actions.ts
@@ -535,6 +535,13 @@ export type RecordingUploadUrlResult =
   | {
       ok: true;
       s3Key: string;
+      /**
+       * BE가 정제한 저장용 파일명 — MEET-18 `recording.fileName`에 **이 값을 그대로** 싣는다.
+       * ⚠️ 화면에 보여줄 이름이 아니다. 표시는 사용자가 고른 원본(`File.name`)을 쓴다.
+       * ⚠️ `s3Key`가 이 이름으로 끝나고 확정 단계가 `s3Key.endsWith("/" + fileName)`을 검사한다 —
+       *    원본 이름을 보내면 한글·공백 파일명이 전부 400 CAP-015로 튕긴다.
+       */
+      storageFileName: string;
       /** `null`이면 목 모드다 — 실제 S3가 없어 클라이언트가 PUT 단계를 건너뛴다. */
       presignedUrl: string | null;
       contentType: string;
@@ -567,6 +574,7 @@ export async function getOnlineMeetingRecordingUploadUrlAction(input: {
       return {
         ok: true,
         s3Key: response.s3Key,
+        storageFileName: response.fileName,
         presignedUrl: response.presignedUrl,
         contentType: input.contentType,
       };
@@ -578,10 +586,16 @@ export async function getOnlineMeetingRecordingUploadUrlAction(input: {
   /*
     ⚠️ 목은 실제 S3가 없다 — `presignedUrl: null`로 돌려 클라이언트가 2단계(S3 PUT)를 건너뛰게
        한다(§정직한 목업, `project`의 `AttachmentUploadTicket.uploadUrl: string | null`과 같은 규칙).
+    ⚠️ **파일명은 실서버와 같은 규칙**(BE `RecordingFilePolicy.sanitizeForStorageName` —
+       영숫자·`.`·`-`·`_` 외 전부 `_`)으로 정제해 s3Key에 박고, 같은 값을 `storageFileName`으로
+       돌려준다. 규칙을 두 벌로 두는 게 아니라 **목 스텁**이다(실서버 경로는 응답의 `fileName`을
+       그대로 쓴다). 이 정제가 없으면 목이 실서버보다 관대해져 한글 파일명 버그가 목에서 안 잡힌다.
   */
+  const storageFileName = input.fileName.replace(/[^A-Za-z0-9.\-_]/g, "_");
   return {
     ok: true,
-    s3Key: `recordings/mock/online-pending/${input.fileName}`,
+    s3Key: `recordings/mock/online-pending/${storageFileName}`,
+    storageFileName,
     presignedUrl: null,
     contentType: input.contentType,
   };

--- a/src/features/meeting/components/meeting-card.test.tsx
+++ b/src/features/meeting/components/meeting-card.test.tsx
@@ -121,15 +121,23 @@ describe("MeetingCard — 둘째 줄", () => {
      상세 화면(`meeting-detail-view.tsx`)과 같은 아이콘·같은 문구다.
 */
 describe("비대면 회의 카드", () => {
-  it("일시·회의실 대신 「온라인으로 진행된 회의입니다」 한 줄이 뜬다", () => {
+  /*
+    ⚠️ **`schedule`/`roomName`이 비어 있지 않아도** 온라인 안내로 대체돼야 한다(2026-08-16
+       CodeRabbit 회귀 방어). 예전 회귀 테스트가 두 값을 빈 문자열로 넘겨서, `isOnline`이 켜져도
+       실수로 대면 메타를 함께 렌더링하는 회귀가 통과할 수 있었다. 매퍼에서 mixed 조합을 거절
+       하도록 만들었지만 화면 계약도 여기서 못박아 둔다.
+  */
+  it("일시·회의실 값이 있어도 「온라인으로 진행된 회의입니다」로 대체되고 원값은 안 뜬다", () => {
     renderCard({
       status: MEETING_STATUS.DONE,
       isOnline: true,
-      schedule: "",
-      roomName: "",
+      schedule: "8월 14일(금) 10:00 – 10:30",
+      roomName: "대회의실",
     });
 
     expect(screen.getByText("온라인으로 진행된 회의입니다")).toBeInTheDocument();
+    expect(screen.queryByText("8월 14일(금) 10:00 – 10:30")).not.toBeInTheDocument();
+    expect(screen.queryByText("대회의실")).not.toBeInTheDocument();
   });
 
   it("비대면이라도 참석자 수는 계속 그린다", () => {

--- a/src/features/meeting/components/meeting-card.test.tsx
+++ b/src/features/meeting/components/meeting-card.test.tsx
@@ -17,6 +17,8 @@ const BASE: MeetingListItem = {
   attendeeCount: 4,
   isHost: true,
   aiSummaryStatus: null,
+  /* ⚠️ 기본값은 대면 회의(2026-08-16 신규 필수 필드). 온라인 케이스는 각 테스트에서 override 한다. */
+  isOnline: false,
 };
 
 function renderCard(patch: Partial<MeetingListItem> = {}) {
@@ -111,5 +113,34 @@ describe("MeetingCard — 둘째 줄", () => {
     );
 
     expect(container.querySelector("p.text-muted-foreground")).toBeNull();
+  });
+});
+
+/*
+  ⚠️ **비대면 회의(2026-08-16 확정, B안)** — 일시·회의실 자리에 안내 한 줄이 대신 뜬다.
+     상세 화면(`meeting-detail-view.tsx`)과 같은 아이콘·같은 문구다.
+*/
+describe("비대면 회의 카드", () => {
+  it("일시·회의실 대신 「온라인으로 진행된 회의입니다」 한 줄이 뜬다", () => {
+    renderCard({
+      status: MEETING_STATUS.DONE,
+      isOnline: true,
+      schedule: "",
+      roomName: "",
+    });
+
+    expect(screen.getByText("온라인으로 진행된 회의입니다")).toBeInTheDocument();
+  });
+
+  it("비대면이라도 참석자 수는 계속 그린다", () => {
+    renderCard({
+      status: MEETING_STATUS.DONE,
+      isOnline: true,
+      schedule: "",
+      roomName: "",
+      attendeeCount: 7,
+    });
+
+    expect(screen.getByText("7명")).toBeInTheDocument();
   });
 });

--- a/src/features/meeting/components/meeting-card.tsx
+++ b/src/features/meeting/components/meeting-card.tsx
@@ -1,4 +1,4 @@
-import { CalendarClock, ChevronRight, MapPin, Mic, Sparkles, Users } from "lucide-react";
+import { CalendarClock, ChevronRight, MapPin, Mic, Sparkles, Users, Video } from "lucide-react";
 import Link from "next/link";
 
 import { ProjectTag } from "@/components/common/project-tag";
@@ -167,23 +167,33 @@ function CardFooter({
       */}
       <div className="flex min-w-0 flex-nowrap items-center gap-x-3">
         {/*
-          ⚠️ **비대면 회의는 이제 이 목록에 안 온다**(2026-08-14 팀 확정 — `server.ts`의
-             `getMeetingDirectory` 주석). 일시·장소는 항상 채워져 있다고 봐도 된다.
+          ⚠️ **확정된 비대면 회의는 목록에 뜬다**(2026-08-16 팀 확정, B안 — 2026-08-14의
+             "안 온다"를 뒤집었다). 이 경우 일시·회의실이 비어 있으니 두 칸 대신 안내 한 줄로
+             대체한다 — 빈 칸을 그대로 두면 카드가 고장 난 것처럼 보인다(§정직성).
+             상세(`meeting-detail-view.tsx`)와 같은 아이콘·같은 문구다.
+             참석자 수는 비대면에도 있으니 계속 그린다.
         */}
-        <span className="flex shrink-0 items-center gap-1.5 text-[13px] leading-5 font-medium">
-          <CalendarClock className="text-muted-foreground size-4 shrink-0" aria-hidden />
-          <span className="tabular-nums">{meeting.schedule}</span>
-        </span>
-        <span className="bg-border h-3 w-px shrink-0" aria-hidden />
-        <span className="text-muted-foreground flex min-w-0 items-center gap-x-3 text-[12px] leading-4">
-          <span className="flex min-w-0 items-center gap-1.5">
-            <MapPin className="size-3.5 shrink-0" aria-hidden />
-            <span className="truncate">{meeting.roomName}</span>
+        {meeting.isOnline ? (
+          <span className="flex shrink-0 items-center gap-1.5 text-[13px] leading-5 font-medium">
+            <Video className="text-muted-foreground size-4 shrink-0" aria-hidden />
+            <span>온라인으로 진행된 회의입니다</span>
           </span>
-          <span className="flex shrink-0 items-center gap-1.5">
-            <Users className="size-3.5 shrink-0" aria-hidden />
-            <span className="tabular-nums">{meeting.attendeeCount}명</span>
-          </span>
+        ) : (
+          <>
+            <span className="flex shrink-0 items-center gap-1.5 text-[13px] leading-5 font-medium">
+              <CalendarClock className="text-muted-foreground size-4 shrink-0" aria-hidden />
+              <span className="tabular-nums">{meeting.schedule}</span>
+            </span>
+            <span className="bg-border h-3 w-px shrink-0" aria-hidden />
+            <span className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-[12px] leading-4">
+              <MapPin className="size-3.5 shrink-0" aria-hidden />
+              <span className="truncate">{meeting.roomName}</span>
+            </span>
+          </>
+        )}
+        <span className="text-muted-foreground flex shrink-0 items-center gap-1.5 text-[12px] leading-4">
+          <Users className="size-3.5 shrink-0" aria-hidden />
+          <span className="tabular-nums">{meeting.attendeeCount}명</span>
         </span>
       </div>
 

--- a/src/features/meeting/components/use-online-meeting-form.ts
+++ b/src/features/meeting/components/use-online-meeting-form.ts
@@ -126,7 +126,13 @@ export function useOnlineMeetingForm({ onCreated }: UseOnlineMeetingFormOptions)
       }
 
       formData.set("recordingS3Key", issued.s3Key);
-      formData.set("recordingFileName", file.name);
+      /*
+        ⚠️ **원본 이름(`file.name`)이 아니라 발급 응답의 저장용 이름이다.** BE 확정 단계가
+           `s3Key.endsWith("/" + fileName)`을 검사한다(`OnlineMeetingRecordingAdapter.java`) —
+           원본을 그대로 보내면 한글·공백·괄호가 든 파일명이 전부 400 CAP-015로 튕긴다.
+           화면에 보여주는 이름은 `file.name` 그대로다(이 훅의 `file` 상태).
+      */
+      formData.set("recordingFileName", issued.storageFileName);
       formData.set("recordingContentType", issued.contentType);
       formData.set("recordingSizeBytes", String(file.size));
     }

--- a/src/features/meeting/mapper.test.ts
+++ b/src/features/meeting/mapper.test.ts
@@ -198,6 +198,30 @@ describe("parseMeetingList", () => {
       "약속한 모양",
     );
   });
+
+  /*
+    ⚠️ **세 필드는 함께 움직인다** — 대면이면 셋 다 채우고 비대면이면 셋 다 `null`이다
+       (MEET-01/18). mixed 조합이 통과되면 `toMeetingListItem`이 `isOnline`을 `meetingRoom`만
+       보고 잘못 판정해 대면 카드의 일시가 사라지거나 비대면 카드에 빈 일시가 뜬다
+       (2026-08-16 CodeRabbit 회귀 방어).
+  */
+  it("startAt은 있는데 meetingRoom이 null인 mixed 조합은 거절한다", () => {
+    expect(() => parseMeetingList({ meetings: [{ ...LIST_ITEM, meetingRoom: null }] })).toThrow(
+      "약속한 모양",
+    );
+  });
+
+  it("meetingRoom은 있는데 startAt이 null인 mixed 조합도 거절한다", () => {
+    expect(() => parseMeetingList({ meetings: [{ ...LIST_ITEM, startAt: null }] })).toThrow(
+      "약속한 모양",
+    );
+  });
+
+  it("endAt만 null(다른 둘은 있음)인 mixed 조합도 거절한다", () => {
+    expect(() => parseMeetingList({ meetings: [{ ...LIST_ITEM, endAt: null }] })).toThrow(
+      "약속한 모양",
+    );
+  });
 });
 
 describe("toMeetingListItem", () => {

--- a/src/features/meeting/mapper.test.ts
+++ b/src/features/meeting/mapper.test.ts
@@ -180,6 +180,24 @@ describe("parseMeetingList", () => {
 
     expect(parseMeetingList({ meetings: [row] })).toEqual([row]);
   });
+
+  /*
+    ⚠️ **확정된 비대면 회의(2026-08-16, B안)** — startAt·endAt·meetingRoom이 모두 null이다.
+       예전 계약은 세 필드를 non-null 문자열로 강제해서, 이 행이 하나만 섞여도 배열 전체가
+       throw로 죽었다. 정상 행과 섞여도 파서가 통과해야 한다.
+  */
+  it("비대면 회의(startAt/endAt/meetingRoom 모두 null)가 섞여도 배열이 통과한다", () => {
+    const online = { ...LIST_ITEM, startAt: null, endAt: null, meetingRoom: null };
+
+    expect(parseMeetingList({ meetings: [LIST_ITEM, online] })).toEqual([LIST_ITEM, online]);
+  });
+
+  /* ⚠️ 계약을 넓힌 것이지 검사를 없앤 게 아니다 — 있는데 모양이 다른 회의실은 여전히 거절한다 */
+  it("meetingRoom이 있는데 모양이 다르면(빈 객체) 여전히 거절한다", () => {
+    expect(() => parseMeetingList({ meetings: [{ ...LIST_ITEM, meetingRoom: {} }] })).toThrow(
+      "약속한 모양",
+    );
+  });
 });
 
 describe("toMeetingListItem", () => {
@@ -210,6 +228,27 @@ describe("toMeetingListItem", () => {
     expect(item.aiSummaryStatus).toBeNull();
     expect(item.originLabel).toBe("");
     expect(item.topicSummary).toBe("");
+  });
+
+  /*
+    ⚠️ **비대면 회의**(2026-08-16, B안) — 상세 매퍼와 같은 규칙으로 세 필드를 접는다.
+       카드가 `isOnline`을 보고 그 자리에 "온라인으로 진행된 회의입니다"를 대신 그린다.
+  */
+  it("startAt/endAt/meetingRoom이 모두 null이면 schedule/roomName을 비우고 isOnline=true", () => {
+    const item = toMeetingListItem({
+      ...LIST_ITEM,
+      startAt: null,
+      endAt: null,
+      meetingRoom: null,
+    });
+
+    expect(item.schedule).toBe("");
+    expect(item.roomName).toBe("");
+    expect(item.isOnline).toBe(true);
+  });
+
+  it("대면 회의는 isOnline=false", () => {
+    expect(toMeetingListItem(LIST_ITEM).isOnline).toBe(false);
   });
 
   /* [확인] BE PR #461 `MeetingListQueryService.originLabel` — `teamId == null`이 Owner다 */

--- a/src/features/meeting/mapper.ts
+++ b/src/features/meeting/mapper.ts
@@ -254,9 +254,13 @@ export interface BeMeetingListItem {
   title: string;
   /** `SCHEDULED` · `IN_PROGRESS` · `DONE` · `CANCELED` (BE `MeetingStatus`) */
   status: string;
-  /** `2026-08-14T10:00:00` — 오프셋이 없다(`BeMeetingDetail.startAt`의 경고가 그대로 적용된다) */
-  startAt: string;
-  endAt: string;
+  /**
+   * `2026-08-14T10:00:00` — 오프셋이 없다(`BeMeetingDetail.startAt`의 경고가 그대로 적용된다).
+   * ⚠️ **비대면 회의는 `null`이다**(MEET-18 — WORKFLOW.md §3-1-A: 사용자가 입력하지 않고
+   *    DB에도 저장하지 않는다). 상세(`BeMeetingDetail.startAt`)와 같은 계약이다.
+   */
+  startAt: string | null;
+  endAt: string | null;
   attendeeCount: number;
   /** 보는 사람이 이 회의의 개설자인가 — 탭을 가르는 값이다 */
   isHost: boolean;
@@ -269,7 +273,12 @@ export interface BeMeetingListItem {
   summaryStatus?: string | null;
   /** 안건 첫 줄 — 안건이 하나도 없는 회의는 `null`이다(BE `indexAgendaPreviews`) */
   agendaPreview?: { mainTopic: string | null; firstSubTopic: string | null } | null;
-  meetingRoom: { meetingRoomId: number; name: string };
+  /**
+   * ⚠️ **비대면 회의는 `null`이다**(MEET-18 — 회의실 예약 자체가 없다). 목록 카드가
+   *    온라인 회의인지 가르는 **유일한 신호**이기도 하다 — 응답에 `isOnline` 필드는 없다
+   *    (상세 `toMeetingDetailView`의 판정과 같은 방식).
+   */
+  meetingRoom: { meetingRoomId: number; name: string } | null;
   project: { projectId: number; tag: string };
 }
 
@@ -299,8 +308,9 @@ function isBeMeetingListItem(value: unknown): value is BeMeetingListItem {
     typeof meeting.meetingId === "number" &&
     typeof meeting.title === "string" &&
     typeof meeting.status === "string" &&
-    typeof meeting.startAt === "string" &&
-    typeof meeting.endAt === "string" &&
+    /* ⚠️ 비대면 회의는 `null`이다(MEET-18, WORKFLOW.md §3-1-A) — 상세 가드와 같은 규칙 */
+    isOptionalNullableString(meeting.startAt) &&
+    isOptionalNullableString(meeting.endAt) &&
     typeof meeting.attendeeCount === "number" &&
     typeof meeting.isHost === "boolean" &&
     /*
@@ -311,7 +321,8 @@ function isBeMeetingListItem(value: unknown): value is BeMeetingListItem {
     isOptionalNullableNumber(meeting.teamId) &&
     isOptionalNullableString(meeting.summaryStatus) &&
     isOptionalAgendaPreview(meeting.agendaPreview) &&
-    typeof meeting.meetingRoom?.name === "string" &&
+    /* ⚠️ 비대면 회의는 `null`이다(MEET-18) — 있는데 모양이 다른 것만 거른다 */
+    (meeting.meetingRoom === null || typeof meeting.meetingRoom?.name === "string") &&
     typeof meeting.project?.tag === "string"
   );
 }
@@ -360,11 +371,19 @@ export function toMeetingListItem(be: BeMeetingListItem): MeetingListItem {
     projectTag: be.project.tag,
     originLabel: originLabelFromTeamId(be.teamId),
     topicSummary: topicSummaryOf(be.agendaPreview),
-    schedule: formatMeetingSchedule(new Date(be.startAt), new Date(be.endAt)),
-    roomName: be.meetingRoom.name,
+    /*
+      ⚠️ **비대면 회의는 셋 다 없다**(WORKFLOW.md §3-1-A). 상세 매퍼(`toMeetingDetailView`)와
+         같은 규칙으로 접는다 — 카드가 `isOnline`을 보고 그 자리에 "온라인으로 진행된 회의입니다"
+         한 줄로 대체한다(`meeting-card.tsx`).
+    */
+    schedule:
+      be.startAt && be.endAt ? formatMeetingSchedule(new Date(be.startAt), new Date(be.endAt)) : "",
+    roomName: be.meetingRoom?.name ?? "",
     attendeeCount: be.attendeeCount,
     isHost: be.isHost,
     aiSummaryStatus: toAiSummaryStatus(be.summaryStatus),
+    /* ⚠️ 응답에 `isOnline` 필드는 없다 — 회의실이 없다는 것 자체가 신호다(상세와 같은 판정) */
+    isOnline: be.meetingRoom === null,
   };
 }
 

--- a/src/features/meeting/mapper.ts
+++ b/src/features/meeting/mapper.ts
@@ -304,7 +304,7 @@ function isBeMeetingListItem(value: unknown): value is BeMeetingListItem {
   if (typeof value !== "object" || value === null) return false;
   const meeting = value as Partial<BeMeetingListItem>;
 
-  return (
+  const basicShape =
     typeof meeting.meetingId === "number" &&
     typeof meeting.title === "string" &&
     typeof meeting.status === "string" &&
@@ -323,8 +323,23 @@ function isBeMeetingListItem(value: unknown): value is BeMeetingListItem {
     isOptionalAgendaPreview(meeting.agendaPreview) &&
     /* ⚠️ 비대면 회의는 `null`이다(MEET-18) — 있는데 모양이 다른 것만 거른다 */
     (meeting.meetingRoom === null || typeof meeting.meetingRoom?.name === "string") &&
-    typeof meeting.project?.tag === "string"
-  );
+    typeof meeting.project?.tag === "string";
+
+  if (!basicShape) return false;
+
+  /*
+    ⚠️ **`startAt`·`endAt`·`meetingRoom` 세 필드는 함께 움직인다** — 대면이면 셋 다 채우고,
+       비대면이면 셋 다 `null`이다(MEET-01/18, WORKFLOW.md §3-1-A). mixed 조합(예: `startAt`은
+       있는데 `meetingRoom`은 `null`)이 오면 `toMeetingListItem`이 `isOnline`을 `meetingRoom`만
+       보고 잘못 판정해 대면 카드의 일시를 숨기거나 비대면 카드에 빈 일시를 그린다 —
+       BE 계약을 방어하는 유일한 자리라 여기서 거절한다(2026-08-16 회귀 방어).
+  */
+  const startNull = meeting.startAt === null || meeting.startAt === undefined;
+  const endNull = meeting.endAt === null || meeting.endAt === undefined;
+  const roomNull = meeting.meetingRoom === null || meeting.meetingRoom === undefined;
+  const allNull = startNull && endNull && roomNull;
+  const noneNull = !startNull && !endNull && !roomNull;
+  return allNull || noneNull;
 }
 
 function isOptionalNullableNumber(value: unknown): value is number | null | undefined {

--- a/src/features/meeting/mapper/online-meetings.ts
+++ b/src/features/meeting/mapper/online-meetings.ts
@@ -1,7 +1,9 @@
 /**
  * 비대면 회의 생성(`POST /api/meetings/online`, MEET-18) BE shape → UI 계약(이슈 #473).
- * [확인] 도메인 담당자 문서(2026-08-14, 팀 확정) 기준 — BE 실코드는 아직 대조 전이다
- *   (§연동 검증: Swagger·구두 추측 금지, 문서와 코드가 다르면 코드가 맞다 — 구현 시 컨트롤러로 재확인).
+ * [확인] BE 실코드 대조 완료(2026-08-16) —
+ *   `OnlineMeetingController.java` · `OnlineRecordingUploadController.java` ·
+ *   `OnlineRecordingUploadUrlService.java` · `OnlineMeetingRecordingAdapter.java` ·
+ *   `RecordingFilePolicy.java`.
  * ⚠️ `rooms/mapper/meetings.ts`의 `toCreateMeetingPayload`/`toSentTopics`와 같은 자리 나눔이다 —
  *    회의실·시간 필드만 없을 뿐 안건 접기 규칙은 같다.
  */
@@ -9,19 +11,28 @@
 import type { MeetingTopicInput } from "../../rooms/types";
 import type { OnlineMeetingDraft } from "../types";
 
-/**
- * `POST /api/meetings/online/recordings/upload-url` 요청 본문·응답(이슈 #473, 2026-08-14 계약
- * 변경 — 도메인 담당자 문서 기준, BE 실코드는 아직 대조 전이다, §연동 검증).
- */
+/** `POST /api/meetings/online/recordings/upload-url` 요청 본문. */
 export interface BeRecordingUploadUrlRequest {
   fileName: string;
   contentType: string;
   sizeBytes: number;
 }
 
-/** ⚠️ `expiresInSeconds`는 화면에서 안 쓴다 — 만료 전에 바로 PUT하므로 카운트다운이 필요 없다. */
+/**
+ * `POST /api/meetings/online/recordings/upload-url` 응답.
+ *
+ * ⚠️ `expiresInSeconds`는 화면에서 안 쓴다 — 만료 전에 바로 PUT하므로 카운트다운이 필요 없다.
+ * ⚠️ **`fileName`은 원본이 아니라 BE가 정제한 저장용 이름이다**
+ *    ([확인] `OnlineRecordingUploadUrlService.java` — `RecordingFilePolicy.sanitizeForStorageName`이
+ *    영숫자·`.`·`-`·`_` 외 모든 글자를 `_`로 치환한다). `s3Key`가 이 이름으로 끝나고, MEET-18
+ *    확정 단계가 `s3Key.endsWith("/" + fileName)`을 검사한다
+ *    (`OnlineMeetingRecordingAdapter.java`) — 원본 이름을 그대로 보내면 한글·공백·괄호가 든 파일명이
+ *    **전부 400 CAP-015**로 튕긴다. MEET-18에는 이 응답의 `fileName`을 **그대로** 실어야 한다.
+ */
 export interface BeRecordingUploadUrlResponse {
   s3Key: string;
+  /** BE가 정제한 저장용 파일명 — MEET-18 `recording.fileName`에 이 값을 그대로 되돌려 싣는다. */
+  fileName: string;
   presignedUrl: string;
   expiresInSeconds: number;
 }

--- a/src/features/meeting/recording-file.ts
+++ b/src/features/meeting/recording-file.ts
@@ -62,6 +62,14 @@ export function validateRecordingFileMeta(meta: {
   if (!RECORDING_FILE_ACCEPTED_EXTENSIONS.includes(extensionOf(meta.fileName))) {
     return `지원하지 않는 형식입니다 (${ACCEPTED_EXTENSIONS_LABEL}만 가능)`;
   }
+  /*
+    ⚠️ BE `RecordingFilePolicy.validate`가 0바이트도 막는다(413 CAP-024:
+       "녹음 파일은 0바이트보다 크고 5GiB 이하여야 합니다."). FE가 상한만 보면 빈 파일이 S3에
+       올라간 뒤에야 거절된다 — 파일 선택 시점에 잡는다.
+  */
+  if (meta.sizeBytes <= 0) {
+    return "빈 파일입니다";
+  }
   if (meta.sizeBytes > RECORDING_FILE_MAX_BYTES) {
     return "파일 용량이 5GiB를 넘었습니다";
   }

--- a/src/features/meeting/review/mapper.ts
+++ b/src/features/meeting/review/mapper.ts
@@ -250,7 +250,11 @@ export interface BePendingActionDistributionMeeting {
   meetingId: number;
   title: string;
   status: string;
-  startAt: string;
+  /**
+   * ⚠️ **비대면 회의는 `null`이다**(MEET-18, WORKFLOW.md §3-1-A). 이 위젯은 안 읽지만
+   *    선언이 거짓이면 다음 사람이 `new Date(startAt)`을 걸어 조용히 1970년을 그린다.
+   */
+  startAt: string | null;
   pendingActionCount: number;
   project: { projectId: number; tag: string; name: string };
 }

--- a/src/features/meeting/server.ts
+++ b/src/features/meeting/server.ts
@@ -101,6 +101,12 @@ function toListItem(meeting: Meeting, viewerId: number, now: Date): MeetingListI
     attendeeCount: meeting.attendeeIds.length,
     isHost: meeting.hostId === viewerId,
     aiSummaryStatus: meeting.aiSummaryStatus,
+    /*
+      ⚠️ 새 필수 필드(2026-08-16). 여기 목 경로는 아래 122행에서 `!isOnline`으로 걸러
+         비대면 회의를 목록에 안 낸다 — 값이 항상 false다. 실서버(BE-18)가 확정된
+         비대면을 실어 주기 시작하면 목 데이터에도 "확정 시각"을 붙여 정리한다.
+    */
+    isOnline: meeting.isOnline,
   };
 }
 
@@ -160,6 +166,21 @@ function sortMeetingListItems(
     .sort((a, b) => {
       const rankGap = STATUS_RANK[a.item.status] - STATUS_RANK[b.item.status];
       if (rankGap !== 0) return rankGap;
+
+      /*
+        ⚠️ **시각 없는 회의(비대면)는 자기 상태 그룹 맨 뒤**로 보낸다.
+           `startMs`가 `NaN`이면 어느 비교도 false·NaN이라 `Array.prototype.sort`가 구현별로
+           흔들린다 — 여기서 명시하지 않으면 정렬이 조용히 뒤바뀐다.
+        ⚠️ 확인필요 — 목록 정렬 기준은 BE가 정한다(WORKFLOW.md §3-1-A). BE가 값을 정하면
+           그 값으로 이 자리를 바꾼다. 지금은 "완료 그룹 안 맨 뒤"가 안전한 임시값이다
+           (비대면 회의는 확정된 것만 오므로 status=DONE 그룹 안에서만 움직인다).
+      */
+      const aMissing = Number.isNaN(a.startMs);
+      const bMissing = Number.isNaN(b.startMs);
+      if (aMissing && bMissing) return 0;
+      if (aMissing) return 1;
+      if (bMissing) return -1;
+
       // 예정·진행중은 가까운 회의부터, 완료·취소는 최근 회의부터
       return a.item.status === MEETING_STATUS.SCHEDULED ||
         a.item.status === MEETING_STATUS.IN_PROGRESS
@@ -204,7 +225,13 @@ function toSortedListItems(meetings: BeMeetingListItem[]): MeetingListItem[] {
   return sortMeetingListItems(
     meetings.map((meeting) => ({
       item: toMeetingListItem(meeting),
-      startMs: new Date(meeting.startAt).getTime(),
+      /*
+        ⚠️ **비대면 회의는 `startAt`이 `null`이다**(MEET-18). `new Date(null).getTime()`은
+           `0(epoch, 1970-01-01)`이 되어 완료 그룹 최근순 정렬의 맨 뒤에 값이 있는 것처럼
+           박히지만, "시각이 없다"는 사실이 사라진다. `NaN`으로 명시해 `sortMeetingListItems`가
+           갈라 보게 한다(같은 함수의 `Number.isNaN` 분기 참고).
+      */
+      startMs: meeting.startAt === null ? Number.NaN : new Date(meeting.startAt).getTime(),
     })),
   );
 }

--- a/src/features/meeting/view-types.ts
+++ b/src/features/meeting/view-types.ts
@@ -11,9 +11,11 @@ import type { AiSummaryStatus, MeetingStatus } from "@/constants/meeting";
 
 /**
  * 목록 카드 한 장.
- * ⚠️ **비대면 회의(`isOnline`)는 여기 안 온다**(2026-08-14 팀 확정 — 실서버 목록·대시보드가
- *    서버에서부터 걸러 준다, `server.ts`의 `getMeetingDirectory` 주석). `isOnline` 필드가 없는
- *    이유다 — 상세(`MeetingDetail`)는 직접 링크로 계속 열리므로 거기는 남겨 둔다.
+ * ⚠️ **확정(하달)까지 끝난 비대면 회의는 목록에 뜬다**(2026-08-16 팀 확정, B안 — 2026-08-14의
+ *    "목록에 안 온다"를 뒤집었다). 확정 전 비대면 회의는 여전히 안 뜨고, 마이페이지
+ *    「미확정 액션」 위젯에서 검토한다. 거르는 일은 **BE 목록 쿼리**가 한다 — FE는 받은 것을 그린다.
+ * ⚠️ 그래서 `isOnline`이 필요하다. 비대면 회의는 `schedule`·`roomName`이 빈 문자열이라
+ *    그 자리에 "온라인으로 진행된 회의입니다"를 대신 그린다(WORKFLOW.md §3-1-A).
  */
 export interface MeetingListItem {
   id: string;
@@ -61,6 +63,11 @@ export interface MeetingListItem {
    *    요약이 어디까지 갔는지는 상세의 `pendingReason`이 말한다.
    */
   aiSummaryStatus: AiSummaryStatus | null;
+  /**
+   * 비대면(온라인) 회의인가 — 실서버는 `meetingRoom === null`로 판정한다(응답에 별도 필드가 없다).
+   * ⚠️ `true`면 `schedule`·`roomName`이 빈 문자열이다 — 카드가 그 자리에 안내 문구를 대신 그린다.
+   */
+  isOnline: boolean;
 }
 
 /** 목록 — 탭 두 개가 이 화면의 전부다(WORKFLOW §3-2) */


### PR DESCRIPTION
## 📋 PR 타입

- [ ] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

## 무엇
비대면 회의 관련 FE 두 건. 한 도메인이고, 하나는 배포 순서 사고 예방·하나는 실사용 버그라 함께 리뷰합니다.

### ① 목록·MEET-10 위젯이 비대면 회의의 `null` 계약을 받아들이게 (FE-3)
팀 결정 5(B안)로 **확정까지 끝낸 비대면 회의는 회의 목록에 뜨기로** 확정됐습니다.
그런데 FE 목록 계약은 `startAt`·`endAt`·`meetingRoom`을 non-null로 강제해서, BE-18(별건)이
나가면 `/app/meeting`이 통째로 예외로 죽습니다. 지금 안 깨지는 이유는 BE `startAt BETWEEN`
조건에서 NULL 비교가 UNKNOWN 이라 SQL 단계에서 조용히 탈락하기 때문이지 계약이 맞아서가 아닙니다.

**⚠️ 이 FE 변경이 BE-18보다 먼저 배포돼야 합니다.**

- 세 필드 nullable 완화(상세 가드와 같은 규칙)
- `toMeetingListItem`이 상세 매퍼와 같은 방식으로 세 필드를 접는다
- `MeetingListItem`에 `isOnline` 추가 — 카드가 이걸 보고 안내 문구로 대체
- `toSortedListItems`가 `startAt=null`을 `NaN`으로 명시(`new Date(null)`은 1970으로 읽혀 "시각이 없다"가 사라진다)
- `sortMeetingListItems`에 `NaN` 처리 — 시각 없는 회의를 그룹 맨 뒤로
- `meeting-card` 발치가 `isOnline`이면 \"온라인으로 진행된 회의입니다\"로 대체
- `BePendingActionDistributionMeeting.startAt`도 nullable로 (MEET-10)

### ② 비대면 녹음 파일명을 BE 발급값으로 (FE-5)
BE 는 upload-url 발급 때 파일명을 `sanitizeForStorageName` 으로 정제해 s3Key 끝에 박는데,
FE 는 원본 `file.name` 을 `recordingFileName` 으로 실어 보냈습니다. BE 확정 단계가
`s3Key.endsWith(\"/\" + fileName)` 을 검사해서 **한글·공백·괄호 든 파일명이 전부 400 CAP-015**
로 튕겼습니다. 한국어 사내 도구라 한글 파일명이 기본값이라 실사용에서 자주 겪는 버그입니다.

- `BeRecordingUploadUrlResponse` 에 `fileName` 추가 (BE 는 이미 실어 줍니다)
- `RecordingUploadUrlResult` 가 그 값을 `storageFileName` 으로 실어 나름 (이름이 `file.name` 과 헷갈리지 않게 별도 필드)
- `use-online-meeting-form` 이 `issued.storageFileName` 을 보낸다 (`file.name` 아님). 화면에 보여주는 이름은 원본 그대로
- **목 스텁도 같은 규칙**(`/[^A-Za-z0-9.\-_]/g` → `_`)을 적용해 실서버와 관대함을 맞춘다
  — 목이 관대하면 이 버그가 목에서 안 잡힌다
- 0바이트 검사 추가 (BE 도 413 `CAP-024` 로 막는다 — 상한만 보면 빈 파일이 S3에 올라간 뒤에야 거절된다)

## 왜 묶었나
둘 다 비대면 회의 도메인이고, ① 은 배포 순서(BE보다 먼저)·② 는 실사용 버그입니다.
한 PR 에서 함께 리뷰하는 게 맥락이 이어집니다.

## 확인법
- \`npx tsc --noEmit\` / \`npx eslint <변경 파일> --max-warnings=0\` / \`npx jest --silent\`(140 suites·1476 tests) / \`npx next build\` 전부 통과
- 회귀 테스트 추가: `parseMeetingList` 가 null 3필드 섞인 응답을 통과시키는지 · `meetingRoom` 빈 객체는 여전히 거절하는지 ·
  `toMeetingListItem` 이 `isOnline=true` 로 갈라내는지 · 카드가 안내 문구를 그리고 참석자 수는 유지하는지

Closes #592

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 회의 목록과 카드에서 비대면 회의를 구분해 온라인 안내 문구와 참석자 수를 표시합니다.
  * 비대면 회의의 일정·회의실 정보가 없어도 목록에서 정상적으로 확인할 수 있습니다.
  * 녹음 업로드 시 서버가 제공하는 저장용 파일명을 사용합니다.

* **버그 수정**
  * 빈 녹음 파일 업로드를 차단하고 안내 메시지를 표시합니다.
  * 시작 시간이 없는 회의가 목록 정렬에서 일관되게 마지막에 배치됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**, 그리고 **서버에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [ ] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시
- [ ] 🎨 디자인 토큰 사용 · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화
- [ ] ♿ a11y
- [ ] ♻️ 재사용 확인
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API 사용 시 미지원 · 권한거부 안내 있음

---

## 🔗 연관 이슈

Closes #592

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

-

---

## 📝 추가 메모
