### PR TITLE
[FIX] 온보딩 완료 요청 타임아웃을 늘리고 대기 화면을 정직하게 고친다 #618

### DIFF
--- a/src/features/onboarding/actions.ts
+++ b/src/features/onboarding/actions.ts
@@ -99,6 +99,15 @@ export async function commitOnboardingAction(input: {
       method: "POST",
       json: payload,
       accessToken: token,
+      /*
+        ⚠️ **기본 15초로는 부족하다**(`lib/api.ts`의 `DEFAULT_TIMEOUT_MS` 주석이 말하는
+           "더 걸리는 호출"이 바로 이거다). 이 요청 하나가 부서·직급 생성뿐 아니라 초대
+           인원수만큼 계정 발급 + 메일 발송까지 **동기로** 끝내고 응답한다 — 인원이 많으면
+           BE는 정상적으로 계속 처리 중인데 Next 쪽에서 먼저 타임아웃으로 끊어 화면에
+           실패로 뜨는 사고가 실제로 있었다. 그 직후 재시도가 `AU-035`(이미 온보딩됨)로
+           떨어지는 게 그 증거다 — BE는 이미 성공했는데 응답만 못 받은 것.
+      */
+      timeoutMs: 60_000,
     });
 
     /*

--- a/src/features/onboarding/components/invite-commit-dialog.tsx
+++ b/src/features/onboarding/components/invite-commit-dialog.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Loader2 } from "lucide-react";
+
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
 
 interface InviteCommitDialogProps {
@@ -68,39 +70,62 @@ export function InviteCommitDialog({
       pendingLabel="등록 중"
       error={error}
     >
-      {/*
-        ⚠️ 칸을 나눠 상자 세 개로 그리지 않는다. 가운데 정렬 창 안에서 테두리 상자가 더 생기면
-           표식·제목·설명·상자·버튼이 다섯 덩어리로 쌓여 눈이 어디를 봐야 할지 흩어진다.
-           **알약 하나**에 담으면 덩어리가 하나로 줄고, 창 높이도 낮아진다.
-      */}
-      <div className="flex justify-center">
-        <dl className="bg-secondary/60 inline-flex items-center gap-3.5 rounded-full px-4 py-2">
-          <Item label="팀" value={departmentCount} />
-          <Divider />
-          <Item label="직급" value={positionCount} />
-          <Divider />
-          <Item label="초대" value={writtenCount} />
-        </dl>
-      </div>
+      {isPending ? (
+        /*
+          ⚠️ **제출 중엔 알약·경고 대신 진행 안내로 바꾼다**(2026-08-18, 타임아웃 60초로
+             늘리며 같이 손봄). 팀·직급 수나 "몇 줄 빠집니다" 경고는 제출 전에만 의미가
+             있다 — 이미 넘어간 뒤에도 그대로 떠 있으면 "지금 뭐가 되고 있는지"와 무관한
+             정보만 보여서 창이 멈춘 것처럼 읽힌다(§정직성). 버튼 글자(`pendingLabel`)만
+             바뀌는 걸로는 최대 1분을 버티기엔 신호가 약하다 — 회전 아이콘 + 얼마나
+             걸릴지까지 적어서 "지금 일하고 있다"를 분명히 한다.
+        */
+        <div
+          className="flex flex-col items-center gap-2 pt-1 text-center"
+          role="status"
+          aria-live="polite"
+        >
+          <Loader2 className="text-muted-foreground size-5 animate-spin" aria-hidden />
+          <p className="text-muted-foreground text-[12px] leading-[18px] break-keep">
+            계정 발급과 초대 메일 발송에 최대 1분 정도 걸립니다. 창을 닫지 말고 기다려 주세요.
+          </p>
+        </div>
+      ) : (
+        <>
+          {/*
+            ⚠️ 칸을 나눠 상자 세 개로 그리지 않는다. 가운데 정렬 창 안에서 테두리 상자가 더 생기면
+               표식·제목·설명·상자·버튼이 다섯 덩어리로 쌓여 눈이 어디를 봐야 할지 흩어진다.
+               **알약 하나**에 담으면 덩어리가 하나로 줄고, 창 높이도 낮아진다.
+          */}
+          <div className="flex justify-center">
+            <dl className="bg-secondary/60 inline-flex items-center gap-3.5 rounded-full px-4 py-2">
+              <Item label="팀" value={departmentCount} />
+              <Divider />
+              <Item label="직급" value={positionCount} />
+              <Divider />
+              <Item label="초대" value={writtenCount} />
+            </dl>
+          </div>
 
-      {/*
-        ⚠️ 빠지는 줄을 **여기서** 알린다. 줄마다 경고를 붙이는 대신 넘어가기 직전에 한 번 말한다 —
-           조용히 빼면 보낸 줄 알고 넘어간다(§정직성).
-      */}
-      {/*
-        ⚠️ **이유를 갈라서 말한다.** 전에는 `목록에서 표시된 줄을 확인해 주세요` 한 문장이었는데,
-           가장 흔한 사유인 **아직 안 고른 줄에는 목록에 표시가 없다** — 안 고른 건 "틀렸다"가
-           아니라 "아직"이라 줄에 빨간 글씨를 안 띄우기 때문이다(`InviteRow`).
-           없는 표시를 가리키면 사용자는 찾다가 못 찾는다(적대적 검토 #163).
-        ⚠️ 표시가 있는 줄(주소 형식·주소 중복·리더 중복)만 `표시가 뜬`이라고 부른다.
-      */}
-      {unfilledCount + flaggedCount > 0 && (
-        <p className="text-muted-foreground pt-3 text-[12px] leading-[18px] break-keep">
-          {unfilledCount > 0 && `팀·역할·직급을 고르지 않은 ${unfilledCount}줄`}
-          {unfilledCount > 0 && flaggedCount > 0 && "과 "}
-          {flaggedCount > 0 && `목록에 표시가 뜬 ${flaggedCount}줄`}
-          {"은 이번 발송에서 빠집니다. 취소하고 고치거나, 나중에 기업 설정에서 초대해 주세요."}
-        </p>
+          {/*
+            ⚠️ 빠지는 줄을 **여기서** 알린다. 줄마다 경고를 붙이는 대신 넘어가기 직전에 한 번 말한다 —
+               조용히 빼면 보낸 줄 알고 넘어간다(§정직성).
+          */}
+          {/*
+            ⚠️ **이유를 갈라서 말한다.** 전에는 `목록에서 표시된 줄을 확인해 주세요` 한 문장이었는데,
+               가장 흔한 사유인 **아직 안 고른 줄에는 목록에 표시가 없다** — 안 고른 건 "틀렸다"가
+               아니라 "아직"이라 줄에 빨간 글씨를 안 띄우기 때문이다(`InviteRow`).
+               없는 표시를 가리키면 사용자는 찾다가 못 찾는다(적대적 검토 #163).
+            ⚠️ 표시가 있는 줄(주소 형식·주소 중복·리더 중복)만 `표시가 뜬`이라고 부른다.
+          */}
+          {unfilledCount + flaggedCount > 0 && (
+            <p className="text-muted-foreground pt-3 text-[12px] leading-[18px] break-keep">
+              {unfilledCount > 0 && `팀·역할·직급을 고르지 않은 ${unfilledCount}줄`}
+              {unfilledCount > 0 && flaggedCount > 0 && "과 "}
+              {flaggedCount > 0 && `목록에 표시가 뜬 ${flaggedCount}줄`}
+              {"은 이번 발송에서 빠집니다. 취소하고 고치거나, 나중에 기업 설정에서 초대해 주세요."}
+            </p>
+          )}
+        </>
       )}
     </ConfirmDialog>
   );

--- a/src/features/onboarding/components/invite-setup.tsx
+++ b/src/features/onboarding/components/invite-setup.tsx
@@ -173,7 +173,16 @@ export function InviteSetup({ departments, positions }: InviteSetupProps) {
 
       <InviteCommitDialog
         isOpen={isConfirmOpen}
-        onOpenChange={setConfirmOpen}
+        onOpenChange={(next) => {
+          /*
+            ⚠️ **보내는 동안엔 Esc·바깥 클릭으로도 못 닫는다**(2026-08-18, 타임아웃을
+               60초로 늘리며 같이 손봄). 계정 발급 + 메일 발송이 최대 1분 걸리는데, 그동안
+               창을 닫아버리면 요청은 그대로 진행 중인데 사용자는 아무 결과도 못 보고
+               "안 됐나" 하고 다시 열어 또 누르게 된다 — 두 벌 커밋 위험(§정직성).
+          */
+          if (!next && isCommitting) return;
+          setConfirmOpen(next);
+        }}
         departmentCount={departmentOptions.length}
         positionCount={positionOptions.length}
         writtenCount={writtenCount}


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정
- [ ] feature — 새로운 기능 추가
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [x] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

- 온보딩 완료(`commitOnboardingAction`) 요청에 `timeoutMs: 60_000`을 줘서, 초대 인원수만큼
  계정 발급·메일 발송을 동기로 끝내는 이 요청이 기본 15초 타임아웃보다 먼저 끊기지 않게 한다
- 확인 모달이 제출 중일 때 회전 아이콘 + "최대 1분 정도 걸립니다" 안내로 바뀌도록 해서,
  늘어난 대기 시간 동안 화면이 멈춘 것처럼 보이지 않게 한다
- 제출 중에는 Esc·바깥 클릭으로 확인 모달을 닫을 수 없게 막아 두 번 커밋되는 걸 막는다

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`fix/onboarding-commit-timeout#{이슈번호}`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [ ] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 해당 없음(권한 로직 변경 없음)
- [x] 🧬 **zod** — 해당 없음(응답 스키마 변경 없음)
- [x] 🕵️ **정직성** — 제출 중 대기 시간을 화면에 실제로 말하고, 관련 없어진 정보(알약·경고)는 숨긴다
- [x] 🎨 디자인 토큰 사용 — `text-muted-foreground` 등 기존 토큰만 사용, 신규 색상 없음

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [x] ♿ a11y — 진행 안내에 `role="status"` + `aria-live="polite"` 추가, 스피너는 `aria-hidden`
- [x] ♻️ 재사용 확인 — 스피너 패턴은 기존 `SubmitButton`(`Loader2` + `animate-spin`)을 그대로 따름, 공용 `ConfirmDialog`는 건드리지 않고 `children` 영역만 사용
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 이번 변경이 `loading`(제출 중) 상태 자체를 다룸, `error`는 기존 로직 유지
- [ ] 브라우저 전용 API — 해당 없음

---

## 🔗 연관 이슈

Closes #618

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
| 버튼 글자만 "등록 중"으로 바뀜, 최대 1분 동안 다른 신호 없음 | 회전 아이콘 + "최대 1분 정도 걸립니다" 안내, 창 닫기 막힘 |

---

## 💬 리뷰 포인트

- 60초가 실제 최대 초대 인원 기준으로 충분한 값인지(인원이 매우 많아지면 BE 쪽 비동기 처리로
  근본 해결이 필요할 수 있음 — 이번 PR 범위 밖)
- 제출 중 닫기를 막는 게 다른 온보딩 단계 UX와 어긋나지 않는지

---

## 📝 추가 메모

`onboarding` 테스트 스위트 151건 통과, `tsc`/`eslint` 클린 확인. 실제 브라우저로 60초
대기를 재현하려면 백엔드를 인위적으로 느리게 만들어야 해서 이번엔 코드 리뷰·타입체크·
기존 테스트로만 검증했다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 온보딩 초대 제출 중 진행 상태와 최대 1분 소요 안내를 표시합니다.
  * 제출 처리 중에는 확인 창을 닫을 수 없도록 개선했습니다.
  * 제출 완료 후 요약 정보와 미발송 사유를 확인할 수 있습니다.

* **버그 수정**
  * 온보딩 요청이 일정 시간 내 완료되지 않을 경우 안정적으로 처리되도록 제한 시간을 적용했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->