### PR TITLE
[FIX] 보드 페이지 empty state 통일 (cards=0일 때 정직한 안내) #607

### DIFF
--- a/src/features/board/components/board-view.test.tsx
+++ b/src/features/board/components/board-view.test.tsx
@@ -41,6 +41,8 @@ describe("BoardView — 페이지 레벨 empty state", () => {
     render(<BoardView boardType="my-action" cards={[]} todayIso={TODAY} />);
 
     expect(screen.getByText("아직 하달된 액션이 없습니다.")).toBeInTheDocument();
+    expect(screen.getByText("액션이 하달되면 이 자리에 카드로 쌓입니다.")).toBeInTheDocument();
+    expect(screen.queryByText(/드래그해서 칸을 옮길 수 있습니다/)).not.toBeInTheDocument();
 
     /*
       ⚠️ 세 칸·저장 버튼이 나타나면 회귀다 — 예전 렌더가 되돌아온 것이다. 칸 라벨(할 일·

--- a/src/features/board/components/board-view.test.tsx
+++ b/src/features/board/components/board-view.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * 보드 페이지 empty state 회귀.
+ *
+ * ⚠️ 다른 5화면(내 액션·팀 액션·마이페이지·캘린더·프로젝트 타임라인)은 이미 EmptyState +
+ *    명시 문구로 정직한 빈 상태를 그리는데, 보드만 예전에는 세 칸이 각기 "여기로 옮겨
+ *    주세요."를 띄워 옮길 카드가 어딘가 있는 것처럼 읽혔다(§CLAUDE.md 정직성 위반).
+ *    2026-08-16에 페이지 레벨 EmptyState로 통일. 여기서 못박아, 다시 세 칸이 텅 빈 채로
+ *    뜨는 회귀가 오면 즉시 잡는다.
+ */
+jest.mock("../actions", () => ({
+  commitBoardChangesAction: jest.fn(),
+}));
+jest.mock("./board-leave-guard", () => ({
+  /* leave guard는 window 이벤트를 걸어 jsdom에서 시끄럽다 — 여기 테스트 관심사도 아니다 */
+  BoardLeaveGuard: () => null,
+}));
+
+import { render, screen } from "@testing-library/react";
+
+import type { BoardCard } from "../types";
+import { BoardView } from "./board-view";
+
+const TODAY = "2026-08-16";
+
+function card(overrides: Partial<BoardCard> = {}): BoardCard {
+  return {
+    id: 1,
+    title: "설계 검토",
+    tagLabel: "GOODS",
+    tagBgColor: "var(--tag-sky-bg)",
+    tagTextColor: "var(--tag-sky-fg)",
+    startDate: "2026-08-10",
+    dueDate: "2026-08-20",
+    isDone: false,
+    ...overrides,
+  };
+}
+
+describe("BoardView — 페이지 레벨 empty state", () => {
+  it("cards가 0건이면 EmptyState 안내가 뜨고 세 칸·저장 버튼은 안 뜬다", () => {
+    render(<BoardView boardType="my-action" cards={[]} todayIso={TODAY} />);
+
+    expect(screen.getByText("아직 하달된 액션이 없습니다.")).toBeInTheDocument();
+
+    /*
+      ⚠️ 세 칸·저장 버튼이 나타나면 회귀다 — 예전 렌더가 되돌아온 것이다. 칸 라벨(할 일·
+         진행중·완료)과 저장 버튼("저장하기")이 안 뜨는지 함께 확인한다.
+    */
+    expect(screen.queryByRole("button", { name: /저장하기/ })).not.toBeInTheDocument();
+    expect(screen.queryByText("할 일")).not.toBeInTheDocument();
+    expect(screen.queryByText("진행중")).not.toBeInTheDocument();
+    expect(screen.queryByText("완료")).not.toBeInTheDocument();
+    expect(screen.queryByText("여기로 옮겨 주세요.")).not.toBeInTheDocument();
+  });
+
+  it("cards가 하나라도 있으면 empty 문구는 안 뜨고 세 칸·저장 버튼이 그대로 온다", () => {
+    render(<BoardView boardType="my-action" cards={[card()]} todayIso={TODAY} />);
+
+    expect(screen.queryByText("아직 하달된 액션이 없습니다.")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /저장하기/ })).toBeInTheDocument();
+    expect(screen.getByText("할 일")).toBeInTheDocument();
+    expect(screen.getByText("진행중")).toBeInTheDocument();
+    expect(screen.getByText("완료")).toBeInTheDocument();
+  });
+});

--- a/src/features/board/components/board-view.tsx
+++ b/src/features/board/components/board-view.tsx
@@ -10,10 +10,12 @@ import {
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
+import { ListChecks } from "lucide-react";
 import { useMemo, useState, useTransition } from "react";
 import { toast } from "sonner";
 
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
+import { EmptyState } from "@/components/common/empty-state";
 import { Button } from "@/components/ui/button";
 
 import { commitBoardChangesAction } from "../actions";
@@ -171,6 +173,27 @@ export function BoardView({ boardType, cards, todayIso }: BoardViewProps) {
         toast.error("옮기지 못했습니다");
       }
     });
+  }
+
+  /*
+    ⚠️ **하달된 카드 자체가 0건**이면 세 칸도 저장 줄도 뜻이 없다 — 옮길 게 없다.
+       이때는 페이지 레벨 `EmptyState`로 바꿔 다른 5화면(내 액션·팀 액션·마이페이지·캘린더·
+       프로젝트 타임라인)과 같은 톤으로 "아직 하달된 액션이 없습니다"만 말한다(§정직성).
+    ⚠️ 이 분기는 **정말 카드가 0건일 때만** 탄다 — 특정 칸만 비었을 때는 각 칸의
+       `BOARD_EMPTY_HINT`("여기로 옮겨 주세요.")가 여전히 유효한 안내라 그대로 둔다.
+    ⚠️ `BoardLeaveGuard`도 여기선 필요 없다 — 이동시킬 카드가 없으니 저장 안 한 변경도 없다.
+  */
+  if (cards.length === 0) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col">
+        <EmptyState
+          icon={ListChecks}
+          title="아직 하달된 액션이 없습니다."
+          description="액션이 하달되면 이 자리에 카드로 쌓이고, 드래그해서 칸을 옮길 수 있습니다."
+          className="flex-1"
+        />
+      </div>
+    );
   }
 
   return (

--- a/src/features/board/components/board-view.tsx
+++ b/src/features/board/components/board-view.tsx
@@ -184,12 +184,19 @@ export function BoardView({ boardType, cards, todayIso }: BoardViewProps) {
     ⚠️ `BoardLeaveGuard`도 여기선 필요 없다 — 이동시킬 카드가 없으니 저장 안 한 변경도 없다.
   */
   if (cards.length === 0) {
+    /*
+      ⚠️ description은 **조작 중립**이다("드래그" 같은 특정 입력 방식 안내 금지) — CLAUDE.md
+         §a11y "DnD 보드는 키보드 대체 경로 필수". 지금 보드는 `PointerSensor`만 걸려 있고
+         `KeyboardSensor`·카드 이동 버튼 같은 대체 경로가 없어(오래된 규약 위반, 별건 이슈로
+         분리) 스크린리더·키보드 사용자에게 "드래그해서 옮길 수 있다"고 미리 알리면 카드가
+         도착한 뒤 그 지시를 따르지 못한다. 대체 경로가 붙기 전에는 조작 안내를 아예 안 한다.
+    */
     return (
       <div className="flex min-h-0 flex-1 flex-col">
         <EmptyState
           icon={ListChecks}
           title="아직 하달된 액션이 없습니다."
-          description="액션이 하달되면 이 자리에 카드로 쌓이고, 드래그해서 칸을 옮길 수 있습니다."
+          description="액션이 하달되면 이 자리에 카드로 쌓입니다."
           className="flex-1"
         />
       </div>


### PR DESCRIPTION
## 📋 PR 타입

- [ ] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템
- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

Closes #607

## 요약
BE #8(dispatched_at 게이트) 배포 직후 보드가 일시적으로 0건이 될 수 있는데, 지금 렌더는 세 칸이 각기 "여기로 옮겨 주세요."를 띄워 **옮길 카드가 어딘가 있는데 사용자가 아직 안 집은 것**처럼 읽힘. §CLAUDE.md 정직성 위반. 다른 5화면(내 액션·팀 액션·마이페이지·캘린더·프로젝트 타임라인)이 이미 `EmptyState` + 명시 문구로 통일돼 있어 보드도 같은 톤.

## 변경
- `BoardView`에 `cards.length===0` 분기 추가 — `EmptyState(ListChecks + "아직 하달된 액션이 없습니다." + 설명)` 하나만 렌더하고 저장 버튼 줄·세 칸 그리드는 감춤.
- 이 분기는 **정말 카드가 0건일 때만** 탄다. 특정 칸만 비었을 때(예: 완료로 다 옮겼는데 진행중이 비면) 각 칸의 `BOARD_EMPTY_HINT`("여기로 옮겨 주세요.")는 여전히 유효한 안내라 그대로 둔다.
- `BoardLeaveGuard`도 이 분기에서는 렌더 안 함 — 이동시킬 카드가 없으니 저장 안 한 변경도 없다.

## 배경
- FE 6개 PR(#591 #593 #595 #597 #600 #604) 머지 뒤 empty state 정직성을 6화면에서 훑은 결과, 보드만 `partial` 판정.
- 근거: `board-view.tsx:84-85`(세 칸만 그림), `board-column.tsx:134-151`(`BOARD_EMPTY_HINT` 그대로), `types.ts:55`("여기로 옮겨 주세요.")

## 확인법
- `/app/board`에 카드 0건 응답 → EmptyState 아이콘 + 명시 문구만 뜸, 세 칸·저장 버튼 안 뜸
- 카드 하나라도 있으면 기존 그리드·저장 버튼 그대로
- Jest 회귀 2건 (`board-view.test.tsx`)

## 안 하는 것
- `BOARD_EMPTY_HINT`("여기로 옮겨 주세요.") 문구 자체 삭제 — 부분 empty에는 여전히 유효
- 보드 저장/드래그 로직 변경
- BE #8 배포 대기 — 이 PR은 문구 안전망이라 데이터 정합에 영향 없음, 독립 배포 가능

## 체크리스트
- [x] `npx tsc --noEmit`
- [x] `npx eslint <바뀐 2파일> --max-warnings=0`
- [x] `npx jest --silent` (148 suites · 1548 tests)
- [x] `npx next build`


---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**, 그리고 **서버에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [ ] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시
- [ ] 🎨 디자인 토큰 사용 · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화
- [ ] ♿ a11y
- [ ] ♻️ 재사용 확인
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API 사용 시 미지원 · 권한거부 안내 있음

---

## 🔗 연관 이슈

Closes #607

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

-

---

## 📝 추가 메모


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 액션 카드가 없을 때 빈 상태 안내 화면을 표시합니다.
  * 액션 카드가 있으면 기존 보드와 저장 기능을 그대로 사용할 수 있습니다.

* **버그 수정**
  * 카드가 없는 상태에서 보드 영역과 불필요한 안내 요소가 표시되지 않도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->