### PR TITLE
[FIX] 캡처 이어하기가 PAUSED 세션 재접속에서 CAP-03으로 안 갈라지던 것 #605

### DIFF
--- a/src/features/meeting/capture/actions.test.ts
+++ b/src/features/meeting/capture/actions.test.ts
@@ -27,7 +27,11 @@ jest.mock("@/lib/api", () => ({
 import { requireAccessToken } from "@/features/auth/session";
 import { ApiError, serverApi } from "@/lib/api";
 
-import { completeCaptureUploadAction, getActiveCaptureAction } from "./actions";
+import {
+  completeCaptureUploadAction,
+  getActiveCaptureAction,
+  startCaptureSessionAction,
+} from "./actions";
 
 const serverApiMock = serverApi as unknown as jest.Mock;
 const requireAccessTokenMock = requireAccessToken as unknown as jest.Mock;
@@ -141,5 +145,58 @@ describe("completeCaptureUploadAction — CAP-07 멱등 처리", () => {
 
     expect(result.ok).toBe(false);
     expect(result.error).toBe("서버 오류");
+  });
+});
+
+/*
+  ⚠️ **PAUSED 세션 재접속(CS-002)은 CAP-03으로 넘긴다**(#605 회귀 방지). [녹음 이어하기]가
+     늘 CAP-01(start)만 불러 새로고침 후 일시정지 세션을 못 살리던 버그다.
+*/
+describe("startCaptureSessionAction — CAP-01, PAUSED 재접속(#605)", () => {
+  it("정상 시작이면 그대로 성공한다", async () => {
+    serverApiMock.mockResolvedValueOnce({
+      captureSessionId: 5,
+      status: "ACTIVE",
+      isPaused: false,
+      startedBy: 1,
+      startedAtEpochMs: 1000,
+      roster: [],
+    });
+
+    const result = await startCaptureSessionAction(3);
+
+    expect(result.ok).toBe(true);
+    expect(serverApiMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("CS-002(이미 있음)면 CAP-03(재개)으로 넘어가고, 성공하면 ok:true다", async () => {
+    serverApiMock
+      .mockRejectedValueOnce(new ApiError(409, "이미 진행 중인 캡처가 있습니다", "CS-002"))
+      .mockResolvedValueOnce(undefined); // 재개(CAP-03) 응답
+
+    const result = await startCaptureSessionAction(3);
+
+    expect(result.ok).toBe(true);
+    expect(serverApiMock).toHaveBeenCalledTimes(2);
+    expect(serverApiMock.mock.calls[1][0]).toBe("/api/meetings/3/capture-session/resume");
+  });
+
+  it("CS-002 뒤 재개마저 실패하면 그 실패 사유를 그대로 전달한다", async () => {
+    serverApiMock
+      .mockRejectedValueOnce(new ApiError(409, "이미 진행 중인 캡처가 있습니다", "CS-002"))
+      .mockRejectedValueOnce(new ApiError(500, "재개에 실패했습니다"));
+
+    const result = await startCaptureSessionAction(3);
+
+    expect(result).toEqual({ ok: false, error: "재개에 실패했습니다" });
+  });
+
+  it("CS-002가 아닌 다른 에러는 재개를 시도하지 않는다", async () => {
+    serverApiMock.mockRejectedValueOnce(new ApiError(403, "권한이 없습니다"));
+
+    const result = await startCaptureSessionAction(3);
+
+    expect(result).toEqual({ ok: false, error: "권한이 없습니다" });
+    expect(serverApiMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/features/meeting/capture/actions.test.ts
+++ b/src/features/meeting/capture/actions.test.ts
@@ -173,12 +173,19 @@ describe("startCaptureSessionAction — CAP-01, PAUSED 재접속(#605)", () => {
     serverApiMock
       .mockRejectedValueOnce(new ApiError(409, "이미 진행 중인 캡처가 있습니다", "CS-002"))
       .mockResolvedValueOnce(undefined); // 재개(CAP-03) 응답
+    // ⚠️ `startedAtEpochMs`는 재개 응답에 없어 `Date.now()`로 채운다(actions.ts 주석 참고) —
+    //    고정해 두지 않으면 그 대체값이 없어지거나 undefined가 돼도 `ok`만 보는 이 테스트는
+    //    통과한다(코드래빗 지적, PR #638). 다른 테스트에 새는 걸 막으려 끝나면 되돌린다.
+    const dateNowSpy = jest.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
 
     const result = await startCaptureSessionAction(3);
 
     expect(result.ok).toBe(true);
+    expect(result.data?.startedAtEpochMs).toBe(1_700_000_000_000);
     expect(serverApiMock).toHaveBeenCalledTimes(2);
     expect(serverApiMock.mock.calls[1][0]).toBe("/api/meetings/3/capture-session/resume");
+
+    dateNowSpy.mockRestore();
   });
 
   it("CS-002 뒤 재개마저 실패하면 그 실패 사유를 그대로 전달한다", async () => {

--- a/src/features/meeting/capture/actions.ts
+++ b/src/features/meeting/capture/actions.ts
@@ -19,6 +19,15 @@ import type { ActiveCapture, CaptionChunkInput, CapturePart, CaptureSession } fr
 const CAP_PART_ALREADY_REGISTERED_CODE = "CAP-005";
 
 /**
+ * 캡처 세션이 이미 있다는 뜻의 BE 에러코드(CS-002, 409) — **PAUSED 재접속 신호로 쓴다**(#605).
+ * BE `CaptureSessionCreationService.create()`는 ACTIVE 세션만 CAP-01에서 멱등 반환하고,
+ * PAUSED 세션은 이 에러를 던진다(주석: "PAUSED 세션은 CAP-03으로 재개해야 하므로 CAP-01
+ * 멱등 반환 대상에서 제외한다") — 즉 이 에러 자체가 "그 세션은 지금 일시정지 상태다"라는
+ * 뜻이라, 별도 `isPaused` 필드 없이도 이 코드 하나로 갈래를 정할 수 있다.
+ */
+const CAPTURE_SESSION_ALREADY_EXISTS_CODE = "CS-002";
+
+/**
  * 캡처 창구 — 격리막(§Mock 격리막).
  *
  * 화면(`use-capture.ts`)은 이 파일의 모양만 안다. BE shape은 전부 여기서 흡수한다.
@@ -77,6 +86,20 @@ export async function startCaptureSessionAction(
       },
     };
   } catch (error) {
+    /*
+      ⚠️ **PAUSED 세션 재접속(CS-002)은 CAP-03(재개)으로 넘긴다**(#605). 새로고침·크래시로
+         돌아온 사용자가 [녹음 이어하기]를 누르면 이 화면은 늘 CAP-01을 부르는데, 일시정지
+         상태였던 세션은 CAP-01이 거절한다 — 실패로 끝내지 않고 재개를 대신 시도한다.
+         `startedAtEpochMs`는 재개 응답에 없다(원래 시작 시각이라 다시 안 준다) — 지금
+         이 값을 읽는 곳이 없어(전부 로컬 시계로 계산한다) `Date.now()`로 채워도 해가 없다.
+    */
+    if (error instanceof ApiError && error.code === CAPTURE_SESSION_ALREADY_EXISTS_CODE) {
+      const resumed = await resumeCaptureSessionAction(meetingId);
+      if (!resumed.ok) {
+        return { ok: false, error: resumed.error ?? "재개를 서버에 알리지 못했습니다." };
+      }
+      return { ok: true, data: { captureSessionId: 0, startedAtEpochMs: Date.now() } };
+    }
     return { ok: false, error: toUserMessage(error) };
   }
 }


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실

---

## 🙋 관련 역할

- [x] 공통 (Host 전용 화면이지만 역할 무관하게 발생)

---

## 📝 작업 내용

[녹음 이어하기] 버튼이 **PAUSED 세션 재접속**에서 항상 CAP-01(start)만 불러 BE가
`CS-002`(CAPTURE_SESSION_ALREADY_EXISTS, 409)로 거절하던 버그.

- BE `CaptureSessionCreationService.create()`는 ACTIVE 세션만 CAP-01에서 멱등 반환하고,
  PAUSED 세션은 이 에러를 던진다 — 즉 이 에러 자체가 "지금 일시정지 상태다"라는 신호다.
  별도 `isPaused` 필드가 응답에 없어도 이 코드 하나로 갈래를 정할 수 있다.
- `startCaptureSessionAction`이 `CS-002`를 받으면 `resumeCaptureSessionAction`(CAP-03)으로
  자동 전환하도록 고쳤다. 화면(`capture-view.tsx`)은 이미 `activeCapture`가 있으면
  버튼 문구를 "녹음 이어하기"로 바꿔 두고 있었는데, 실제 호출은 안 갈라지고 있었다.
- `startedAtEpochMs`는 재개 응답에 없어(원래 시작 시각을 다시 안 준다) `Date.now()`로
  채운다 — 이 값을 실제로 읽는 곳이 없어(전부 로컬 시계로 계산) 해가 없다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`fix/cap03-resume-on-reconnect#605`, base `develop`)
- [x] 커밋 컨벤션 준수
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [ ] 🔐 권한 2축 검사 — 해당 없음(기존 host-only 검사 그대로, 분기만 추가)
- [ ] 🧬 zod — 해당 없음
- [x] 🕵️ 정직성 — 실패 시 재개 실패 사유를 그대로 화면에 전달(삼키지 않음)
- [ ] 🎨 디자인 토큰 — 해당 없음(UI 변경 없음, 기존 버튼 문구 로직 그대로 작동하게 함)

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [ ] ♿ a11y — 해당 없음
- [x] ♻️ 재사용 확인 — 기존 `resumeCaptureSessionAction`(CAP-02/03 토글용) 그대로 재사용
- [ ] 🧪 loading/error/empty 3상태 — 해당 없음
- [x] 브라우저 전용 API 관련 — 해당 없음(서버 액션 로직만 변경)

---

## 🔗 연관 이슈

Closes #605

---

## 💬 리뷰 포인트

- CS-002를 "PAUSED"의 유일한 신호로 삼는 게 맞는지 재확인 부탁드립니다 — BE 주석상 ACTIVE는
  멱등 반환, 그 외(PAUSED)만 이 에러를 던지는 걸로 확인했습니다(BE `CaptureSessionCreationService`
  실코드 대조).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 이미 진행 중인 캡처 세션을 새로 시작하려 할 때, 기존 세션을 자동으로 재개합니다.
  * 세션 재개에 성공하면 성공 결과를 반환하며, 재개 실패 시 관련 오류를 전달합니다.

* **버그 수정**
  * 캡처 세션 중복 시작 상황에서 불필요한 실패가 발생하지 않도록 개선했습니다.

* **테스트**
  * 정상 시작, 세션 재개 성공 및 실패, 기타 오류 처리에 대한 회귀 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->