### PR TITLE
[FIX] 액션 상세 nullable 계약·회의 개설 오류코드 매핑 정정 #596

### DIFF
--- a/src/app/(shell)/app/actions/[actionId]/page.tsx
+++ b/src/app/(shell)/app/actions/[actionId]/page.tsx
@@ -53,10 +53,12 @@ export default async function PersonalActionDetailPage({ params }: PersonalActio
       key: "assignee",
       icon: User,
       label: "담당자",
-      // ⚠️ 역할 미지정이면 이름만 보여준다 — 없는 역할을 지어내지 않는다(§정직성).
-      content: action.assigneeRoleLabel
-        ? `${action.assigneeName}(${action.assigneeRoleLabel})`
-        : action.assigneeName,
+      // ⚠️ 역할 미지정이면 이름만, 담당자 자체가 없으면 "담당자 미정"(WORKFLOW.md §3-1-A) — 빈 칸으로 두지 않는다.
+      content: action.assigneeName
+        ? action.assigneeRoleLabel
+          ? `${action.assigneeName}(${action.assigneeRoleLabel})`
+          : action.assigneeName
+        : "담당자 미정",
     },
     ...(action.sourceMeeting
       ? [
@@ -68,7 +70,7 @@ export default async function PersonalActionDetailPage({ params }: PersonalActio
               <>
                 <div className="flex items-center gap-1.5">
                   <p className="truncate">{action.sourceMeeting.title}</p>
-                  <ProjectTag tag={action.projectTag} />
+                  {action.projectTag ? <ProjectTag tag={action.projectTag} /> : null}
                 </div>
                 <p className="text-muted-foreground text-[11px] leading-4">
                   {formatMeetingDate(action.sourceMeeting.scheduledAt)}
@@ -89,7 +91,7 @@ export default async function PersonalActionDetailPage({ params }: PersonalActio
               <>
                 <div className="flex items-center gap-1.5">
                   <p className="truncate">{action.parentTeamAction.name}</p>
-                  <ProjectTag tag={action.projectTag} />
+                  {action.projectTag ? <ProjectTag tag={action.projectTag} /> : null}
                   <TeamChip team={action.parentTeamAction.team} />
                 </div>
                 <p className="text-muted-foreground text-[11px] leading-4">
@@ -134,8 +136,12 @@ export default async function PersonalActionDetailPage({ params }: PersonalActio
           <h2 className="text-foreground text-[22px] leading-[30px] font-semibold tracking-[-0.4px]">
             {action.name}
           </h2>
-          <ProjectTag tag={action.projectTag} />
-          <TeamChip team={action.team} />
+          {action.projectTag ? <ProjectTag tag={action.projectTag} /> : null}
+          {/*
+            ⚠️ **개인 액션은 팀이 없다**(BE `ActionTypeShapePolicy`) — 없으면 칩 자체를 안 그린다.
+               전에는 빈 회색 칩이 매번 그려졌다.
+          */}
+          {action.team ? <TeamChip team={action.team} /> : null}
         </div>
 
         {/*

--- a/src/features/action/mapper.test.ts
+++ b/src/features/action/mapper.test.ts
@@ -1,0 +1,126 @@
+/**
+ * 개인 액션 상세 매퍼 — nullable 필드 계약 회귀.
+ *
+ * ⚠️ 이 파일이 지키는 것 둘:
+ *   ① `parseActionDetail`은 **BE가 실제로 내리는 nullable 5필드**(`description`·`assigneeName`·
+ *      `projectTag`·`projectName`·`teamName`)의 `null`을 통과시키고, 모르는 `status` 같은
+ *      **모양이 다른** 응답은 던진다. 지금까지 `serverApi<BeActionDetail>` 단언만 있어
+ *      가드 없이 화면까지 흘렀다.
+ *   ② `toPersonalActionDetail`은 그 null을 화면 계약으로 **빈 문자열이 아니라 `undefined`**로
+ *      접는다 — 빈 칩·빈 태그를 그리면 화면이 뭔가 있는 척한다(§정직성).
+ */
+import { type BeActionDetail, parseActionDetail, toPersonalActionDetail } from "./mapper";
+
+const BASE: BeActionDetail = {
+  id: 1,
+  projectId: 10,
+  title: "온보딩 플로우 와이어프레임 검토",
+  description: "온보딩 화면 흐름을 검토한다.",
+  status: "TODO",
+  startDate: "2026-08-20",
+  dueDate: "2026-08-29",
+  needsReview: false,
+  assigneeName: "이하윤",
+  assigneeRoleLabel: "프론트엔드",
+  projectTag: "GOODS",
+  projectName: "굿즈 앱",
+  /* ⚠️ 개인 액션은 팀이 없다(BE ActionTypeShapePolicy) — 기본값도 null */
+  teamName: null,
+  parentActionId: 3,
+  parentActionTitle: "앱 개발 착수",
+  parentActionTeamName: "개발팀",
+  parentActionDueDate: "2026-08-29",
+  sourceMeetingId: 5,
+  sourceMeetingTitle: "앱 개발 착수 팀 액션 회의",
+  sourceMeetingScheduledAt: "2026-07-21T10:00",
+};
+
+describe("parseActionDetail — 응답 가드", () => {
+  it("nullable 5필드(description·assigneeName·projectTag·projectName·teamName)가 전부 null인 응답을 통과시킨다", () => {
+    /*
+      ⚠️ 여기 나열한 다섯이 BE가 정말로 null로 내려보내는 필드들이다 —
+      description(TEXT NULL, `@NotBlank` 없음)·assigneeName(ActionService:258)·
+      projectTag(:288)·projectName(:289)·teamName(:267-269).
+      가드가 이 다섯을 거절하면 실서버에서 오는 정상 응답이 화면까지 못 온다.
+    */
+    const raw = {
+      ...BASE,
+      description: null,
+      assigneeName: null,
+      projectTag: null,
+      projectName: null,
+      teamName: null,
+    };
+    expect(() => parseActionDetail(raw)).not.toThrow();
+  });
+
+  it("id가 문자열이면 던진다 — 단언만으로는 못 잡던 것", () => {
+    expect(() => parseActionDetail({ ...BASE, id: "1" })).toThrow(
+      "액션 상세 응답이 약속한 모양이 아닙니다.",
+    );
+  });
+
+  it("status가 모르는 값이면 던진다 — 지금은 단언이라 그대로 흘러갔다", () => {
+    /*
+      ⚠️ ACTION_STATUS는 3개(TODO·IN_PROGRESS·DONE)뿐이고, BE 도메인 정책이 마이그레이션 없이
+         새 상태를 더하지 않는다는 조건에서 화면이 안전하다. 모르는 값이 오면 화면 렌더가
+         조용히 이상해지느니 명시 오류가 낫다(회의 상세 가드와 같은 기준).
+    */
+    expect(() => parseActionDetail({ ...BASE, status: "WIP" })).toThrow(
+      "액션 상세 응답이 약속한 모양이 아닙니다.",
+    );
+  });
+
+  it("필드가 통째로 undefined면 던진다 — BE record는 항상 키를 내려보내므로 확장 필드가 아니다", () => {
+    /*
+      ⚠️ 회의 상세 가드가 확장 필드에만 `isOptionalNullableString`을 쓰는 것과 같은 이유:
+         이 필드들은 확장이 아니라 필수라, `undefined`(키 자체가 없음)는 이상 신호다.
+    */
+    const raw: Record<string, unknown> = { ...BASE };
+    delete raw.assigneeName;
+    expect(() => parseActionDetail(raw)).toThrow("액션 상세 응답이 약속한 모양이 아닙니다.");
+  });
+});
+
+describe("toPersonalActionDetail — null을 화면 계약으로 접는다", () => {
+  it("팀·태그·담당자가 null이면 undefined로 접는다 — 빈 문자열이 아니다(빈 칩·빈 태그 방지)", () => {
+    const detail = toPersonalActionDetail({
+      ...BASE,
+      teamName: null,
+      projectTag: null,
+      assigneeName: null,
+    });
+    expect(detail.team).toBeUndefined();
+    expect(detail.projectTag).toBeUndefined();
+    expect(detail.assigneeName).toBeUndefined();
+  });
+
+  it("description이 null이면 빈 문자열로 접는다 — UI 계약이 non-null string이라 대체값이 필요하다", () => {
+    /*
+      ⚠️ description만 별도 처리다 — 화면(`ActionContentCard`)이 문단으로 그리므로 undefined보다
+         빈 문자열이 자연스럽다. 나머지 nullable은 칩·태그·이름이라 없으면 아예 안 그린다.
+    */
+    const detail = toPersonalActionDetail({ ...BASE, description: null });
+    expect(detail.description).toBe("");
+  });
+
+  it("정상 값은 그대로 통과한다 — 목 데이터가 계속 통과해야 한다", () => {
+    const detail = toPersonalActionDetail(BASE);
+    expect(detail.team).toBe(BASE.teamName ?? undefined); // BASE의 teamName은 null
+    expect(detail.projectTag).toBe("GOODS");
+    expect(detail.assigneeName).toBe("이하윤");
+    expect(detail.assigneeRoleLabel).toBe("프론트엔드");
+    expect(detail.sourceMeeting?.id).toBe(5);
+    expect(detail.parentTeamAction?.id).toBe(3);
+  });
+
+  it("상위 팀 액션·출처 회의는 4·3필드가 다 있어야 블록을 만든다 — 하나라도 null이면 undefined", () => {
+    /* 기존 매퍼 규칙 회귀 — 이 작업에서 손대지 않았음을 명시한다 */
+    expect(
+      toPersonalActionDetail({ ...BASE, parentActionTeamName: null }).parentTeamAction,
+    ).toBeUndefined();
+    expect(
+      toPersonalActionDetail({ ...BASE, sourceMeetingTitle: null }).sourceMeeting,
+    ).toBeUndefined();
+  });
+});

--- a/src/features/action/mapper.ts
+++ b/src/features/action/mapper.ts
@@ -1,3 +1,4 @@
+import { ACTION_STATUS } from "@/constants/action";
 import type { ActionStatus } from "@/constants/domain";
 import type { MemberAction } from "@/features/member/types";
 import { type BeAttachment, toProjectAttachment } from "@/features/project/mapper";
@@ -233,17 +234,30 @@ export interface BeActionDetail {
   id: number;
   projectId: number;
   title: string;
-  description: string;
+  /**
+   * BE `action.description`은 `TEXT NULL`(V1__init_schema.sql:173)이고 `CreateActionRequest`에
+   * `@NotBlank`가 없다 — 수동 추가 액션은 `null`로 저장된다.
+   */
+  description: string | null;
   status: ActionStatus;
   startDate: string | null;
   dueDate: string;
   needsReview: boolean;
-  assigneeName: string;
+  /** 담당자 미지정이면 `null`(BE `ActionService.getActionDetail`:258 `assignee == null ? null : assignee.name()`). */
+  assigneeName: string | null;
   /** 역할(sub_team) 미지정이면 `null`. */
   assigneeRoleLabel: string | null;
-  projectTag: string;
-  projectName: string;
-  teamName: string;
+  /** 프로젝트 참조 조회 실패면 `null`(BE `ActionService`:288 `project == null ? null : project.tag()`). */
+  projectTag: string | null;
+  /** 프로젝트 참조 조회 실패면 `null`(BE `ActionService`:289 `project == null ? null : project.name()`). */
+  projectName: string | null;
+  /**
+   * ⚠️ **개인 액션은 항상 `null`이다.** `ActionTypeShapePolicy.checkTeamShape`
+   *    (ActionTypeShapePolicy.java:52-53)가 "PERSONAL 액션은 팀을 가질 수 없다"를 강제해
+   *    `teamId`가 늘 null이고, BE는 `teamId == null ? null : ...`(ActionService:267-269)로
+   *    이름을 만든다.
+   */
+  teamName: string | null;
   parentActionId: number | null;
   parentActionTitle: string | null;
   parentActionTeamName: string | null;
@@ -254,15 +268,65 @@ export interface BeActionDetail {
   sourceMeetingScheduledAt: string | null;
 }
 
+function isNullableString(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+/**
+ * 응답이 우리가 읽는 모양인가 — `serverApi<BeActionDetail>`는 **단언일 뿐 검사가 아니다**
+ * (회의 상세 `isBeMeetingDetail`과 같은 이유·같은 범위: 화면이 읽는 필드만 본다).
+ *
+ * ⚠️ nullable 5필드(`description`·`assigneeName`·`projectTag`·`projectName`·`teamName`)는
+ *    `null`을 통과시킨다 — BE record가 항상 키를 내려보내므로 확장 필드가 아니라 필수 필드다.
+ */
+function isBeActionDetail(value: unknown): value is BeActionDetail {
+  if (typeof value !== "object" || value === null) return false;
+  const detail = value as Partial<BeActionDetail>;
+
+  return (
+    typeof detail.id === "number" &&
+    typeof detail.projectId === "number" &&
+    typeof detail.title === "string" &&
+    isNullableString(detail.description) &&
+    typeof detail.status === "string" &&
+    (Object.values(ACTION_STATUS) as string[]).includes(detail.status) &&
+    (detail.startDate === null || typeof detail.startDate === "string") &&
+    typeof detail.dueDate === "string" &&
+    typeof detail.needsReview === "boolean" &&
+    isNullableString(detail.assigneeName) &&
+    isNullableString(detail.assigneeRoleLabel) &&
+    isNullableString(detail.projectTag) &&
+    isNullableString(detail.projectName) &&
+    isNullableString(detail.teamName) &&
+    (detail.parentActionId === null || typeof detail.parentActionId === "number") &&
+    isNullableString(detail.parentActionTitle) &&
+    isNullableString(detail.parentActionTeamName) &&
+    isNullableString(detail.parentActionDueDate) &&
+    (detail.sourceMeetingId === null || typeof detail.sourceMeetingId === "number") &&
+    isNullableString(detail.sourceMeetingTitle) &&
+    isNullableString(detail.sourceMeetingScheduledAt)
+  );
+}
+
+export function parseActionDetail(raw: unknown): BeActionDetail {
+  if (!isBeActionDetail(raw)) {
+    throw new Error("액션 상세 응답이 약속한 모양이 아닙니다.");
+  }
+  return raw;
+}
+
 export function toPersonalActionDetail(be: BeActionDetail): PersonalActionDetail {
   return {
     id: be.id,
     name: be.title,
-    description: be.description,
-    team: be.teamName,
+    /* description은 TEXT NULL이라 없을 수 있다 — 화면 계약(non-null string)에 맞춰 빈 문자열로 접는다. */
+    description: be.description ?? "",
+    /* ⚠️ 개인 액션은 팀이 없다(ActionTypeShapePolicy) — 없으면 칩 자체를 안 그린다 */
+    team: be.teamName ?? undefined,
     projectId: be.projectId,
-    projectTag: be.projectTag,
-    assigneeName: be.assigneeName,
+    /* ⚠️ `null`을 그대로 넘기면 `pickPaletteColor`가 `null.length`에서 던진다(palette.ts:105) */
+    projectTag: be.projectTag ?? undefined,
+    assigneeName: be.assigneeName ?? undefined,
     assigneeRoleLabel: be.assigneeRoleLabel ?? undefined,
     sourceMeeting:
       be.sourceMeetingId !== null && be.sourceMeetingTitle && be.sourceMeetingScheduledAt

--- a/src/features/action/server.ts
+++ b/src/features/action/server.ts
@@ -10,8 +10,8 @@ import { paginate, type PaginatedResult } from "@/lib/paginate";
 import { isMock } from "@/mocks/config";
 
 import {
-  type BeActionDetail,
   type BeActionSummary,
+  parseActionDetail,
   toMyActionListItem,
   toPersonalActionDetail,
   toTeamActionListItem,
@@ -37,8 +37,13 @@ export async function getPersonalActionDetail(
 
   const accessToken = await requireAccessToken();
   try {
-    const detail = await serverApi<BeActionDetail>(ep.action(numericId), { accessToken });
-    return toPersonalActionDetail(detail);
+    /*
+      ⚠️ `serverApi<BeActionDetail>`는 **단언일 뿐 검사가 아니다.** 회의 상세와 같이 실런타임
+         검사(가드)를 세운다 — nullable 5필드가 정말 nullable로 오는데 non-null string으로
+         읽으면 화면이 조용히 이상해지거나 페이지가 통째로 죽는다.
+    */
+    const raw = await serverApi<unknown>(ep.action(numericId), { accessToken });
+    return toPersonalActionDetail(parseActionDetail(raw));
   } catch (error) {
     if (error instanceof ApiError && error.status === 404) return null;
     throw error;
@@ -78,10 +83,16 @@ export async function getMyActionsPage(
           id: item.id,
           title: item.title,
           description: detail.description,
-          team: detail.team,
+          /*
+            ⚠️ `PersonalActionDetail.team`·`projectTag`는 개인 액션이 팀·태그 참조를 못 가질 수
+               있어 optional이지만, 이 리스트 계약(`MyActionListItem`)은 여전히 non-null이다
+               (`toMyActionListItem`이 `?? "-"`·`?? ""`로 접는다). 실서버 매퍼와 같은 방어를
+               mock 분기에서도 그대로 쓴다 — 목이 실서버보다 관대해서는 안 된다(§정직한 목업).
+          */
+          team: detail.team ?? "-",
           projectId: detail.projectId,
           projectName: project.name,
-          projectTag: detail.projectTag,
+          projectTag: detail.projectTag ?? "",
           startDate: item.startDate,
           dueDate: item.dueDate,
           status: item.status,

--- a/src/features/action/types.ts
+++ b/src/features/action/types.ts
@@ -11,10 +11,13 @@ export interface PersonalActionDetail {
   id: number;
   name: string;
   description: string;
-  team: string;
+  /** 소속 팀 — **개인 액션은 없다**(BE `ActionTypeShapePolicy` — PERSONAL은 팀을 못 가짐). 없으면 화면이 칩을 안 그린다. */
+  team?: string;
   projectId: number;
-  projectTag: string;
-  assigneeName: string;
+  /** 프로젝트 태그 — 참조 조회 실패 시 없다. 없으면 태그 칩을 안 그린다(빈 칩 금지). */
+  projectTag?: string;
+  /** 담당자 이름 — 미지정이면 없다. 화면은 그때 "담당자 미정"이라 적는다(WORKFLOW.md §3-1-A). */
+  assigneeName?: string;
   /** 본인 역할 — "프론트엔드"·"백엔드" 등. Leader면 "팀장". 역할 미지정이면 없음. */
   assigneeRoleLabel?: string;
   /**

--- a/src/features/meeting/actions.online-real.test.ts
+++ b/src/features/meeting/actions.online-real.test.ts
@@ -115,10 +115,14 @@ describe("비대면 회의 만들기(이슈 #473, MEET-18) — 실서버 분기(
     expect(serverApiMock).not.toHaveBeenCalled();
   });
 
-  it("PROJECT_NOT_FOUND는 projectId 칸 오류로 바뀐다(MEET-01의 PJ-001과 리터럴이 다르다)", async () => {
-    serverApiMock.mockRejectedValue(
-      new ApiError(404, "존재하지 않는 프로젝트", "PROJECT_NOT_FOUND"),
-    );
+  it("PJ-001은 projectId 칸 오류로 바뀐다", async () => {
+    /*
+      ⚠️ 2026-08-16 정정 — 예전 이 테스트는 리터럴이 `"PROJECT_NOT_FOUND"`이고 제목도
+         "MEET-01의 PJ-001과 리터럴이 다르다"였다. 그 전제(도메인 담당자 명세 2026-08-14)가
+         틀렸다: `ErrorResponse.of`(BE global/exception/ErrorResponse.java:23)가 **전 도메인**에서
+         `errorCode.getCode()`를 내리므로 이 엔드포인트도 실제로 오는 값은 `"PJ-001"`이다.
+    */
+    serverApiMock.mockRejectedValue(new ApiError(404, "존재하지 않는 프로젝트", "PJ-001"));
 
     const result = await createOnlineMeetingAction({ errors: {} }, VALID_FORM());
 
@@ -141,7 +145,7 @@ describe("비대면 회의 만들기(이슈 #473, MEET-18) — 실서버 분기(
     expect(result.errors.topics).toBe("안건 오류");
   });
 
-  it.each(["MT-016", "MT-017", "MT-018", "MT-019"])(
+  it.each(["MT-016", "MT-018", "MT-019"])(
     "%s는 parentTeamActionId 칸 오류로 바뀐다",
     async (code) => {
       serverApiMock.mockRejectedValue(new ApiError(400, "상위 팀 액션 오류", code));
@@ -151,6 +155,22 @@ describe("비대면 회의 만들기(이슈 #473, MEET-18) — 실서버 분기(
       expect(result.errors.parentTeamActionId).toBe("상위 팀 액션 오류");
     },
   );
+
+  it("MT-017은 attendeeIds 칸 오류로 바뀐다 — 상위 팀 액션 오류(016·018·019) 묶음과 다른 자리다", async () => {
+    /*
+      ⚠️ 2026-08-16 정정 — 예전엔 MT-017이 016 묶음에 섞여 `parentTeamActionId` 칸에 붙었지만,
+         뜻은 "개설자 외 참석자를 한 명 이상 선택해야 합니다"라 참석자 칸이 맞다.
+         MT-010(존재하지 않는 참석자)과 같은 칸을 쓰지만 문구가 달라 사용자가 구분할 수 있다.
+    */
+    serverApiMock.mockRejectedValue(
+      new ApiError(400, "개설자 외 참석자를 한 명 이상 선택해야 합니다", "MT-017"),
+    );
+
+    const result = await createOnlineMeetingAction({ errors: {} }, VALID_FORM());
+
+    expect(result.errors.attendeeIds).toBe("개설자 외 참석자를 한 명 이상 선택해야 합니다");
+    expect(result.errors.parentTeamActionId).toBeUndefined();
+  });
 
   it("목록에 없는 오류 코드는 title 칸으로 떨어진다(필드 슬롯이 없는 오류의 기본 자리)", async () => {
     serverApiMock.mockRejectedValue(new ApiError(400, "알 수 없는 오류", "MT-999"));

--- a/src/features/meeting/actions.ts
+++ b/src/features/meeting/actions.ts
@@ -491,9 +491,11 @@ function readOnlineMeetingDraft(formData: FormData): OnlineMeetingDraft {
 /**
  * `POST /api/meetings/online`(MEET-18) 실패를 폼 필드 오류로 바꾼다.
  * ⚠️ `rooms/actions.ts`의 `toMeetingCreateFormErrors`(MEET-01)와 같은 자리 — 필드 슬롯이 없는
- *    오류(`PROJECT_NOT_FOUND` 등 프로젝트 슬롯이 있는 것 빼고)는 `title` 칸에 얹는다.
- * ⚠️ **`PROJECT_NOT_FOUND`가 이 엔드포인트만 리터럴이 다르다**(도메인 담당자 명세, 2026-08-14) —
- *    MEET-01은 `PJ-001`을 쓰지만 여기는 그대로 이 문자열이다. 어긋나 보여도 그게 명세다.
+ *    오류(`Z-001` 등 전용 슬롯이 있는 것 빼고)는 `title` 칸에 얹는다.
+ * ⚠️ **`PROJECT_NOT_FOUND` 리터럴은 오지 않는다**(2026-08-16 BE 실코드 대조로 정정 —
+ *    2026-08-14 도메인 담당자 명세가 틀렸다). `ErrorResponse.of`(BE global/exception/ErrorResponse.java:23)가
+ *    **전 도메인에서** `errorCode.getCode()`를 `errorCode` 필드로 내리므로 실제 값은 `"PJ-001"`이다.
+ *    이 엔드포인트만 예외를 두지 않는다.
  */
 function toOnlineMeetingCreateFormErrors(error: unknown): OnlineMeetingFormErrors {
   if (!(error instanceof ApiError)) throw error;
@@ -503,12 +505,15 @@ function toOnlineMeetingCreateFormErrors(error: unknown): OnlineMeetingFormError
       return { attendeeIds: "존재하지 않는 참석자가 있습니다" };
     case "MT-015":
       return { topics: error.message };
-    case "MT-016":
+    /* ⚠️ MT-017은 **참석자 부족**이다("개설자 외 참석자를 한 명 이상 선택해야 합니다") —
+       상위 팀 액션 오류(016·018·019)와 다른 칸이다. */
     case "MT-017":
+      return { attendeeIds: error.message };
+    case "MT-016":
     case "MT-018":
     case "MT-019":
       return { parentTeamActionId: error.message };
-    case "PROJECT_NOT_FOUND":
+    case "PJ-001":
       return { projectId: "존재하지 않는 프로젝트입니다" };
     // ⚠️ **여기 도착한 CAP-0XX는 "발급 뒤 상태가 바뀐" 경우다** — CAP-024(용량)·CAP-025(형식)는
     //    보통 업로드 URL 발급 단계(`getOnlineMeetingRecordingUploadUrlAction`)에서 먼저 걸리지만,

--- a/src/features/meeting/server.ts
+++ b/src/features/meeting/server.ts
@@ -242,7 +242,12 @@ function outputsOf(meeting: Meeting): { kindLabel: string; outputs: MeetingOutpu
     .map(({ ref, action }) => ({
       id: action.id,
       name: action.name,
-      assignee: action.assigneeName,
+      /*
+        ⚠️ `PersonalActionDetail.assigneeName`이 optional로 바뀌었다(개인 액션 담당자 미지정
+           가능) — `MeetingOutput.assignee`는 여전히 non-null string이라 화면 계약대로 정본
+           문구(WORKFLOW.md §3-1-A "담당자 미정")로 접는다.
+      */
+      assignee: action.assigneeName ?? "담당자 미정",
       status: ref.status,
       dueDate: ref.dueDate,
       href: `/app/actions/${action.id}`,

--- a/src/features/rooms/actions.real.test.ts
+++ b/src/features/rooms/actions.real.test.ts
@@ -19,7 +19,7 @@ jest.mock("@/lib/api", () => ({
 import { AUTHORITY } from "@/constants/authority";
 import { requireAccessToken } from "@/features/auth/session";
 import { getViewer } from "@/features/shell/viewer";
-import { serverApi } from "@/lib/api";
+import { ApiError, serverApi } from "@/lib/api";
 
 import {
   createMeetingRoomAction,
@@ -126,6 +126,62 @@ describe("createRoomReservationAction — 실서버 참석자 재검증", () => 
     expect(result.errors.attendeeIds).toBeDefined();
     expect(result.created).toBeUndefined();
     expect(serverApiMock).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * MEET-01 오류코드 → 폼 필드 매핑(2026-08-16 정정).
+ *
+ * ⚠️ 지키는 것 셋:
+ *   ① MT-015·MT-016·MT-017·MT-018·MT-019 — 예전엔 매핑이 없어 전부 `title`로 떨어졌다.
+ *      MEET-18(비대면)과 **같은 칸·같은 문구**를 쓴다.
+ *   ② MT-017은 참석자 부족이라 `attendeeIds`(016·018·019 묶음과 다른 칸이다).
+ *   ③ **MT-004는 BE에 없다**(운영시간 개념이 BE PR #523에서 폐기됐다) — `case`를 지웠다.
+ */
+async function createWithApiError(
+  code: string,
+  message = "BE 오류",
+): Promise<Record<string, string>> {
+  serverApiMock.mockRejectedValue(new ApiError(400, message, code));
+
+  const result = await createRoomReservationAction({ errors: {} }, form([3, 4]));
+
+  return result.errors as Record<string, string>;
+}
+
+describe("createRoomReservationAction — MEET-01 오류코드 매핑", () => {
+  it("MT-015는 topics 칸 오류로 바뀐다", async () => {
+    const errors = await createWithApiError("MT-015", "안건이 유효하지 않습니다");
+    expect(errors.topics).toBe("안건이 유효하지 않습니다");
+    expect(errors.title).toBeUndefined();
+  });
+
+  it("MT-017은 attendeeIds 칸 오류로 바뀐다 — 016·018·019 묶음과 다른 자리다", async () => {
+    const errors = await createWithApiError(
+      "MT-017",
+      "개설자 외 참석자를 한 명 이상 선택해야 합니다",
+    );
+    expect(errors.attendeeIds).toBe("개설자 외 참석자를 한 명 이상 선택해야 합니다");
+    expect(errors.parentTeamActionId).toBeUndefined();
+  });
+
+  it.each(["MT-016", "MT-018", "MT-019"])(
+    "%s는 parentTeamActionId 칸 오류로 바뀐다",
+    async (code) => {
+      const errors = await createWithApiError(code, "상위 팀 액션 오류");
+      expect(errors.parentTeamActionId).toBe("상위 팀 액션 오류");
+    },
+  );
+
+  /*
+    ⚠️ MT-004 매핑이 남아 있던 시절엔 이 코드가 `startTime`으로 갔지만, 지금은 BE가 절대
+       던지지 않는 값이라 `default`(title)로 떨어지는 것이 정상이다. 굳이 온다면 그것이
+       계약 위반이므로 사용자가 볼 수 있는 자리(title)에 얹는다.
+  */
+  it("MT-004(BE에 없는 코드)가 어쩌다 오면 default(title)로 떨어진다", async () => {
+    const errors = await createWithApiError("MT-004", "폐기된 오류");
+    expect(errors.title).toBe("폐기된 오류");
+    expect(errors.startTime).toBeUndefined();
   });
 });
 

--- a/src/features/rooms/actions.ts
+++ b/src/features/rooms/actions.ts
@@ -71,8 +71,9 @@ const MANAGE_ROOMS_PATH = "/manage/rooms";
 
 /**
  * 회의 개설(`POST /api/meetings`, MEET-01) 실패를 폼 필드 오류로 바꾼다.
- * ⚠️ 필드 슬롯이 없는 오류(`PJ-001` 등)는 `title` 칸에 얹는다(회의실 도메인의 `toMeetingRoomFormErrors`
- *    와 같은 자리 — 이 폼도 "전체 오류"를 보여줄 별도 자리가 없다).
+ * ⚠️ 필드 슬롯이 없는 오류(`Z-001` 등)는 `title` 칸에 얹는다(회의실 도메인의 `toMeetingRoomFormErrors`
+ *    와 같은 자리 — 이 폼도 "전체 오류"를 보여줄 별도 자리가 없다). `PJ-001`은 아래에서 이미
+ *    `projectId` 슬롯으로 간다.
  */
 function toMeetingCreateFormErrors(error: unknown): RoomReservationFormErrors {
   if (!(error instanceof ApiError)) throw error;
@@ -80,8 +81,6 @@ function toMeetingCreateFormErrors(error: unknown): RoomReservationFormErrors {
   switch (error.code) {
     case "MT-002":
       return { roomId: "그 시간에는 이미 예약된 회의실입니다" };
-    case "MT-004":
-      return { startTime: "회의실 이용 가능 시간 안에서 선택해 주세요" };
     case "MT-005":
       return { startTime: "예약은 30분 단위로만 가능합니다" };
     case "MT-010":
@@ -90,10 +89,24 @@ function toMeetingCreateFormErrors(error: unknown): RoomReservationFormErrors {
       return { startTime: "지난 시간은 선택할 수 없습니다" };
     case "MT-003":
       return { startTime: error.message };
+    /* ⚠️ 아래 다섯은 비대면(MEET-18)과 **같은 칸·같은 문구**다 — 같은 계약을 쓰는 두 생성
+       경로가 다른 칸에 오류를 띄우면 안 된다(`meeting/actions.ts` toOnlineMeetingCreateFormErrors).
+       ⚠️ MT-017은 참석자 부족이라 `attendeeIds`, 나머지 016·018·019는 상위 팀 액션 오류라
+          `parentTeamActionId`다 — MT-017을 016 묶음에 넣지 않는다. */
+    case "MT-015":
+      return { topics: error.message };
+    case "MT-017":
+      return { attendeeIds: error.message };
+    case "MT-016":
+    case "MT-018":
+    case "MT-019":
+      return { parentTeamActionId: error.message };
     case "MR-001":
       return { roomId: "존재하지 않는 회의실입니다" };
     case "PJ-001":
       return { projectId: "존재하지 않는 프로젝트입니다" };
+    /* ⚠️ **MT-004는 BE에 없다** — 운영시간 개념이 BE PR #523에서 폐기되며 enum에서 사라졌다.
+       이 자리에 `case "MT-004"`가 남으면 죽은 분기다. */
     default:
       return { title: error.message };
   }


### PR DESCRIPTION
## 📋 PR 타입

- [ ] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

Closes #596

## 요약
BE 실코드와 어긋난 두 지점(개인 액션 상세·회의 개설 오류코드)을 붙인다.

## 무엇을 왜
**① 개인 액션 상세 (FE-8)** — `ActionService.getActionDetail`은 `assigneeName`·`teamName`·`projectTag`·`projectName`을 명시적으로 `null`로 내려보내는데 FE는 넷 다 non-null `string`으로 단언만 하고 있었다.
- `BeActionDetail`의 nullable 5필드(위 넷 + `description` = `TEXT NULL`)를 실 스펙대로 고치고, 회의 상세와 같은 방식으로 `parseActionDetail` 가드를 세운다.
- 화면 계약(`PersonalActionDetail`)의 `team`·`projectTag`·`assigneeName`을 optional로 바꾸고, 없으면 칩·태그를 아예 안 그린다(빈 칩 그리지 않는다 — §정직성).
- 담당자 자체가 없으면 "담당자 미정"(정본: `docs/WORKFLOW.md` §3-1-A).

**어떻게 죽고 있었나**
- `ActionTypeShapePolicy.checkTeamShape`이 PERSONAL의 팀 소속을 금지 → 개인 액션은 **항상** `teamName === null` → 매번 빈 회색 칩이 그려졌다.
- `projectTag: null`이 그대로 `<ProjectTag>` → `pickPaletteColor` → `hashString`에 흘러가 `null.length`에서 `TypeError` → 페이지가 통째로 죽었다(`src/lib/palette.ts:105`).

**② 회의 개설 오류코드 (FE-17)** — 두 함수가 서로 어긋나 있었다.
- **MEET-01(`rooms/actions.ts`)**: MT-015·016·017·018·019 다섯이 매핑 없어 전부 `title`로 떨어졌다. 반대로 **BE에 없는 MT-004**(운영시간 개념이 BE PR #523에서 폐기)를 `startTime`에 매핑한 죽은 분기가 남아 있었다.
- **MEET-18(`meeting/actions.ts`)**: `case "PROJECT_NOT_FOUND"`를 기다렸지만 `ErrorResponse.of`(`global/exception/ErrorResponse.java:23`)가 **전 도메인에서** `errorCode.getCode()`를 내리므로 실제로 오는 값은 `"PJ-001"`이다 — 없는 프로젝트를 고르면 `projectId` 대신 `title` 칸에 오류가 붙었다.
- MT-017(참석자 부족)은 016/018/019(상위 팀 액션 오류)와 다른 뜻이라 `attendeeIds` 칸으로 옮긴다.

## BE 실코드 근거 (2026-08-16 대조)
- `ActionService.java:258·267·288·289` — `assigneeName`·`teamName`·`projectTag`·`projectName`이 각각 `null`로 조립되는 자리
- `ActionTypeShapePolicy.java:52-53` — "PERSONAL 액션은 팀을 가질 수 없다"
- `ErrorResponse.java:23` — `errorCode.getCode()`가 전 도메인에서 내려간다(리터럴 예외 없음)
- `MeetingErrorCode.java` — MT-015·016·017·018·019 실재, **MT-004는 없다**(폐기)
- `V1__init_schema.sql:173` — `action.description TEXT NULL`

## 안 하는 것
- BE 수정(MT-004 부활·`PROJECT_NOT_FOUND` 리터럴 내리기)
- `default` 분기 삭제
- `src/lib/endpoints.ts:187`의 MT-004 언급 — 별건(엔드포인트 주석 정리)
- 회의실 도메인 `toMeetingRoomFormErrors`(MR-001·MR-002)
- MEET-05·MEET-06·MEET-09 오류 매핑
- `BeTeamActionDetail`·팀 액션 상세 화면
- 비대면 참석자 서버 재검증(FE-18 별건)

## 확인법
- `/app/actions/:actionId` 개인 액션 상세 → 빈 회색 팀 칩 사라짐
- (연동 후) MT-015 트리거 → `topics` 칸(기존 `title`)
- (연동 후) MT-017 트리거 → `attendeeIds` 칸(기존 `parentTeamActionId`)
- (연동 후) PJ-001 트리거(비대면) → `projectId` 칸(기존 `title`)
- 지금 여기: `npx jest --silent` → 141 suites · 1484 tests (+10건)
  - 신규: `src/features/action/mapper.test.ts` (parseActionDetail·toPersonalActionDetail nullable)
  - 갱신: `actions.online-real.test.ts` (PROJECT_NOT_FOUND → PJ-001·MT-017 분리)
  - 추가: `actions.real.test.ts` (MEET-01 새 매핑 4건 + MT-004 default 확인)

## 체크리스트
- [x] `npx tsc --noEmit`
- [x] `npx eslint <바뀐 10파일> --max-warnings=0`
- [x] `npx jest --silent` (141 suites · 1484 tests)
- [x] `npx next build`


---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**, 그리고 **서버에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [ ] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시
- [ ] 🎨 디자인 토큰 사용 · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화
- [ ] ♿ a11y
- [ ] ♻️ 재사용 확인
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API 사용 시 미지원 · 권한거부 안내 있음

---

## 🔗 연관 이슈

Closes #596

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

-

---

## 📝 추가 메모
