### PR TITLE
[FIX] 요약 실패 알림 카드에 실제 재분석 버튼을 연결한다 #599

### DIFF
--- a/src/features/notification/components/analysis-progress-card.tsx
+++ b/src/features/notification/components/analysis-progress-card.tsx
@@ -2,7 +2,7 @@
 
 import { Check, CircleAlert, Loader2, RotateCcw, X } from "lucide-react";
 import Link from "next/link";
-import type { ReactNode } from "react";
+import { type ReactNode, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 
@@ -49,7 +49,12 @@ function faceOf(state: AnalysisCardState): CardFace {
         /* ⚠️ 여기만 색을 쓴다 — DESIGN §5가 색을 허용한 유일한 자리가 에러다 */
         icon: <CircleAlert className="text-destructive size-4" aria-hidden />,
         title: "요약에 실패했습니다",
-        detail: "회의 상세에서 다시 분석할 수 있습니다",
+        /*
+          ⚠️ **"회의 상세에서"라고 안 쓴다**(2026-08-16 정정). 회의 상세 화면은 일부러 이
+             자리에 이동 수단을 안 둔다(meeting-detail-view.tsx 주석 참고) — 예전 문구는
+             갈 곳 없는 안내였다. 지금은 이 카드 자체가 [다시 분석] 버튼을 갖는다.
+        */
+        detail: "아래 버튼으로 다시 분석할 수 있습니다",
       };
     case ANALYSIS_CARD_STATE.UNAVAILABLE:
       return {
@@ -65,14 +70,28 @@ function faceOf(state: AnalysisCardState): CardFace {
 }
 
 export function AnalysisProgressCard() {
-  const { tracking, dismissAnalysis, retryAnalysis } = useNotificationCenter();
+  const { tracking, dismissAnalysis, retryAnalysis, retryFailedSummary } = useNotificationCenter();
+  /* ⚠️ 요청이 오가는 동안만 쓰는 로컬 상태다 — 트래킹 자체는 아직 안 바뀐다(응답 전엔
+     회의가 정말 다시 도는지 모른다). 버튼을 두 번 누르는 것만 막는다. */
+  const [isRetryingFailed, setIsRetryingFailed] = useState(false);
   if (!tracking) return null;
+
+  async function handleRetryFailed() {
+    setIsRetryingFailed(true);
+    try {
+      await retryFailedSummary();
+    } finally {
+      setIsRetryingFailed(false);
+    }
+  }
 
   return (
     <CardBody
       tracking={tracking}
       onClose={dismissAnalysis}
       onRetry={retryAnalysis}
+      onRetryFailed={handleRetryFailed}
+      isRetryingFailed={isRetryingFailed}
       face={faceOf(tracking.state)}
     />
   );
@@ -83,11 +102,15 @@ function CardBody({
   face,
   onClose,
   onRetry,
+  onRetryFailed,
+  isRetryingFailed,
 }: {
   tracking: AnalysisTracking;
   face: CardFace;
   onClose: () => void;
   onRetry: () => void;
+  onRetryFailed: () => void;
+  isRetryingFailed: boolean;
 }) {
   const isDone = tracking.state === ANALYSIS_CARD_STATE.DONE;
 
@@ -152,6 +175,19 @@ function CardBody({
           <Button variant="outline" size="sm" onClick={onRetry}>
             <RotateCcw aria-hidden />
             다시 시도
+          </Button>
+        </div>
+      ) : tracking.state === ANALYSIS_CARD_STATE.FAILED ? (
+        /*
+          ⚠️ **`onRetry`(상태 재조회)가 아니라 `onRetryFailed`(ANLZ-02 실제 재분석)다.**
+             이 버튼은 마이페이지 「요약이 중단된 회의」의 [다시 분석]과 같은 일을 한다 —
+             그 화면으로 보내는 대신 카드에서 바로 끝낸다(2026-08-16, 알림 카드 문구가
+             갈 곳 없는 "회의 상세에서" 안내였던 것을 대체).
+        */
+        <div className="px-4 pb-3.5">
+          <Button variant="outline" size="sm" onClick={onRetryFailed} disabled={isRetryingFailed}>
+            <RotateCcw aria-hidden className={isRetryingFailed ? "animate-spin" : undefined} />
+            {isRetryingFailed ? "요청 중…" : "다시 분석"}
           </Button>
         </div>
       ) : null}

--- a/src/features/notification/notification-provider.test.tsx
+++ b/src/features/notification/notification-provider.test.tsx
@@ -1,0 +1,127 @@
+jest.mock("./actions", () => ({ fetchAnalysisStatusAction: jest.fn() }));
+jest.mock("@/features/meeting/summary/actions", () => ({
+  retryMeetingSummaryAction: jest.fn(),
+}));
+jest.mock("sonner", () => ({
+  toast: Object.assign(jest.fn(), { error: jest.fn(), success: jest.fn() }),
+}));
+
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { toast } from "sonner";
+
+import { PROCESSING_STATUS } from "@/constants/meeting";
+import { retryMeetingSummaryAction } from "@/features/meeting/summary/actions";
+
+import { fetchAnalysisStatusAction } from "./actions";
+import { ANALYSIS_POLL_INTERVAL_MS } from "./analysis";
+import { NotificationProvider, useNotificationCenter } from "./notification-provider";
+
+/*
+  ⚠️ **`retryFailedSummary`는 `retryAnalysis`와 다른 함수다** — 이 파일은 그 차이를 지킨다.
+     `retryAnalysis`(상태 재조회)는 이미 `analysis.test.ts`의 `restart` 테스트가 다루므로,
+     여기서는 **ANLZ-02를 실제로 부르고 그 결과에 따라 트래킹을 되돌리는지**만 검증한다.
+*/
+
+const mockedFetchStatus = fetchAnalysisStatusAction as jest.Mock;
+const mockedRetry = retryMeetingSummaryAction as jest.Mock;
+const mockedToast = toast as unknown as jest.Mock & { error: jest.Mock };
+
+function TestConsumer() {
+  const { tracking, trackAnalysis, retryFailedSummary } = useNotificationCenter();
+  return (
+    <div>
+      <button onClick={() => trackAnalysis("meeting-1", "주간 회의")}>start</button>
+      <button onClick={() => void retryFailedSummary()}>retry</button>
+      <span data-testid="state">{tracking?.state ?? "NONE"}</span>
+    </div>
+  );
+}
+
+async function renderFailedTracking() {
+  mockedFetchStatus.mockResolvedValue({ ok: true, status: PROCESSING_STATUS.FAILED });
+  render(
+    <NotificationProvider>
+      <TestConsumer />
+    </NotificationProvider>,
+  );
+
+  fireEvent.click(screen.getByText("start"));
+  // 5초 폴링 한 번으로 FAILED까지 간다(mock이 첫 조회부터 FAILED를 돌려준다).
+  await act(async () => {
+    jest.advanceTimersByTime(ANALYSIS_POLL_INTERVAL_MS);
+  });
+  await waitFor(() => expect(screen.getByTestId("state")).toHaveTextContent("FAILED"));
+}
+
+describe("retryFailedSummary — ANLZ-02 실제 재분석", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockedFetchStatus.mockReset();
+    mockedRetry.mockReset();
+    mockedToast.mockReset();
+    mockedToast.error.mockReset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("성공하면 트래킹을 RUNNING으로 되돌린다(폴링이 다시 쫓게)", async () => {
+    await renderFailedTracking();
+    mockedRetry.mockResolvedValue({ error: null, needsFullRerun: false, pendingNote: null });
+
+    fireEvent.click(screen.getByText("retry"));
+
+    await waitFor(() => expect(mockedRetry).toHaveBeenCalledWith("meeting-1"));
+    await waitFor(() => expect(screen.getByTestId("state")).toHaveTextContent("RUNNING"));
+    expect(mockedToast.error).not.toHaveBeenCalled();
+  });
+
+  it("일반 실패면 에러 토스트만 띄우고 FAILED에 그대로 둔다(다시 누를 수 있어야 한다)", async () => {
+    await renderFailedTracking();
+    mockedRetry.mockResolvedValue({
+      error: "서버가 응답하지 않습니다",
+      needsFullRerun: false,
+      pendingNote: null,
+    });
+
+    fireEvent.click(screen.getByText("retry"));
+
+    await waitFor(() => expect(mockedToast.error).toHaveBeenCalledWith("서버가 응답하지 않습니다"));
+    expect(screen.getByTestId("state")).toHaveTextContent("FAILED");
+  });
+
+  it("재개할 지점이 없으면(ANLZ-008) 처음부터 다시 캡처하라는 별도 문구를 띄운다", async () => {
+    await renderFailedTracking();
+    mockedRetry.mockResolvedValue({
+      error: "재개할 계층이 없습니다",
+      needsFullRerun: true,
+      pendingNote: null,
+    });
+
+    fireEvent.click(screen.getByText("retry"));
+
+    await waitFor(() =>
+      expect(mockedToast.error).toHaveBeenCalledWith(
+        "재개할 수 있는 지점이 없습니다. 회의를 다시 캡처해야 합니다.",
+      ),
+    );
+    expect(screen.getByTestId("state")).toHaveTextContent("FAILED");
+  });
+
+  it("요청은 갔지만 아직 요약이 없으면(pendingNote) 안내 토스트를 띄우고 RUNNING으로 돌아간다", async () => {
+    await renderFailedTracking();
+    mockedRetry.mockResolvedValue({
+      error: null,
+      needsFullRerun: false,
+      pendingNote: "다른 재분석이 이미 진행 중입니다",
+    });
+
+    fireEvent.click(screen.getByText("retry"));
+
+    await waitFor(() =>
+      expect(mockedToast).toHaveBeenCalledWith("다른 재분석이 이미 진행 중입니다"),
+    );
+    await waitFor(() => expect(screen.getByTestId("state")).toHaveTextContent("RUNNING"));
+  });
+});

--- a/src/features/notification/notification-provider.tsx
+++ b/src/features/notification/notification-provider.tsx
@@ -2,6 +2,9 @@
 
 import type { ReactNode } from "react";
 import { createContext, useCallback, useContext, useEffect, useState } from "react";
+import { toast } from "sonner";
+
+import { retryMeetingSummaryAction } from "@/features/meeting/summary/actions";
 
 import { fetchAnalysisStatusAction } from "./actions";
 import {
@@ -16,7 +19,7 @@ import {
   startTracking,
 } from "./analysis";
 import { type NotificationEnvelope, toAnalysisSignal, toBannerNotification } from "./event";
-import type { AnalysisTracking, BannerNotification } from "./types";
+import { ANALYSIS_CARD_STATE, type AnalysisTracking, type BannerNotification } from "./types";
 import { useNotificationStream } from "./use-notification-stream";
 
 /**
@@ -41,6 +44,11 @@ interface NotificationContextValue {
   trackAnalysis: (meetingId: string, title: string) => void;
   dismissAnalysis: () => void;
   retryAnalysis: () => void;
+  /**
+   * 진짜 재분석(ANLZ-02) — `FAILED` 카드 전용. `retryAnalysis`(상태 재조회)와 다른 일이다 —
+   * 이건 서버에 "실패한 계층부터 다시 돌려라"를 실제로 요청한다.
+   */
+  retryFailedSummary: () => Promise<void>;
 }
 
 const NotificationContext = createContext<NotificationContextValue | null>(null);
@@ -138,6 +146,35 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
   }, []);
 
   /*
+    ⚠️ **`retryAnalysis`와 다른 함수다.** 저건 상태 조회를 다시 하는 것뿐이고(`UNAVAILABLE` 전용),
+       이건 실제로 BE에 "실패한 계층부터 다시 돌려라"를 요청한다(ANLZ-02, `retryMeetingSummaryAction`
+       — 마이페이지 「요약이 중단된 회의」의 [다시 분석]과 같은 액션). 성공하면 트래킹을
+       `RUNNING`으로 되돌려 기존 폴링이 다시 진행 상황을 쫓게 한다.
+    ⚠️ **`tracking`을 의존성에 둔다.** 요청 시점의 `meetingId`가 최신이어야 한다 — 그 사이
+       다른 회의를 쫓기 시작했는데 옛 회의로 재분석을 걸면 안 된다.
+  */
+  const retryFailedSummary = useCallback(async () => {
+    if (!tracking || tracking.state !== ANALYSIS_CARD_STATE.FAILED) return;
+    const meetingId = tracking.meetingId;
+    const result = await retryMeetingSummaryAction(meetingId);
+
+    if (result.error) {
+      toast.error(
+        result.needsFullRerun
+          ? "재개할 수 있는 지점이 없습니다. 회의를 다시 캡처해야 합니다."
+          : result.error,
+      );
+      return;
+    }
+
+    if (result.pendingNote) toast(result.pendingNote);
+
+    setTracking((prev) =>
+      prev && prev.meetingId === meetingId ? restart(prev, Date.now()) : prev,
+    );
+  }, [tracking]);
+
+  /*
     ⚠️ **의존성이 `tracking` 통째다.** 한 번 물어볼 때마다 `attempt`가 올라 새 객체가 되고,
        그때마다 이 효과가 다시 돌며 다음 한 번을 예약한다 — `setInterval` 하나로 돌리면
        응답이 늦을 때 요청이 겹쳐 쌓인다.
@@ -216,6 +253,7 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
         trackAnalysis,
         dismissAnalysis,
         retryAnalysis,
+        retryFailedSummary,
       }}
     >
       {children}


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

- `notification-provider.tsx`에 `retryFailedSummary()` 신규 — ANLZ-02(`retryMeetingSummaryAction`,
  마이페이지 「요약이 중단된 회의」의 [다시 분석]과 같은 액션)를 실제로 호출한다. 성공/`pendingNote`면
  트래킹을 `RUNNING`으로 되돌려 기존 폴링이 이어서 쫓게 하고, 실패면 토스트로 알린다
  (`needsFullRerun`이면 "처음부터 다시 캡처해야 한다"는 별도 문구).
- `analysis-progress-card.tsx`의 `FAILED` 상태에 `[다시 분석]` 버튼 신규(요청 중 스피너+비활성화).
  "회의 상세에서 다시 분석할 수 있습니다"라는 갈 곳 없는 문구도 정정.
- 원인: 카드는 완료 상태만 링크였고, 회의 상세도 FAILED엔 일부러 링크가 없다(2026-08-10 결정 —
  참석자에게 Host 전용 마이페이지를 잘못 안내하지 않기 위함). 비대면 회의는 FAILED면
  `actionsConfirmedAt`이 영원히 안 찍혀 목록에도 다시 안 뜬다 — 이 카드가 유일한 복귀 경로였다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`fix/notification-card-retry#599`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 권한 2축 검사 — `retryMeetingSummaryAction` 자체가 서버에서 `canOperateMeeting`(Host만)로
  재검사(기존 로직, 이번 변경 없음)
- [ ] 🧬 zod — 해당 없음(기존 액션 재사용, 응답 shape 변경 없음)
- [x] 🕵️ 정직성 — 갈 곳 없는 안내 문구를 실제 동작으로 교체
- [ ] 🎨 디자인 토큰 — 해당 없음(기존 버튼·아이콘 재사용)

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [x] ♿ a11y — 기존 `role="status" aria-live="polite"` 그대로, 버튼에 disabled 상태 명시
- [x] ♻️ 재사용 확인 — `UNAVAILABLE` 상태 버튼과 같은 자리·같은 컴포넌트 패턴 재사용
- [ ] 🧪 loading/error/empty 3상태 — 해당 없음(카드 컴포넌트)
- [ ] 브라우저 전용 API 안내 — 해당 없음

---

## 🔗 연관 이슈

Closes #599

---

## 💬 리뷰 포인트

- `retryFailedSummary`가 `tracking`을 의존성으로 두는 이유(요청 시점 `meetingId`가 최신이어야
  다른 회의로 잘못 재분석 걸리지 않음)가 주석으로 충분히 설명됐는지
- `pendingNote`(요청은 갔지만 아직 요약이 없는 경우)를 에러가 아니라 정보 토스트로 처리한 게 맞는지

## 📝 추가 메모

타입체크 0에러, 전체 테스트 141 suites / 1474개(신규 4개 포함) 통과 확인. 실제 서비스에서
재현했던 시나리오 기반.

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |
