### PR TITLE
[MERGE] develop → main 배포 병합

### DIFF
--- a/src/features/board/components/board-view.test.tsx
+++ b/src/features/board/components/board-view.test.tsx
@@ -41,6 +41,8 @@ describe("BoardView — 페이지 레벨 empty state", () => {
     render(<BoardView boardType="my-action" cards={[]} todayIso={TODAY} />);
 
     expect(screen.getByText("아직 하달된 액션이 없습니다.")).toBeInTheDocument();
+    expect(screen.getByText("액션이 하달되면 이 자리에 카드로 쌓입니다.")).toBeInTheDocument();
+    expect(screen.queryByText(/드래그해서 칸을 옮길 수 있습니다/)).not.toBeInTheDocument();
 
     /*
       ⚠️ 세 칸·저장 버튼이 나타나면 회귀다 — 예전 렌더가 되돌아온 것이다. 칸 라벨(할 일·

--- a/src/features/board/components/board-view.test.tsx
+++ b/src/features/board/components/board-view.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * 보드 페이지 empty state 회귀.
+ *
+ * ⚠️ 다른 5화면(내 액션·팀 액션·마이페이지·캘린더·프로젝트 타임라인)은 이미 EmptyState +
+ *    명시 문구로 정직한 빈 상태를 그리는데, 보드만 예전에는 세 칸이 각기 "여기로 옮겨
+ *    주세요."를 띄워 옮길 카드가 어딘가 있는 것처럼 읽혔다(§CLAUDE.md 정직성 위반).
+ *    2026-08-16에 페이지 레벨 EmptyState로 통일. 여기서 못박아, 다시 세 칸이 텅 빈 채로
+ *    뜨는 회귀가 오면 즉시 잡는다.
+ */
+jest.mock("../actions", () => ({
+  commitBoardChangesAction: jest.fn(),
+}));
+jest.mock("./board-leave-guard", () => ({
+  /* leave guard는 window 이벤트를 걸어 jsdom에서 시끄럽다 — 여기 테스트 관심사도 아니다 */
+  BoardLeaveGuard: () => null,
+}));
+
+import { render, screen } from "@testing-library/react";
+
+import type { BoardCard } from "../types";
+import { BoardView } from "./board-view";
+
+const TODAY = "2026-08-16";
+
+function card(overrides: Partial<BoardCard> = {}): BoardCard {
+  return {
+    id: 1,
+    title: "설계 검토",
+    tagLabel: "GOODS",
+    tagBgColor: "var(--tag-sky-bg)",
+    tagTextColor: "var(--tag-sky-fg)",
+    startDate: "2026-08-10",
+    dueDate: "2026-08-20",
+    isDone: false,
+    ...overrides,
+  };
+}
+
+describe("BoardView — 페이지 레벨 empty state", () => {
+  it("cards가 0건이면 EmptyState 안내가 뜨고 세 칸·저장 버튼은 안 뜬다", () => {
+    render(<BoardView boardType="my-action" cards={[]} todayIso={TODAY} />);
+
+    expect(screen.getByText("아직 하달된 액션이 없습니다.")).toBeInTheDocument();
+
+    /*
+      ⚠️ 세 칸·저장 버튼이 나타나면 회귀다 — 예전 렌더가 되돌아온 것이다. 칸 라벨(할 일·
+         진행중·완료)과 저장 버튼("저장하기")이 안 뜨는지 함께 확인한다.
+    */
+    expect(screen.queryByRole("button", { name: /저장하기/ })).not.toBeInTheDocument();
+    expect(screen.queryByText("할 일")).not.toBeInTheDocument();
+    expect(screen.queryByText("진행중")).not.toBeInTheDocument();
+    expect(screen.queryByText("완료")).not.toBeInTheDocument();
+    expect(screen.queryByText("여기로 옮겨 주세요.")).not.toBeInTheDocument();
+  });
+
+  it("cards가 하나라도 있으면 empty 문구는 안 뜨고 세 칸·저장 버튼이 그대로 온다", () => {
+    render(<BoardView boardType="my-action" cards={[card()]} todayIso={TODAY} />);
+
+    expect(screen.queryByText("아직 하달된 액션이 없습니다.")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /저장하기/ })).toBeInTheDocument();
+    expect(screen.getByText("할 일")).toBeInTheDocument();
+    expect(screen.getByText("진행중")).toBeInTheDocument();
+    expect(screen.getByText("완료")).toBeInTheDocument();
+  });
+});

--- a/src/features/board/components/board-view.tsx
+++ b/src/features/board/components/board-view.tsx
@@ -10,10 +10,12 @@ import {
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
+import { ListChecks } from "lucide-react";
 import { useMemo, useState, useTransition } from "react";
 import { toast } from "sonner";
 
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
+import { EmptyState } from "@/components/common/empty-state";
 import { Button } from "@/components/ui/button";
 
 import { commitBoardChangesAction } from "../actions";
@@ -171,6 +173,27 @@ export function BoardView({ boardType, cards, todayIso }: BoardViewProps) {
         toast.error("옮기지 못했습니다");
       }
     });
+  }
+
+  /*
+    ⚠️ **하달된 카드 자체가 0건**이면 세 칸도 저장 줄도 뜻이 없다 — 옮길 게 없다.
+       이때는 페이지 레벨 `EmptyState`로 바꿔 다른 5화면(내 액션·팀 액션·마이페이지·캘린더·
+       프로젝트 타임라인)과 같은 톤으로 "아직 하달된 액션이 없습니다"만 말한다(§정직성).
+    ⚠️ 이 분기는 **정말 카드가 0건일 때만** 탄다 — 특정 칸만 비었을 때는 각 칸의
+       `BOARD_EMPTY_HINT`("여기로 옮겨 주세요.")가 여전히 유효한 안내라 그대로 둔다.
+    ⚠️ `BoardLeaveGuard`도 여기선 필요 없다 — 이동시킬 카드가 없으니 저장 안 한 변경도 없다.
+  */
+  if (cards.length === 0) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col">
+        <EmptyState
+          icon={ListChecks}
+          title="아직 하달된 액션이 없습니다."
+          description="액션이 하달되면 이 자리에 카드로 쌓이고, 드래그해서 칸을 옮길 수 있습니다."
+          className="flex-1"
+        />
+      </div>
+    );
   }
 
   return (

--- a/src/features/board/components/board-view.tsx
+++ b/src/features/board/components/board-view.tsx
@@ -184,12 +184,19 @@ export function BoardView({ boardType, cards, todayIso }: BoardViewProps) {
     ⚠️ `BoardLeaveGuard`도 여기선 필요 없다 — 이동시킬 카드가 없으니 저장 안 한 변경도 없다.
   */
   if (cards.length === 0) {
+    /*
+      ⚠️ description은 **조작 중립**이다("드래그" 같은 특정 입력 방식 안내 금지) — CLAUDE.md
+         §a11y "DnD 보드는 키보드 대체 경로 필수". 지금 보드는 `PointerSensor`만 걸려 있고
+         `KeyboardSensor`·카드 이동 버튼 같은 대체 경로가 없어(오래된 규약 위반, 별건 이슈로
+         분리) 스크린리더·키보드 사용자에게 "드래그해서 옮길 수 있다"고 미리 알리면 카드가
+         도착한 뒤 그 지시를 따르지 못한다. 대체 경로가 붙기 전에는 조작 안내를 아예 안 한다.
+    */
     return (
       <div className="flex min-h-0 flex-1 flex-col">
         <EmptyState
           icon={ListChecks}
           title="아직 하달된 액션이 없습니다."
-          description="액션이 하달되면 이 자리에 카드로 쌓이고, 드래그해서 칸을 옮길 수 있습니다."
+          description="액션이 하달되면 이 자리에 카드로 쌓입니다."
           className="flex-1"
         />
       </div>

--- a/src/features/meeting/review/components/action-review-row.tsx
+++ b/src/features/meeting/review/components/action-review-row.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { MessageSquareQuote, Users, X } from "lucide-react";
+import { CircleAlert, MessageSquareQuote, RotateCcw, Users, X } from "lucide-react";
 
 import { DatePickerField } from "@/components/common/date-picker-field";
 import { ProfileAvatar } from "@/components/common/profile-avatar";
@@ -12,7 +12,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { REVIEW_ASSIGNMENT_TARGET_LABEL } from "@/constants/meeting";
+import {
+  ACTION_REJECT_REASON_LABEL,
+  type ActionRejectReason,
+  REVIEW_ASSIGNMENT_TARGET_LABEL,
+} from "@/constants/meeting";
+import { cn } from "@/lib/utils";
 
 import { formatAssigneeLabel } from "../lib";
 import type { AiActionDraft, AssigneeOption, TeamOption } from "../types";
@@ -34,6 +39,13 @@ interface ActionReviewRowProps {
    */
   teamOptions?: TeamOption[];
   onTeamChange?: (teamId: number) => void;
+  /**
+   * 반려된 아이템은 목록에서 지우지 않고 상태로 남긴다(2026-08-18, #622).
+   * 사유가 있으면 반려된 것으로 취급 — 아이템은 흐려지고 편집이 잠기며, ✕ 자리에는
+   * [반려 취소]가 뜬다. 사유는 아이템 하단에 빨간 텍스트로 표시한다.
+   */
+  rejectReason?: ActionRejectReason | null;
+  onUnreject?: () => void;
 }
 
 /**
@@ -53,11 +65,26 @@ export function ActionReviewRow({
   onReject,
   teamOptions,
   onTeamChange,
+  rejectReason,
+  onUnreject,
 }: ActionReviewRowProps) {
   /* ⚠️ 모드는 이 prop 하나로 정해진다 — 부모(`MeetingReviewView`)가 회의 전체 기준으로 내려준다 */
   const isTeamMode = teamOptions !== undefined;
+  const isRejected = rejectReason != null;
   return (
-    <div className="border-border hover:bg-foreground/[0.015] px-7 py-4 transition-colors not-first:border-t">
+    <div
+      className={cn(
+        "border-border px-7 py-4 transition-colors not-first:border-t",
+        isRejected
+          ? /* ⚠️ 반려된 행은 흐리게 두고 배경도 옅게 — 살아있는 다른 행과 시각적으로 갈린다.
+               hover도 죽여 "만질 것 없음"을 모양으로 말한다(§정직성).
+             ⚠️ 조작(편집·셀렉트·날짜)은 아래에서 `pointer-events-none`으로 잠근다 —
+               반려 취소 버튼만 살려 사람이 되돌릴 길을 준다. */
+            "bg-muted/20"
+          : "hover:bg-foreground/[0.015]",
+      )}
+      aria-label={isRejected ? "반려된 액션" : undefined}
+    >
       {/*
         ⚠️ **두 열이다**(2026-08-11). 왼쪽은 읽는 것(이름·설명·근거), 오른쪽은 고치는 것
            (담당자·기간·반려) — 글이 조작 아래로 흘러들지 않게 열을 못 박는다.
@@ -65,7 +92,15 @@ export function ActionReviewRow({
            글이 세 줄인데 조작만 맨 위에 붙어 행의 무게중심이 위로 쏠린다.
       */}
       <div className="flex items-center gap-6">
-        <div className="flex min-w-0 flex-1 flex-col gap-2">
+        <div
+          className={cn(
+            "flex min-w-0 flex-1 flex-col gap-2",
+            /* ⚠️ 반려된 초안은 편집을 잠근다(#622) — pointer-events로 클릭·포커스도 막고,
+               opacity로 취소선 대신 감춰진 느낌을 준다. 취소선을 그으면 반려 사유의 빨간
+               텍스트와 시각이 두 겹으로 겹쳐 지저분해진다. */
+            isRejected && "pointer-events-none opacity-60",
+          )}
+        >
           <InlineEditableField value={draft.title} onChange={onTitleChange} ariaLabel="액션명" />
 
           {/* ⚠️ 설명과 근거는 **한 덩이**다(gap-1) — 근거는 그 설명의 출처라 사이를 벌리지 않는다 */}
@@ -121,122 +156,167 @@ export function ActionReviewRow({
         */}
         {/* ⚠️ 좁아지면 줄을 바꾼다 — 셋(180+140+140)+✕는 1180px 아래에서 글 칸을 0으로 밀어냈다 */}
         <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
-          {isTeamMode ? (
-            /*
+          {/*
+            ⚠️ 반려된 초안은 조작을 통째로 잠근다(#622) — 셀렉트·날짜 편집이 다시 열리면
+               "반려됐지만 여전히 손댈 수 있는" 것처럼 읽혀 상태가 흐려진다. 잠금은 이 감싸는
+               div가 하고, [반려 취소] 버튼만 아래에서 따로 살려 되돌릴 길을 준다.
+          */}
+          <div
+            className={cn(
+              "flex flex-wrap items-center gap-2",
+              isRejected && "pointer-events-none opacity-60",
+            )}
+          >
+            {isTeamMode ? (
+              /*
               ⚠️ **담당자가 아니라 부서를 고른다**(2026-08-13, 오너 회의 → 팀 액션 배분). 팀장
                  이름은 안 보여준다 — 팀장이 바뀌어도 팀 액션은 그대로라, 담당 팀장은 팀 액션
                  화면에서 그때그때 조회한다(`TeamActionService` 패턴, BE 쪽 담당).
             */
-            <Select
-              value={draft.teamId === null ? "" : String(draft.teamId)}
-              onValueChange={(value) => value && onTeamChange?.(Number(value))}
-            >
-              <SelectTrigger
-                aria-label={`${REVIEW_ASSIGNMENT_TARGET_LABEL.TEAM} 선택`}
-                className="w-[180px]"
+              <Select
+                value={draft.teamId === null ? "" : String(draft.teamId)}
+                onValueChange={(value) => value && onTeamChange?.(Number(value))}
               >
-                <SelectValue>
-                  {(value) => {
-                    const option = teamOptions?.find(
-                      (candidate) => String(candidate.teamId) === value,
-                    );
-                    if (!option)
-                      return (
-                        <span className="text-muted-foreground">
-                          {REVIEW_ASSIGNMENT_TARGET_LABEL.TEAM} 미정
-                        </span>
+                <SelectTrigger
+                  aria-label={`${REVIEW_ASSIGNMENT_TARGET_LABEL.TEAM} 선택`}
+                  className="w-[180px]"
+                >
+                  <SelectValue>
+                    {(value) => {
+                      const option = teamOptions?.find(
+                        (candidate) => String(candidate.teamId) === value,
                       );
-                    return (
-                      <>
-                        <Users className="size-4 shrink-0" aria-hidden />
-                        <span className="truncate">{option.teamName}</span>
-                      </>
-                    );
-                  }}
-                </SelectValue>
-              </SelectTrigger>
-              <SelectContent side="bottom" alignItemWithTrigger={false}>
-                {teamOptions?.map((option) => (
-                  <SelectItem key={option.teamId} value={String(option.teamId)}>
-                    <Users className="size-4 shrink-0" aria-hidden />
-                    {option.teamName}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          ) : (
-            /* ⚠️ 미정(null)은 빈 값으로 둔다 — String(null)은 "null"이라는 가짜 값이 된다 */
-            <Select
-              value={draft.assigneeId === null ? "" : String(draft.assigneeId)}
-              onValueChange={(value) => value && onAssigneeChange(Number(value))}
-            >
-              <SelectTrigger
-                aria-label={`${REVIEW_ASSIGNMENT_TARGET_LABEL.PERSONAL} 선택`}
-                className="w-[180px]"
+                      if (!option)
+                        return (
+                          <span className="text-muted-foreground">
+                            {REVIEW_ASSIGNMENT_TARGET_LABEL.TEAM} 미정
+                          </span>
+                        );
+                      return (
+                        <>
+                          <Users className="size-4 shrink-0" aria-hidden />
+                          <span className="truncate">{option.teamName}</span>
+                        </>
+                      );
+                    }}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent side="bottom" alignItemWithTrigger={false}>
+                  {teamOptions?.map((option) => (
+                    <SelectItem key={option.teamId} value={String(option.teamId)}>
+                      <Users className="size-4 shrink-0" aria-hidden />
+                      {option.teamName}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : (
+              /* ⚠️ 미정(null)은 빈 값으로 둔다 — String(null)은 "null"이라는 가짜 값이 된다 */
+              <Select
+                value={draft.assigneeId === null ? "" : String(draft.assigneeId)}
+                onValueChange={(value) => value && onAssigneeChange(Number(value))}
               >
-                {/*
+                <SelectTrigger
+                  aria-label={`${REVIEW_ASSIGNMENT_TARGET_LABEL.PERSONAL} 선택`}
+                  className="w-[180px]"
+                >
+                  {/*
                   ⚠️ **아바타를 붙인다**(2026-08-11). 이름만 늘어놓으니 다섯 줄이 회색 글자
                      덩어리였다 — 아바타는 색을 써도 되는 자리이고(§DESIGN 5), 그 사람 id에서
                      나온 색이라 목록·회의 상세에서 익힌 색과 같다. 누가 맡는지가 색으로 먼저 잡힌다.
                 */}
-                <SelectValue>
-                  {(value) => {
-                    const option = assigneeOptions.find(
-                      (candidate) => String(candidate.id) === value,
-                    );
-                    /* AI가 못 짚었거나 명단 밖을 가리킨 액션 — 숨기지 말고 미정으로 보여준다(매퍼 주석) */
-                    if (!option)
-                      return (
-                        <span className="text-muted-foreground">
-                          {REVIEW_ASSIGNMENT_TARGET_LABEL.PERSONAL} 미정
-                        </span>
+                  <SelectValue>
+                    {(value) => {
+                      const option = assigneeOptions.find(
+                        (candidate) => String(candidate.id) === value,
                       );
-                    return (
-                      <>
-                        <ProfileAvatar userId={option.id} size={18} />
-                        <span className="truncate">{formatAssigneeLabel(option)}</span>
-                      </>
-                    );
-                  }}
-                </SelectValue>
-              </SelectTrigger>
-              <SelectContent side="bottom" alignItemWithTrigger={false}>
-                {assigneeOptions.map((option) => (
-                  <SelectItem key={option.id} value={String(option.id)}>
-                    <ProfileAvatar userId={option.id} size={18} />
-                    {formatAssigneeLabel(option)}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+                      /* AI가 못 짚었거나 명단 밖을 가리킨 액션 — 숨기지 말고 미정으로 보여준다(매퍼 주석) */
+                      if (!option)
+                        return (
+                          <span className="text-muted-foreground">
+                            {REVIEW_ASSIGNMENT_TARGET_LABEL.PERSONAL} 미정
+                          </span>
+                        );
+                      return (
+                        <>
+                          <ProfileAvatar userId={option.id} size={18} />
+                          <span className="truncate">{formatAssigneeLabel(option)}</span>
+                        </>
+                      );
+                    }}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent side="bottom" alignItemWithTrigger={false}>
+                  {assigneeOptions.map((option) => (
+                    <SelectItem key={option.id} value={String(option.id)}>
+                      <ProfileAvatar userId={option.id} size={18} />
+                      {formatAssigneeLabel(option)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+
+            <DatePickerField
+              aria-label="시작일"
+              value={draft.startDate}
+              max={draft.dueDate}
+              onChange={onStartDateChange}
+              className="w-[140px]"
+            />
+            <DatePickerField
+              aria-label="마감일"
+              value={draft.dueDate}
+              min={draft.startDate}
+              onChange={onDueDateChange}
+              className="w-[140px]"
+            />
+          </div>
+
+          {/*
+            ⚠️ **반려 상태에 따라 버튼이 갈린다**(#622). 활성 상태에서는 ✕(반려 다이얼로그
+               열기), 반려 상태에서는 [반려 취소]로 되돌린다. 아이콘·라벨을 통째로 바꿔
+               같은 자리에서 다른 조작임을 분명히 한다(색은 안 쓴다 — DESIGN §5, 색은 에러 자리).
+          */}
+          {isRejected ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              aria-label="반려 취소"
+              onClick={onUnreject}
+            >
+              <RotateCcw aria-hidden />
+              반려 취소
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label="이 액션 반려"
+              onClick={onReject}
+            >
+              <X />
+            </Button>
           )}
-
-          <DatePickerField
-            aria-label="시작일"
-            value={draft.startDate}
-            max={draft.dueDate}
-            onChange={onStartDateChange}
-            className="w-[140px]"
-          />
-          <DatePickerField
-            aria-label="마감일"
-            value={draft.dueDate}
-            min={draft.startDate}
-            onChange={onDueDateChange}
-            className="w-[140px]"
-          />
-
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            aria-label="이 액션 반려"
-            onClick={onReject}
-          >
-            <X />
-          </Button>
         </div>
       </div>
+
+      {/*
+        ⚠️ **반려 사유는 행 하단에 빨간 텍스트로**(#622). 색을 쓸 수 있는 자리는 에러뿐이라
+           (DESIGN §5) `--destructive`를 그대로 쓴다. 아이콘 하나로 "이유가 붙어 있음"을
+           모양으로도 알린다 — 스크린리더도 `role="status"`로 상태 변화를 읽는다.
+      */}
+      {isRejected && (
+        <div
+          role="status"
+          className="text-destructive mt-3 flex items-center gap-1.5 pl-[6px] text-[12px] leading-4"
+        >
+          <CircleAlert className="size-3.5 shrink-0" aria-hidden />
+          <span className="min-w-0">반려됨 · {ACTION_REJECT_REASON_LABEL[rejectReason]}</span>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/features/meeting/review/components/meeting-review-view.tsx
+++ b/src/features/meeting/review/components/meeting-review-view.tsx
@@ -60,9 +60,16 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
   const [isConfirmed, setIsConfirmed] = useState(false);
   const [isPending, startTransition] = useTransition();
 
-  const visibleDrafts = drafts.filter((draft) => !(draft.id in rejectedReasons));
-  const highConfidence = visibleDrafts.filter((d) => d.confidence === AI_CONFIDENCE.HIGH);
-  const needsReview = visibleDrafts.filter((d) => d.confidence === AI_CONFIDENCE.NEEDS_REVIEW);
+  /*
+    ⚠️ **반려된 것도 목록에 남긴다**(2026-08-18, #622). 이전엔 filter로 아예 뺐는데, 사람이
+       무엇을 반려했는지·왜 반려했는지가 화면에서 사라져 다시 훑는 사람이 이유를 못 찾았다.
+       분배 확정 대상만 골라내는 자리(대상 카운트·확정 잠금·서버 요청)는 아래 `activeDrafts`가
+       담당한다 — 화면에는 전부 남긴다.
+  */
+  const highConfidence = drafts.filter((d) => d.confidence === AI_CONFIDENCE.HIGH);
+  const needsReview = drafts.filter((d) => d.confidence === AI_CONFIDENCE.NEEDS_REVIEW);
+  /** 반려 안 된 초안 — 확정 대상·미정 검사·요청 페이로드는 전부 이 기준. */
+  const activeDrafts = drafts.filter((draft) => !(draft.id in rejectedReasons));
   /* ⚠️ 이 화면이 "부서"·"담당자" 중 뭐라고 부를지는 이 한 곳에서만 고른다(CodeRabbit 지적) */
   const assignmentTargetLabel = review.isOwnerMeeting
     ? REVIEW_ASSIGNMENT_TARGET_LABEL.TEAM
@@ -76,12 +83,43 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
     ⚠️ **Owner 회의는 `teamId`가 미정 기준이다**(2026-08-13). 그 외엔 그대로 `assigneeId` —
        회의 하나가 두 모드를 섞지 않으므로 검사도 회의 전체 기준(`review.isOwnerMeeting`)으로
        한 번만 가른다.
+    ⚠️ **반려된 초안은 검사 대상이 아니다**(#622) — 반려는 사람이 이미 판단을 끝낸 것이라
+       담당자가 없어도 확정을 막을 이유가 없다(BE `ConfirmDistributionService`도 반려를
+       담당자 검사보다 먼저 걸러낸다 — `skipReasonOf` 주석).
   */
   const hasUnassigned = review.isOwnerMeeting
-    ? visibleDrafts.some((draft) => draft.teamId === null)
-    : visibleDrafts.some((draft) => draft.assigneeId === null);
+    ? activeDrafts.some((draft) => draft.teamId === null)
+    : activeDrafts.some((draft) => draft.assigneeId === null);
   function updateDraft(id: string, patch: Partial<AiActionDraft>) {
     setDrafts((prev) => prev.map((draft) => (draft.id === id ? { ...draft, ...patch } : draft)));
+  }
+
+  /*
+    ⚠️ **부서를 고르면 그 팀 팀장 memberId를 `assigneeId`에도 함께 세팅한다**(#622).
+       BE `ConfirmDistributionService.skipReasonOf`는 `actionType != TEAM`인데 `assigneeMemberId`가
+       null이면 `NO_ASSIGNEE`로 걸어낸다 — 오너 회의라도 확정 요청에는 assignee가 실려야 한다.
+       오너 회의 참석자 정책상 그 팀의 팀장 = 참석자 memberId라(actions.test.ts "Owner가 개설하는
+       회의에는 팀장만 참석자로 지정할 수 있습니다"), 옵션에 미리 짝지어 둔 `leaderMemberId`를
+       그대로 옮긴다.
+  */
+  function handleTeamChange(draftId: string, teamId: number) {
+    const option = review.teamOptions.find((candidate) => candidate.teamId === teamId);
+    updateDraft(draftId, {
+      teamId,
+      assigneeId: option?.leaderMemberId ?? null,
+    });
+  }
+
+  /**
+   * 반려 취소 — 목록에 남아 있던 반려 아이템을 다시 활성 상태로 되돌린다(#622).
+   * ⚠️ 반려 사유만 지운다. 초안의 내용·담당자·일정은 반려 전 값이 그대로 유지된다.
+   */
+  function unrejectDraft(id: string) {
+    setRejectedReasons((prev) => {
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
   }
 
   function openRejectDialog(id: string) {
@@ -139,7 +177,7 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
         const result = await confirmActionDistributionAction(
           review.meetingId,
           {
-            reviewed: visibleDrafts
+            reviewed: activeDrafts
               .filter((draft) => !isLocalManual(draft.id))
               .map((draft) => {
                 const initial = initialById.get(draft.id);
@@ -149,13 +187,18 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
                     ? { description: draft.description }
                     : {}),
                   /*
-                    ⚠️ **`teamId`와 `assigneeId`는 상호 배타다**(BE `REVIEW_ASSIGNEE_TEAM_CONFLICT`
-                       422, 2026-08-13). Owner 회의는 부서만, 그 외엔 담당자만 보낸다 — 화면이
-                       둘 다 채운 상태를 만들 수 없게 모드로 갈라 둔다.
+                    ⚠️ **오너 회의는 `teamId`와 `assigneeId`를 함께 보낸다**(2026-08-18, #622).
+                       BE `ConfirmDistributionService.skipReasonOf`가 오너 회의여도 assignee가
+                       비어 있으면 `NO_ASSIGNEE`로 걸어내기 때문 — 예전에는 `teamId`만 보내
+                       확정이 항상 실패했다. 오너 회의 참석자 정책상 그 팀의 팀장이 곧
+                       assignee라, `handleTeamChange`가 부서 선택 시 `draft.assigneeId`에도
+                       팀장 memberId를 세팅해 두면 여기서 함께 실린다.
+                    ⚠️ 그 외(팀 회의)는 그대로 `assigneeId`만 보낸다 — 사용자가 담당자를
+                       바꿨을 때만 실어 서버가 "사람이 고쳤다" 라벨을 정확히 남기게 한다.
                   */
                   ...(review.isOwnerMeeting
-                    ? draft.teamId !== null
-                      ? { teamId: draft.teamId }
+                    ? draft.teamId !== null && draft.assigneeId !== null
+                      ? { teamId: draft.teamId, assigneeId: draft.assigneeId }
                       : {}
                     : initial &&
                         draft.assigneeId !== initial.assigneeId &&
@@ -330,7 +373,9 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
             onDueDateChange={(dueDate) => updateDraft(draft.id, { dueDate })}
             onReject={() => openRejectDialog(draft.id)}
             teamOptions={review.isOwnerMeeting ? review.teamOptions : undefined}
-            onTeamChange={(teamId) => updateDraft(draft.id, { teamId })}
+            onTeamChange={(teamId) => handleTeamChange(draft.id, teamId)}
+            rejectReason={rejectedReasons[draft.id] ?? null}
+            onUnreject={() => unrejectDraft(draft.id)}
           />
         ))}
       </ActionReviewGroup>
@@ -348,7 +393,9 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
             onDueDateChange={(dueDate) => updateDraft(draft.id, { dueDate })}
             onReject={() => openRejectDialog(draft.id)}
             teamOptions={review.isOwnerMeeting ? review.teamOptions : undefined}
-            onTeamChange={(teamId) => updateDraft(draft.id, { teamId })}
+            onTeamChange={(teamId) => handleTeamChange(draft.id, teamId)}
+            rejectReason={rejectedReasons[draft.id] ?? null}
+            onUnreject={() => unrejectDraft(draft.id)}
           />
         ))}
 
@@ -384,7 +431,7 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
         )}
         <Button
           type="button"
-          disabled={visibleDrafts.length === 0 || hasUnassigned}
+          disabled={activeDrafts.length === 0 || hasUnassigned}
           className="bg-foreground text-background hover:bg-foreground/90"
           onClick={() => setConfirmOpen(true)}
         >
@@ -413,7 +460,7 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
         title="액션 분배를 확정할까요?"
         description={
           <>
-            총 {visibleDrafts.length}건의 액션이 지금 화면에 보이는 {assignmentTargetLabel}·일정
+            총 {activeDrafts.length}건의 액션이 지금 화면에 보이는 {assignmentTargetLabel}·일정
             그대로 생성됩니다.
             <br />
             확정 뒤에는 이 화면을 다시 열 수 없습니다.

--- a/src/features/meeting/review/mapper.test.ts
+++ b/src/features/meeting/review/mapper.test.ts
@@ -166,9 +166,11 @@ describe("toMeetingReviewInfo", () => {
       ⚠️ 호스트(대표 계정, teamId null)는 제외 · teamId 기준 dedupe(같은 팀 팀장이 둘 잡히면
          하나만) · teamName이 null인 항목은 애초에 옵션이 될 수 없다(호스트 케이스와 같은 이유).
     */
+    /* ⚠️ `leaderMemberId`는 첫 등장한 팀장 참석자의 memberId다(#622) — 오너 회의 참석자
+       정책상 팀당 한 명만 잡히지만, 목 데이터의 중복 dedupe는 먼저 만난 사람이 이긴다. */
     expect(info.teamOptions).toEqual([
-      { teamId: 3, teamName: "개발팀" },
-      { teamId: 4, teamName: "디자인팀" },
+      { teamId: 3, teamName: "개발팀", leaderMemberId: 2 },
+      { teamId: 4, teamName: "디자인팀", leaderMemberId: 9 },
     ]);
   });
 

--- a/src/features/meeting/review/mapper.ts
+++ b/src/features/meeting/review/mapper.ts
@@ -181,19 +181,31 @@ export function toAssigneeOptions(detail: BeMeetingDetail): AssigneeOption[] {
  *    `attendee-scope.ts`가 참석자 지정에서 host를 빼는 것과 같은 이유(host는 고르는 사람이지
  *    배정 후보가 아니다).
  * ⚠️ **`teamId` 기준으로 dedupe한다** — `teamName`은 같은 이름이 둘일 수 있어 키로 못 쓴다.
+ * ⚠️ **`leaderMemberId`를 함께 뽑는다**(2026-08-18, #622). 오너 회의는 참석자 정책상 팀별
+ *    팀장 한 명씩만 지정되므로, 참석자의 `memberId`가 그대로 그 팀의 팀장이다 — 별도 조회
+ *    없이 여기서 짝지어 두면 확정 요청 시 부서와 함께 팀장 assignee를 실을 수 있다.
  */
 export function toTeamOptions(detail: BeMeetingDetail): TeamOption[] {
   const hostMemberId = hostIdOf(detail);
-  const seen = new Map<number, string>();
+  const seen = new Map<number, { teamName: string; leaderMemberId: number }>();
 
   for (const attendee of detail.attendees) {
     if (attendee.memberId === hostMemberId) continue;
     /* ⚠️ `teamId`가 `undefined`인 것(#472 배포 전)도 여기서 같이 거른다 — 없는 팀을 옵션으로 못 만든다 */
     if (attendee.teamId == null || attendee.teamName === null) continue;
-    if (!seen.has(attendee.teamId)) seen.set(attendee.teamId, attendee.teamName);
+    if (!seen.has(attendee.teamId)) {
+      seen.set(attendee.teamId, {
+        teamName: attendee.teamName,
+        leaderMemberId: attendee.memberId,
+      });
+    }
   }
 
-  return Array.from(seen, ([teamId, teamName]) => ({ teamId, teamName }));
+  return Array.from(seen, ([teamId, value]) => ({
+    teamId,
+    teamName: value.teamName,
+    leaderMemberId: value.leaderMemberId,
+  }));
 }
 
 /**

--- a/src/features/meeting/review/mock/review.ts
+++ b/src/features/meeting/review/mock/review.ts
@@ -31,8 +31,10 @@ const ASSIGNEE_OPTIONS: AssigneeOption[] = [
  * ⚠️ 실 연동에서는 참석자에서 만들지만(타입 주석 참고), 목은 데모 시나리오 고정이라 직접 둔다.
  */
 const TEAM_OPTIONS: TeamOption[] = [
-  { teamId: 10, teamName: "개발팀" },
-  { teamId: 11, teamName: "디자인팀" },
+  /* ⚠️ `leaderMemberId`는 오너 회의 참석자 정책상 그 팀의 팀장 memberId다(#622, 타입 주석).
+     목에서는 위 `ASSIGNEES`의 팀장에 해당하는 id를 그대로 짝지어 둔다. */
+  { teamId: 10, teamName: "개발팀", leaderMemberId: 2 },
+  { teamId: 11, teamName: "디자인팀", leaderMemberId: 1 },
 ];
 
 function seedReview(meetingId: string): MeetingReviewInfo {

--- a/src/features/meeting/review/types.ts
+++ b/src/features/meeting/review/types.ts
@@ -26,10 +26,17 @@ export interface AssigneeOption {
  *    참석자 목록 자체가 팀별 대표 목록이다 — 그래서 옵션도 참석자에서 만든다(별도 팀 조회 API 없음).
  * ⚠️ 담당자(사람)가 아니라 **부서**가 확정 대상이다 — 팀장 이름은 화면에 안 보여준다
  *    (팀장이 바뀌어도 팀 액션은 그대로이므로, 담당 팀장은 팀 액션 화면에서 그때그때 조회한다).
+ * ⚠️ **`leaderMemberId`는 확정 요청에 실린다**(2026-08-18, #622). BE `ConfirmDistributionService`가
+ *    오너 회의여도 `assigneeMemberId == null`인 액션은 `NO_ASSIGNEE`로 걸어내기 때문에,
+ *    사용자가 부서를 고르면 그 팀의 팀장 memberId를 `draft.assigneeId`에도 함께 세팅해
+ *    확정 요청 `changes`에 실어 보내야 한다. 오너 회의의 참석자 = 팀장이라는 정책
+ *    (`Owner 회의는 팀장만 받는다`)이 근거다 — 매퍼가 참석자 `memberId`를 그대로 옮긴다.
  */
 export interface TeamOption {
   teamId: number;
   teamName: string;
+  /** 이 팀의 팀장 memberId — 오너 회의 참석자 정책상 `attendee.memberId`가 곧 그 팀 팀장. */
+  leaderMemberId: number;
 }
 
 /** 근거 발화 — 수정 판단의 근거이므로 AI가 뽑은 항목엔 반드시 있다(WORKFLOW.md §3-4). */

--- a/src/features/onboarding/actions.ts
+++ b/src/features/onboarding/actions.ts
@@ -99,6 +99,15 @@ export async function commitOnboardingAction(input: {
       method: "POST",
       json: payload,
       accessToken: token,
+      /*
+        ⚠️ **기본 15초로는 부족하다**(`lib/api.ts`의 `DEFAULT_TIMEOUT_MS` 주석이 말하는
+           "더 걸리는 호출"이 바로 이거다). 이 요청 하나가 부서·직급 생성뿐 아니라 초대
+           인원수만큼 계정 발급 + 메일 발송까지 **동기로** 끝내고 응답한다 — 인원이 많으면
+           BE는 정상적으로 계속 처리 중인데 Next 쪽에서 먼저 타임아웃으로 끊어 화면에
+           실패로 뜨는 사고가 실제로 있었다. 그 직후 재시도가 `AU-035`(이미 온보딩됨)로
+           떨어지는 게 그 증거다 — BE는 이미 성공했는데 응답만 못 받은 것.
+      */
+      timeoutMs: 60_000,
     });
 
     /*

--- a/src/features/onboarding/components/invite-commit-dialog.tsx
+++ b/src/features/onboarding/components/invite-commit-dialog.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Loader2 } from "lucide-react";
+
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
 
 interface InviteCommitDialogProps {
@@ -68,39 +70,62 @@ export function InviteCommitDialog({
       pendingLabel="등록 중"
       error={error}
     >
-      {/*
-        ⚠️ 칸을 나눠 상자 세 개로 그리지 않는다. 가운데 정렬 창 안에서 테두리 상자가 더 생기면
-           표식·제목·설명·상자·버튼이 다섯 덩어리로 쌓여 눈이 어디를 봐야 할지 흩어진다.
-           **알약 하나**에 담으면 덩어리가 하나로 줄고, 창 높이도 낮아진다.
-      */}
-      <div className="flex justify-center">
-        <dl className="bg-secondary/60 inline-flex items-center gap-3.5 rounded-full px-4 py-2">
-          <Item label="팀" value={departmentCount} />
-          <Divider />
-          <Item label="직급" value={positionCount} />
-          <Divider />
-          <Item label="초대" value={writtenCount} />
-        </dl>
-      </div>
+      {isPending ? (
+        /*
+          ⚠️ **제출 중엔 알약·경고 대신 진행 안내로 바꾼다**(2026-08-18, 타임아웃 60초로
+             늘리며 같이 손봄). 팀·직급 수나 "몇 줄 빠집니다" 경고는 제출 전에만 의미가
+             있다 — 이미 넘어간 뒤에도 그대로 떠 있으면 "지금 뭐가 되고 있는지"와 무관한
+             정보만 보여서 창이 멈춘 것처럼 읽힌다(§정직성). 버튼 글자(`pendingLabel`)만
+             바뀌는 걸로는 최대 1분을 버티기엔 신호가 약하다 — 회전 아이콘 + 얼마나
+             걸릴지까지 적어서 "지금 일하고 있다"를 분명히 한다.
+        */
+        <div
+          className="flex flex-col items-center gap-2 pt-1 text-center"
+          role="status"
+          aria-live="polite"
+        >
+          <Loader2 className="text-muted-foreground size-5 animate-spin" aria-hidden />
+          <p className="text-muted-foreground text-[12px] leading-[18px] break-keep">
+            계정 발급과 초대 메일 발송에 최대 1분 정도 걸립니다. 창을 닫지 말고 기다려 주세요.
+          </p>
+        </div>
+      ) : (
+        <>
+          {/*
+            ⚠️ 칸을 나눠 상자 세 개로 그리지 않는다. 가운데 정렬 창 안에서 테두리 상자가 더 생기면
+               표식·제목·설명·상자·버튼이 다섯 덩어리로 쌓여 눈이 어디를 봐야 할지 흩어진다.
+               **알약 하나**에 담으면 덩어리가 하나로 줄고, 창 높이도 낮아진다.
+          */}
+          <div className="flex justify-center">
+            <dl className="bg-secondary/60 inline-flex items-center gap-3.5 rounded-full px-4 py-2">
+              <Item label="팀" value={departmentCount} />
+              <Divider />
+              <Item label="직급" value={positionCount} />
+              <Divider />
+              <Item label="초대" value={writtenCount} />
+            </dl>
+          </div>
 
-      {/*
-        ⚠️ 빠지는 줄을 **여기서** 알린다. 줄마다 경고를 붙이는 대신 넘어가기 직전에 한 번 말한다 —
-           조용히 빼면 보낸 줄 알고 넘어간다(§정직성).
-      */}
-      {/*
-        ⚠️ **이유를 갈라서 말한다.** 전에는 `목록에서 표시된 줄을 확인해 주세요` 한 문장이었는데,
-           가장 흔한 사유인 **아직 안 고른 줄에는 목록에 표시가 없다** — 안 고른 건 "틀렸다"가
-           아니라 "아직"이라 줄에 빨간 글씨를 안 띄우기 때문이다(`InviteRow`).
-           없는 표시를 가리키면 사용자는 찾다가 못 찾는다(적대적 검토 #163).
-        ⚠️ 표시가 있는 줄(주소 형식·주소 중복·리더 중복)만 `표시가 뜬`이라고 부른다.
-      */}
-      {unfilledCount + flaggedCount > 0 && (
-        <p className="text-muted-foreground pt-3 text-[12px] leading-[18px] break-keep">
-          {unfilledCount > 0 && `팀·역할·직급을 고르지 않은 ${unfilledCount}줄`}
-          {unfilledCount > 0 && flaggedCount > 0 && "과 "}
-          {flaggedCount > 0 && `목록에 표시가 뜬 ${flaggedCount}줄`}
-          {"은 이번 발송에서 빠집니다. 취소하고 고치거나, 나중에 기업 설정에서 초대해 주세요."}
-        </p>
+          {/*
+            ⚠️ 빠지는 줄을 **여기서** 알린다. 줄마다 경고를 붙이는 대신 넘어가기 직전에 한 번 말한다 —
+               조용히 빼면 보낸 줄 알고 넘어간다(§정직성).
+          */}
+          {/*
+            ⚠️ **이유를 갈라서 말한다.** 전에는 `목록에서 표시된 줄을 확인해 주세요` 한 문장이었는데,
+               가장 흔한 사유인 **아직 안 고른 줄에는 목록에 표시가 없다** — 안 고른 건 "틀렸다"가
+               아니라 "아직"이라 줄에 빨간 글씨를 안 띄우기 때문이다(`InviteRow`).
+               없는 표시를 가리키면 사용자는 찾다가 못 찾는다(적대적 검토 #163).
+            ⚠️ 표시가 있는 줄(주소 형식·주소 중복·리더 중복)만 `표시가 뜬`이라고 부른다.
+          */}
+          {unfilledCount + flaggedCount > 0 && (
+            <p className="text-muted-foreground pt-3 text-[12px] leading-[18px] break-keep">
+              {unfilledCount > 0 && `팀·역할·직급을 고르지 않은 ${unfilledCount}줄`}
+              {unfilledCount > 0 && flaggedCount > 0 && "과 "}
+              {flaggedCount > 0 && `목록에 표시가 뜬 ${flaggedCount}줄`}
+              {"은 이번 발송에서 빠집니다. 취소하고 고치거나, 나중에 기업 설정에서 초대해 주세요."}
+            </p>
+          )}
+        </>
       )}
     </ConfirmDialog>
   );

--- a/src/features/onboarding/components/invite-setup.tsx
+++ b/src/features/onboarding/components/invite-setup.tsx
@@ -173,7 +173,16 @@ export function InviteSetup({ departments, positions }: InviteSetupProps) {
 
       <InviteCommitDialog
         isOpen={isConfirmOpen}
-        onOpenChange={setConfirmOpen}
+        onOpenChange={(next) => {
+          /*
+            ⚠️ **보내는 동안엔 Esc·바깥 클릭으로도 못 닫는다**(2026-08-18, 타임아웃을
+               60초로 늘리며 같이 손봄). 계정 발급 + 메일 발송이 최대 1분 걸리는데, 그동안
+               창을 닫아버리면 요청은 그대로 진행 중인데 사용자는 아무 결과도 못 보고
+               "안 됐나" 하고 다시 열어 또 누르게 된다 — 두 벌 커밋 위험(§정직성).
+          */
+          if (!next && isCommitting) return;
+          setConfirmOpen(next);
+        }}
         departmentCount={departmentOptions.length}
         positionCount={positionOptions.length}
         writtenCount={writtenCount}

--- a/src/features/profile/components/change-password-dialog.tsx
+++ b/src/features/profile/components/change-password-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Eye, EyeOff } from "lucide-react";
 import { type FormEvent, useActionState, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
@@ -39,6 +40,14 @@ export function ChangePasswordDialog() {
   const [state, formAction, isPending] = useActionState(changePasswordAction, INITIAL_STATE);
   const [draft, setDraft] = useState<PasswordDraft>(EMPTY_DRAFT);
   const shownAttempt = useRef(0);
+  /*
+    ⚠️ **세 칸을 따로 토글한다.** 하나로 묶으면 현재 비밀번호를 확인하려고 켰을 뿐인데
+       새 비밀번호 두 칸까지 같이 드러난다 — 로그인 화면(`LoginForm`)과 같은 눈 아이콘
+       패턴이되, 칸마다 독립된 상태를 갖는다.
+  */
+  const [isCurrentShown, setCurrentShown] = useState(false);
+  const [isNewShown, setNewShown] = useState(false);
+  const [isConfirmShown, setConfirmShown] = useState(false);
 
   // 닫는 경로(취소·ESC·바깥 클릭) 전부 여기로 모은다 — 한 곳만 고치면 전부 반영된다.
   const handleClose = () => {
@@ -96,21 +105,28 @@ export function ChangePasswordDialog() {
             <div className="flex flex-col gap-4 px-6 py-5">
               <div className="flex flex-col gap-2">
                 <Label htmlFor="current-password">현재 비밀번호</Label>
-                <Input
-                  id="current-password"
-                  name="currentPassword"
-                  type="password"
-                  autoComplete="current-password"
-                  required
-                  value={draft.currentPassword}
-                  onChange={(event) =>
-                    setDraft((prev) => ({ ...prev, currentPassword: event.target.value }))
-                  }
-                  aria-describedby={
-                    state.errors.currentPassword ? "current-password-error" : undefined
-                  }
-                  aria-invalid={state.errors.currentPassword ? true : undefined}
-                />
+                <div className="relative">
+                  <Input
+                    id="current-password"
+                    name="currentPassword"
+                    type={isCurrentShown ? "text" : "password"}
+                    autoComplete="current-password"
+                    required
+                    className="pr-10"
+                    value={draft.currentPassword}
+                    onChange={(event) =>
+                      setDraft((prev) => ({ ...prev, currentPassword: event.target.value }))
+                    }
+                    aria-describedby={
+                      state.errors.currentPassword ? "current-password-error" : undefined
+                    }
+                    aria-invalid={state.errors.currentPassword ? true : undefined}
+                  />
+                  <PasswordVisibilityToggle
+                    isShown={isCurrentShown}
+                    onToggle={() => setCurrentShown((shown) => !shown)}
+                  />
+                </div>
                 {state.errors.currentPassword && (
                   <p id="current-password-error" className="text-destructive text-[12px] leading-4">
                     {state.errors.currentPassword}
@@ -120,20 +136,27 @@ export function ChangePasswordDialog() {
 
               <div className="flex flex-col gap-2">
                 <Label htmlFor="new-password">새 비밀번호</Label>
-                <Input
-                  id="new-password"
-                  name="newPassword"
-                  type="password"
-                  autoComplete="new-password"
-                  maxLength={16}
-                  required
-                  value={draft.newPassword}
-                  onChange={(event) =>
-                    setDraft((prev) => ({ ...prev, newPassword: event.target.value }))
-                  }
-                  aria-describedby="new-password-hints"
-                  aria-invalid={state.errors.newPassword ? true : undefined}
-                />
+                <div className="relative">
+                  <Input
+                    id="new-password"
+                    name="newPassword"
+                    type={isNewShown ? "text" : "password"}
+                    autoComplete="new-password"
+                    maxLength={16}
+                    required
+                    className="pr-10"
+                    value={draft.newPassword}
+                    onChange={(event) =>
+                      setDraft((prev) => ({ ...prev, newPassword: event.target.value }))
+                    }
+                    aria-describedby="new-password-hints"
+                    aria-invalid={state.errors.newPassword ? true : undefined}
+                  />
+                  <PasswordVisibilityToggle
+                    isShown={isNewShown}
+                    onToggle={() => setNewShown((shown) => !shown)}
+                  />
+                </div>
                 {state.errors.newPassword && (
                   <p className="text-destructive text-[12px] leading-4">
                     {state.errors.newPassword}
@@ -148,22 +171,29 @@ export function ChangePasswordDialog() {
 
               <div className="flex flex-col gap-2">
                 <Label htmlFor="new-password-confirm">새 비밀번호 확인</Label>
-                <Input
-                  id="new-password-confirm"
-                  name="newPasswordConfirm"
-                  type="password"
-                  autoComplete="new-password"
-                  maxLength={16}
-                  required
-                  value={draft.newPasswordConfirm}
-                  onChange={(event) =>
-                    setDraft((prev) => ({ ...prev, newPasswordConfirm: event.target.value }))
-                  }
-                  aria-describedby="new-password-confirm-hint"
-                  aria-invalid={
-                    state.errors.newPasswordConfirm || confirmMatch === false ? true : undefined
-                  }
-                />
+                <div className="relative">
+                  <Input
+                    id="new-password-confirm"
+                    name="newPasswordConfirm"
+                    type={isConfirmShown ? "text" : "password"}
+                    autoComplete="new-password"
+                    maxLength={16}
+                    required
+                    className="pr-10"
+                    value={draft.newPasswordConfirm}
+                    onChange={(event) =>
+                      setDraft((prev) => ({ ...prev, newPasswordConfirm: event.target.value }))
+                    }
+                    aria-describedby="new-password-confirm-hint"
+                    aria-invalid={
+                      state.errors.newPasswordConfirm || confirmMatch === false ? true : undefined
+                    }
+                  />
+                  <PasswordVisibilityToggle
+                    isShown={isConfirmShown}
+                    onToggle={() => setConfirmShown((shown) => !shown)}
+                  />
+                </div>
                 {/*
                   ⚠️ **서버 오류가 우선이다.** 방금 제출해서 돌아온 문구가 있으면 그걸 보여주고,
                      없으면 타이핑 중 실시간 판정을 보여준다 — 같은 뜻의 줄이 두 개 뜨지 않는다.
@@ -205,5 +235,25 @@ export function ChangePasswordDialog() {
         </DialogContent>
       </Dialog>
     </>
+  );
+}
+
+/** 눈 아이콘 토글 — `LoginForm`의 비밀번호 칸과 같은 자리·같은 문구다(일관성). */
+function PasswordVisibilityToggle({
+  isShown,
+  onToggle,
+}: {
+  isShown: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-label={isShown ? "비밀번호 숨기기" : "비밀번호 보기"}
+      className="text-muted-foreground hover:text-foreground focus-visible:ring-ring absolute top-1/2 right-2 -translate-y-1/2 rounded p-1 focus-visible:ring-2 focus-visible:outline-hidden"
+    >
+      {isShown ? <EyeOff className="size-4" aria-hidden /> : <Eye className="size-4" aria-hidden />}
+    </button>
   );
 }

--- a/src/features/rooms/server.test.ts
+++ b/src/features/rooms/server.test.ts
@@ -88,41 +88,61 @@ describe("getReservableMembers — 실서버", () => {
  * 예약 폼의 "프로젝트" select — 2026-08-14 프로덕션에서 무조건 throw하던 것을 고쳤다.
  * `getProjectsPage`(project 도메인, 이미 실연동)를 그대로 재사용하는지 확인한다.
  */
+function projectFixture(overrides: { id: number; tag: string; name: string; status: string }) {
+  return {
+    ...overrides,
+    color: "blue",
+    description: "",
+    startDate: null,
+    dueDate: "2026-12-31",
+    teamCount: 1,
+    actionCount: 0,
+    completedActionCount: 0,
+    meetingCount: 0,
+    progressPct: 0,
+    teamNames: [],
+  };
+}
+
 describe("getReservableProjects — 실서버", () => {
-  it("getProjectsPage를 재사용해 select 모양으로 줄인다 — 새 경로를 만들지 않는다", async () => {
-    serverApiMock.mockResolvedValue({
-      content: [
-        {
-          id: 12,
-          tag: "product-v2",
-          color: "blue",
-          name: "제품 v2.0",
-          description: "",
-          status: "IN_PROGRESS",
-          startDate: null,
-          dueDate: "2026-12-31",
-          teamCount: 1,
-          actionCount: 0,
-          completedActionCount: 0,
-          meetingCount: 0,
-          progressPct: 0,
-          teamNames: [],
-        },
-      ],
-      page: 0,
-      size: 200,
-      totalElements: 1,
-      totalPages: 1,
-      hasNext: false,
+  it("getProjectsPage를 재사용해 select 모양으로 줄인다 — TODO·IN_PROGRESS 둘 다 불러 합친다", async () => {
+    serverApiMock.mockImplementation(async (path: string) => {
+      const isTodo = path.includes("status=TODO");
+      return {
+        content: [
+          isTodo
+            ? projectFixture({ id: 13, tag: "product-v3", name: "제품 v3.0", status: "TODO" })
+            : projectFixture({
+                id: 12,
+                tag: "product-v2",
+                name: "제품 v2.0",
+                status: "IN_PROGRESS",
+              }),
+        ],
+        page: 0,
+        size: 200,
+        totalElements: 1,
+        totalPages: 1,
+        hasNext: false,
+      };
     });
 
     const projects = await getReservableProjects();
 
-    expect(projects).toEqual([{ id: "12", name: "제품 v2.0", tag: "product-v2" }]);
+    // ⚠️ 순서까지 확인한다 — IN_PROGRESS를 먼저, TODO를 뒤에 붙인다(진행중 항목이 우선).
+    expect(projects).toEqual([
+      { id: "12", name: "제품 v2.0", tag: "product-v2" },
+      { id: "13", name: "제품 v3.0", tag: "product-v3" },
+    ]);
     expect(serverApiMock).toHaveBeenCalledWith(
       expect.stringContaining("status=IN_PROGRESS"),
       expect.objectContaining({ accessToken: "token" }),
     );
+    expect(serverApiMock).toHaveBeenCalledWith(
+      expect.stringContaining("status=TODO"),
+      expect.objectContaining({ accessToken: "token" }),
+    );
+    expect(serverApiMock).toHaveBeenCalledTimes(2);
     // ⚠️ page·size도 확인한다 — 기본 페이지 크기(20)로 조용히 바뀌어도 status만 보면 통과했다(코드래빗 지적)
     const requestUrl = serverApiMock.mock.calls[0][0] as string;
     expect(requestUrl).toContain("page=0");
@@ -134,7 +154,7 @@ describe("getReservableProjects — 실서버", () => {
        조용히 자르지 않는다. `totalPages`가 1보다 크면 뒤 페이지 프로젝트는 select에서
        영원히 안 보인다(§정직성).
   */
-  it("진행중 프로젝트가 200건 상한을 넘으면(totalPages>1) 잘린 목록을 정상으로 돌려주지 않는다", async () => {
+  it("어느 한 상태의 프로젝트가 200건 상한을 넘으면(totalPages>1) 잘린 목록을 정상으로 돌려주지 않는다", async () => {
     serverApiMock.mockResolvedValue({
       content: [],
       page: 0,
@@ -161,48 +181,62 @@ describe("getReservableTeamActions — 실서버", () => {
     expect(serverApiMock).not.toHaveBeenCalled();
   });
 
-  it("Leader·Member는 GET /api/team/actions를 IN_PROGRESS로만 불러 select 모양으로 줄인다", async () => {
-    serverApiMock.mockResolvedValue({
-      content: [
-        {
-          id: 7,
-          actionType: "TEAM",
-          title: "3분기 마케팅 캠페인 기획",
-          description: "",
-          status: "IN_PROGRESS",
-          startDate: null,
-          plannedStartDate: null,
-          dueDate: "2026-09-30",
-          needsReview: false,
-          isDelayed: false,
-          assigneeName: null,
-          projectId: 3,
-          projectTag: "marketing-q3",
-          projectName: "마케팅 캠페인 Q3",
-          teamName: "개발팀",
-          sourceMeetingTitle: null,
-          parentActionId: null,
-          parentActionTitle: null,
-          childDoneCount: 2,
-          childTotalCount: 5,
-        },
-      ],
-      page: 0,
-      size: 200,
-      totalElements: 1,
-      totalPages: 1,
-      hasNext: false,
+  it("Leader·Member는 GET /api/team/actions를 TODO·IN_PROGRESS 둘 다 불러 합친다", async () => {
+    function actionFixture(overrides: { id: number; title: string; status: string }) {
+      return {
+        ...overrides,
+        actionType: "TEAM",
+        description: "",
+        startDate: null,
+        plannedStartDate: null,
+        dueDate: "2026-09-30",
+        needsReview: false,
+        isDelayed: false,
+        assigneeName: null,
+        projectId: 3,
+        projectTag: "marketing-q3",
+        projectName: "마케팅 캠페인 Q3",
+        teamName: "개발팀",
+        sourceMeetingTitle: null,
+        parentActionId: null,
+        parentActionTitle: null,
+        childDoneCount: 2,
+        childTotalCount: 5,
+      };
+    }
+
+    serverApiMock.mockImplementation(async (path: string) => {
+      const isTodo = path.includes("status=TODO");
+      return {
+        content: [
+          isTodo
+            ? actionFixture({ id: 8, title: "4분기 캠페인 초안", status: "TODO" })
+            : actionFixture({ id: 7, title: "3분기 마케팅 캠페인 기획", status: "IN_PROGRESS" }),
+        ],
+        page: 0,
+        size: 200,
+        totalElements: 1,
+        totalPages: 1,
+        hasNext: false,
+      };
     });
 
     const teamActions = await getReservableTeamActions(LEADER);
 
+    // ⚠️ 순서까지 확인한다 — IN_PROGRESS를 먼저, TODO를 뒤에 붙인다(진행중 항목이 우선).
     expect(teamActions).toEqual([
       { id: 7, name: "3분기 마케팅 캠페인 기획", projectTag: "marketing-q3" },
+      { id: 8, name: "4분기 캠페인 초안", projectTag: "marketing-q3" },
     ]);
     expect(serverApiMock).toHaveBeenCalledWith(
       ep.teamActions({ status: "IN_PROGRESS", page: 0, size: 200 }),
       expect.objectContaining({ accessToken: "token" }),
     );
+    expect(serverApiMock).toHaveBeenCalledWith(
+      ep.teamActions({ status: "TODO", page: 0, size: 200 }),
+      expect.objectContaining({ accessToken: "token" }),
+    );
+    expect(serverApiMock).toHaveBeenCalledTimes(2);
   });
 
   /*

--- a/src/features/rooms/server.ts
+++ b/src/features/rooms/server.ts
@@ -200,9 +200,12 @@ const RESERVABLE_PROJECTS_PAGE_SIZE = 200;
  * ⚠️ **`getProjectsPage`를 재사용한다.** 프로젝트 목록 API가 이미 실서버에 연동돼 있으므로
  *    (`features/project/server.ts`) 여기서 새 경로를 만들지 않는다(§환각 API 방지) — 같은
  *    회사의 프로젝트가 두 곳에서 다르게 보이면 안 된다.
- * ⚠️ select는 **한 화면에 다 보여줄 목록**이라 페이지네이션이 안 맞는다. 진행중 프로젝트만
- *    대상으로 좁히고(완료된 프로젝트에 새 회의를 묶을 일이 없다) 큰 페이지 하나로 받는다 —
- *    회사 프로젝트가 이 상한을 넘으면 그때 BE에 전용 select 응답을 요청한다.
+ * ⚠️ select는 **한 화면에 다 보여줄 목록**이라 페이지네이션이 안 맞는다. 아직 안 끝난
+ *    프로젝트(`TODO`·`IN_PROGRESS`)만 대상으로 좁히고(완료된 프로젝트에 새 회의를 묶을
+ *    일이 없다) 큰 페이지 하나로 받는다 — 회사 프로젝트가 이 상한을 넘으면 그때 BE에
+ *    전용 select 응답을 요청한다.
+ * ⚠️ **`status`는 BE가 한 번에 하나만 받는다**(`ListPageParams.status`, `lib/endpoints.ts`)
+ *    — `TODO`·`IN_PROGRESS` 둘 다 보여주려면 상태별로 따로 불러 합친다.
  */
 export async function getReservableProjects(): Promise<RoomProjectOption[]> {
   if (isMock) {
@@ -213,22 +216,27 @@ export async function getReservableProjects(): Promise<RoomProjectOption[]> {
     }));
   }
 
-  const { items, totalPages } = await getProjectsPage(
-    { status: PROJECT_STATUS.IN_PROGRESS, keyword: "" },
-    0,
-    RESERVABLE_PROJECTS_PAGE_SIZE,
-  );
-  /*
-    ⚠️ **200개를 조용히 자르지 않는다**(코드래빗이 팀 액션 select에서 잡은 것과 같은
-       결함을 여기서도 먼저 막는다). 진행중 프로젝트가 상한을 넘으면 BE 전용 select
-       응답이 필요한 신호로 던진다(조직도 `manage-server.ts`와 같은 정책).
-  */
-  if (totalPages > 1) {
-    throw new Error(
-      `이 회사의 진행중 프로젝트가 ${RESERVABLE_PROJECTS_PAGE_SIZE}건 상한을 넘어 select를 전부 채우지 못했습니다 — BE 전용 응답이 필요합니다.`,
+  const statuses = [PROJECT_STATUS.IN_PROGRESS, PROJECT_STATUS.TODO] as const;
+  const projects = [];
+  for (const status of statuses) {
+    const { items, totalPages } = await getProjectsPage(
+      { status, keyword: "" },
+      0,
+      RESERVABLE_PROJECTS_PAGE_SIZE,
     );
+    /*
+      ⚠️ **200개를 조용히 자르지 않는다**(코드래빗이 팀 액션 select에서 잡은 것과 같은
+         결함을 여기서도 먼저 막는다). 이 상태의 프로젝트가 상한을 넘으면 BE 전용 select
+         응답이 필요한 신호로 던진다(조직도 `manage-server.ts`와 같은 정책).
+    */
+    if (totalPages > 1) {
+      throw new Error(
+        `이 회사의 ${status} 프로젝트가 ${RESERVABLE_PROJECTS_PAGE_SIZE}건 상한을 넘어 select를 전부 채우지 못했습니다 — BE 전용 응답이 필요합니다.`,
+      );
+    }
+    projects.push(...items);
   }
-  return items.map((project) => ({
+  return projects.map((project) => ({
     id: String(project.id),
     name: project.name,
     tag: project.tag,
@@ -248,8 +256,10 @@ const RESERVABLE_TEAM_ACTIONS_PAGE_SIZE = 200;
  *    분기에는 `actor.teamName` 필터가 필요 없다(항상 자기 팀만 온다). BE 주석에도 이
  *    API를 "회의 개설 모달의 상위 팀 액션 드롭다운"용으로 이미 열어 뒀다고 적혀 있다
  *    (이슈 #389, MEMBER도 호출 가능하게 완화).
- * ⚠️ 완료된 팀 액션은 상위로 고를 이유가 없어 `IN_PROGRESS`만 받는다(진행중 항목이 새
- *    회의를 낳을 수 있다는 게 이 필드의 뜻이다).
+ * ⚠️ 완료된 팀 액션은 상위로 고를 이유가 없어 `TODO`·`IN_PROGRESS`만 받는다(아직 안 끝난
+ *    항목이 새 회의를 낳을 수 있다는 게 이 필드의 뜻이다).
+ * ⚠️ **`status`는 BE가 한 번에 하나만 받는다**(`ep.teamActions`) — 두 상태를 다 보여주려면
+ *    상태별로 따로 불러 합친다.
  */
 export async function getReservableTeamActions(actor: Actor): Promise<RoomTeamActionOption[]> {
   if (!requiresParentTeamAction(actor)) return [];
@@ -274,26 +284,27 @@ export async function getReservableTeamActions(actor: Actor): Promise<RoomTeamAc
   }
 
   const accessToken = await requireAccessToken();
-  const response = await serverApi<BePageResponse<BeActionSummary>>(
-    ep.teamActions({
-      status: ACTION_STATUS.IN_PROGRESS,
-      page: 0,
-      size: RESERVABLE_TEAM_ACTIONS_PAGE_SIZE,
-    }),
-    { accessToken },
-  );
-  /*
-    ⚠️ **200개를 조용히 자르지 않는다**(코드래빗 지적, 2026-08-14). `hasNext`가 참인데
-       첫 페이지만 돌려주면 뒤 페이지 항목은 select에서 영원히 안 보인다 — 회사 안 한
-       팀에 진행중 팀 액션이 그렇게 많을 일은 드물지만, 조용히 자르는 건 §정직성 위반이다.
-       BE 전용 select 응답이 필요한 신호로 던진다(조직도 `manage-server.ts`와 같은 정책).
-  */
-  if (response.hasNext) {
-    throw new Error(
-      `이 팀의 진행중 팀 액션이 ${RESERVABLE_TEAM_ACTIONS_PAGE_SIZE}건 상한을 넘어 select를 전부 채우지 못했습니다 — BE 전용 응답이 필요합니다.`,
+  const statuses = [ACTION_STATUS.IN_PROGRESS, ACTION_STATUS.TODO] as const;
+  const teamActions = [];
+  for (const status of statuses) {
+    const response = await serverApi<BePageResponse<BeActionSummary>>(
+      ep.teamActions({ status, page: 0, size: RESERVABLE_TEAM_ACTIONS_PAGE_SIZE }),
+      { accessToken },
     );
+    /*
+      ⚠️ **200개를 조용히 자르지 않는다**(코드래빗 지적, 2026-08-14). `hasNext`가 참인데
+         첫 페이지만 돌려주면 뒤 페이지 항목은 select에서 영원히 안 보인다 — 회사 안 한
+         팀에 이 상태 팀 액션이 그렇게 많을 일은 드물지만, 조용히 자르는 건 §정직성 위반이다.
+         BE 전용 select 응답이 필요한 신호로 던진다(조직도 `manage-server.ts`와 같은 정책).
+    */
+    if (response.hasNext) {
+      throw new Error(
+        `이 팀의 ${status} 팀 액션이 ${RESERVABLE_TEAM_ACTIONS_PAGE_SIZE}건 상한을 넘어 select를 전부 채우지 못했습니다 — BE 전용 응답이 필요합니다.`,
+      );
+    }
+    teamActions.push(...response.content);
   }
-  return response.content
+  return teamActions
     .filter((item) => item.projectTag !== null)
     .map((item) => ({ id: item.id, name: item.title, projectTag: item.projectTag! }));
 }


### PR DESCRIPTION
## 📋 PR 타입

- [ ] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [x] merge

---

## 🗂 작업 영역

- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

- develop → main 배포 병합

**보드 empty state (#607)**
- cards=0건이면 EmptyState 하나만 렌더, 세 칸·저장 버튼 숨김
- 설명 문구를 조작 중립으로 좁히고, 드래그 안내 문구 부재까지 테스트로 고정

**온보딩 완료 대기 (#618)**
- 완료 요청 타임아웃 연장 + 대기 화면 안내를 정직하게 고침

**마이페이지 비밀번호 변경 (#620)**
- 비밀번호 변경 모달 세 칸에 보기/숨기기 토글 추가

**검토 화면 반려·오너 회의 확정 (#622)**
- 반려한 항목도 목록에 남아 사유 표시(되돌리기 가능)
- 오너 회의 확정 시 팀장 memberId를 함께 보내 `NO_ASSIGNEE` 실패 수정

**회의 예약 모달 TODO 노출 (#624)**
- 예약 모달의 프로젝트·상위 팀 액션 select가 `IN_PROGRESS`만 보여주던 것을 `TODO`도 함께 노출

---

## ✅ 작업 체크리스트

**기본**

- [ ] 브랜치 명명 규칙 준수 — 해당 없음(develop→main 배포 병합 PR)
- [x] 커밋 컨벤션 준수
- [ ] 아래 `Closes #` 에 이슈 번호 기입 — 해당 없음(다건 병합)
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 권한 2축 검사 — 해당 없음(개별 PR에서 이미 검사)
- [ ] 🧬 zod — 해당 없음
- [x] 🕵️ 정직성 — 보드 empty state·온보딩 대기 화면 정직성 항목 이번 반영분에 포함
- [ ] 🎨 디자인 토큰 — 해당 없음

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [ ] ♿ a11y — 해당 없음
- [x] ♻️ 재사용 확인
- [ ] 🧪 loading/error/empty 3상태 — 해당 없음
- [ ] 브라우저 전용 API 안내 — 해당 없음

---

## 🔗 연관 이슈

Closes #

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- main 반영 후 실배포로 최종 확인 필요

---

## 📝 추가 메모

develop → main 배포 병합입니다.
