### PR TITLE
[FIX] 팀 액션 페이지 스코프 가드 추가 #614

### DIFF
--- a/src/app/(shell)/(authority)/team/action/page.test.tsx
+++ b/src/app/(shell)/(authority)/team/action/page.test.tsx
@@ -1,0 +1,73 @@
+/*
+  ⚠️ 회귀 방지(#614) — 가드 없이 `getTeamActionsPage`를 부르면 Owner에게 BE가 403
+     (`DENIED_FILTER`)을 던졌다. `/team/*`은 LEADER 스코프라 LEADER만 조회로 넘어가고,
+     그 외(Owner·Member)는 조회 전에 AccessDenied로 걸러져야 한다. 가드가 다시 빠지거나
+     `canAccessTeamScope`가 뒤집히면 이 테스트가 잡는다.
+*/
+jest.mock("server-only", () => ({}));
+
+jest.mock("@/features/shell/viewer", () => ({
+  getViewer: jest.fn(),
+}));
+
+jest.mock("@/features/shell/home", () => ({
+  roleHome: jest.fn(() => "/"),
+}));
+
+jest.mock("@/lib/permission", () => ({
+  canAccessTeamScope: jest.fn(),
+}));
+
+jest.mock("@/features/action/server", () => ({
+  getTeamActionsPage: jest.fn(async () => ({
+    items: [],
+    page: 0,
+    totalPages: 1,
+    totalCount: 0,
+  })),
+}));
+
+jest.mock("@/components/common/access-denied", () => ({
+  AccessDenied: () => <div data-testid="access-denied" />,
+}));
+
+jest.mock("@/features/action/components/team-action-list-view", () => ({
+  TeamActionListView: () => <div data-testid="team-action-list" />,
+}));
+
+import { render, screen } from "@testing-library/react";
+
+import { getTeamActionsPage } from "@/features/action/server";
+import { getViewer } from "@/features/shell/viewer";
+import { canAccessTeamScope } from "@/lib/permission";
+
+import TeamActionPage from "./page";
+
+describe("/app/team/action — 팀 스코프 진입 가드(#614)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getViewer as jest.Mock).mockResolvedValue({ role: "leader" });
+  });
+
+  it("LEADER는 팀 액션 목록을 본다", async () => {
+    (canAccessTeamScope as jest.Mock).mockReturnValue(true);
+
+    const ui = await TeamActionPage();
+    render(ui);
+
+    expect(screen.getByTestId("team-action-list")).toBeInTheDocument();
+    expect(screen.queryByTestId("access-denied")).not.toBeInTheDocument();
+  });
+
+  it("진입 자격이 없으면(Owner·Member) 조회 전에 AccessDenied로 막고 BE를 부르지 않는다", async () => {
+    (canAccessTeamScope as jest.Mock).mockReturnValue(false);
+
+    const ui = await TeamActionPage();
+    render(ui);
+
+    expect(screen.getByTestId("access-denied")).toBeInTheDocument();
+    expect(screen.queryByTestId("team-action-list")).not.toBeInTheDocument();
+    // ⚠️ 403의 근원 — 가드에 막혔으면 목록 조회가 아예 안 나가야 한다
+    expect(getTeamActionsPage).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(shell)/(authority)/team/action/page.tsx
+++ b/src/app/(shell)/(authority)/team/action/page.tsx
@@ -1,7 +1,11 @@
 import type { Metadata } from "next";
 
+import { AccessDenied } from "@/components/common/access-denied";
 import { TeamActionListView } from "@/features/action/components/team-action-list-view";
 import { getTeamActionsPage } from "@/features/action/server";
+import { roleHome } from "@/features/shell/home";
+import { getViewer } from "@/features/shell/viewer";
+import { canAccessTeamScope } from "@/lib/permission";
 
 export const metadata: Metadata = {
   title: "팀 액션",
@@ -11,8 +15,16 @@ export const metadata: Metadata = {
  * ⚠️ **첫 페이지만 서버가 렌더**한다(CLAUDE.md §목록·페이지네이션) — 2페이지부터는
  *    `TeamActionListView`가 스크롤 끝에서 서버 액션으로 이어 붙인다. 프로젝트별 묶기는
  *    이어 붙인 전체를 대상으로 화면이 매번 다시 한다(§mapper `groupTeamActionsByProject`).
+ * ⚠️ **문을 먼저 보고 데이터를 뒤에 부른다**(owner 대시보드·manage/rooms와 같은 패턴).
+ *    `/team/*`은 LEADER 스코프라(§라우트 그룹) Owner·Member는 진입 대상이 아니다 — 가드 없이
+ *    `getTeamActionsPage`를 부르면 BE가 팀 액션 목록을 LEADER/MEMBER 전용으로 잠가 놓아
+ *    Owner에게 403(`DENIED_FILTER`)이 난다(#614). `requiresParentTeamAction`(non-Owner)이
+ *    아니라 `canAccessTeamScope`(LEADER 전용)로 막아야 Member도 조회 전에 걸러진다.
  */
 export default async function TeamActionPage() {
+  const viewer = await getViewer();
+  if (!canAccessTeamScope(viewer)) return <AccessDenied homeHref={roleHome(viewer.role)} />;
+
   const firstPage = await getTeamActionsPage(0);
 
   return (


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계

---

## 🙋 관련 역할

- [x] OWNER (대표)
- [x] MEMBER (사원)
- [x] LEADER (팀장)

---

## 📝 작업 내용

- `/app/team/action` 진입 시 **권한 가드 없이** `getTeamActionsPage(0)`을 바로 호출해, BE가 팀 액션 목록을 LEADER/MEMBER 전용으로 잠가 둔 탓에 Owner에게 403(`DENIED_FILTER`)이 나던 문제를 수정.
- 형제 페이지(`owner/(dashboard)`·`manage/rooms`, 그리고 `team/handover`·`dashboard`·`members`)와 **같은 패턴**으로 `getViewer()` → 가드 → `<AccessDenied />`를 **데이터 조회 전에** 둠.
- 가드는 `requiresParentTeamAction`(non-Owner)이 아니라 **`canAccessTeamScope`(LEADER 전용)**를 사용 — `/team/*`은 LEADER 스코프라 Owner뿐 아니라 Member도 진입 대상이 아니다(§라우트 그룹).
- 회귀 방지 테스트 추가: LEADER는 목록을 보고, 그 외는 조회 전에 AccessDenied로 막히며 **`getTeamActionsPage`가 호출되지 않음**(403 근원 차단)을 검증.

---

## ✅ 작업 체크리스트

- [x] 브랜치 명명 규칙 준수 (base `develop`)
- [x] 커밋 컨벤션 준수
- [x] 불필요한 `console` · 주석 코드 없음
- [x] 민감 정보 없음
- [x] 🔐 권한 — 화면 가드는 UX일 뿐, 실제 차단은 BE가 유지(이 PR은 403을 안내 화면으로 전환). 판정은 `lib/permission.ts`의 `canAccessTeamScope` 재사용
- [x] 🕵️ 정직성 — 진입 자격 없을 때 조용히 빈 화면이 아니라 `AccessDenied`로 안내
- [x] ♻️ 재사용 — 공용 `AccessDenied`·`roleHome`·기존 판정 함수 사용, 신규 컴포넌트 없음

---

## 🔗 연관 이슈

Closes #614

---

## 💬 리뷰 포인트

- `requiresParentTeamAction`(non-Owner)이 아니라 `canAccessTeamScope`(LEADER 전용)를 쓴 이유 — Member도 걸러야 정확.
- 가드를 데이터 조회 **앞**에 둔 순서 — 뒤에 두면 403을 던지는 조회가 먼저 나가 AccessDenied 대신 에러 화면이 뜬다.

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |


---

## 📝 추가 메모
