### PR TITLE
[FIX] 회의 예약 모달 select에 TODO 상태 프로젝트·팀 액션이 안 보인다 #624

### DIFF
--- a/src/features/rooms/server.test.ts
+++ b/src/features/rooms/server.test.ts
@@ -88,41 +88,61 @@ describe("getReservableMembers — 실서버", () => {
  * 예약 폼의 "프로젝트" select — 2026-08-14 프로덕션에서 무조건 throw하던 것을 고쳤다.
  * `getProjectsPage`(project 도메인, 이미 실연동)를 그대로 재사용하는지 확인한다.
  */
+function projectFixture(overrides: { id: number; tag: string; name: string; status: string }) {
+  return {
+    ...overrides,
+    color: "blue",
+    description: "",
+    startDate: null,
+    dueDate: "2026-12-31",
+    teamCount: 1,
+    actionCount: 0,
+    completedActionCount: 0,
+    meetingCount: 0,
+    progressPct: 0,
+    teamNames: [],
+  };
+}
+
 describe("getReservableProjects — 실서버", () => {
-  it("getProjectsPage를 재사용해 select 모양으로 줄인다 — 새 경로를 만들지 않는다", async () => {
-    serverApiMock.mockResolvedValue({
-      content: [
-        {
-          id: 12,
-          tag: "product-v2",
-          color: "blue",
-          name: "제품 v2.0",
-          description: "",
-          status: "IN_PROGRESS",
-          startDate: null,
-          dueDate: "2026-12-31",
-          teamCount: 1,
-          actionCount: 0,
-          completedActionCount: 0,
-          meetingCount: 0,
-          progressPct: 0,
-          teamNames: [],
-        },
-      ],
-      page: 0,
-      size: 200,
-      totalElements: 1,
-      totalPages: 1,
-      hasNext: false,
+  it("getProjectsPage를 재사용해 select 모양으로 줄인다 — TODO·IN_PROGRESS 둘 다 불러 합친다", async () => {
+    serverApiMock.mockImplementation(async (path: string) => {
+      const isTodo = path.includes("status=TODO");
+      return {
+        content: [
+          isTodo
+            ? projectFixture({ id: 13, tag: "product-v3", name: "제품 v3.0", status: "TODO" })
+            : projectFixture({
+                id: 12,
+                tag: "product-v2",
+                name: "제품 v2.0",
+                status: "IN_PROGRESS",
+              }),
+        ],
+        page: 0,
+        size: 200,
+        totalElements: 1,
+        totalPages: 1,
+        hasNext: false,
+      };
     });
 
     const projects = await getReservableProjects();
 
-    expect(projects).toEqual([{ id: "12", name: "제품 v2.0", tag: "product-v2" }]);
+    // ⚠️ 순서까지 확인한다 — IN_PROGRESS를 먼저, TODO를 뒤에 붙인다(진행중 항목이 우선).
+    expect(projects).toEqual([
+      { id: "12", name: "제품 v2.0", tag: "product-v2" },
+      { id: "13", name: "제품 v3.0", tag: "product-v3" },
+    ]);
     expect(serverApiMock).toHaveBeenCalledWith(
       expect.stringContaining("status=IN_PROGRESS"),
       expect.objectContaining({ accessToken: "token" }),
     );
+    expect(serverApiMock).toHaveBeenCalledWith(
+      expect.stringContaining("status=TODO"),
+      expect.objectContaining({ accessToken: "token" }),
+    );
+    expect(serverApiMock).toHaveBeenCalledTimes(2);
     // ⚠️ page·size도 확인한다 — 기본 페이지 크기(20)로 조용히 바뀌어도 status만 보면 통과했다(코드래빗 지적)
     const requestUrl = serverApiMock.mock.calls[0][0] as string;
     expect(requestUrl).toContain("page=0");
@@ -134,7 +154,7 @@ describe("getReservableProjects — 실서버", () => {
        조용히 자르지 않는다. `totalPages`가 1보다 크면 뒤 페이지 프로젝트는 select에서
        영원히 안 보인다(§정직성).
   */
-  it("진행중 프로젝트가 200건 상한을 넘으면(totalPages>1) 잘린 목록을 정상으로 돌려주지 않는다", async () => {
+  it("어느 한 상태의 프로젝트가 200건 상한을 넘으면(totalPages>1) 잘린 목록을 정상으로 돌려주지 않는다", async () => {
     serverApiMock.mockResolvedValue({
       content: [],
       page: 0,
@@ -161,48 +181,62 @@ describe("getReservableTeamActions — 실서버", () => {
     expect(serverApiMock).not.toHaveBeenCalled();
   });
 
-  it("Leader·Member는 GET /api/team/actions를 IN_PROGRESS로만 불러 select 모양으로 줄인다", async () => {
-    serverApiMock.mockResolvedValue({
-      content: [
-        {
-          id: 7,
-          actionType: "TEAM",
-          title: "3분기 마케팅 캠페인 기획",
-          description: "",
-          status: "IN_PROGRESS",
-          startDate: null,
-          plannedStartDate: null,
-          dueDate: "2026-09-30",
-          needsReview: false,
-          isDelayed: false,
-          assigneeName: null,
-          projectId: 3,
-          projectTag: "marketing-q3",
-          projectName: "마케팅 캠페인 Q3",
-          teamName: "개발팀",
-          sourceMeetingTitle: null,
-          parentActionId: null,
-          parentActionTitle: null,
-          childDoneCount: 2,
-          childTotalCount: 5,
-        },
-      ],
-      page: 0,
-      size: 200,
-      totalElements: 1,
-      totalPages: 1,
-      hasNext: false,
+  it("Leader·Member는 GET /api/team/actions를 TODO·IN_PROGRESS 둘 다 불러 합친다", async () => {
+    function actionFixture(overrides: { id: number; title: string; status: string }) {
+      return {
+        ...overrides,
+        actionType: "TEAM",
+        description: "",
+        startDate: null,
+        plannedStartDate: null,
+        dueDate: "2026-09-30",
+        needsReview: false,
+        isDelayed: false,
+        assigneeName: null,
+        projectId: 3,
+        projectTag: "marketing-q3",
+        projectName: "마케팅 캠페인 Q3",
+        teamName: "개발팀",
+        sourceMeetingTitle: null,
+        parentActionId: null,
+        parentActionTitle: null,
+        childDoneCount: 2,
+        childTotalCount: 5,
+      };
+    }
+
+    serverApiMock.mockImplementation(async (path: string) => {
+      const isTodo = path.includes("status=TODO");
+      return {
+        content: [
+          isTodo
+            ? actionFixture({ id: 8, title: "4분기 캠페인 초안", status: "TODO" })
+            : actionFixture({ id: 7, title: "3분기 마케팅 캠페인 기획", status: "IN_PROGRESS" }),
+        ],
+        page: 0,
+        size: 200,
+        totalElements: 1,
+        totalPages: 1,
+        hasNext: false,
+      };
     });
 
     const teamActions = await getReservableTeamActions(LEADER);
 
+    // ⚠️ 순서까지 확인한다 — IN_PROGRESS를 먼저, TODO를 뒤에 붙인다(진행중 항목이 우선).
     expect(teamActions).toEqual([
       { id: 7, name: "3분기 마케팅 캠페인 기획", projectTag: "marketing-q3" },
+      { id: 8, name: "4분기 캠페인 초안", projectTag: "marketing-q3" },
     ]);
     expect(serverApiMock).toHaveBeenCalledWith(
       ep.teamActions({ status: "IN_PROGRESS", page: 0, size: 200 }),
       expect.objectContaining({ accessToken: "token" }),
     );
+    expect(serverApiMock).toHaveBeenCalledWith(
+      ep.teamActions({ status: "TODO", page: 0, size: 200 }),
+      expect.objectContaining({ accessToken: "token" }),
+    );
+    expect(serverApiMock).toHaveBeenCalledTimes(2);
   });
 
   /*

--- a/src/features/rooms/server.ts
+++ b/src/features/rooms/server.ts
@@ -200,9 +200,12 @@ const RESERVABLE_PROJECTS_PAGE_SIZE = 200;
  * ⚠️ **`getProjectsPage`를 재사용한다.** 프로젝트 목록 API가 이미 실서버에 연동돼 있으므로
  *    (`features/project/server.ts`) 여기서 새 경로를 만들지 않는다(§환각 API 방지) — 같은
  *    회사의 프로젝트가 두 곳에서 다르게 보이면 안 된다.
- * ⚠️ select는 **한 화면에 다 보여줄 목록**이라 페이지네이션이 안 맞는다. 진행중 프로젝트만
- *    대상으로 좁히고(완료된 프로젝트에 새 회의를 묶을 일이 없다) 큰 페이지 하나로 받는다 —
- *    회사 프로젝트가 이 상한을 넘으면 그때 BE에 전용 select 응답을 요청한다.
+ * ⚠️ select는 **한 화면에 다 보여줄 목록**이라 페이지네이션이 안 맞는다. 아직 안 끝난
+ *    프로젝트(`TODO`·`IN_PROGRESS`)만 대상으로 좁히고(완료된 프로젝트에 새 회의를 묶을
+ *    일이 없다) 큰 페이지 하나로 받는다 — 회사 프로젝트가 이 상한을 넘으면 그때 BE에
+ *    전용 select 응답을 요청한다.
+ * ⚠️ **`status`는 BE가 한 번에 하나만 받는다**(`ListPageParams.status`, `lib/endpoints.ts`)
+ *    — `TODO`·`IN_PROGRESS` 둘 다 보여주려면 상태별로 따로 불러 합친다.
  */
 export async function getReservableProjects(): Promise<RoomProjectOption[]> {
   if (isMock) {
@@ -213,22 +216,27 @@ export async function getReservableProjects(): Promise<RoomProjectOption[]> {
     }));
   }
 
-  const { items, totalPages } = await getProjectsPage(
-    { status: PROJECT_STATUS.IN_PROGRESS, keyword: "" },
-    0,
-    RESERVABLE_PROJECTS_PAGE_SIZE,
-  );
-  /*
-    ⚠️ **200개를 조용히 자르지 않는다**(코드래빗이 팀 액션 select에서 잡은 것과 같은
-       결함을 여기서도 먼저 막는다). 진행중 프로젝트가 상한을 넘으면 BE 전용 select
-       응답이 필요한 신호로 던진다(조직도 `manage-server.ts`와 같은 정책).
-  */
-  if (totalPages > 1) {
-    throw new Error(
-      `이 회사의 진행중 프로젝트가 ${RESERVABLE_PROJECTS_PAGE_SIZE}건 상한을 넘어 select를 전부 채우지 못했습니다 — BE 전용 응답이 필요합니다.`,
+  const statuses = [PROJECT_STATUS.IN_PROGRESS, PROJECT_STATUS.TODO] as const;
+  const projects = [];
+  for (const status of statuses) {
+    const { items, totalPages } = await getProjectsPage(
+      { status, keyword: "" },
+      0,
+      RESERVABLE_PROJECTS_PAGE_SIZE,
     );
+    /*
+      ⚠️ **200개를 조용히 자르지 않는다**(코드래빗이 팀 액션 select에서 잡은 것과 같은
+         결함을 여기서도 먼저 막는다). 이 상태의 프로젝트가 상한을 넘으면 BE 전용 select
+         응답이 필요한 신호로 던진다(조직도 `manage-server.ts`와 같은 정책).
+    */
+    if (totalPages > 1) {
+      throw new Error(
+        `이 회사의 ${status} 프로젝트가 ${RESERVABLE_PROJECTS_PAGE_SIZE}건 상한을 넘어 select를 전부 채우지 못했습니다 — BE 전용 응답이 필요합니다.`,
+      );
+    }
+    projects.push(...items);
   }
-  return items.map((project) => ({
+  return projects.map((project) => ({
     id: String(project.id),
     name: project.name,
     tag: project.tag,
@@ -248,8 +256,10 @@ const RESERVABLE_TEAM_ACTIONS_PAGE_SIZE = 200;
  *    분기에는 `actor.teamName` 필터가 필요 없다(항상 자기 팀만 온다). BE 주석에도 이
  *    API를 "회의 개설 모달의 상위 팀 액션 드롭다운"용으로 이미 열어 뒀다고 적혀 있다
  *    (이슈 #389, MEMBER도 호출 가능하게 완화).
- * ⚠️ 완료된 팀 액션은 상위로 고를 이유가 없어 `IN_PROGRESS`만 받는다(진행중 항목이 새
- *    회의를 낳을 수 있다는 게 이 필드의 뜻이다).
+ * ⚠️ 완료된 팀 액션은 상위로 고를 이유가 없어 `TODO`·`IN_PROGRESS`만 받는다(아직 안 끝난
+ *    항목이 새 회의를 낳을 수 있다는 게 이 필드의 뜻이다).
+ * ⚠️ **`status`는 BE가 한 번에 하나만 받는다**(`ep.teamActions`) — 두 상태를 다 보여주려면
+ *    상태별로 따로 불러 합친다.
  */
 export async function getReservableTeamActions(actor: Actor): Promise<RoomTeamActionOption[]> {
   if (!requiresParentTeamAction(actor)) return [];
@@ -274,26 +284,27 @@ export async function getReservableTeamActions(actor: Actor): Promise<RoomTeamAc
   }
 
   const accessToken = await requireAccessToken();
-  const response = await serverApi<BePageResponse<BeActionSummary>>(
-    ep.teamActions({
-      status: ACTION_STATUS.IN_PROGRESS,
-      page: 0,
-      size: RESERVABLE_TEAM_ACTIONS_PAGE_SIZE,
-    }),
-    { accessToken },
-  );
-  /*
-    ⚠️ **200개를 조용히 자르지 않는다**(코드래빗 지적, 2026-08-14). `hasNext`가 참인데
-       첫 페이지만 돌려주면 뒤 페이지 항목은 select에서 영원히 안 보인다 — 회사 안 한
-       팀에 진행중 팀 액션이 그렇게 많을 일은 드물지만, 조용히 자르는 건 §정직성 위반이다.
-       BE 전용 select 응답이 필요한 신호로 던진다(조직도 `manage-server.ts`와 같은 정책).
-  */
-  if (response.hasNext) {
-    throw new Error(
-      `이 팀의 진행중 팀 액션이 ${RESERVABLE_TEAM_ACTIONS_PAGE_SIZE}건 상한을 넘어 select를 전부 채우지 못했습니다 — BE 전용 응답이 필요합니다.`,
+  const statuses = [ACTION_STATUS.IN_PROGRESS, ACTION_STATUS.TODO] as const;
+  const teamActions = [];
+  for (const status of statuses) {
+    const response = await serverApi<BePageResponse<BeActionSummary>>(
+      ep.teamActions({ status, page: 0, size: RESERVABLE_TEAM_ACTIONS_PAGE_SIZE }),
+      { accessToken },
     );
+    /*
+      ⚠️ **200개를 조용히 자르지 않는다**(코드래빗 지적, 2026-08-14). `hasNext`가 참인데
+         첫 페이지만 돌려주면 뒤 페이지 항목은 select에서 영원히 안 보인다 — 회사 안 한
+         팀에 이 상태 팀 액션이 그렇게 많을 일은 드물지만, 조용히 자르는 건 §정직성 위반이다.
+         BE 전용 select 응답이 필요한 신호로 던진다(조직도 `manage-server.ts`와 같은 정책).
+    */
+    if (response.hasNext) {
+      throw new Error(
+        `이 팀의 ${status} 팀 액션이 ${RESERVABLE_TEAM_ACTIONS_PAGE_SIZE}건 상한을 넘어 select를 전부 채우지 못했습니다 — BE 전용 응답이 필요합니다.`,
+      );
+    }
+    teamActions.push(...response.content);
   }
-  return response.content
+  return teamActions
     .filter((item) => item.projectTag !== null)
     .map((item) => ({ id: item.id, name: item.title, projectTag: item.projectTag! }));
 }


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실

---

## 🙋 관련 역할

- [x] LEADER (팀장)
- [x] MEMBER (사원)
- [ ] 공통

---

## 📝 작업 내용

- 회의 예약 모달의 "프로젝트"·"상위 팀 액션" select가 `IN_PROGRESS` 상태만 조회하던 것을, `TODO`도 함께 조회해 합치도록 고쳤다
- BE의 `status` 쿼리 파라미터가 한 번에 한 값만 받아서(`ListPageParams.status`), `getReservableProjects`·`getReservableTeamActions`에서 상태별로 두 번 호출한 뒤 병합하는 방식으로 구현 — BE API 변경 없이 프론트에서만 해결
- 두 select 모두 `IN_PROGRESS`를 먼저, `TODO`를 뒤에 붙여 진행중 항목이 우선 노출되게 함
- 기존에 있던 "200건 상한 초과 시 조용히 자르지 않고 예외를 던지는" 안전장치는 상태별로 각각 적용되도록 유지

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`fix/rooms-reservable-todo#{이슈번호}` 꼴, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [ ] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 권한 2축 검사 — *(해당 없음, 조회 select 채우기 로직이라 권한 분기 변경 없음)*
- [ ] 🧬 zod — *(해당 없음, 기존 매퍼·타입 그대로 재사용)*
- [x] 🕵️ 정직성 — 200건 상한 초과 시 예외 문구에 어느 상태(`TODO`/`IN_PROGRESS`)에서 넘겼는지 명시
- [ ] 🎨 디자인 토큰 — *(해당 없음, 서버 로직만 변경)*

**품질**

- [ ] ⚡ 최적화 — *(해당 없음)*
- [ ] ♿ a11y — *(해당 없음, 마크업 변경 없음)*
- [x] ♻️ 재사용 확인 — 기존 `getProjectsPage`·`ep.teamActions` 그대로 재사용, 새 API 경로 안 만듦
- [ ] 🧪 loading/error/empty 3상태 — *(해당 없음, 기존 select 로딩/빈 상태 그대로)*
- [ ] 브라우저 전용 API 관련 — *(해당 없음)*

---

## 🔗 연관 이슈

Closes #624 

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
| TODO 프로젝트/팀 액션이 select에 안 보임 | TODO 항목도 IN_PROGRESS 뒤에 이어서 노출 |

---

## 💬 리뷰 포인트

- 상태별 호출을 두 번으로 나눈 게 맞는 접근인지 (BE가 `status`에 배열/콤마 구분 값을 지원한다면 한 번 호출로 줄일 수 있음 — 확인 필요)
- `IN_PROGRESS` 우선 정렬 순서가 실제 UX상 맞는 선택인지
- 회사/팀 규모가 커져 `TODO`+`IN_PROGRESS` 각각 200건 상한에 걸릴 가능성

---

## 📝 추가 메모

`src/features/rooms/server.test.ts`의 관련 테스트 2건을 상태별 응답을 구분해서 반환하도록 갱신하고, 병합 순서(`IN_PROGRESS` → `TODO`)까지 검증하도록 보강함.