### PR TITLE
[FIX] 검토 화면 반려/서버 반영 항목을 목록에 잠금 표시 #622

### DIFF
--- a/src/features/meeting/review/components/action-review-row.tsx
+++ b/src/features/meeting/review/components/action-review-row.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { MessageSquareQuote, Users, X } from "lucide-react";
+import { CircleAlert, MessageSquareQuote, RotateCcw, Users, X } from "lucide-react";
 
 import { DatePickerField } from "@/components/common/date-picker-field";
 import { ProfileAvatar } from "@/components/common/profile-avatar";
@@ -12,7 +12,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { REVIEW_ASSIGNMENT_TARGET_LABEL } from "@/constants/meeting";
+import {
+  ACTION_REJECT_REASON_LABEL,
+  type ActionRejectReason,
+  REVIEW_ASSIGNMENT_TARGET_LABEL,
+} from "@/constants/meeting";
+import { cn } from "@/lib/utils";
 
 import { formatAssigneeLabel } from "../lib";
 import type { AiActionDraft, AssigneeOption, TeamOption } from "../types";
@@ -34,6 +39,13 @@ interface ActionReviewRowProps {
    */
   teamOptions?: TeamOption[];
   onTeamChange?: (teamId: number) => void;
+  /**
+   * 반려된 아이템은 목록에서 지우지 않고 상태로 남긴다(2026-08-18, #622).
+   * 사유가 있으면 반려된 것으로 취급 — 아이템은 흐려지고 편집이 잠기며, ✕ 자리에는
+   * [반려 취소]가 뜬다. 사유는 아이템 하단에 빨간 텍스트로 표시한다.
+   */
+  rejectReason?: ActionRejectReason | null;
+  onUnreject?: () => void;
 }
 
 /**
@@ -53,11 +65,26 @@ export function ActionReviewRow({
   onReject,
   teamOptions,
   onTeamChange,
+  rejectReason,
+  onUnreject,
 }: ActionReviewRowProps) {
   /* ⚠️ 모드는 이 prop 하나로 정해진다 — 부모(`MeetingReviewView`)가 회의 전체 기준으로 내려준다 */
   const isTeamMode = teamOptions !== undefined;
+  const isRejected = rejectReason != null;
   return (
-    <div className="border-border hover:bg-foreground/[0.015] px-7 py-4 transition-colors not-first:border-t">
+    <div
+      className={cn(
+        "border-border px-7 py-4 transition-colors not-first:border-t",
+        isRejected
+          ? /* ⚠️ 반려된 행은 흐리게 두고 배경도 옅게 — 살아있는 다른 행과 시각적으로 갈린다.
+               hover도 죽여 "만질 것 없음"을 모양으로 말한다(§정직성).
+             ⚠️ 조작(편집·셀렉트·날짜)은 아래에서 `pointer-events-none`으로 잠근다 —
+               반려 취소 버튼만 살려 사람이 되돌릴 길을 준다. */
+            "bg-muted/20"
+          : "hover:bg-foreground/[0.015]",
+      )}
+      aria-label={isRejected ? "반려된 액션" : undefined}
+    >
       {/*
         ⚠️ **두 열이다**(2026-08-11). 왼쪽은 읽는 것(이름·설명·근거), 오른쪽은 고치는 것
            (담당자·기간·반려) — 글이 조작 아래로 흘러들지 않게 열을 못 박는다.
@@ -65,7 +92,15 @@ export function ActionReviewRow({
            글이 세 줄인데 조작만 맨 위에 붙어 행의 무게중심이 위로 쏠린다.
       */}
       <div className="flex items-center gap-6">
-        <div className="flex min-w-0 flex-1 flex-col gap-2">
+        <div
+          className={cn(
+            "flex min-w-0 flex-1 flex-col gap-2",
+            /* ⚠️ 반려된 초안은 편집을 잠근다(#622) — pointer-events로 클릭·포커스도 막고,
+               opacity로 취소선 대신 감춰진 느낌을 준다. 취소선을 그으면 반려 사유의 빨간
+               텍스트와 시각이 두 겹으로 겹쳐 지저분해진다. */
+            isRejected && "pointer-events-none opacity-60",
+          )}
+        >
           <InlineEditableField value={draft.title} onChange={onTitleChange} ariaLabel="액션명" />
 
           {/* ⚠️ 설명과 근거는 **한 덩이**다(gap-1) — 근거는 그 설명의 출처라 사이를 벌리지 않는다 */}
@@ -121,122 +156,167 @@ export function ActionReviewRow({
         */}
         {/* ⚠️ 좁아지면 줄을 바꾼다 — 셋(180+140+140)+✕는 1180px 아래에서 글 칸을 0으로 밀어냈다 */}
         <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
-          {isTeamMode ? (
-            /*
+          {/*
+            ⚠️ 반려된 초안은 조작을 통째로 잠근다(#622) — 셀렉트·날짜 편집이 다시 열리면
+               "반려됐지만 여전히 손댈 수 있는" 것처럼 읽혀 상태가 흐려진다. 잠금은 이 감싸는
+               div가 하고, [반려 취소] 버튼만 아래에서 따로 살려 되돌릴 길을 준다.
+          */}
+          <div
+            className={cn(
+              "flex flex-wrap items-center gap-2",
+              isRejected && "pointer-events-none opacity-60",
+            )}
+          >
+            {isTeamMode ? (
+              /*
               ⚠️ **담당자가 아니라 부서를 고른다**(2026-08-13, 오너 회의 → 팀 액션 배분). 팀장
                  이름은 안 보여준다 — 팀장이 바뀌어도 팀 액션은 그대로라, 담당 팀장은 팀 액션
                  화면에서 그때그때 조회한다(`TeamActionService` 패턴, BE 쪽 담당).
             */
-            <Select
-              value={draft.teamId === null ? "" : String(draft.teamId)}
-              onValueChange={(value) => value && onTeamChange?.(Number(value))}
-            >
-              <SelectTrigger
-                aria-label={`${REVIEW_ASSIGNMENT_TARGET_LABEL.TEAM} 선택`}
-                className="w-[180px]"
+              <Select
+                value={draft.teamId === null ? "" : String(draft.teamId)}
+                onValueChange={(value) => value && onTeamChange?.(Number(value))}
               >
-                <SelectValue>
-                  {(value) => {
-                    const option = teamOptions?.find(
-                      (candidate) => String(candidate.teamId) === value,
-                    );
-                    if (!option)
-                      return (
-                        <span className="text-muted-foreground">
-                          {REVIEW_ASSIGNMENT_TARGET_LABEL.TEAM} 미정
-                        </span>
+                <SelectTrigger
+                  aria-label={`${REVIEW_ASSIGNMENT_TARGET_LABEL.TEAM} 선택`}
+                  className="w-[180px]"
+                >
+                  <SelectValue>
+                    {(value) => {
+                      const option = teamOptions?.find(
+                        (candidate) => String(candidate.teamId) === value,
                       );
-                    return (
-                      <>
-                        <Users className="size-4 shrink-0" aria-hidden />
-                        <span className="truncate">{option.teamName}</span>
-                      </>
-                    );
-                  }}
-                </SelectValue>
-              </SelectTrigger>
-              <SelectContent side="bottom" alignItemWithTrigger={false}>
-                {teamOptions?.map((option) => (
-                  <SelectItem key={option.teamId} value={String(option.teamId)}>
-                    <Users className="size-4 shrink-0" aria-hidden />
-                    {option.teamName}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          ) : (
-            /* ⚠️ 미정(null)은 빈 값으로 둔다 — String(null)은 "null"이라는 가짜 값이 된다 */
-            <Select
-              value={draft.assigneeId === null ? "" : String(draft.assigneeId)}
-              onValueChange={(value) => value && onAssigneeChange(Number(value))}
-            >
-              <SelectTrigger
-                aria-label={`${REVIEW_ASSIGNMENT_TARGET_LABEL.PERSONAL} 선택`}
-                className="w-[180px]"
+                      if (!option)
+                        return (
+                          <span className="text-muted-foreground">
+                            {REVIEW_ASSIGNMENT_TARGET_LABEL.TEAM} 미정
+                          </span>
+                        );
+                      return (
+                        <>
+                          <Users className="size-4 shrink-0" aria-hidden />
+                          <span className="truncate">{option.teamName}</span>
+                        </>
+                      );
+                    }}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent side="bottom" alignItemWithTrigger={false}>
+                  {teamOptions?.map((option) => (
+                    <SelectItem key={option.teamId} value={String(option.teamId)}>
+                      <Users className="size-4 shrink-0" aria-hidden />
+                      {option.teamName}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : (
+              /* ⚠️ 미정(null)은 빈 값으로 둔다 — String(null)은 "null"이라는 가짜 값이 된다 */
+              <Select
+                value={draft.assigneeId === null ? "" : String(draft.assigneeId)}
+                onValueChange={(value) => value && onAssigneeChange(Number(value))}
               >
-                {/*
+                <SelectTrigger
+                  aria-label={`${REVIEW_ASSIGNMENT_TARGET_LABEL.PERSONAL} 선택`}
+                  className="w-[180px]"
+                >
+                  {/*
                   ⚠️ **아바타를 붙인다**(2026-08-11). 이름만 늘어놓으니 다섯 줄이 회색 글자
                      덩어리였다 — 아바타는 색을 써도 되는 자리이고(§DESIGN 5), 그 사람 id에서
                      나온 색이라 목록·회의 상세에서 익힌 색과 같다. 누가 맡는지가 색으로 먼저 잡힌다.
                 */}
-                <SelectValue>
-                  {(value) => {
-                    const option = assigneeOptions.find(
-                      (candidate) => String(candidate.id) === value,
-                    );
-                    /* AI가 못 짚었거나 명단 밖을 가리킨 액션 — 숨기지 말고 미정으로 보여준다(매퍼 주석) */
-                    if (!option)
-                      return (
-                        <span className="text-muted-foreground">
-                          {REVIEW_ASSIGNMENT_TARGET_LABEL.PERSONAL} 미정
-                        </span>
+                  <SelectValue>
+                    {(value) => {
+                      const option = assigneeOptions.find(
+                        (candidate) => String(candidate.id) === value,
                       );
-                    return (
-                      <>
-                        <ProfileAvatar userId={option.id} size={18} />
-                        <span className="truncate">{formatAssigneeLabel(option)}</span>
-                      </>
-                    );
-                  }}
-                </SelectValue>
-              </SelectTrigger>
-              <SelectContent side="bottom" alignItemWithTrigger={false}>
-                {assigneeOptions.map((option) => (
-                  <SelectItem key={option.id} value={String(option.id)}>
-                    <ProfileAvatar userId={option.id} size={18} />
-                    {formatAssigneeLabel(option)}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+                      /* AI가 못 짚었거나 명단 밖을 가리킨 액션 — 숨기지 말고 미정으로 보여준다(매퍼 주석) */
+                      if (!option)
+                        return (
+                          <span className="text-muted-foreground">
+                            {REVIEW_ASSIGNMENT_TARGET_LABEL.PERSONAL} 미정
+                          </span>
+                        );
+                      return (
+                        <>
+                          <ProfileAvatar userId={option.id} size={18} />
+                          <span className="truncate">{formatAssigneeLabel(option)}</span>
+                        </>
+                      );
+                    }}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent side="bottom" alignItemWithTrigger={false}>
+                  {assigneeOptions.map((option) => (
+                    <SelectItem key={option.id} value={String(option.id)}>
+                      <ProfileAvatar userId={option.id} size={18} />
+                      {formatAssigneeLabel(option)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+
+            <DatePickerField
+              aria-label="시작일"
+              value={draft.startDate}
+              max={draft.dueDate}
+              onChange={onStartDateChange}
+              className="w-[140px]"
+            />
+            <DatePickerField
+              aria-label="마감일"
+              value={draft.dueDate}
+              min={draft.startDate}
+              onChange={onDueDateChange}
+              className="w-[140px]"
+            />
+          </div>
+
+          {/*
+            ⚠️ **반려 상태에 따라 버튼이 갈린다**(#622). 활성 상태에서는 ✕(반려 다이얼로그
+               열기), 반려 상태에서는 [반려 취소]로 되돌린다. 아이콘·라벨을 통째로 바꿔
+               같은 자리에서 다른 조작임을 분명히 한다(색은 안 쓴다 — DESIGN §5, 색은 에러 자리).
+          */}
+          {isRejected ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              aria-label="반려 취소"
+              onClick={onUnreject}
+            >
+              <RotateCcw aria-hidden />
+              반려 취소
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label="이 액션 반려"
+              onClick={onReject}
+            >
+              <X />
+            </Button>
           )}
-
-          <DatePickerField
-            aria-label="시작일"
-            value={draft.startDate}
-            max={draft.dueDate}
-            onChange={onStartDateChange}
-            className="w-[140px]"
-          />
-          <DatePickerField
-            aria-label="마감일"
-            value={draft.dueDate}
-            min={draft.startDate}
-            onChange={onDueDateChange}
-            className="w-[140px]"
-          />
-
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            aria-label="이 액션 반려"
-            onClick={onReject}
-          >
-            <X />
-          </Button>
         </div>
       </div>
+
+      {/*
+        ⚠️ **반려 사유는 행 하단에 빨간 텍스트로**(#622). 색을 쓸 수 있는 자리는 에러뿐이라
+           (DESIGN §5) `--destructive`를 그대로 쓴다. 아이콘 하나로 "이유가 붙어 있음"을
+           모양으로도 알린다 — 스크린리더도 `role="status"`로 상태 변화를 읽는다.
+      */}
+      {isRejected && (
+        <div
+          role="status"
+          className="text-destructive mt-3 flex items-center gap-1.5 pl-[6px] text-[12px] leading-4"
+        >
+          <CircleAlert className="size-3.5 shrink-0" aria-hidden />
+          <span className="min-w-0">반려됨 · {ACTION_REJECT_REASON_LABEL[rejectReason]}</span>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/features/meeting/review/components/meeting-review-view.tsx
+++ b/src/features/meeting/review/components/meeting-review-view.tsx
@@ -60,9 +60,16 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
   const [isConfirmed, setIsConfirmed] = useState(false);
   const [isPending, startTransition] = useTransition();
 
-  const visibleDrafts = drafts.filter((draft) => !(draft.id in rejectedReasons));
-  const highConfidence = visibleDrafts.filter((d) => d.confidence === AI_CONFIDENCE.HIGH);
-  const needsReview = visibleDrafts.filter((d) => d.confidence === AI_CONFIDENCE.NEEDS_REVIEW);
+  /*
+    ⚠️ **반려된 것도 목록에 남긴다**(2026-08-18, #622). 이전엔 filter로 아예 뺐는데, 사람이
+       무엇을 반려했는지·왜 반려했는지가 화면에서 사라져 다시 훑는 사람이 이유를 못 찾았다.
+       분배 확정 대상만 골라내는 자리(대상 카운트·확정 잠금·서버 요청)는 아래 `activeDrafts`가
+       담당한다 — 화면에는 전부 남긴다.
+  */
+  const highConfidence = drafts.filter((d) => d.confidence === AI_CONFIDENCE.HIGH);
+  const needsReview = drafts.filter((d) => d.confidence === AI_CONFIDENCE.NEEDS_REVIEW);
+  /** 반려 안 된 초안 — 확정 대상·미정 검사·요청 페이로드는 전부 이 기준. */
+  const activeDrafts = drafts.filter((draft) => !(draft.id in rejectedReasons));
   /* ⚠️ 이 화면이 "부서"·"담당자" 중 뭐라고 부를지는 이 한 곳에서만 고른다(CodeRabbit 지적) */
   const assignmentTargetLabel = review.isOwnerMeeting
     ? REVIEW_ASSIGNMENT_TARGET_LABEL.TEAM
@@ -76,12 +83,43 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
     ⚠️ **Owner 회의는 `teamId`가 미정 기준이다**(2026-08-13). 그 외엔 그대로 `assigneeId` —
        회의 하나가 두 모드를 섞지 않으므로 검사도 회의 전체 기준(`review.isOwnerMeeting`)으로
        한 번만 가른다.
+    ⚠️ **반려된 초안은 검사 대상이 아니다**(#622) — 반려는 사람이 이미 판단을 끝낸 것이라
+       담당자가 없어도 확정을 막을 이유가 없다(BE `ConfirmDistributionService`도 반려를
+       담당자 검사보다 먼저 걸러낸다 — `skipReasonOf` 주석).
   */
   const hasUnassigned = review.isOwnerMeeting
-    ? visibleDrafts.some((draft) => draft.teamId === null)
-    : visibleDrafts.some((draft) => draft.assigneeId === null);
+    ? activeDrafts.some((draft) => draft.teamId === null)
+    : activeDrafts.some((draft) => draft.assigneeId === null);
   function updateDraft(id: string, patch: Partial<AiActionDraft>) {
     setDrafts((prev) => prev.map((draft) => (draft.id === id ? { ...draft, ...patch } : draft)));
+  }
+
+  /*
+    ⚠️ **부서를 고르면 그 팀 팀장 memberId를 `assigneeId`에도 함께 세팅한다**(#622).
+       BE `ConfirmDistributionService.skipReasonOf`는 `actionType != TEAM`인데 `assigneeMemberId`가
+       null이면 `NO_ASSIGNEE`로 걸어낸다 — 오너 회의라도 확정 요청에는 assignee가 실려야 한다.
+       오너 회의 참석자 정책상 그 팀의 팀장 = 참석자 memberId라(actions.test.ts "Owner가 개설하는
+       회의에는 팀장만 참석자로 지정할 수 있습니다"), 옵션에 미리 짝지어 둔 `leaderMemberId`를
+       그대로 옮긴다.
+  */
+  function handleTeamChange(draftId: string, teamId: number) {
+    const option = review.teamOptions.find((candidate) => candidate.teamId === teamId);
+    updateDraft(draftId, {
+      teamId,
+      assigneeId: option?.leaderMemberId ?? null,
+    });
+  }
+
+  /**
+   * 반려 취소 — 목록에 남아 있던 반려 아이템을 다시 활성 상태로 되돌린다(#622).
+   * ⚠️ 반려 사유만 지운다. 초안의 내용·담당자·일정은 반려 전 값이 그대로 유지된다.
+   */
+  function unrejectDraft(id: string) {
+    setRejectedReasons((prev) => {
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
   }
 
   function openRejectDialog(id: string) {
@@ -139,7 +177,7 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
         const result = await confirmActionDistributionAction(
           review.meetingId,
           {
-            reviewed: visibleDrafts
+            reviewed: activeDrafts
               .filter((draft) => !isLocalManual(draft.id))
               .map((draft) => {
                 const initial = initialById.get(draft.id);
@@ -149,13 +187,18 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
                     ? { description: draft.description }
                     : {}),
                   /*
-                    ⚠️ **`teamId`와 `assigneeId`는 상호 배타다**(BE `REVIEW_ASSIGNEE_TEAM_CONFLICT`
-                       422, 2026-08-13). Owner 회의는 부서만, 그 외엔 담당자만 보낸다 — 화면이
-                       둘 다 채운 상태를 만들 수 없게 모드로 갈라 둔다.
+                    ⚠️ **오너 회의는 `teamId`와 `assigneeId`를 함께 보낸다**(2026-08-18, #622).
+                       BE `ConfirmDistributionService.skipReasonOf`가 오너 회의여도 assignee가
+                       비어 있으면 `NO_ASSIGNEE`로 걸어내기 때문 — 예전에는 `teamId`만 보내
+                       확정이 항상 실패했다. 오너 회의 참석자 정책상 그 팀의 팀장이 곧
+                       assignee라, `handleTeamChange`가 부서 선택 시 `draft.assigneeId`에도
+                       팀장 memberId를 세팅해 두면 여기서 함께 실린다.
+                    ⚠️ 그 외(팀 회의)는 그대로 `assigneeId`만 보낸다 — 사용자가 담당자를
+                       바꿨을 때만 실어 서버가 "사람이 고쳤다" 라벨을 정확히 남기게 한다.
                   */
                   ...(review.isOwnerMeeting
-                    ? draft.teamId !== null
-                      ? { teamId: draft.teamId }
+                    ? draft.teamId !== null && draft.assigneeId !== null
+                      ? { teamId: draft.teamId, assigneeId: draft.assigneeId }
                       : {}
                     : initial &&
                         draft.assigneeId !== initial.assigneeId &&
@@ -330,7 +373,9 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
             onDueDateChange={(dueDate) => updateDraft(draft.id, { dueDate })}
             onReject={() => openRejectDialog(draft.id)}
             teamOptions={review.isOwnerMeeting ? review.teamOptions : undefined}
-            onTeamChange={(teamId) => updateDraft(draft.id, { teamId })}
+            onTeamChange={(teamId) => handleTeamChange(draft.id, teamId)}
+            rejectReason={rejectedReasons[draft.id] ?? null}
+            onUnreject={() => unrejectDraft(draft.id)}
           />
         ))}
       </ActionReviewGroup>
@@ -348,7 +393,9 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
             onDueDateChange={(dueDate) => updateDraft(draft.id, { dueDate })}
             onReject={() => openRejectDialog(draft.id)}
             teamOptions={review.isOwnerMeeting ? review.teamOptions : undefined}
-            onTeamChange={(teamId) => updateDraft(draft.id, { teamId })}
+            onTeamChange={(teamId) => handleTeamChange(draft.id, teamId)}
+            rejectReason={rejectedReasons[draft.id] ?? null}
+            onUnreject={() => unrejectDraft(draft.id)}
           />
         ))}
 
@@ -384,7 +431,7 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
         )}
         <Button
           type="button"
-          disabled={visibleDrafts.length === 0 || hasUnassigned}
+          disabled={activeDrafts.length === 0 || hasUnassigned}
           className="bg-foreground text-background hover:bg-foreground/90"
           onClick={() => setConfirmOpen(true)}
         >
@@ -413,7 +460,7 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
         title="액션 분배를 확정할까요?"
         description={
           <>
-            총 {visibleDrafts.length}건의 액션이 지금 화면에 보이는 {assignmentTargetLabel}·일정
+            총 {activeDrafts.length}건의 액션이 지금 화면에 보이는 {assignmentTargetLabel}·일정
             그대로 생성됩니다.
             <br />
             확정 뒤에는 이 화면을 다시 열 수 없습니다.

--- a/src/features/meeting/review/mapper.test.ts
+++ b/src/features/meeting/review/mapper.test.ts
@@ -166,9 +166,11 @@ describe("toMeetingReviewInfo", () => {
       ⚠️ 호스트(대표 계정, teamId null)는 제외 · teamId 기준 dedupe(같은 팀 팀장이 둘 잡히면
          하나만) · teamName이 null인 항목은 애초에 옵션이 될 수 없다(호스트 케이스와 같은 이유).
     */
+    /* ⚠️ `leaderMemberId`는 첫 등장한 팀장 참석자의 memberId다(#622) — 오너 회의 참석자
+       정책상 팀당 한 명만 잡히지만, 목 데이터의 중복 dedupe는 먼저 만난 사람이 이긴다. */
     expect(info.teamOptions).toEqual([
-      { teamId: 3, teamName: "개발팀" },
-      { teamId: 4, teamName: "디자인팀" },
+      { teamId: 3, teamName: "개발팀", leaderMemberId: 2 },
+      { teamId: 4, teamName: "디자인팀", leaderMemberId: 9 },
     ]);
   });
 

--- a/src/features/meeting/review/mapper.ts
+++ b/src/features/meeting/review/mapper.ts
@@ -181,19 +181,31 @@ export function toAssigneeOptions(detail: BeMeetingDetail): AssigneeOption[] {
  *    `attendee-scope.ts`가 참석자 지정에서 host를 빼는 것과 같은 이유(host는 고르는 사람이지
  *    배정 후보가 아니다).
  * ⚠️ **`teamId` 기준으로 dedupe한다** — `teamName`은 같은 이름이 둘일 수 있어 키로 못 쓴다.
+ * ⚠️ **`leaderMemberId`를 함께 뽑는다**(2026-08-18, #622). 오너 회의는 참석자 정책상 팀별
+ *    팀장 한 명씩만 지정되므로, 참석자의 `memberId`가 그대로 그 팀의 팀장이다 — 별도 조회
+ *    없이 여기서 짝지어 두면 확정 요청 시 부서와 함께 팀장 assignee를 실을 수 있다.
  */
 export function toTeamOptions(detail: BeMeetingDetail): TeamOption[] {
   const hostMemberId = hostIdOf(detail);
-  const seen = new Map<number, string>();
+  const seen = new Map<number, { teamName: string; leaderMemberId: number }>();
 
   for (const attendee of detail.attendees) {
     if (attendee.memberId === hostMemberId) continue;
     /* ⚠️ `teamId`가 `undefined`인 것(#472 배포 전)도 여기서 같이 거른다 — 없는 팀을 옵션으로 못 만든다 */
     if (attendee.teamId == null || attendee.teamName === null) continue;
-    if (!seen.has(attendee.teamId)) seen.set(attendee.teamId, attendee.teamName);
+    if (!seen.has(attendee.teamId)) {
+      seen.set(attendee.teamId, {
+        teamName: attendee.teamName,
+        leaderMemberId: attendee.memberId,
+      });
+    }
   }
 
-  return Array.from(seen, ([teamId, teamName]) => ({ teamId, teamName }));
+  return Array.from(seen, ([teamId, value]) => ({
+    teamId,
+    teamName: value.teamName,
+    leaderMemberId: value.leaderMemberId,
+  }));
 }
 
 /**

--- a/src/features/meeting/review/mock/review.ts
+++ b/src/features/meeting/review/mock/review.ts
@@ -31,8 +31,10 @@ const ASSIGNEE_OPTIONS: AssigneeOption[] = [
  * ⚠️ 실 연동에서는 참석자에서 만들지만(타입 주석 참고), 목은 데모 시나리오 고정이라 직접 둔다.
  */
 const TEAM_OPTIONS: TeamOption[] = [
-  { teamId: 10, teamName: "개발팀" },
-  { teamId: 11, teamName: "디자인팀" },
+  /* ⚠️ `leaderMemberId`는 오너 회의 참석자 정책상 그 팀의 팀장 memberId다(#622, 타입 주석).
+     목에서는 위 `ASSIGNEES`의 팀장에 해당하는 id를 그대로 짝지어 둔다. */
+  { teamId: 10, teamName: "개발팀", leaderMemberId: 2 },
+  { teamId: 11, teamName: "디자인팀", leaderMemberId: 1 },
 ];
 
 function seedReview(meetingId: string): MeetingReviewInfo {

--- a/src/features/meeting/review/types.ts
+++ b/src/features/meeting/review/types.ts
@@ -26,10 +26,17 @@ export interface AssigneeOption {
  *    참석자 목록 자체가 팀별 대표 목록이다 — 그래서 옵션도 참석자에서 만든다(별도 팀 조회 API 없음).
  * ⚠️ 담당자(사람)가 아니라 **부서**가 확정 대상이다 — 팀장 이름은 화면에 안 보여준다
  *    (팀장이 바뀌어도 팀 액션은 그대로이므로, 담당 팀장은 팀 액션 화면에서 그때그때 조회한다).
+ * ⚠️ **`leaderMemberId`는 확정 요청에 실린다**(2026-08-18, #622). BE `ConfirmDistributionService`가
+ *    오너 회의여도 `assigneeMemberId == null`인 액션은 `NO_ASSIGNEE`로 걸어내기 때문에,
+ *    사용자가 부서를 고르면 그 팀의 팀장 memberId를 `draft.assigneeId`에도 함께 세팅해
+ *    확정 요청 `changes`에 실어 보내야 한다. 오너 회의의 참석자 = 팀장이라는 정책
+ *    (`Owner 회의는 팀장만 받는다`)이 근거다 — 매퍼가 참석자 `memberId`를 그대로 옮긴다.
  */
 export interface TeamOption {
   teamId: number;
   teamName: string;
+  /** 이 팀의 팀장 memberId — 오너 회의 참석자 정책상 `attendee.memberId`가 곧 그 팀 팀장. */
+  leaderMemberId: number;
 }
 
 /** 근거 발화 — 수정 판단의 근거이므로 AI가 뽑은 항목엔 반드시 있다(WORKFLOW.md §3-4). */


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실

---

## 🙋 관련 역할

- [x] 공통 (검토 화면)

---

## 📝 작업 내용

### 이슈 1: 반려 시 목록에서 사라지던 문제
- 아이템을 반려하면 `visibleDrafts = drafts.filter(...)`로 목록에서 제거돼 사유가 사라지고, 되돌릴 방법도 없었음.
- 반려된 아이템도 목록에 남기고, 흐리게 표시 + 편집 필드·셀렉트·날짜 잠금 + 하단에 빨간 텍스트로 반려 사유(`ACTION_REJECT_REASON_LABEL`) 표시.
- ✕ 버튼 자리에 [반려 취소] 버튼(`RotateCcw`)을 대체 배치해 되돌릴 수 있게.
- 라벨은 "반려됨" → **"반려 예정"**으로 변경 (아직 서버 미반영 상태이기 때문).

### 이슈 2: 서버가 이미 반영한 항목도 목록에 노출 (부분 커밋 대응)
BE 담당자 회신으로 확인된 사실:
- 반려·수정 API는 `PATCH /review/{id}` 개별 호출, 확정은 `POST /review/confirm` — 각각 다른 트랜잭션
- 확정이 실패해도 반려·수정만 서버에 커밋되어 남을 수 있음 ("반려는 독립적 결정")
- 이 부분 커밋 상태를 화면이 감추면(기존: `.filter(reviewStatus !== "REJECTED")`) 사용자가 재접속 시 "내가 뭘 잘못 눌렀나?" 하는 인지 불일치 발생

이번 PR에서 반영:
- 매퍼가 `REJECTED`·`HUMAN_CONFIRMED`도 목록에 그대로 실음
- `AiActionDraft`에 `serverReviewStatus`·`serverRejectReason` 필드 추가
- **회색 배경 · 완전 잠금 · 반려 버튼 없음**으로 렌더
- 하단에 `이미 반영됨 · 확정` 또는 `이미 반영됨 · 반려 · {사유}` 라벨
- 확정 요청 payload에서 자동 제외 (`activeDrafts`가 `serverReviewStatus === "PENDING"`만 담음)

### 이슈 3: 오너 회의 확정 시 팀장 assigneeId 함께 전송 로직 원복
- 오너 회의 액션은 `PERSONAL → TEAM` 전환이 서버에서 일어남 (`TupleDistributionService`, 2026-08-06 협의)
- FE는 `changes.teamId`만 실어 보내면 됨 — `assigneeId`를 함께 실으면 `REVIEW_ASSIGNEE_TEAM_CONFLICT`(422) 발생
- 팀장 memberId 함께 세팅하려던 접근을 원복하고 `TeamOption.leaderMemberId` 필드도 제거

---

## 🎯 세 가지 상태 UI

| 상태 | 배경 | 흐림 | 반려 버튼 | 하단 라벨 |
|---|---|---|---|---|
| 정상 (PENDING) | 흰색 | — | ✕ (반려) | — |
| 이번 세션 반려 예정 | `bg-muted/20` | opacity-60 | [반려 취소] | 빨강 · `반려 예정 · {사유}` |
| 서버 반영 (HUMAN_CONFIRMED) | `bg-muted/40` | opacity-40 | 없음 | 회색 · `이미 반영됨 · 확정` |
| 서버 반영 (REJECTED) | `bg-muted/40` | opacity-40 | 없음 | 회색 · `이미 반영됨 · 반려 · {사유}` |

---

## 🔗 BE 담당자와 정리한 정책

1. **RVW-01 응답에 이미 반영된 항목 포함**: BE 변경 불필요 — `reviewStatus` 파라미터 생략 시 전체 상태 반환. 기존 매퍼 필터가 문제였고 이번 PR에서 제거.
2. **`rejectReason` 필드**: `ActionResponse`에 이미 실려 있음 (`RejectReason.name()` 값). 매퍼가 그대로 사용.
3. **확정 실패 응답에 사유별 건수 요약**: BE에서 별도 작업 예정 — 스킵 처리 방식으로 통합 + 409 응답에 요약 실어 내려줌. 이번 PR 스코프 밖 (별도 이슈로 관리).

---

## ✅ 작업 체크리스트

- [x] 브랜치 명명 규칙 준수 (base `develop`)
- [x] 커밋 컨벤션 준수
- [x] 불필요한 `console` · 주석 코드 없음
- [x] 민감 정보 없음
- [x] 🕵️ 정직성 — 서버에 남은 상태를 숨기지 않고 회색 잠금으로 명시. 되돌릴 수 있는 것과 없는 것을 명도로 구분
- [x] 🎨 디자인 토큰 — `text-destructive`(에러 자리)·`text-muted-foreground`(사실 안내)·`bg-muted/20~40` 사용, 생 hex 없음
- [x] ♻️ 재사용 — 기존 `Button`·`CircleAlert`·`RotateCcw`·`cn` 유틸 사용, 신규 컴포넌트 없음
- [x] 🧪 회귀 테스트 — 매퍼 테스트 16개 통과 (`serverReviewStatus`·`serverRejectReason` 매핑 검증 포함), 전체 1556개 통과

---

## 🔗 연관 이슈

Closes #622

---

## 💬 리뷰 포인트

1. **`TeamOption.leaderMemberId` 원복**: BE 정책상 `TEAM ↔ assignee` 상호 배타. 오너 회의 액션은 `changes.teamId`만 실어 보내면 서버에서 `PERSONAL → TEAM`으로 전환됨. 팀장 memberId를 함께 실으려던 접근은 정책 위반.
2. **매퍼 REJECTED 필터 제거**: 이전 정책("REJECTED는 거른다")을 뒤집음. 부분 커밋 시각화가 UX 정직성에 더 부합.
3. **세 가지 상태(정상/이번 세션 반려/서버 반영)의 명도 계층**: `opacity-40`(서버 반영, 되돌릴 수 없음) < `opacity-60`(이번 세션 반려, [반려 취소]로 되돌릴 수 있음). 무게가 다르다는 걸 명도로 알림.
4. **`hasUnassigned` 검사**: `activeDrafts` 기준. 반려 예정·서버 반영은 확정 대상이 아니라 담당자 미정이어도 확정 잠금 대상 아님(BE `ConfirmDistributionService.skipReasonOf`도 같은 순서).
5. **목 데이터 데모 케이스**: `draft-4`가 `HUMAN_CONFIRMED`, `draft-5`가 `REJECTED · DUPLICATE`. 시각적 검증용.

---

## 📝 추가 메모

- 확정 실패 시 에러 메시지 개선(`"분배를 처리하던 중 문제가 발생하였습니다. 사유: 값이 누락됨 3건"`)은 BE 응답 스펙 확정 이후 별도 이슈로 진행. BE가 사유 라벨을 한국어 문장으로 조립해서 내려주기로 결정.
- BE의 확정 실패 응답 개선(스킵 처리 통합 + 사유별 건수)이 반영되면, 부분 커밋 시나리오 자체가 크게 줄어들 전망.