### PR TITLE
[FIX] 캡처 조각 409(CAP-005) 멱등 처리로 재시도 루프 제거 #616

### DIFF
--- a/src/features/meeting/capture/actions.test.ts
+++ b/src/features/meeting/capture/actions.test.ts
@@ -27,7 +27,7 @@ jest.mock("@/lib/api", () => ({
 import { requireAccessToken } from "@/features/auth/session";
 import { ApiError, serverApi } from "@/lib/api";
 
-import { getActiveCaptureAction } from "./actions";
+import { completeCaptureUploadAction, getActiveCaptureAction } from "./actions";
 
 const serverApiMock = serverApi as unknown as jest.Mock;
 const requireAccessTokenMock = requireAccessToken as unknown as jest.Mock;
@@ -108,5 +108,38 @@ describe("getActiveCaptureAction — CAP-09", () => {
 
     expect(result.ok).toBe(false);
     expect(result.error).toBe("이 회의 참석자가 아닙니다");
+  });
+});
+
+/*
+  ⚠️ 회귀 방지(#616) — 이미 등록된 조각(409 CAP-005)을 실패로 돌려주면 `upload.ts`가 같은
+     조각을 3회 재시도해 `Duplicate entry` 소음을 남겼다. 멱등이라 성공으로 흘려보내야 한다.
+*/
+describe("completeCaptureUploadAction — CAP-07 멱등 처리", () => {
+  const body = { segmentSeq: 0, s3Key: "recordings/x", sizeBytes: 100 };
+
+  it("정상 완료면 ok:true", async () => {
+    serverApiMock.mockResolvedValueOnce(undefined);
+
+    const result = await completeCaptureUploadAction(1, 18, body);
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("이미 등록됨(409 CAP-005)은 실패가 아니라 성공으로 취급한다 — 재시도 금지", async () => {
+    serverApiMock.mockRejectedValueOnce(new ApiError(409, "이미 등록된 조각입니다", "CAP-005"));
+
+    const result = await completeCaptureUploadAction(1, 18, body);
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("그 외 에러는 {ok:false}로 감싼다", async () => {
+    serverApiMock.mockRejectedValueOnce(new ApiError(500, "서버 오류"));
+
+    const result = await completeCaptureUploadAction(1, 18, body);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("서버 오류");
   });
 });

--- a/src/features/meeting/capture/actions.ts
+++ b/src/features/meeting/capture/actions.ts
@@ -1,11 +1,22 @@
 "use server";
 
 import { requireAccessToken } from "@/features/auth/session";
-import { serverApi, toUserMessage } from "@/lib/api";
+import { ApiError, serverApi, toUserMessage } from "@/lib/api";
 import { ep } from "@/lib/endpoints";
 import { isMock } from "@/mocks/config";
 
 import type { ActiveCapture, CaptionChunkInput, CapturePart, CaptureSession } from "./types";
+
+/**
+ * 조각이 **이미 등록됨**을 뜻하는 BE 에러코드(CAP-07, 409). `completeCaptureUploadAction`이
+ * 이걸 실패가 아니라 성공으로 흘려보낸다 — 아래 주석 참고.
+ *
+ * ⚠️ **상태코드(409)가 아니라 이 코드로 가른다** — 409가 다른 충돌에도 쓰일 수 있다.
+ *    값은 enum 이름(`CAP_PART_ALREADY_REGISTERED`)이 아니라 **짧은 코드 문자열**이다
+ *    (BE `CapErrorCode`에서 그 enum이 `"CAP-005"`로 매핑됨 — `api.ts`의 "HO-016 등"과 같은 형식).
+ *    BE가 값을 바꾸면 여기 한 곳만 고친다.
+ */
+const CAP_PART_ALREADY_REGISTERED_CODE = "CAP-005";
 
 /**
  * 캡처 창구 — 격리막(§Mock 격리막).
@@ -181,6 +192,16 @@ export async function completeCaptureUploadAction(
     });
     return { ok: true };
   } catch (error) {
+    /*
+      ⚠️ **이미 등록된 조각은 실패가 아니라 성공이다**(#616). 재연결·중복 enqueue로 같은 seq가
+         두 번 도달하면 BE가 409(`CAP-005`)를 준다 — 멱등이라 다시 보내도 결과가 같은데,
+         이걸 실패로 돌려주면 `upload.ts`의 `uploadOne`이 같은 조각을 3회 재시도해
+         로그에 `Duplicate entry` 소음만 남긴다. 이미 서버에 있으니 성공으로 흘려보내
+         다음 seq로 진행하게 한다(프로젝트 첨부의 confirm 멱등 처리와 같은 취지).
+    */
+    if (error instanceof ApiError && error.code === CAP_PART_ALREADY_REGISTERED_CODE) {
+      return { ok: true };
+    }
     return { ok: false, error: toUserMessage(error) };
   }
 }


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실

---

## 🙋 관련 역할

- [x] 공통 (회의 담당자 캡처 중)

---

## 📝 작업 내용

- 캡처 청크(오디오 part) 완료 통보에서, BE가 `CAP_PART_ALREADY_REGISTERED`(409, errorCode `CAP-005`)를 돌려줄 때 FE가 **일시 실패로 오해해 같은 조각을 3회 재시도**하던 문제를 수정(로그 `Duplicate entry '1-0-18'` 3회 → `'1-0-19'` 3회).
- `completeCaptureUploadAction`의 `catch`에서 **409 `CAP-005`는 "이미 등록됨 = 성공"으로 취급**해 다음 seq로 진행. 멱등이라 재시도해도 결과가 같아 소음만 남았음(프로젝트 첨부의 confirm 멱등 처리와 같은 취지).
- 매칭은 상태코드(409)가 아니라 **errorCode `CAP-005`**로 — 409가 다른 충돌에도 쓰일 수 있어서(BE 확인: `CapErrorCode`에서 해당 enum이 `"CAP-005"`로 매핑).
- 코드 값은 `CAP_PART_ALREADY_REGISTERED_CODE` 상수로 한 곳에 둠. 처리 위치는 BE 경계(`actions.ts`) 한 곳이고 `upload.ts`는 에러코드를 모르게 유지(§Mock 격리막).

---

## ✅ 작업 체크리스트

- [x] 브랜치 명명 규칙 준수 (base `develop`)
- [x] 커밋 컨벤션 준수
- [x] 불필요한 `console` · 주석 코드 없음
- [x] 민감 정보 없음
- [x] 🕵️ 정직성 — 이미 서버에 있는 조각을 성공으로 흘려보낼 뿐, 실제 실패(그 외 에러)는 그대로 `{ok:false}`로 화면에 알림
- [x] 🧪 회귀 테스트 추가 — 409 CAP-005 → ok:true / 정상 → ok:true / 그 외 → ok:false

---

## 🔗 연관 이슈

Closes #616

---

## 💬 리뷰 포인트

- 상태코드(409)가 아니라 errorCode(`CAP-005`)로 가른 이유 — 409 재사용 가능성.
- 처리를 `completeCaptureUploadAction`(BE 경계) 한 곳에 두고 `upload.ts`는 손대지 않은 이유(격리막).

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |


---

## 📝 추가 메모
