### PR TITLE
[FIX] 액션 검토 화면 확정 실패 사유 파싱·필수 필드 검증 #631

### DIFF
--- a/src/features/meeting/review/actions.ts
+++ b/src/features/meeting/review/actions.ts
@@ -244,10 +244,32 @@ export async function confirmActionDistributionAction(
       if (error.status === 404) return { status: "notFound", createdCount: 0, createdManuals };
       /* 확인되지 않은 STT 구간·미검토가 남았다 — 사람이 알고 강행할지 정한다(§정직성) */
       if (error.status === 409)
-        return { status: "blocked", message: error.message, createdManuals };
+        return { status: "blocked", message: composeConfirmFailureMessage(error), createdManuals };
     }
-    return { status: "failed", message: toUserMessage(error), createdManuals };
+    return { status: "failed", message: composeConfirmFailureMessage(error), createdManuals };
   }
+}
+
+/**
+ * 확정 실패 문구 — BE가 표준 에러 포맷(`details: [{field, reason}]`)에 사유 코드를 담아 준다
+ * (2026-08-18 BE 협의). 한글 라벨만 갈아 끼워 **"어느 단계가 성공했다"는 티는 안 낸다** —
+ * 판정·추가는 트랜잭션이 별개라 일부가 이미 커밋됐어도 재조회에서 이미 반영됨 상태로 다시
+ * 얹혀 나오므로, 사용자에게는 남은 원인만 보여 준다(§정직성).
+ */
+const CONFIRM_FAILURE_LABEL: Record<string, string> = {
+  STILL_PENDING: "미검토 액션",
+  UNRESOLVED_GAP: "미확인 발화 구간",
+};
+
+function composeConfirmFailureMessage(error: unknown): string {
+  if (!(error instanceof ApiError) || !error.details || error.details.length === 0) {
+    return toUserMessage(error);
+  }
+  const parts = error.details.map((detail) => {
+    const label = CONFIRM_FAILURE_LABEL[detail.field] ?? detail.field;
+    return detail.reason ? `${label} ${detail.reason}` : label;
+  });
+  return `분배를 처리하던 중 문제가 발생했습니다. 사유: ${parts.join(", ")}`;
 }
 
 /** 목 — 기존 흐름 그대로. 권한 재검사까지 목 경로에서도 같은 함수로 한다(§권한). */

--- a/src/features/meeting/review/components/meeting-review-view.tsx
+++ b/src/features/meeting/review/components/meeting-review-view.tsx
@@ -90,6 +90,21 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
   const hasUnassigned = review.isOwnerMeeting
     ? activeDrafts.some((draft) => draft.teamId === null)
     : activeDrafts.some((draft) => draft.assigneeId === null);
+  /*
+    ⚠️ **필수 입력값(제목·세부내용·마감일) 누락 검사**(#622). BE는 입력 스키마 위반을
+       422로 튕기는데, 확정 다이얼로그가 뜬 뒤에 그걸 마주치면 사용자는 "다이얼로그까지
+       왔는데 왜 실패?"로 인지 불일치가 생긴다. 다이얼로그 진입 전이 아니라 다이얼로그
+       안에서 안내한다 — 확정 대상은 이 시점에 확정된 값(`activeDrafts`)이라 여기서 검사가
+       가장 정확하다.
+    ⚠️ **`title`·`description`은 `trim()`으로 본다** — 공백만 있는 값은 BE도 빈 값 취급.
+    ⚠️ **반려된 항목은 검사 대상이 아니다** — `activeDrafts`가 이미 걸렀다.
+  */
+  const hasMissingRequired = activeDrafts.some(
+    (draft) =>
+      draft.title.trim().length === 0 ||
+      draft.description.trim().length === 0 ||
+      draft.dueDate.length === 0,
+  );
   function updateDraft(id: string, patch: Partial<AiActionDraft>) {
     setDrafts((prev) => prev.map((draft) => (draft.id === id ? { ...draft, ...patch } : draft)));
   }
@@ -423,15 +438,23 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
       </ActionReviewGroup>
 
       <div className="flex items-center justify-end gap-3">
-        {/* 왜 잠겼는지 버튼 옆에서 말한다 — 눌리지 않는 버튼만 두면 고장으로 읽힌다(§정직성) */}
-        {hasUnassigned && (
+        {/*
+          왜 잠겼는지 버튼 옆에서 말한다 — 눌리지 않는 버튼만 두면 고장으로 읽힌다(§정직성).
+          ⚠️ 필수 입력 누락이 우선순위가 더 높다(제목·설명·마감은 담당자보다 먼저 채워야 하는
+             기본 필드) — 두 안내가 동시에 뜰 수는 있지만 하나만 뜰 상황에선 이쪽을 앞세운다.
+        */}
+        {hasMissingRequired ? (
+          <p className="text-muted-foreground text-[12px] leading-4">
+            제목·세부 내용·마감일이 비어 있는 액션이 있습니다. 채운 뒤 다시 시도해 주세요.
+          </p>
+        ) : hasUnassigned ? (
           <p className="text-muted-foreground text-[12px] leading-4">
             {assignmentTargetLabel} 미정인 액션이 있습니다. {assignmentTargetLabel}를 지정해 주세요.
           </p>
-        )}
+        ) : null}
         <Button
           type="button"
-          disabled={activeDrafts.length === 0 || hasUnassigned}
+          disabled={activeDrafts.length === 0 || hasUnassigned || hasMissingRequired}
           className="bg-foreground text-background hover:bg-foreground/90"
           onClick={() => setConfirmOpen(true)}
         >

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -31,6 +31,19 @@ interface ApiEnvelope<T> {
  * BE가 돌려준 실패.
  * ⚠️ `message`를 그대로 화면에 쓴다. `code`는 흐름을 가를 때만 본다(예: `ALREADY_ONBOARDED`).
  */
+/**
+ * BE 실패 봉투의 `details` 한 원소 — 필드 검증 에러 표준 포맷.
+ *
+ * ⚠️ **회의 검토 확정(MEETING_409_5)이 이 배열을 재사용해 사유별 건수를 실어 보낸다**
+ *    (BE 담당자 협의, 2026-08-18) — `{field: "STILL_PENDING", reason: "3"}`처럼 사유 코드에
+ *    건수를 담아 준다. 원래 필드 검증(입력 스키마 위반) 자리에 쓰던 포맷이지만, "필드 이름
+ *    자리에 사유 코드를 담는다"는 재사용이라 화면이 확정 실패 문구 조립에도 그대로 활용한다.
+ */
+export interface ApiErrorDetail {
+  field: string;
+  reason: string;
+}
+
 export class ApiError extends Error {
   constructor(
     readonly status: number,
@@ -44,6 +57,12 @@ export class ApiError extends Error {
      *    Server Action은 브라우저 네트워크 탭에도 안 잡혀서 더욱 그렇다(2026-08-12).
      */
     readonly traceId?: string,
+    /**
+     * BE가 실어 준 세부 정보 — 필드 검증 에러 포맷(`[{field, reason}]`). 원래는 입력 스키마
+     * 위반 자리에 쓰지만, 회의 검토 확정(MEETING_409_5)이 사유별 건수 요약에도 재사용한다
+     * (BE 담당자 협의, 2026-08-18). 있을 때만 담긴다.
+     */
+    readonly details?: ApiErrorDetail[],
   ) {
     super(message);
     this.name = "ApiError";
@@ -165,7 +184,12 @@ function toApiError(status: number, raw: unknown): ApiError {
     return new ApiError(status, "요청을 처리하지 못했습니다. 잠시 후 다시 시도해 주세요.");
   }
 
-  const envelope = raw as { message?: unknown; errorCode?: unknown; traceId?: unknown };
+  const envelope = raw as {
+    message?: unknown;
+    errorCode?: unknown;
+    traceId?: unknown;
+    details?: unknown;
+  };
   const message =
     typeof envelope.message === "string" && envelope.message.trim().length > 0
       ? envelope.message
@@ -173,8 +197,25 @@ function toApiError(status: number, raw: unknown): ApiError {
 
   const code = typeof envelope.errorCode === "string" ? envelope.errorCode : undefined;
   const traceId = typeof envelope.traceId === "string" ? envelope.traceId : undefined;
+  const details = toApiErrorDetails(envelope.details);
 
-  return new ApiError(status, message, code, traceId);
+  return new ApiError(status, message, code, traceId, details);
+}
+
+/**
+ * `details` 배열 정규화 — BE가 안 보내는 경우가 정상이라 없으면 `undefined`로 둔다(빈 배열
+ * 아님). "필드 이름 자리"라도 검토 확정에서는 사유 코드가 들어와서, 값 검증은 필드명 규칙이
+ * 아니라 **모양(문자열 두 개)**만 본다.
+ */
+function toApiErrorDetails(value: unknown): ApiErrorDetail[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const items = value.flatMap((entry): ApiErrorDetail[] => {
+    if (typeof entry !== "object" || entry === null) return [];
+    const { field, reason } = entry as { field?: unknown; reason?: unknown };
+    if (typeof field !== "string" || typeof reason !== "string") return [];
+    return [{ field, reason }];
+  });
+  return items.length > 0 ? items : undefined;
 }
 
 /**


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실

---

## 🙋 관련 역할

- [x] OWNER (대표)
- [x] LEADER (팀장)
- [x] MEMBER (사원)

Host만 확정할 수 있어 실패 문구도 Host에서만 보인다.

---

## 📝 작업 내용

- **확정 실패 사유 파싱** — BE 표준 에러 포맷(\`details: [{field, reason}]\`)을 \`ApiError.details\`로 배선. 확정 실패(\`STILL_PENDING\`·\`UNRESOLVED_GAP\` 등) 시 라벨을 한글로 매핑해 \"분배를 처리하던 중 문제가 발생했습니다. 사유: 미검토 액션 3건, 미확인 발화 구간 1건\" 형태로 조립한다.
- **필수 필드 검증** — 제목·세부·마감 중 하나라도 비면 [액션 분배 확정] 잠그고 안내 문구(\"제목·세부 내용·마감일이 비어 있는 액션이 있습니다\") 노출.
- **오너 회의 MODIFY 확인** — 이미 \`changes.teamId\`만 실어 MODIFY로 보내는 로직 유지 확인(코드 변경 없음).
- 어느 단계가 성공했는지는 화면에서 티 내지 않는다 — 판정·추가는 각기 커밋되므로 재조회 시 \`이미 반영됨\` 상태로 얹혀 나와 화면이 자연스럽게 복구된다(#622에서 처리됨).

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수
- [x] 아래 \`Closes #\` 에 이슈 번호 기입
- [x] 불필요한 \`console\` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [x] 🔐 권한 2축 검사 — 서버 액션이 Host만 확정 가능하게 재검사(기존)
- [x] 🕵️ 정직성 — 어느 단계가 성공했는지 티 내지 않음, 남은 원인만 보여 준다
- [x] 🎨 디자인 토큰 사용

**품질**

- [x] ♿ a11y — 버튼 disabled 시 옆에 사유 문구
- [x] ♻️ 재사용 확인 — \`ApiError\` 확장

---

## 🔗 연관 이슈

Closes #631

---

## 💬 리뷰 포인트

- \`src/lib/api.ts\` — \`ApiError.details\` 배선과 \`toApiErrorDetails\` 정규화(문자열 필드 두 개만 통과)
- \`src/features/meeting/review/actions.ts\` — \`composeConfirmFailureMessage\` 라벨 매핑, 409/일반 실패 모두에서 사용
- \`src/features/meeting/review/components/meeting-review-view.tsx\` — \`hasMissingRequired\`가 확정 버튼 disabled·안내 문구에 반영

---

## 📝 추가 메모

BE 협의(2026-08-18): 표준 에러 포맷 재사용, FE가 라벨 매핑 담당. BE가 \`STILL_PENDING\`·\`UNRESOLVED_GAP\` 외 다른 사유 코드를 추가로 내면 매핑 상수에 추가하면 된다.