### PR TITLE
[FEAT] 마이페이지 비밀번호 변경 칸에 보기/숨기기 토글 추가 #620

### DIFF
--- a/src/features/profile/components/change-password-dialog.tsx
+++ b/src/features/profile/components/change-password-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Eye, EyeOff } from "lucide-react";
 import { type FormEvent, useActionState, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
@@ -39,6 +40,14 @@ export function ChangePasswordDialog() {
   const [state, formAction, isPending] = useActionState(changePasswordAction, INITIAL_STATE);
   const [draft, setDraft] = useState<PasswordDraft>(EMPTY_DRAFT);
   const shownAttempt = useRef(0);
+  /*
+    ⚠️ **세 칸을 따로 토글한다.** 하나로 묶으면 현재 비밀번호를 확인하려고 켰을 뿐인데
+       새 비밀번호 두 칸까지 같이 드러난다 — 로그인 화면(`LoginForm`)과 같은 눈 아이콘
+       패턴이되, 칸마다 독립된 상태를 갖는다.
+  */
+  const [isCurrentShown, setCurrentShown] = useState(false);
+  const [isNewShown, setNewShown] = useState(false);
+  const [isConfirmShown, setConfirmShown] = useState(false);
 
   // 닫는 경로(취소·ESC·바깥 클릭) 전부 여기로 모은다 — 한 곳만 고치면 전부 반영된다.
   const handleClose = () => {
@@ -96,21 +105,28 @@ export function ChangePasswordDialog() {
             <div className="flex flex-col gap-4 px-6 py-5">
               <div className="flex flex-col gap-2">
                 <Label htmlFor="current-password">현재 비밀번호</Label>
-                <Input
-                  id="current-password"
-                  name="currentPassword"
-                  type="password"
-                  autoComplete="current-password"
-                  required
-                  value={draft.currentPassword}
-                  onChange={(event) =>
-                    setDraft((prev) => ({ ...prev, currentPassword: event.target.value }))
-                  }
-                  aria-describedby={
-                    state.errors.currentPassword ? "current-password-error" : undefined
-                  }
-                  aria-invalid={state.errors.currentPassword ? true : undefined}
-                />
+                <div className="relative">
+                  <Input
+                    id="current-password"
+                    name="currentPassword"
+                    type={isCurrentShown ? "text" : "password"}
+                    autoComplete="current-password"
+                    required
+                    className="pr-10"
+                    value={draft.currentPassword}
+                    onChange={(event) =>
+                      setDraft((prev) => ({ ...prev, currentPassword: event.target.value }))
+                    }
+                    aria-describedby={
+                      state.errors.currentPassword ? "current-password-error" : undefined
+                    }
+                    aria-invalid={state.errors.currentPassword ? true : undefined}
+                  />
+                  <PasswordVisibilityToggle
+                    isShown={isCurrentShown}
+                    onToggle={() => setCurrentShown((shown) => !shown)}
+                  />
+                </div>
                 {state.errors.currentPassword && (
                   <p id="current-password-error" className="text-destructive text-[12px] leading-4">
                     {state.errors.currentPassword}
@@ -120,20 +136,27 @@ export function ChangePasswordDialog() {
 
               <div className="flex flex-col gap-2">
                 <Label htmlFor="new-password">새 비밀번호</Label>
-                <Input
-                  id="new-password"
-                  name="newPassword"
-                  type="password"
-                  autoComplete="new-password"
-                  maxLength={16}
-                  required
-                  value={draft.newPassword}
-                  onChange={(event) =>
-                    setDraft((prev) => ({ ...prev, newPassword: event.target.value }))
-                  }
-                  aria-describedby="new-password-hints"
-                  aria-invalid={state.errors.newPassword ? true : undefined}
-                />
+                <div className="relative">
+                  <Input
+                    id="new-password"
+                    name="newPassword"
+                    type={isNewShown ? "text" : "password"}
+                    autoComplete="new-password"
+                    maxLength={16}
+                    required
+                    className="pr-10"
+                    value={draft.newPassword}
+                    onChange={(event) =>
+                      setDraft((prev) => ({ ...prev, newPassword: event.target.value }))
+                    }
+                    aria-describedby="new-password-hints"
+                    aria-invalid={state.errors.newPassword ? true : undefined}
+                  />
+                  <PasswordVisibilityToggle
+                    isShown={isNewShown}
+                    onToggle={() => setNewShown((shown) => !shown)}
+                  />
+                </div>
                 {state.errors.newPassword && (
                   <p className="text-destructive text-[12px] leading-4">
                     {state.errors.newPassword}
@@ -148,22 +171,29 @@ export function ChangePasswordDialog() {
 
               <div className="flex flex-col gap-2">
                 <Label htmlFor="new-password-confirm">새 비밀번호 확인</Label>
-                <Input
-                  id="new-password-confirm"
-                  name="newPasswordConfirm"
-                  type="password"
-                  autoComplete="new-password"
-                  maxLength={16}
-                  required
-                  value={draft.newPasswordConfirm}
-                  onChange={(event) =>
-                    setDraft((prev) => ({ ...prev, newPasswordConfirm: event.target.value }))
-                  }
-                  aria-describedby="new-password-confirm-hint"
-                  aria-invalid={
-                    state.errors.newPasswordConfirm || confirmMatch === false ? true : undefined
-                  }
-                />
+                <div className="relative">
+                  <Input
+                    id="new-password-confirm"
+                    name="newPasswordConfirm"
+                    type={isConfirmShown ? "text" : "password"}
+                    autoComplete="new-password"
+                    maxLength={16}
+                    required
+                    className="pr-10"
+                    value={draft.newPasswordConfirm}
+                    onChange={(event) =>
+                      setDraft((prev) => ({ ...prev, newPasswordConfirm: event.target.value }))
+                    }
+                    aria-describedby="new-password-confirm-hint"
+                    aria-invalid={
+                      state.errors.newPasswordConfirm || confirmMatch === false ? true : undefined
+                    }
+                  />
+                  <PasswordVisibilityToggle
+                    isShown={isConfirmShown}
+                    onToggle={() => setConfirmShown((shown) => !shown)}
+                  />
+                </div>
                 {/*
                   ⚠️ **서버 오류가 우선이다.** 방금 제출해서 돌아온 문구가 있으면 그걸 보여주고,
                      없으면 타이핑 중 실시간 판정을 보여준다 — 같은 뜻의 줄이 두 개 뜨지 않는다.
@@ -205,5 +235,25 @@ export function ChangePasswordDialog() {
         </DialogContent>
       </Dialog>
     </>
+  );
+}
+
+/** 눈 아이콘 토글 — `LoginForm`의 비밀번호 칸과 같은 자리·같은 문구다(일관성). */
+function PasswordVisibilityToggle({
+  isShown,
+  onToggle,
+}: {
+  isShown: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-label={isShown ? "비밀번호 숨기기" : "비밀번호 보기"}
+      className="text-muted-foreground hover:text-foreground focus-visible:ring-ring absolute top-1/2 right-2 -translate-y-1/2 rounded p-1 focus-visible:ring-2 focus-visible:outline-hidden"
+    >
+      {isShown ? <EyeOff className="size-4" aria-hidden /> : <Eye className="size-4" aria-hidden />}
+    </button>
   );
 }


### PR DESCRIPTION
## 📋 PR 타입

- [x] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

- 마이페이지 비밀번호 변경 모달의 현재/새/확인 세 칸에 눈 아이콘 보기·숨기기 토글을 추가한다
- 로그인 화면(`LoginForm`)과 동일한 아이콘·위치·`aria-label` 패턴을 그대로 따른다
- 세 칸은 서로 독립된 상태로 토글된다

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/profile-password-visibility-toggle#{이슈번호}`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [ ] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 해당 없음(본인 비밀번호 변경 화면, 권한 로직 변경 없음)
- [x] 🧬 **zod** — 해당 없음(폼 검증 스키마 변경 없음)
- [x] 🕵️ **정직성** — 해당 없음(목·미구현 아님)
- [x] 🎨 디자인 토큰 사용 — `text-muted-foreground` 등 기존 토큰만 사용, 신규 색상 없음

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [x] ♿ a11y — 토글 버튼에 `aria-label`(보기/숨기기) 부여, 포커스 링 유지
- [x] ♻️ 재사용 확인 — 새 컴포넌트를 만들지 않고 로그인 화면과 같은 패턴을 이 파일 안 로컬 헬퍼로 재현
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 해당 없음(기존 폼 상태 로직 변경 없음)
- [ ] 브라우저 전용 API — 해당 없음

---

## 🔗 연관 이슈

Closes #620

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
| 세 칸 모두 항상 가려짐, 확인 방법 없음 | 칸마다 눈 아이콘으로 개별 토글 가능 |

---

## 💬 리뷰 포인트

- 로그인 화면과 시각적으로 동일하게 보이는지(아이콘 크기·위치·색)
- 세 칸이 서로 영향 없이 독립적으로 토글되는지

---

## 📝 추가 메모

`tsc`·`eslint` 클린, `profile` 테스트 스위트 14건 통과(기존 커버리지 그대로 — 이 변경은
로컬 UI 상태만 추가해 새 테스트를 따로 만들지 않았다, 로그인 화면 쪽도 같은 패턴이라
테스트가 없다).