### PR TITLE
[FIX] 지연 판정 통일·진척률 계약 문구 정정 #598

### DIFF
--- a/src/app/(shell)/app/projects/[projectId]/page.tsx
+++ b/src/app/(shell)/app/projects/[projectId]/page.tsx
@@ -5,7 +5,6 @@ import { notFound } from "next/navigation";
 import { AttachmentList } from "@/components/common/attachment-list";
 import { Badge } from "@/components/ui/badge";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { isDelayed } from "@/constants/domain";
 import type { TimelineActionInput } from "@/features/member/action-timeline";
 import { ActionTimeline, ActionTimelineLegend } from "@/features/member/components/action-timeline";
 import { getProjectAttachmentDownloadUrlAction } from "@/features/project/actions";
@@ -59,7 +58,13 @@ export default async function ProjectDetailPage({ params, searchParams }: Projec
       tagTextColor: "var(--muted-foreground)",
       startDate: action.startDate,
       dueDate: action.dueDate,
-      tone: isDelayed(action) ? "DELAYED" : action.status,
+      /*
+        ⚠️ **BE 판정을 쓴다** — 프로젝트 타임라인만 BE가 이미 `isDelayed`를 계산해 보낸다
+           (`ProjectTimelineItemResponse`). 다른 화면(내 액션·팀 액션 목록 등)은 목 경로에도
+           같은 배지가 필요해 로컬 계산(`isDelayed`)을 그대로 쓴다 — 여기만 두 벌이 되는 것을
+           피한다(자정 경계 어긋남 방지).
+      */
+      tone: action.isDelayed ? "DELAYED" : action.status,
       // ⚠️ 식별자는 action.id(팀 액션 ID)를 쓴다 — action.team(팀명)으로 경로를 만들면
       //    같은 팀에 팀 액션이 여러 개일 때 서로 구분이 안 된다.
       href: `/app/projects/${project.id}/team/${action.id}`,

--- a/src/constants/action.test.ts
+++ b/src/constants/action.test.ts
@@ -1,0 +1,60 @@
+/**
+ * 지연 판정 회귀 — 팀 확정 규칙(진행중 && 마감 경과, WORKFLOW.md §7)에 못박는다.
+ *
+ * ⚠️ 이 규칙이 세 곳(FE `isDelayed`·보드 `isCardDelayed`·BE `ActionSummaryResponse`)에서
+ *    같아야 한다. 조건을 `status !== DONE`으로 넓히면 여기서 먼저 실패한다.
+ */
+import { ACTION_STATUS, isDelayed, isPastDue } from "./action";
+
+/* 오늘: 2026-08-16 오전 9시(KST 오전 9시 → 자정 경계 회귀에 필요) */
+const TODAY = new Date("2026-08-16T09:00:00");
+
+describe("isPastDue — 로컬 자정 기준", () => {
+  it("어제 마감은 지났다", () => {
+    expect(isPastDue("2026-08-15", TODAY)).toBe(true);
+  });
+
+  it("오늘 마감은 아직 지나지 않았다 — KST 오전 9시에도 false", () => {
+    /*
+      ⚠️ 이 케이스가 자정 경계 회귀의 핵심이다. `new Date("2026-08-16")`(UTC 자정)로 파싱하면
+         KST +9 환경에서 오전 9시 이후 true가 되어 '오늘 마감'이 지연으로 뜬다.
+    */
+    expect(isPastDue("2026-08-16", TODAY)).toBe(false);
+  });
+
+  it("내일 마감은 지나지 않았다", () => {
+    expect(isPastDue("2026-08-17", TODAY)).toBe(false);
+  });
+});
+
+describe("isDelayed — 진행중 한정(팀 확정 · BE와 같은 규칙)", () => {
+  it("진행중 + 어제 마감이면 지연이다", () => {
+    expect(isDelayed({ status: ACTION_STATUS.IN_PROGRESS, dueDate: "2026-08-15" }, TODAY)).toBe(
+      true,
+    );
+  });
+
+  it("진행중 + 오늘 마감은 지연이 아니다(KST 자정 경계 회귀)", () => {
+    expect(isDelayed({ status: ACTION_STATUS.IN_PROGRESS, dueDate: "2026-08-16" }, TODAY)).toBe(
+      false,
+    );
+  });
+
+  it("할일 + 어제 마감은 지연이 아니다 — 확정 규칙 변경의 핵심", () => {
+    /*
+      ⚠️ 예전 규칙(`status !== DONE`)에서는 true였다. 여기가 릴리즈 노트 대상 화면들(내 액션
+         목록·팀 액션 목록·마이페이지 대시보드·팀 액션 상세 타임라인·인수인계 액션 목록·
+         팀장 인수인계 액션 목록·사원 상세 담당 액션 카드)에서 배지가 사라지는 이유다.
+    */
+    expect(isDelayed({ status: ACTION_STATUS.TODO, dueDate: "2026-08-15" }, TODAY)).toBe(false);
+  });
+
+  it("완료 + 어제 마감은 지연이 아니다", () => {
+    expect(isDelayed({ status: ACTION_STATUS.DONE, dueDate: "2026-08-15" }, TODAY)).toBe(false);
+  });
+
+  it("today 기본값은 현재 시각이다 — 인자 안 주면 new Date() 사용", () => {
+    /* 미래 마감은 어느 시점에서 봐도 지연이 아니다 — 기본값 사용을 확인하는 안전한 회귀. */
+    expect(isDelayed({ status: ACTION_STATUS.IN_PROGRESS, dueDate: "2099-12-31" })).toBe(false);
+  });
+});

--- a/src/constants/action.ts
+++ b/src/constants/action.ts
@@ -33,15 +33,34 @@ export const ACTION_TYPE = {
 export type ActionType = (typeof ACTION_TYPE)[keyof typeof ACTION_TYPE];
 
 /**
- * ⚠️ DELAYED는 **상태가 아니라 파생값**이다(마감 경과).
- * 상태 필드에 넣으면 IN_PROGRESS와 충돌한다 — 항상 계산해서 쓴다.
+ * `YYYY-MM-DD` 마감일이 이미 지났는가 — **로컬 자정 기준**이다.
+ *
+ * ⚠️ `new Date("2026-08-05")`는 UTC 자정이라 KST(+9)에선 '오늘 마감'이 오전 9시부터 지연으로
+ *    잘못 뜬다 — 마감일은 시각이 아니라 날짜다. **이 프로젝트에서 마감 경과를 판정하는
+ *    구현은 이 함수 하나뿐이다.** 자정 계산이 두 벌이면 서버 시각과 브라우저 시각이 갈리는
+ *    자정 무렵에 목록과 보드가 다른 배지를 단다.
+ * ⚠️ `today`를 주입 가능하게 둔다 — 테스트가 시각을 못 박고, 보드가 렌더 시점 `today`를
+ *    한 번 만들어 여러 카드에 넘길 수 있다.
  */
-export function isDelayed(action: { status: ActionStatus; dueDate: string }): boolean {
-  if (action.status === ACTION_STATUS.DONE) return false;
-  // 날짜 전용 값이라 **로컬 자정** 기준으로 비교한다. `new Date("2026-08-05")`는 UTC 자정이라
-  // KST(+9)에선 '오늘 마감'이 오전 9시부터 지연으로 잘못 뜬다 — 마감일은 시각이 아니라 날짜다.
-  const due = new Date(`${action.dueDate}T00:00:00`);
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-  return due < today;
+export function isPastDue(dueDate: string, today: Date = new Date()): boolean {
+  const due = new Date(`${dueDate}T00:00:00`);
+  const midnight = new Date(today);
+  midnight.setHours(0, 0, 0, 0);
+  return due < midnight;
+}
+
+/**
+ * ⚠️ DELAYED는 **상태가 아니라 파생값**이다(마감 경과).
+ * ⚠️ **진행중 한정이다**(팀 확정 · docs/WORKFLOW.md §7 "진행중 칸 안의 배지").
+ *    할일은 아직 안 늦은 것이고 완료는 지연이 아니다 — BE `ActionSummaryResponse`도 같은
+ *    식을 쓴다(`status == IN_PROGRESS && dueDate.isBefore(today)`). 여기를 `status !== DONE`
+ *    으로 되돌리면 같은 액션이 화면과 서버에서 다른 배지를 단다.
+ * ⚠️ 마감 경과 비교는 `isPastDue` 하나뿐이다 — 자정 계산을 여기 다시 쓰지 않는다.
+ */
+export function isDelayed(
+  action: { status: ActionStatus; dueDate: string },
+  today: Date = new Date(),
+): boolean {
+  if (action.status !== ACTION_STATUS.IN_PROGRESS) return false;
+  return isPastDue(action.dueDate, today);
 }

--- a/src/features/board/components/board-view.tsx
+++ b/src/features/board/components/board-view.tsx
@@ -88,13 +88,17 @@ export function BoardView({ boardType, cards, todayIso }: BoardViewProps) {
   const activeCard = cards.find((card) => card.id === activeId) ?? null;
 
   /**
-   * 지연 배지 — **지금 서 있는 칸**으로 판정한다(저장된 `isDone`이 아니라).
+   * 지연 배지 — **지금 서 있는 칸**(드래그 override 포함)이 진행중일 때만 단다.
    *
    * ⚠️ 칸과 드래그 사본이 **같은 함수**를 쓴다. 따로 적어 두면 한쪽만 고쳐져 같은 카드가
    *    자리에 따라 다른 배지를 단다(2026-08-11 코드래빗 지적).
+   * ⚠️ **칸 판정은 여기서 한다** — `isCardDelayed`는 저장된 `isDone`만 보는 `getBoardColumn`을
+   *    부르지 않는다(드래그 override를 모른다). 확정 규칙(WORKFLOW.md §7 "진행중 칸 안의
+   *    배지")대로 `IN_PROGRESS`일 때만 단다 — 할일 칸(마감 데이터 오류로 dueDate < startDate)이
+   *    나 완료 칸에는 안 뜬다.
    */
   function isDelayedInView(card: BoardCard): boolean {
-    return columnOf(card) !== BOARD_COLUMN.DONE && isCardDelayed(card, today);
+    return columnOf(card) === BOARD_COLUMN.IN_PROGRESS && isCardDelayed(card, today);
   }
 
   function handleDragStart(event: DragStartEvent) {

--- a/src/features/board/lib.test.ts
+++ b/src/features/board/lib.test.ts
@@ -39,12 +39,27 @@ describe("isCardDelayed", () => {
     expect(isCardDelayed(card({ isDone: true, dueDate: "2026-07-01" }), TODAY)).toBe(false);
   });
 
-  it("완료가 아니고 마감이 지났으면 지연이다", () => {
+  it("완료가 아니고 마감이 지났으면 지연이다 — 칸 판정은 호출부(`board-view.tsx`) 몫이다", () => {
+    /*
+      ⚠️ 시작일이 미래(할 일 칸)이든 과거(진행중 칸)이든 `isCardDelayed`는 마감 경과만 본다.
+         "진행중 칸 안의 배지"라는 확정 규칙은 호출부(`isDelayedInView`)가 `columnOf(card)`를
+         함께 봐서 지운다 — `getBoardColumn`을 여기서 부르면 드래그 override를 놓친다.
+    */
     expect(isCardDelayed(card({ dueDate: "2026-08-01" }), TODAY)).toBe(true);
+    expect(isCardDelayed(card({ startDate: "2026-08-07", dueDate: "2026-08-01" }), TODAY)).toBe(
+      true,
+    );
+    expect(isCardDelayed(card({ startDate: "2026-07-01", dueDate: "2026-08-01" }), TODAY)).toBe(
+      true,
+    );
   });
 
   it("마감이 안 지났으면 지연이 아니다", () => {
     expect(isCardDelayed(card({ dueDate: "2026-08-10" }), TODAY)).toBe(false);
+  });
+
+  it("오늘 마감은 지연이 아니다 — KST 자정 경계 회귀(공용 `isPastDue`)", () => {
+    expect(isCardDelayed(card({ dueDate: "2026-08-06" }), TODAY)).toBe(false);
   });
 });
 

--- a/src/features/board/lib.ts
+++ b/src/features/board/lib.ts
@@ -1,6 +1,11 @@
+import { isPastDue } from "@/constants/action";
+
 import { BOARD_COLUMN, type BoardCard, type BoardColumnId } from "./types";
 
-/** `YYYY-MM-DD`를 로컬 자정 기준 `Date`로 — 마감일 비교는 시각이 아니라 날짜다(§isDelayed와 동일). */
+/**
+ * `YYYY-MM-DD`를 로컬 자정 기준 `Date`로 — 마감일 비교는 시각이 아니라 날짜다(§isPastDue와 동일).
+ * ⚠️ `getBoardColumn`의 시작일 비교가 여기 쓴다 — 마감 경과 비교는 `isPastDue`로 공용화됐다.
+ */
 function toLocalMidnight(iso: string): Date {
   return new Date(`${iso}T00:00:00`);
 }
@@ -26,10 +31,18 @@ export function getBoardColumn(
     : BOARD_COLUMN.IN_PROGRESS;
 }
 
-/** 지연 배지 — 완료가 아니고 마감이 지났으면. 시작일은 안 본다(`isDelayed`와 같은 결). */
+/**
+ * 지연 배지 — 마감 경과 여부만 본다. **칸(진행중 한정) 판정은 호출부**가 한다.
+ *
+ * ⚠️ 여기서 `getBoardColumn`을 부르지 않는다 — 화면(`board-view.tsx`)이 드래그 중에 임시로
+ *    옮긴 칸(`overrides[card.id]`)까지 함께 봐야 하고, 그건 저장된 값(`isDone`)만 보는
+ *    `getBoardColumn`이 모른다. 여기서 칸을 판정하면 카드를 완료로 끌어다 놓아도 서버
+ *    저장 전까지 지연 배지가 남는다.
+ * ⚠️ 자정 계산은 `isPastDue` 하나뿐이다 — 여기 다시 쓰지 않는다.
+ */
 export function isCardDelayed(card: Pick<BoardCard, "isDone" | "dueDate">, today: Date): boolean {
   if (card.isDone) return false;
-  return toLocalMidnight(card.dueDate) < startOfToday(today);
+  return isPastDue(card.dueDate, today);
 }
 
 /**

--- a/src/features/member/manage-mapper.ts
+++ b/src/features/member/manage-mapper.ts
@@ -166,10 +166,11 @@ export function toManagedMember(item: BeMemberListItem | BeMemberDetail): Manage
  * ⚠️ **이 카드가 쓰는 네 값만 옮긴다.** 응답엔 `projectTag`·`teamName`·`sourceMeetingTitle`·
  *    `parentActionTitle`까지 오지만, 카드는 `액션 · 상태 · 마감` 세 열뿐이다(§명세: 화면에
  *    없는 걸 새로 만들지 않는다). 안 쓰는 필드를 옮겨 두면 화면이 의존하는 값처럼 읽힌다.
- * ⚠️ **`isDelayed`를 안 가져온다.** BE도 저장값이 아니라 조회 시점에 계산해 주는 값인데
- *    (`ActionSummaryResponse` 주석), 우리 카드는 이미 `isDelayed(action)`으로 마감일에서
- *    계산한다(§도메인 상수: 파생값은 상태 필드에 안 넣는다). 두 벌이 되면 서버 시각과
- *    브라우저 시각이 갈리는 자정 무렵에 배지가 서로 다른 말을 한다.
+ * ⚠️ **`isDelayed`를 안 가져온다.** 판정 규칙이 BE(`ActionSummaryResponse` — `IN_PROGRESS &&
+ *    dueDate < today`)와 FE(`constants/action.ts` `isDelayed`)에서 같아졌으므로(진행중 && 마감
+ *    경과, 2026-08-16 팀 확정) 이 카드는 로컬 계산을 계속 쓴다 — 목(mock) 경로에도 같은
+ *    배지가 필요한데 거기엔 BE 값이 없다. **정본은 하나(확정 규칙)이고 구현이 둘인 상태**
+ *    이므로, 규칙이 바뀌면 두 곳을 함께 고쳐야 한다.
  * ⚠️ `id`를 문자열로 바꾼다 — 화면 계약(`ManagedMemberAction.id`)이 문자열이다.
  */
 export function toManagedMemberAction(be: BeCompanyAction): ManagedMemberAction {

--- a/src/features/project/lib.ts
+++ b/src/features/project/lib.ts
@@ -59,7 +59,15 @@ export function sortProjects(list: ProjectListItem[], sort: ProjectSort): Projec
   }
 }
 
-/** 진척율(%) — 액션이 없으면 0. 파생값이라 저장하지 않고 계산한다. */
+/**
+ * 진척율(%) — 액션이 없으면 0. 파생값이라 저장하지 않고 계산한다.
+ * ⚠️ **여기가 진척율의 유일한 구현이다.** BE `ProjectSummaryResponse.progressPct`(소수)는 안
+ *    쓴다 — 표시 규칙(반올림·소수점 없음)이 FE 몫이고 목 경로에도 같은 숫자가 필요하다
+ *    (`project/mapper.ts`의 `toProjectListItem` 위 주석 참고).
+ * ⚠️ **분자·분모 모두 개인 액션(리프) 기준이다**(docs/WORKFLOW.md §1). BE-12 배포 전에는
+ *    분모가 팀 액션까지 세고 있어 진척율이 실제보다 낮게 나온다 — FE는 보정하지 않는다
+ *    (어떤 액션이 세어졌는지 FE는 모른다).
+ */
 export function getProgressPercent(done: number, total: number): number {
   if (total <= 0) return 0;
   return Math.round((done / total) * 100);

--- a/src/features/project/mapper.test.ts
+++ b/src/features/project/mapper.test.ts
@@ -1,0 +1,72 @@
+/**
+ * 프로젝트 매퍼 회귀 — 진척율 계약과 타임라인 `isDelayed` 옮기기.
+ *
+ * ⚠️ 지키는 것 둘:
+ *   ① `toProjectListItem`은 BE `progressPct`(소수)를 **버린다** — 표시 규칙이 FE 몫이라
+ *      두 벌로 두지 않는다. 결과 객체에 `progressPct` 키가 있으면 다음 사람이 그 값을
+ *      화면에 그리기 시작한다.
+ *   ② `toProjectTeamAction`은 BE `isDelayed`를 **옮긴다** — 지금까지 조용히 버려지고
+ *      있었다(같은 파일에 필드가 선언돼 있는데 매퍼에서 안 읽었다).
+ */
+import {
+  type BeProjectSummary,
+  type BeProjectTimelineItem,
+  toProjectListItem,
+  toProjectTeamAction,
+} from "./mapper";
+
+describe("toProjectListItem — 진척율 계약", () => {
+  const BE: BeProjectSummary = {
+    id: 1,
+    tag: "GOODS",
+    color: "#123456",
+    name: "굿즈 앱",
+    description: "설명",
+    status: "IN_PROGRESS",
+    startDate: "2026-07-01",
+    dueDate: "2026-09-30",
+    teamCount: 3,
+    actionCount: 3,
+    completedActionCount: 1,
+    meetingCount: 5,
+    /* ⚠️ FE는 안 쓴다 — 결과 객체에 이 키가 없어야 한다 */
+    progressPct: 33.333,
+    teamNames: ["개발팀", "마케팅팀", "디자인팀"],
+  };
+
+  it("`progressPct`를 결과 객체로 옮기지 않는다 — FE `getProgressPercent`가 정본이다", () => {
+    /*
+      ⚠️ 여기서 실패하면 다음 사람이 BE 소수 값을 그대로 화면에 그리기 시작한다는 신호다.
+         라인이 두 벌이 되면 목 경로가 진척율을 못 만들고, 반올림 규칙도 두 곳에 흩어진다.
+    */
+    const result = toProjectListItem(BE);
+    expect(result).not.toHaveProperty("progressPct");
+  });
+
+  it("`actionCount`·`completedActionCount`만 UI 계약(`actionTotal`·`actionDone`)으로 옮긴다", () => {
+    const result = toProjectListItem(BE);
+    expect(result.actionTotal).toBe(3);
+    expect(result.actionDone).toBe(1);
+  });
+});
+
+describe("toProjectTeamAction — 타임라인 지연 배지", () => {
+  const BE: BeProjectTimelineItem = {
+    actionId: 42,
+    title: "설계 검토",
+    teamId: 1,
+    teamName: "개발팀",
+    status: "IN_PROGRESS",
+    dueDate: "2026-08-20",
+    isDelayed: true,
+  };
+
+  it("BE `isDelayed`를 그대로 UI 계약(`ProjectTeamAction.isDelayed`)에 싣는다", () => {
+    /*
+      ⚠️ 예전엔 이 값이 매퍼에서 조용히 버려지고 있었다. 프로젝트 타임라인만 BE가 이미
+         계산해 보내므로 화면이 다시 계산하지 않는다 — 두 벌이면 자정 경계에서 어긋난다.
+    */
+    expect(toProjectTeamAction(BE).isDelayed).toBe(true);
+    expect(toProjectTeamAction({ ...BE, isDelayed: false }).isDelayed).toBe(false);
+  });
+});

--- a/src/features/project/mapper.ts
+++ b/src/features/project/mapper.ts
@@ -31,6 +31,11 @@ export interface BeProjectSummary {
   actionCount: number;
   completedActionCount: number;
   meetingCount: number;
+  /**
+   * ⚠️ **FE는 안 쓴다**(소수 값이다). 진척율 표시는 `getProgressPercent(actionDone, actionTotal)`가
+   *    만든다 — 반올림·소수점 없음 규칙이 FE 몫이라 두 벌로 두지 않는다(`toProjectListItem`
+   *    위 주석 참고).
+   */
   progressPct: number;
   /** 생성·수정 응답에서는 항상 빈 배열 — 실제 값은 목록 조회에서만 온다. */
   teamNames: string[];
@@ -91,6 +96,15 @@ function fallbackStartDate(startDate: string | null): string {
   return startDate ?? new Date().toISOString().slice(0, 10);
 }
 
+/**
+ * ⚠️ **`be.progressPct`는 안 옮긴다 — 쓰지 않는 필드다.** 진척율의 표시 규칙(소수점 없이
+ *    반올림)이 FE 몫이라(`lib.ts` `getProgressPercent`, `project-list-table.tsx`가 `%`만 쓴다)
+ *    같은 숫자를 두 벌로 만들지 않으려면 한쪽을 버려야 한다. `actionCount`·`completedActionCount`
+ *    두 숫자만 받아 화면이 계산하는 쪽을 정본으로 둔다 — BE 값을 표시하려면 반올림 규칙까지
+ *    BE로 옮겨야 하고, 그러면 목(mock) 경로가 진척율을 못 만든다.
+ * ⚠️ `actionCount`·`completedActionCount`는 **개인 액션(리프)만** 센다(docs/WORKFLOW.md §1,
+ *    BE-12). 팀 액션을 함께 세면 같은 일이 두 번 세어져 진척율이 실제보다 낮게 나온다.
+ */
 export function toProjectListItem(be: BeProjectSummary): ProjectListItem {
   return {
     id: be.id,
@@ -137,6 +151,15 @@ export function toProjectTeamAction(be: BeProjectTimelineItem): ProjectTeamActio
     startDate: be.dueDate,
     dueDate: be.dueDate,
     status: be.status,
+    /*
+      ⚠️ **BE 판정을 그대로 옮긴다** — 프로젝트 타임라인은 BE `ProjectService.getTimeline`이
+         이미 계산해 보낸다(같은 파일 71행에 `isDelayed`가 선언돼 있는데 지금까지 조용히
+         버려지고 있었다). 두 벌이면 서버·브라우저 시각이 갈리는 자정에 어긋난다.
+      ⚠️ 지금 BE 판정식은 `status != DONE && dueDate < today`라 FE 확정 규칙(진행중 && 마감
+         경과)과 다르다 — BE-13이 좁힌다. 그전까지 이 타임라인만 '할일 + 마감 경과'가
+         지연으로 뜬다(다른 화면은 FE 로컬 계산이라 이번 변경으로 사라진다).
+    */
+    isDelayed: be.isDelayed,
   };
 }
 

--- a/src/features/project/mock/projects.ts
+++ b/src/features/project/mock/projects.ts
@@ -6,6 +6,8 @@ import type { ProjectDraft, ProjectListItem } from "../types";
  * ⚠️ 목 데이터 — BE 연동 전(ERD·API 스펙 미확정, DECISIONS.md).
  * 워크플로우 문서의 대표 프로젝트 3개(GOODS·BRAND·COLLAB) 기준. 전부 Owner(박대표)가 개설했고
  * 현재 진행중이라 진척율은 착수 직후(0%)다. 마감 임박순 정렬은 서버가 얹는다.
+ * ⚠️ `actionTotal`·`actionDone`은 **개인 액션(리프)만** 센 값이다(docs/WORKFLOW.md §1) —
+ *    팀 액션을 섞어 세면 목만 보고 만든 화면이 연동 후 다른 숫자를 낸다(§정직한 목업).
  */
 export const TOP_LEVEL_PROJECTS: ProjectListItem[] = [
   {

--- a/src/features/project/mock/team-actions.ts
+++ b/src/features/project/mock/team-actions.ts
@@ -9,6 +9,11 @@ import type { ProjectTeamAction } from "../types";
  *    `member/mock/dashboard.ts`와 같은 규칙). 진행중은 오늘을 가로질러도 된다.
  * ⚠️ 날짜는 **2026-08-11 기준**으로 잡았다. 목이라 값이 고정이므로 시간이 지나면 이 규칙이
  *    저절로 깨진다 — 화면에서 할 일 막대가 오늘선 왼쪽에 걸리면 여기 날짜를 뒤로 민다.
+ * ⚠️ **`isDelayed`는 확정 규칙대로 고정한다**(`IN_PROGRESS && dueDate < 오늘`) — 실서버
+ *    타임라인이 BE 판정을 그대로 옮기므로(§`toProjectTeamAction`) 목도 같은 판정 규칙을
+ *    따라야 목만 보고 만든 화면이 연동 후 다른 배지를 내지 않는다(§정직한 목업).
+ *    지금 값은 전부 `false`다 — 목 시점(2026-08-11)·BE-13 후 확정 규칙 기준으로 마감이
+ *    지난 진행중 항목이 없다. 시간이 지나 이 규칙이 저절로 참이 되면 값을 손으로 켠다.
  */
 export const PROJECT_TEAM_ACTIONS_MOCK: Record<string, ProjectTeamAction[]> = {
   GOODS: [
@@ -19,6 +24,7 @@ export const PROJECT_TEAM_ACTIONS_MOCK: Record<string, ProjectTeamAction[]> = {
       startDate: "2026-07-21",
       dueDate: "2026-08-29",
       status: ACTION_STATUS.IN_PROGRESS,
+      isDelayed: false,
     },
     {
       id: 2,
@@ -27,6 +33,7 @@ export const PROJECT_TEAM_ACTIONS_MOCK: Record<string, ProjectTeamAction[]> = {
       startDate: "2026-08-18",
       dueDate: "2026-09-12",
       status: ACTION_STATUS.TODO,
+      isDelayed: false,
     },
     {
       id: 3,
@@ -35,6 +42,7 @@ export const PROJECT_TEAM_ACTIONS_MOCK: Record<string, ProjectTeamAction[]> = {
       startDate: "2026-08-14",
       dueDate: "2026-08-22",
       status: ACTION_STATUS.TODO,
+      isDelayed: false,
     },
     {
       id: 4,
@@ -43,6 +51,7 @@ export const PROJECT_TEAM_ACTIONS_MOCK: Record<string, ProjectTeamAction[]> = {
       startDate: "2026-07-21",
       dueDate: "2026-08-22",
       status: ACTION_STATUS.IN_PROGRESS,
+      isDelayed: false,
     },
   ],
   BRAND: [
@@ -53,6 +62,7 @@ export const PROJECT_TEAM_ACTIONS_MOCK: Record<string, ProjectTeamAction[]> = {
       startDate: "2026-08-01",
       dueDate: "2026-08-20",
       status: ACTION_STATUS.IN_PROGRESS,
+      isDelayed: false,
     },
     {
       id: 6,
@@ -61,6 +71,7 @@ export const PROJECT_TEAM_ACTIONS_MOCK: Record<string, ProjectTeamAction[]> = {
       startDate: "2026-08-15",
       dueDate: "2026-09-12",
       status: ACTION_STATUS.TODO,
+      isDelayed: false,
     },
   ],
   COLLAB: [
@@ -71,6 +82,7 @@ export const PROJECT_TEAM_ACTIONS_MOCK: Record<string, ProjectTeamAction[]> = {
       startDate: "2026-07-25",
       dueDate: "2026-08-25",
       status: ACTION_STATUS.IN_PROGRESS,
+      isDelayed: false,
     },
     {
       id: 8,
@@ -79,6 +91,7 @@ export const PROJECT_TEAM_ACTIONS_MOCK: Record<string, ProjectTeamAction[]> = {
       startDate: "2026-08-17",
       dueDate: "2026-09-19",
       status: ACTION_STATUS.TODO,
+      isDelayed: false,
     },
   ],
 };

--- a/src/features/project/types.ts
+++ b/src/features/project/types.ts
@@ -22,9 +22,13 @@ export interface ProjectListItem {
   tag: string;
   /** 참여 부서명들 — 2개까지 노출 후 `+N` */
   departments: string[];
-  /** 이 태그가 달린 전체 액션 수 */
+  /**
+   * 이 프로젝트의 **개인 액션(리프)** 수 — 팀 액션은 세지 않는다(docs/WORKFLOW.md §1).
+   * ⚠️ 팀 액션을 함께 세면 같은 일이 두 번 세어져 진척율이 실제보다 낮게 나온다
+   *    (팀 액션 1건 + 그 하위 개인 액션 3건 = 4건이 아니라 3건이다).
+   */
   actionTotal: number;
-  /** 그중 완료 액션 수 — 진척율 = done/total */
+  /** 그중 완료(`DONE`)인 개인 액션 수 — 진척율 = `getProgressPercent(actionDone, actionTotal)`. */
   actionDone: number;
   /**
    * 시작일 `YYYY-MM-DD`. ⚠️ 화면엔 노출하지 않는다 — 상태(할 일/진행중/지연)·타임라인 계산용
@@ -118,6 +122,15 @@ export interface ProjectTeamAction {
   /** 마감일 `YYYY-MM-DD` */
   dueDate: string;
   status: ActionStatus;
+  /**
+   * 지연 배지 — **BE 판정을 그대로 쓴다**(`ProjectTimelineItemResponse.isDelayed`).
+   * ⚠️ 파생값이라 저장되지 않는다. 프로젝트 타임라인은 BE가 이미 계산해 보내므로 화면이
+   *    다시 계산하지 않는다 — 두 벌이면 서버·브라우저 시각이 갈리는 자정 무렵에 어긋난다.
+   * ⚠️ 지금(2026-08-16) BE 판정식은 `status != DONE && dueDate < today`라 확정 규칙(진행중 &&
+   *    마감 경과)과 다르다 — BE-13이 좁힌다. 그전에는 이 타임라인만 '할일 + 마감 경과'가
+   *    지연으로 뜬다(로컬 계산과 결과가 다르다는 점을 매퍼 주석에 남겼다).
+   */
+  isDelayed: boolean;
 }
 
 /**


### PR DESCRIPTION
## 📋 PR 타입

- [ ] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [x] OWNER (대표)
- [ ] ADMIN (관리자)
- [x] LEADER (팀장)
- [x] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

Closes #598

## 요약
지연 배지와 진척율에서 저장값·계산값이 흐트러진 자리를 붙인다.

## 무엇을 왜
**① 지연 판정 (FE-14)**
- `isDelayed`(`src/constants/action.ts`)를 확정 규칙(진행중 && 마감 경과, `docs/WORKFLOW.md` §7 "진행중 칸 안의 배지")으로 좁힌다. 예전엔 `status !== DONE`이라 **할일 상태의 마감 경과도 지연**으로 찍었다. BE `ActionSummaryResponse`가 이미 확정 규칙을 쓰고 있어 화면과 서버가 다른 값을 만들던 상태를 해소한다.
- 마감 경과 비교를 `isPastDue(dueDate, today)` 한 함수로 뽑는다. `today`를 주입 가능하게 두고, `isDelayed`·`isCardDelayed`가 이 하나만 부른다 — 자정 계산이 두 벌이면 서버·브라우저 시각이 갈리는 자정 무렵에 목록과 보드가 다른 배지를 단다.
- 보드의 `isCardDelayed`는 마감 경과만 판정하고 칸 판정은 호출부가 한다(드래그 override를 놓치지 않기 위해 — `board-view.tsx`의 `columnOf(card)`가 override를 포함한다).
- 프로젝트 타임라인만 BE 판정을 그대로 옮긴다(`ProjectTeamAction.isDelayed` ← `BeProjectTimelineItem.isDelayed`). 지금까지 매퍼에서 조용히 버려지고 있었다 — 화면이 다시 계산하지 않아 자정 경계 어긋남을 피한다.
- `PROJECT_TEAM_ACTIONS_MOCK`에 `isDelayed`를 확정 규칙대로 고정한다(전부 false — 목 시점 기준 마감이 지난 진행중 없음).

**② 진척율 계약 (FE-15)**
- `ProjectListItem.actionTotal`·`actionDone` 주석을 "이 프로젝트의 개인 액션(리프) 수"로 정정(WORKFLOW.md §1) — BE-12 후 문서·코드가 다시 어긋나지 않도록.
- `BeProjectSummary.progressPct`와 `toProjectListItem` 위에 왜 `progressPct`를 안 옮기는지 남긴다(FE 반올림 규칙 정본 유지·목 경로도 진척율 필요).
- `getProgressPercent` 주석에 "여기가 진척율의 유일한 구현"·"BE-12 전에는 분모가 팀 액션까지 세고 있어 FE는 보정하지 않는다"를 명시.

## 릴리즈 노트 대상 (배지가 사라지는 자리)
할일 + 마감 경과 액션에서 배지가 사라진다 — 예전 규칙(`status !== DONE`)이 확정 규칙(`IN_PROGRESS`)으로 좁혀졌기 때문.
- 내 액션 목록 (`/app/my/actions`)
- 팀 액션 목록 (`/team/action`, `/app/projects/:projectId/team/:teamActionId`)
- 마이페이지 대시보드 (`/my`)
- 팀 액션 상세 타임라인
- 인수인계 액션 목록 (`/app/handover/:id`)
- 팀장 인수인계 액션 목록 (`/owner/leader-handovers/:id`)
- 사원 상세 담당 액션 카드 (`/manage/members/:id`)

프로젝트 타임라인은 BE-13 배포 전까지 예전 동작 유지(BE가 아직 `status != DONE` 기준).

## 안 하는 것
- 로컬 계산을 전부 지우고 BE `isDelayed`만 쓰기 — 목 경로·보드에는 BE 값이 안 온다
- FE에서 팀 액션 보정 계산 — FE는 무엇이 세어졌는지 모른다
- BE 수정(BE-12·BE-13·BE-18)
- 프로젝트 상세에 진척율 새로 추가 — 명세에 없는 항목
- `overdue` 파라미터로 '지연만 보기' 필터 신설 — 별건
- `BeActionSummary.isDelayed`를 UI 계약(`MyActionListItem` 등)에 싣기 — 목 경로도 함께 굴러야 해서 로컬 계산 유지

## 확인법
- 오늘 이전 마감의 **할일** 액션: 배지가 사라진다(위 목록)
- 오늘 이전 마감의 **진행중** 액션: 배지 유지
- 보드 카드를 완료 칸으로 드래그 중 지연 배지가 즉시 사라진다(override 반영)
- Jest: 142 suites · 1482 tests

## 체크리스트
- [x] `npx tsc --noEmit`
- [x] `npx eslint <바뀐 13파일> --max-warnings=0`
- [x] `npx jest --silent` (142 suites · 1482 tests)
- [x] `npx next build`


---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**, 그리고 **서버에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [ ] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시
- [ ] 🎨 디자인 토큰 사용 · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화
- [ ] ♿ a11y
- [ ] ♻️ 재사용 확인
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API 사용 시 미지원 · 권한거부 안내 있음

---

## 🔗 연관 이슈

Closes #598

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

-

---

## 📝 추가 메모
