### PR TITLE
[FEAT] 캡처 새로고침·크래시 복구 (CAP-09 진행 중 캡처 조회 배선) #594

### DIFF
--- a/src/features/meeting/capture/actions.test.ts
+++ b/src/features/meeting/capture/actions.test.ts
@@ -1,0 +1,112 @@
+/**
+ * CAP-09 진행 중 캡처 조회(`getActiveCaptureAction`) 실서버 분기 회귀 테스트.
+ *
+ * ⚠️ **화면이 죽으면 안 되는 값이 셋이다.**
+ *   - `data: null`(진행 중 없음) → 오류로 올리지 않고 그대로 null
+ *   - 정상 응답 → captureSessionId 같은 안 쓰는 필드는 계약에서 뺀다
+ *   - 예외(권한 없음 등) → 던지지 않고 `{ok:false, error}`로 감싸 화면이 무시할 수 있게
+ */
+
+jest.mock("@/mocks/config", () => ({ isMock: false }));
+jest.mock("@/features/auth/session", () => ({ requireAccessToken: jest.fn() }));
+jest.mock("@/lib/api", () => ({
+  ApiError: class ApiError extends Error {
+    status: number;
+    code?: string;
+    constructor(status: number, message: string, code?: string) {
+      super(message);
+      this.status = status;
+      this.code = code;
+    }
+  },
+  serverApi: jest.fn(),
+  toUserMessage: (error: unknown) =>
+    error instanceof Error ? error.message : "알 수 없는 오류가 발생했습니다",
+}));
+
+import { requireAccessToken } from "@/features/auth/session";
+import { ApiError, serverApi } from "@/lib/api";
+
+import { getActiveCaptureAction } from "./actions";
+
+const serverApiMock = serverApi as unknown as jest.Mock;
+const requireAccessTokenMock = requireAccessToken as unknown as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  requireAccessTokenMock.mockResolvedValue("token");
+});
+
+describe("getActiveCaptureAction — CAP-09", () => {
+  it("진행 중 캡처가 없으면(data:null) 오류가 아니라 그대로 null을 돌려준다", async () => {
+    serverApiMock.mockResolvedValueOnce(null);
+
+    const result = await getActiveCaptureAction();
+
+    expect(result).toEqual({ ok: true, data: null });
+  });
+
+  it("진행 중 캡처가 있으면 안 쓰는 captureSessionId를 뺀 계약으로 옮긴다", async () => {
+    serverApiMock.mockResolvedValueOnce({
+      meetingId: 91,
+      captureSessionId: 1204, // 계약에서 뺀다
+      segmentSeq: 3,
+      lastSeq: 42,
+      recorderPersonId: 7,
+      canTakeover: false,
+      elapsedMs: 12_345,
+    });
+
+    const result = await getActiveCaptureAction();
+
+    expect(result).toEqual({
+      ok: true,
+      data: {
+        meetingId: 91,
+        segmentSeq: 3,
+        lastSeq: 42,
+        recorderPersonId: 7,
+        canTakeover: false,
+        elapsedMs: 12_345,
+      },
+    });
+  });
+
+  it("녹음자 하트비트가 끊긴 상태(canTakeover:true, recorderPersonId:null)도 그대로 옮긴다", async () => {
+    serverApiMock.mockResolvedValueOnce({
+      meetingId: 91,
+      captureSessionId: null,
+      segmentSeq: 0,
+      lastSeq: 0,
+      recorderPersonId: null,
+      canTakeover: true,
+      elapsedMs: 0,
+    });
+
+    const result = await getActiveCaptureAction();
+
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual({
+      meetingId: 91,
+      segmentSeq: 0,
+      lastSeq: 0,
+      recorderPersonId: null,
+      canTakeover: true,
+      elapsedMs: 0,
+    });
+  });
+
+  /*
+    ⚠️ 던지지 않고 값으로 돌려준다 — 훅이 알림/화면 오류로 올리지 않고 조용히 무시하므로
+       (복구 안내가 없더라도 나머지 캡처 흐름은 돌아야 한다), 여기서 예외가 새면 훅 마운트
+       효과 안에서 unhandled rejection이 된다.
+  */
+  it("예외는 던지지 않고 {ok:false}로 감싼다", async () => {
+    serverApiMock.mockRejectedValueOnce(new ApiError(403, "이 회의 참석자가 아닙니다"));
+
+    const result = await getActiveCaptureAction();
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("이 회의 참석자가 아닙니다");
+  });
+});

--- a/src/features/meeting/capture/actions.ts
+++ b/src/features/meeting/capture/actions.ts
@@ -5,7 +5,7 @@ import { serverApi, toUserMessage } from "@/lib/api";
 import { ep } from "@/lib/endpoints";
 import { isMock } from "@/mocks/config";
 
-import type { CaptionChunkInput, CapturePart, CaptureSession } from "./types";
+import type { ActiveCapture, CaptionChunkInput, CapturePart, CaptureSession } from "./types";
 
 /**
  * 캡처 창구 — 격리막(§Mock 격리막).
@@ -63,6 +63,60 @@ export async function startCaptureSessionAction(
       data: {
         captureSessionId: response.captureSessionId,
         startedAtEpochMs: response.startedAtEpochMs,
+      },
+    };
+  } catch (error) {
+    return { ok: false, error: toUserMessage(error) };
+  }
+}
+
+/* ────────────────────────── CAP-09 진행 중 캡처 조회(새로고침·크래시 복구) ────────────────────────── */
+
+/** [확인] BE `CaptureQueryController.active` — `ActiveCaptureResponse`, 진행 중 없으면 data:null */
+interface ActiveCaptureApiResponse {
+  meetingId: number;
+  captureSessionId: number | null;
+  segmentSeq: number;
+  lastSeq: number;
+  recorderPersonId: number | null;
+  canTakeover: boolean;
+  elapsedMs: number;
+}
+
+/**
+ * 진행 중 캡처 조회(CAP-09) — 새로고침·크래시 복구의 첫 단추.
+ *
+ * ⚠️ **`data: null`이 정상값이다**(진행 중 캡처 없음). 오류로 올리지 않는다 — 아무것도 없는
+ *    사용자의 첫 진입 때 오류 배너가 뜨면 오히려 고장으로 읽힌다.
+ * ⚠️ **파라미터가 없다.** 회의는 토큰의 memberId로 서버가 찾는다(남의 진행 캡처 열람 차단).
+ *    여기서 `meetingId`를 받아 검사하지 않는 이유는, 사용자가 A 회의 녹음 중 B 회의 캡처
+ *    화면을 열었을 때 이 액션이 A 회의 정보를 그대로 돌려주는 것이 **정상 동작**이기
+ *    때문이다("지금 다른 회의 녹음 중"을 알리는 데 쓴다). 이 화면과 무관한지 판정은
+ *    호출부(`use-capture`)가 `meetingId` 비교로 한다.
+ * ⚠️ 목 모드는 항상 `{ok:true, data:null}`이다 — 목엔 서버 상태가 없다(§정직한 목업).
+ */
+export async function getActiveCaptureAction(): Promise<CaptureActionResult<ActiveCapture | null>> {
+  if (isMock) return { ok: true, data: null };
+
+  try {
+    const accessToken = await requireAccessToken();
+    const response = await serverApi<ActiveCaptureApiResponse | null>(ep.capturesActive(), {
+      accessToken,
+    });
+    if (response === null) return { ok: true, data: null };
+    /*
+      ⚠️ `captureSessionId`는 화면 계약에서 뺀다 — 안 쓰는 값이다(BE 응답에도 null로 오는
+         경우가 있고, 이후 다른 액션이 이 값을 참조하지 않는다).
+    */
+    return {
+      ok: true,
+      data: {
+        meetingId: response.meetingId,
+        segmentSeq: response.segmentSeq,
+        lastSeq: response.lastSeq,
+        recorderPersonId: response.recorderPersonId,
+        canTakeover: response.canTakeover,
+        elapsedMs: response.elapsedMs,
       },
     };
   } catch (error) {

--- a/src/features/meeting/capture/capture-view.tsx
+++ b/src/features/meeting/capture/capture-view.tsx
@@ -16,7 +16,7 @@ import { cn } from "@/lib/utils";
 
 import type { CaptureAttendee, MeetingCaptureInfo } from "../view-types";
 import { canSubmit, CAPTURE_PHASE, type CapturePhase, formatRecordedTime } from "./phase";
-import type { LiveCaption } from "./types";
+import type { ActiveCapture, LiveCaption } from "./types";
 import { useCapture } from "./use-capture";
 import { useLiveCaptions } from "./use-live-captions";
 
@@ -174,7 +174,12 @@ export function CaptureView({
       <LeaveGuard hasUnsaved={hasUnsaved} />
 
       {capture.phase === CAPTURE_PHASE.BEFORE_START ? (
-        <ReadyCard meeting={meeting} support={capture.support} onReady={capture.enter} />
+        <ReadyCard
+          meeting={meeting}
+          support={capture.support}
+          onReady={capture.enter}
+          activeCapture={capture.activeCapture}
+        />
       ) : (
         <div className="mx-auto flex min-h-0 w-full max-w-[1440px] flex-1 flex-col gap-7">
           {/*
@@ -223,8 +228,19 @@ export function CaptureView({
                   onClick={() => void capture.start()}
                 >
                   <Mic className="size-4" aria-hidden />
-                  {/* 아이콘 옆 한글은 1px 내린다(DESIGN §5) */}
-                  <span className="translate-y-[1px]">녹음 시작</span>
+                  {/*
+                    아이콘 옆 한글은 1px 내린다(DESIGN §5).
+                    ⚠️ **이 회의에 진행 중 캡처가 이미 있으면 [녹음 이어하기]**(2026-08-16, CAP-09).
+                       새로고침·크래시로 돌아온 사용자에게 "녹음 시작"이라 말하면 이미 있는 녹음이
+                       사라지는 것처럼 읽힌다 — 실제로 서버는 세션을 이어 준다. 다른 회의 정보
+                       (`meetingId` 다름)는 이 라벨을 안 바꾼다(그 안내는 아래 ReadyCard가 한다).
+                  */}
+                  <span className="translate-y-[1px]">
+                    {capture.activeCapture !== null &&
+                    String(capture.activeCapture.meetingId) === meeting.id
+                      ? "녹음 이어하기"
+                      : "녹음 시작"}
+                  </span>
                 </Button>
               ) : (
                 <Button
@@ -359,10 +375,23 @@ interface ReadyCardProps {
   /** 이 브라우저가 받쳐 주는가 — 하나라도 없으면 안내를 먼저 띄운다 */
   support: { stt: boolean; recording: boolean };
   onReady: () => void;
+  /**
+   * 새로고침·크래시로 잃은 진행 중 캡처(CAP-09).
+   *
+   * ⚠️ **`null`이 정상**이다(진행 중 없음). 값이 있고 이 회의라면 [이어하기] 안내를,
+   *    다른 회의라면 "지금 다른 회의 녹음 중" 안내를 붙인다 — 아무 말 없이 BEFORE_START로
+   *    두면 이미 녹음 중인 회의를 처음부터 다시 시작할 수 있다(§정직성).
+   */
+  activeCapture: ActiveCapture | null;
 }
 
-function ReadyCard({ meeting, support, onReady }: ReadyCardProps) {
+function ReadyCard({ meeting, support, onReady, activeCapture }: ReadyCardProps) {
   const unsupported = !support.stt || !support.recording;
+  /*
+    ⚠️ **다른 회의는 안내만 다르게**(같은 회의 이어하기와 뜻이 반대다) — 카드 안에 두 경우를
+       한 자리에 담고, 여기 판정은 두 경우 모두 `activeCapture !== null` 이면 켠다.
+  */
+  const isSameMeeting = activeCapture !== null && String(activeCapture.meetingId) === meeting.id;
 
   return (
     <div className="mx-auto flex w-full max-w-[560px] flex-col justify-center py-16">
@@ -391,6 +420,24 @@ function ReadyCard({ meeting, support, onReady }: ReadyCardProps) {
         </div>
 
         {unsupported && <UnsupportedNotice support={support} className="mt-6" />}
+
+        {activeCapture !== null && (
+          /*
+            ⚠️ **새로고침·크래시 복구 안내**(CAP-09). 두 경우가 문구만 다르다:
+               - 같은 회의: "이 회의는 이미 녹음 중입니다" + [준비 완료] → 다음 화면에서 [녹음 이어하기]
+               - 다른 회의: 이 화면에서 이어받을 수는 없다(회의별 화면 단위) — 사실만 알린다
+            ⚠️ 시각을 지어내지 않는다 — `elapsedMs`만 있고 인간 표기는 화면 회복 후에도 계속
+               갱신되어야 하므로 여기서는 "이미 진행 중"이라는 사실만 문구로 남긴다.
+          */
+          <p
+            role="status"
+            className="border-border bg-secondary/50 mt-6 rounded-lg border px-3.5 py-2.5 text-left text-[12px] leading-4"
+          >
+            {isSameMeeting
+              ? "이 회의는 이미 녹음 중입니다. [준비 완료] 후 [녹음 이어하기]를 눌러 주세요."
+              : "지금 다른 회의를 녹음 중입니다. 이 회의에서 새로 시작하면 그쪽 세션은 그대로 남습니다."}
+          </p>
+        )}
 
         <Button
           type="button"

--- a/src/features/meeting/capture/types.ts
+++ b/src/features/meeting/capture/types.ts
@@ -82,3 +82,30 @@ export interface LiveCaption {
    */
   seq?: number;
 }
+
+/**
+ * 새로고침·크래시 뒤 되돌아왔을 때 화면이 아는 것 — CAP-09가 채운다.
+ *
+ * ⚠️ **화면 계약이지 BE shape이 아니다** — `captureSessionId` 같은 안 쓰는 값은 여기 없다.
+ *    BE 응답에서 `actions.ts`가 여기로 옮긴다(§Mock 격리막).
+ * ⚠️ 이 값이 `null`이 아닌 채 도착하면 캡처 화면은 "돌아왔다"는 사실을 사용자에게 알려야 한다 —
+ *    아무 말 없이 BEFORE_START로 두면 이미 녹음 중인 회의를 처음부터 다시 시작할 수 있다.
+ */
+export interface ActiveCapture {
+  meetingId: number;
+  /** 현재 세그먼트 번호(10분 단위로 하나) */
+  segmentSeq: number;
+  /** 서버가 기록한 이 세그먼트의 마지막 조각 순번 — 0이면 아직 한 조각도 안 올라갔다 */
+  lastSeq: number;
+  /** 지금 녹음자 memberId — 다른 세션이 잡고 있으면 이 값으로 안다 */
+  recorderPersonId: number | null;
+  /**
+   * 녹음자 하트비트가 30초 이상 끊겼는가.
+   *
+   * ⚠️ 캡처 화면은 Host 전용이라 참석자 이어받기 진입로는 만들지 않는다 —
+   *    이 값은 안내 문구를 가르는 용도로만 쓴다.
+   */
+  canTakeover: boolean;
+  /** 캡처 시작(첫 presign) 이후 경과 ms — 복구 화면 타이머의 기준점 */
+  elapsedMs: number;
+}

--- a/src/features/meeting/capture/use-capture.ts
+++ b/src/features/meeting/capture/use-capture.ts
@@ -6,6 +6,7 @@ import { CAPTURE_FAILURE_MESSAGE } from "@/constants/meeting";
 
 import {
   completeMeetingAction,
+  getActiveCaptureAction,
   pauseCaptureSessionAction,
   resumeCaptureSessionAction,
   startCaptureSessionAction,
@@ -24,7 +25,7 @@ import {
 } from "./phase";
 import { type CaptureRecorder, createCaptureRecorder, isRecordingSupported } from "./recorder";
 import { createSttEngine, isSttSupported, type SttEngine, type TranscriptChunk } from "./stt";
-import type { CaptionChunkInput } from "./types";
+import type { ActiveCapture, CaptionChunkInput } from "./types";
 import { createSliceUploader, type SliceUploader } from "./upload";
 
 /**
@@ -68,6 +69,16 @@ export interface UseCaptureResult {
    *    모르는데 사람은 다 끝난 줄 안다(§정직성).
    */
   end(): Promise<{ ok: boolean; error?: string }>;
+  /**
+   * 새로고침·크래시로 잃은 진행 중 캡처(CAP-09) — 없으면 `null`.
+   *
+   * ⚠️ **이 훅이 화면 흐름을 자동으로 바꾸지 않는다** — 값만 노출한다. 실제 안내(복구 카드·
+   *    버튼 라벨)는 `capture-view`가 이 값과 `phase`를 보고 그린다. 훅에서 `phase`를 자동으로
+   *    돌리면 사용자가 [녹음 시작]을 눌러 명시적으로 이어받는 흐름이 사라진다(§정직성).
+   * ⚠️ 다른 회의 정보가 실려 올 수 있다 — 화면이 `String(meetingId) !== capture.meetingId`로
+   *    거른 뒤 안내 문구를 정한다.
+   */
+  activeCapture: ActiveCapture | null;
 }
 
 /** 1초마다 다시 그린다 — 경과 시간이 흘러야 녹음 중인 게 보인다 */
@@ -96,6 +107,13 @@ export function useCapture(meetingId: string, initialSeq = 0): UseCaptureResult 
   const [partial, setPartial] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [now, setNow] = useState(() => Date.now());
+  /*
+    ⚠️ **CAP-09 결과 — 새로고침·크래시 복구용**(2026-08-16 신규).
+       마운트 시 한 번만 부른다(진행 중 캡처의 정본은 서버라 폴링 불필요). 결과는 값으로만
+       노출하고 흐름은 화면이 정한다 — 훅이 자동으로 phase를 바꾸면 사용자의 [녹음 시작]
+       클릭이 사라져 이어받기 의사표시가 없어진다(§정직성).
+  */
+  const [activeCapture, setActiveCapture] = useState<ActiveCapture | null>(null);
 
   /*
     ⚠️ 지원 여부는 **첫 렌더에 한 번만** 본다(`useState` 지연 초기화). 캡처 화면은
@@ -349,6 +367,26 @@ export function useCapture(meetingId: string, initialSeq = 0): UseCaptureResult 
   const enter = useCallback(() => setPhase(CAPTURE_PHASE.READY), []);
 
   /*
+    ⚠️ **CAP-09 새로고침·크래시 복구 조회**(2026-08-16 신규).
+       마운트 시 한 번만 부른다 — 이 값의 정본은 서버라 폴링이 필요 없고, 캡처 화면은
+       `next/dynamic(ssr:false)`로만 들어오므로 이 효과는 항상 브라우저에서 돈다.
+    ⚠️ `alive` 플래그로 언마운트 경합을 막는다 — 응답이 늦게 오면 언마운트된 뒤 setState가
+       된다.
+    ⚠️ 실패는 조용히 무시한다 — 복구 안내가 없더라도 캡처 화면의 나머지 흐름은 돌아야 한다.
+       (오류 배너를 여기서 띄우면 진짜 캡처 오류와 섞여 시끄러워진다.)
+  */
+  useEffect(() => {
+    let alive = true;
+    void getActiveCaptureAction().then((result) => {
+      if (!alive) return;
+      if (result.ok && result.data) setActiveCapture(result.data);
+    });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  /*
     ⚠️ **마이크가 열린 뒤에 "녹음 중"으로 넘어간다.** 먼저 넘어가 두면 권한이 막힌 브라우저에서
        배지는 `녹음 중`, 타이머는 도는데 담기는 건 아무것도 없다 — 화면이 거짓말을 한다
        (§정직성). 실패하면 `READY`에 머물고 이유만 남긴다.
@@ -575,5 +613,18 @@ export function useCapture(meetingId: string, initialSeq = 0): UseCaptureResult 
     }
   }, [drainCaptions, meetingId]);
 
-  return { phase, support, recordedMs, chunks, partial, error, enter, start, pause, resume, end };
+  return {
+    phase,
+    support,
+    recordedMs,
+    chunks,
+    partial,
+    error,
+    enter,
+    start,
+    pause,
+    resume,
+    end,
+    activeCapture,
+  };
 }

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -248,8 +248,11 @@ export const ep = {
    *    경로는 이제 `SCHEDULED → IN_PROGRESS` 전이와 캡처 세션 생성을 한 트랜잭션으로 한다.
    *    ⚠️ **아직 `status: spec`이다**(D도메인 명세 기준 미구현) — 흡수된 흐름에 맞춘 호출부
    *    (`capture/actions.ts`) 재설계는 별도 이슈다.
-   * ⚠️ **CAP-09(이어받기)·CAP-10(세션 단독 조회)은 폐기됐다**(2026-08-12) — host 장애는
-   *    참석자 이어받기가 아니라 host 본인 재접속으로 복구한다.
+   * ⚠️ **CAP-10(세션 단독 조회)은 폐기됐다**(2026-08-12) — host 장애는 참석자 이어받기가
+   *    아니라 host 본인 재접속으로 복구한다.
+   *    ⚠️ **CAP-09(진행 중 캡처 조회)는 살아 있다**(2026-08-16 실코드 대조 정정 — 예전 이
+   *    자리에 "폐기됐다"고 잘못 적혀 있었다). BE `CaptureQueryController` 참고 — 새로고침
+   *    복구의 첫 단추라 상수는 아래 `capturesActive`에 별도로 뒀다.
    */
   captureSession: (meetingId: number) => `/api/meetings/${meetingId}/capture-session`,
   captureSessionPause: (meetingId: number) => `/api/meetings/${meetingId}/capture-session/pause`,
@@ -274,6 +277,16 @@ export const ep = {
     `/api/meetings/${meetingId}/parts/${seq}/complete`,
   /** 어디까지 올라갔는지(CAP-08) — 새로고침·크래시 뒤 이어 올리기 */
   partsStatus: (meetingId: number) => `/api/meetings/${meetingId}/parts/status`,
+  /**
+   * 진행 중 캡처 조회(CAP-09) — 새로고침·크래시 복구의 첫 단추.
+   * [확인] BE `cap/presentation/api/CaptureQueryController.java` (2026-08-16).
+   *
+   * ⚠️ **파라미터가 없다.** 회의는 토큰의 memberId로 서버가 찾는다(남의 진행 캡처 열람 차단).
+   * ⚠️ **진행 중인 캡처가 없으면 200 + `data: null`이다** — 404가 아니다.
+   * ⚠️ 응답 `canTakeover`가 true여도 캡처 화면은 Host 전용이라(`getMeetingCapture`가 참석자를
+   *    막는다) 이 값은 안내 문구로만 쓰고 참석자용 진입로를 새로 만들지 않는다.
+   */
+  capturesActive: () => "/api/captures/active",
   /** AI 처리 상태(CAP-06) — 종료 뒤 폴링 */
   processingStatus: (meetingId: number) => `/api/meetings/${meetingId}/processing-status`,
   /**


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

## 무엇
WORKFLOW §3-3의 '상태를 서버에 알리는 이유' 다섯 중 **ⓒ새로고침 복구**가 FE에 배선돼 있지 않았습니다.
`/api/captures/active`(CAP-09)는 `endpoints.ts`에 상수조차 없었고, 캡처 화면을 새로고침하면
`BEFORE_START`로 돌아가서 사용자는 이 회의가 이미 녹음 중이라는 사실을 어디서도 못 봤습니다.

## 왜 지금 발견됐나
`endpoints.ts:251` 주석이 *"CAP-09(이어받기)·CAP-10은 폐기됐다(2026-08-12)"* 라고 잘못 적혀 있어
다들 배선이 필요없는 줄 알고 있었습니다. **BE 실코드 대조 결과 `CaptureQueryController` 가 실재**합니다
— 주석이 코드와 어긋난 경우(§연동 검증: 문서와 코드가 다르면 코드가 맞다).

## 어떻게
- `ep.capturesActive` 상수 추가. 낡은 주석 정정.
- `capture/types.ts` 에 UI 계약 `ActiveCapture` 추가 — `captureSessionId` 같은 안 쓰는 필드는 제외
- `capture/actions.ts` 에 `getActiveCaptureAction` 추가
  - `data: null` 이 정상값(진행 중 없음) — 오류로 안 올림
  - 파라미터 없음 — 회의는 서버가 토큰 memberId 로 찾음
  - 예외는 던지지 않고 `{ok:false, error}` 로 감싸 훅이 조용히 무시할 수 있게
- `useCapture` 마운트 시 1회 CAP-09 호출, 결과를 `activeCapture` 상태로 노출
  - 훅에서 `phase` 자동 전환 안 함 — 사용자의 [녹음 시작] 클릭이 사라져 이어받기 의사표시가 없어지면 안 됨(§정직성)
- `ReadyCard`(BEFORE_START)에 복구 안내
  - 같은 회의: *"이 회의는 이미 녹음 중입니다. [준비 완료] 후 [녹음 이어하기]를 눌러 주세요."*
  - 다른 회의: *"지금 다른 회의를 녹음 중입니다."*
- READY 분기의 [녹음 시작] 라벨이 같은 회의 진행 중일 때 [녹음 이어하기]로

## 검증 교정 반영
명세를 검토한 검증 에이전트가 **치명 1건**을 잡았습니다 — 처음엔 "BEFORE_START 에서 버튼 라벨을 바꾼다"고
지시했는데, 실제로는 BEFORE_START 에 [녹음 시작] 버튼이 없습니다(ReadyCard 만 있음). READY 분기로 옮겼습니다.

## 안 한 것 (범위 밖)
- **CAP-08 `partsStatus` 배선** — 호출부가 없는 상태로 서버 액션만 더 만드는 꼴이 반복돼 이번엔 뺐습니다.
  필요해지는 시점에 별건으로 배선합니다.
- `upload.ts` seq 계산 — BE 가 정합니다(presign 응답의 `parts[].seq` 를 그대로 쓰는 지금 구조가 맞음)
- '다른 참석자가 이어받기' 진입로 — 캡처 화면은 Host 전용(`getMeetingCapture` 가 참석자를 막음)
- `missingSeqs` 재전송 — 새로고침 뒤에는 올릴 Blob 이 없음

## 확인법
- \`npx tsc --noEmit\` / \`npx eslint <변경 파일> --max-warnings=0\` / \`npx jest --silent\`(141 suites·1474 tests) / \`npx next build\` 전부 통과
- 회귀 테스트 4건: `data:null` 처리 · 안 쓰는 `captureSessionId` 제거 · null 필드 그대로 옮기기 · 예외 던지지 않기

Closes #594

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**, 그리고 **서버에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [ ] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시
- [ ] 🎨 디자인 토큰 사용 · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화
- [ ] ♿ a11y
- [ ] ♻️ 재사용 확인
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API 사용 시 미지원 · 권한거부 안내 있음

---

## 🔗 연관 이슈

Closes #594

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

-

---

## 📝 추가 메모
