### PR TITLE
[FIX] 오너 회의 확정 시 teamId만 실어 보내도록 원복 #634

### DIFF
--- a/src/features/meeting/review/components/meeting-review-view.tsx
+++ b/src/features/meeting/review/components/meeting-review-view.tsx
@@ -112,19 +112,15 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
   }
 
   /*
-    ⚠️ **부서를 고르면 그 팀 팀장 memberId를 `assigneeId`에도 함께 세팅한다**(#622).
-       BE `ConfirmDistributionService.skipReasonOf`는 `actionType != TEAM`인데 `assigneeMemberId`가
-       null이면 `NO_ASSIGNEE`로 걸어낸다 — 오너 회의라도 확정 요청에는 assignee가 실려야 한다.
-       오너 회의 참석자 정책상 그 팀의 팀장 = 참석자 memberId라(actions.test.ts "Owner가 개설하는
-       회의에는 팀장만 참석자로 지정할 수 있습니다"), 옵션에 미리 짝지어 둔 `leaderMemberId`를
-       그대로 옮긴다.
+    ⚠️ **부서만 세팅하고 `assigneeId`는 손대지 않는다**(2026-08-18 원복, #631).
+       BE 검사(`ApplyReviewDecisionService#requireDecisionShape`)가 요청 body에 assignee·teamId가
+       둘 다 있으면 무조건 `REVIEW_ASSIGNEE_TEAM_CONFLICT` 422로 막는다 — 전에 팀장 memberId를
+       assignee에 함께 세팅했더니 항상 여기서 걸렸다. BE는 MODIFY + teamId만 오면
+       `Action.convertToTeam`이 기존 assigneeMemberId를 알아서 null로 비우고 `ActionType=TEAM`으로
+       바꾼다(BE 정본 확인 2026-08-18).
   */
   function handleTeamChange(draftId: string, teamId: number) {
-    const option = review.teamOptions.find((candidate) => candidate.teamId === teamId);
-    updateDraft(draftId, {
-      teamId,
-      assigneeId: option?.leaderMemberId ?? null,
-    });
+    updateDraft(draftId, { teamId, assigneeId: null });
   }
 
   /**
@@ -204,18 +200,17 @@ export function MeetingReviewView({ review }: MeetingReviewViewProps) {
                     ? { description: draft.description }
                     : {}),
                   /*
-                    ⚠️ **오너 회의는 `teamId`와 `assigneeId`를 함께 보낸다**(2026-08-18, #622).
-                       BE `ConfirmDistributionService.skipReasonOf`가 오너 회의여도 assignee가
-                       비어 있으면 `NO_ASSIGNEE`로 걸어내기 때문 — 예전에는 `teamId`만 보내
-                       확정이 항상 실패했다. 오너 회의 참석자 정책상 그 팀의 팀장이 곧
-                       assignee라, `handleTeamChange`가 부서 선택 시 `draft.assigneeId`에도
-                       팀장 memberId를 세팅해 두면 여기서 함께 실린다.
+                    ⚠️ **오너 회의는 `teamId`만 보낸다**(2026-08-18 원복, #631). BE 검사
+                       (`ApplyReviewDecisionService#requireDecisionShape`)가 body에 둘 다 있으면
+                       무조건 `REVIEW_ASSIGNEE_TEAM_CONFLICT` 422로 막고, MODIFY + teamId만
+                       오면 `Action.convertToTeam`이 기존 assigneeMemberId를 자동으로 null 처리
+                       하며 `ActionType`을 TEAM으로 전환한다(BE 정본).
                     ⚠️ 그 외(팀 회의)는 그대로 `assigneeId`만 보낸다 — 사용자가 담당자를
                        바꿨을 때만 실어 서버가 "사람이 고쳤다" 라벨을 정확히 남기게 한다.
                   */
                   ...(review.isOwnerMeeting
-                    ? draft.teamId !== null && draft.assigneeId !== null
-                      ? { teamId: draft.teamId, assigneeId: draft.assigneeId }
+                    ? draft.teamId !== null
+                      ? { teamId: draft.teamId }
                       : {}
                     : initial &&
                         draft.assigneeId !== initial.assigneeId &&

--- a/src/features/meeting/review/mapper.test.ts
+++ b/src/features/meeting/review/mapper.test.ts
@@ -166,11 +166,9 @@ describe("toMeetingReviewInfo", () => {
       ⚠️ 호스트(대표 계정, teamId null)는 제외 · teamId 기준 dedupe(같은 팀 팀장이 둘 잡히면
          하나만) · teamName이 null인 항목은 애초에 옵션이 될 수 없다(호스트 케이스와 같은 이유).
     */
-    /* ⚠️ `leaderMemberId`는 첫 등장한 팀장 참석자의 memberId다(#622) — 오너 회의 참석자
-       정책상 팀당 한 명만 잡히지만, 목 데이터의 중복 dedupe는 먼저 만난 사람이 이긴다. */
     expect(info.teamOptions).toEqual([
-      { teamId: 3, teamName: "개발팀", leaderMemberId: 2 },
-      { teamId: 4, teamName: "디자인팀", leaderMemberId: 9 },
+      { teamId: 3, teamName: "개발팀" },
+      { teamId: 4, teamName: "디자인팀" },
     ]);
   });
 

--- a/src/features/meeting/review/mapper.ts
+++ b/src/features/meeting/review/mapper.ts
@@ -181,31 +181,21 @@ export function toAssigneeOptions(detail: BeMeetingDetail): AssigneeOption[] {
  *    `attendee-scope.ts`가 참석자 지정에서 host를 빼는 것과 같은 이유(host는 고르는 사람이지
  *    배정 후보가 아니다).
  * ⚠️ **`teamId` 기준으로 dedupe한다** — `teamName`은 같은 이름이 둘일 수 있어 키로 못 쓴다.
- * ⚠️ **`leaderMemberId`를 함께 뽑는다**(2026-08-18, #622). 오너 회의는 참석자 정책상 팀별
- *    팀장 한 명씩만 지정되므로, 참석자의 `memberId`가 그대로 그 팀의 팀장이다 — 별도 조회
- *    없이 여기서 짝지어 두면 확정 요청 시 부서와 함께 팀장 assignee를 실을 수 있다.
  */
 export function toTeamOptions(detail: BeMeetingDetail): TeamOption[] {
   const hostMemberId = hostIdOf(detail);
-  const seen = new Map<number, { teamName: string; leaderMemberId: number }>();
+  const seen = new Map<number, string>();
 
   for (const attendee of detail.attendees) {
     if (attendee.memberId === hostMemberId) continue;
     /* ⚠️ `teamId`가 `undefined`인 것(#472 배포 전)도 여기서 같이 거른다 — 없는 팀을 옵션으로 못 만든다 */
     if (attendee.teamId == null || attendee.teamName === null) continue;
     if (!seen.has(attendee.teamId)) {
-      seen.set(attendee.teamId, {
-        teamName: attendee.teamName,
-        leaderMemberId: attendee.memberId,
-      });
+      seen.set(attendee.teamId, attendee.teamName);
     }
   }
 
-  return Array.from(seen, ([teamId, value]) => ({
-    teamId,
-    teamName: value.teamName,
-    leaderMemberId: value.leaderMemberId,
-  }));
+  return Array.from(seen, ([teamId, teamName]) => ({ teamId, teamName }));
 }
 
 /**

--- a/src/features/meeting/review/mock/review.ts
+++ b/src/features/meeting/review/mock/review.ts
@@ -31,10 +31,8 @@ const ASSIGNEE_OPTIONS: AssigneeOption[] = [
  * ⚠️ 실 연동에서는 참석자에서 만들지만(타입 주석 참고), 목은 데모 시나리오 고정이라 직접 둔다.
  */
 const TEAM_OPTIONS: TeamOption[] = [
-  /* ⚠️ `leaderMemberId`는 오너 회의 참석자 정책상 그 팀의 팀장 memberId다(#622, 타입 주석).
-     목에서는 위 `ASSIGNEES`의 팀장에 해당하는 id를 그대로 짝지어 둔다. */
-  { teamId: 10, teamName: "개발팀", leaderMemberId: 2 },
-  { teamId: 11, teamName: "디자인팀", leaderMemberId: 1 },
+  { teamId: 10, teamName: "개발팀" },
+  { teamId: 11, teamName: "디자인팀" },
 ];
 
 function seedReview(meetingId: string): MeetingReviewInfo {

--- a/src/features/meeting/review/types.ts
+++ b/src/features/meeting/review/types.ts
@@ -26,17 +26,10 @@ export interface AssigneeOption {
  *    참석자 목록 자체가 팀별 대표 목록이다 — 그래서 옵션도 참석자에서 만든다(별도 팀 조회 API 없음).
  * ⚠️ 담당자(사람)가 아니라 **부서**가 확정 대상이다 — 팀장 이름은 화면에 안 보여준다
  *    (팀장이 바뀌어도 팀 액션은 그대로이므로, 담당 팀장은 팀 액션 화면에서 그때그때 조회한다).
- * ⚠️ **`leaderMemberId`는 확정 요청에 실린다**(2026-08-18, #622). BE `ConfirmDistributionService`가
- *    오너 회의여도 `assigneeMemberId == null`인 액션은 `NO_ASSIGNEE`로 걸어내기 때문에,
- *    사용자가 부서를 고르면 그 팀의 팀장 memberId를 `draft.assigneeId`에도 함께 세팅해
- *    확정 요청 `changes`에 실어 보내야 한다. 오너 회의의 참석자 = 팀장이라는 정책
- *    (`Owner 회의는 팀장만 받는다`)이 근거다 — 매퍼가 참석자 `memberId`를 그대로 옮긴다.
  */
 export interface TeamOption {
   teamId: number;
   teamName: string;
-  /** 이 팀의 팀장 memberId — 오너 회의 참석자 정책상 `attendee.memberId`가 곧 그 팀 팀장. */
-  leaderMemberId: number;
 }
 
 /** 근거 발화 — 수정 판단의 근거이므로 AI가 뽑은 항목엔 반드시 있다(WORKFLOW.md §3-4). */


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실

---

## 🙋 관련 역할

- [x] OWNER (대표)

Host만 확정 가능, 그중 오너 개설 회의에서만 발생.

---

## 📝 작업 내용

- **원인**: 배포된 main에 이전 협의(2026-08-15 즈음)로 원복하기로 한 \"부서 선택 시 팀장 memberId를 assigneeId에 함께 세팅해 함께 전송\" 로직이 남아 있어, 오너 회의 확정 요청 body에 \`teamId\`+\`assigneeMemberId\`가 항상 둘 다 실리고 있었다. BE 최신 main 코드 재확인 결과 \`ApplyReviewDecisionService#requireDecisionShape\`가 요청 body 검사만 하므로 무조건 \`REVIEW_ASSIGNEE_TEAM_CONFLICT\` 422로 막힌다.
- **수정**:
  - \`handleTeamChange\` — \`assigneeId: leaderMemberId ?? null\` 세팅 제거, \`teamId\` 세팅 시 \`assigneeId\`를 명시적으로 null로 되돌린다.
  - \`handleConfirm\`의 \`changes\` 조립 — 오너 회의는 \`teamId\`만 담고 \`assigneeId\`는 담지 않는다.
  - \`TeamOption.leaderMemberId\` 필드·매퍼(\`toTeamOptions\`)·목·테스트에서 전부 제거.
  - 잘못된 주석(\"NO_ASSIGNEE로 걸어낸다\", \"팀장 memberId를 함께 세팅\") 정리 — BE 검사 실제 근거로 교체.
- **BE 근거**:
  - \`ApplyReviewDecisionService.java:161-171\` \`requireDecisionShape\`가 body의 \`assignee\`+\`teamId\`가 둘 다 non-null이면 던짐 (요청 body 검사).
  - \`Action.java:238-248\` \`convertToTeam\`이 MODIFY+teamId가 오면 기존 \`assigneeMemberId\`를 null로 비우고 \`ActionType=TEAM\`으로 전환.
  - \`ApplyReviewDecisionService#requireAssigneeForConfirm\`이 \`teamId != null\`이면 담당자 필수 검사를 면제.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수
- [x] 커밋 컨벤션 준수
- [x] 아래 \`Closes #\` 에 이슈 번호 기입
- [x] 불필요한 \`console\` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [x] 🔐 권한 2축 검사 — 서버 액션 Host 검사 기존 유지
- [x] 🕵️ 정직성 — 잘못된 주석 근거를 BE 실코드로 교체

**품질**

- [x] 🧪 기존 테스트 1553개 통과 확인

---

## 🔗 연관 이슈

Closes #634

---

## 💬 리뷰 포인트

- \`src/features/meeting/review/components/meeting-review-view.tsx\` — \`handleTeamChange\`와 \`changes\` 조립부 원복
- \`src/features/meeting/review/types.ts\` / \`mapper.ts\` — \`TeamOption.leaderMemberId\` 제거
- 이후 오너 회의 확정 시도 시 실제 요청 body에 \`assigneeMemberId\` 키가 없어야 함(네트워크 탭 검증)

---

## 📝 추가 메모

이 PR이 머지·배포되면 오너 회의 확정 실패 원인 재확인 및 다음 이슈(다른 사유 등) 검토로 넘어감.