### PR TITLE
[FIX] 좌석 과금 폐기 뒤에도 남아있던 인원×단가 계산을 걷어낸다 #243

### DIFF
--- a/src/features/billing/server.ts
+++ b/src/features/billing/server.ts
@@ -121,8 +121,11 @@ const MOCK_PENDING: Subscription = {
  * 요금 설정 — **BE가 내려주는 값**이다(팀 확정: 하드코딩 금지).
  *
  * ⚠️ 아래 숫자는 **실측 전 v0 가정값**이다. 실측이 나오면 이 값만 바꾼다.
+ * ⚠️ **export한다** — SYSTEM 대시보드의 구독 목 데이터(`system/mock/billing.ts`)도 같은
+ *    값을 써야 한다(CLAUDE.md §요금제: "금액·포함량·단가의 정본은 BillingConfig 하나").
+ *    거기서 따로 단가를 만들면 두 화면이 같은 회사를 다른 금액으로 보여준다.
  */
-const MOCK_CONFIG: BillingConfig = {
+export const MOCK_CONFIG: BillingConfig = {
   baseFee: 150_000,
   includedTokens: 1_500_000,
   includedStorageGb: 50,

--- a/src/features/system/mock/billing.test.ts
+++ b/src/features/system/mock/billing.test.ts
@@ -1,4 +1,6 @@
 import { COMPANY_STATUS, PAYMENT_STATUS } from "@/constants/domain";
+import { calculatePrice } from "@/features/billing/pricing";
+import { MOCK_CONFIG } from "@/features/billing/server";
 
 import { MOCK_BILLING_OVERVIEW } from "./billing";
 import { listMockCompanies } from "./companies";
@@ -34,12 +36,21 @@ describe("구독 목록은 기업 관리 데이터에서 파생한다", () => {
     }
   });
 
-  // ⚠️ 요금제가 하나뿐이라 0원짜리 구독은 없다(CLAUDE.md §요금제) — 한 건이라도 0원이면
-  //    없앤 무료 요금제가 어딘가에서 되살아난 것이다.
-  it("모든 기업이 인원×단가로 결제된다 — 0원도 결제일 없는 건도 없다", () => {
+  /*
+    ⚠️ **좌석 과금이 아니다**(2026-08-04 팀 확정, FE 감사 #243). 인원은 금액과 무관하고
+       모든 기업이 같은 기본료를 낸다 — `BillingConfig`(정본, `billing/server.ts`)에서
+       파생한 값과 같아야 한다. 회사마다 인원이 달라도 금액은 전부 같다.
+  */
+  it("모든 기업이 인원과 무관하게 같은 기본료로 결제된다 — 0원도 결제일 없는 건도 없다", () => {
+    const expectedAmount = calculatePrice(MOCK_CONFIG).total;
+
     for (const record of subscriptions) {
-      expect(record.amount).toBe(record.memberCount * 9_900);
+      expect(record.amount).toBe(expectedAmount);
       expect(record.billingDate).not.toBeNull();
     }
+
+    // 인원이 서로 다른데도 금액이 같다는 사실 자체를 확인한다 — 좌석 과금이 아니라는 증거.
+    const memberCounts = new Set(subscriptions.map((record) => record.memberCount));
+    expect(memberCounts.size).toBeGreaterThan(1);
   });
 });

--- a/src/features/system/mock/billing.ts
+++ b/src/features/system/mock/billing.ts
@@ -1,14 +1,9 @@
 import { COMPANY_STATUS, PAYMENT_STATUS } from "@/constants/domain";
+import { calculatePrice } from "@/features/billing/pricing";
+import { MOCK_CONFIG } from "@/features/billing/server";
 
 import type { BillingOverview, ManagedCompany, SubscriptionRecord } from "../types";
 import { listMockCompanies } from "./companies";
-
-/**
- * 1인당 월 단가 — `features/billing/plans.ts`의 시안값과 맞춘다(₩9,900).
- * ⚠️ **목이다.** 금액의 정본은 BE가 주는 `BillingConfig`이고, 좌석 과금 여부도 확정 전이다
- *    (CLAUDE.md §요금제). 확정되면 여기가 아니라 그 값을 읽는다.
- */
-const UNIT_PRICE = 9_900;
 
 /** 화면에 보여줄 구독 목록 수 — 화면 명세: 미납 우선, 모자라면 최신 가입순으로 채운다. */
 const SUBSCRIPTION_DISPLAY_COUNT = 5;
@@ -48,6 +43,14 @@ function countMockUnpaidCompanies(): number {
  * ⚠️ 화면 명세: **항상 5건만** — 미납 기업을 먼저 채우고, 모자라면 `joinedAt` 최신순으로 채운다.
  */
 function buildMockSubscriptions(): SubscriptionRecord[] {
+  /*
+    ⚠️ **좌석 과금이 아니다**(2026-08-04 팀 확정, `billing/pricing.ts`와 같은 규칙). 인원은
+       금액과 무관하고, 모든 회사가 같은 기본료를 낸다 — 이 목엔 회사별 AI 토큰·스토리지
+       사용량이 없어(그 화면 것과 다른, 운영자용 요약 목이라) 초과분은 계산하지 않는다.
+       실제로도 초과분은 회사별로 다른데, 이건 그 사실을 지어내지 않고 기본료까지만 보여준다.
+  */
+  const baseAmount = calculatePrice(MOCK_CONFIG).total;
+
   const toRecord = (company: ManagedCompany): SubscriptionRecord => ({
     companyId: company.id,
     companyName: company.name,
@@ -57,7 +60,7 @@ function buildMockSubscriptions(): SubscriptionRecord[] {
          (CLAUDE.md §요금제). 예전엔 `plan === TEAM`이 아니면 0원·결제일 없음으로 쳤는데,
          그건 없는 무료 요금제를 전제한 계산이었다.
     */
-    amount: company.memberCount * UNIT_PRICE,
+    amount: baseAmount,
     billingDate: "2025-07-01",
     paymentStatus:
       company.status === COMPANY_STATUS.SUSPENDED


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독

---

## 🙋 관련 역할

- [x] OWNER (SYSTEM 운영자 화면이지만 base role 표기상 이 항목이 가장 가까움)

---

## 📝 작업 내용

좌석 과금은 2026-08-04에 걷어냈는데(`billing/pricing.ts` — "인원은 과금 단위가 아니다"),
SYSTEM 운영자 대시보드의 구독 목만 옛 방식(`memberCount × 9,900원`)으로 금액을 계산하고
있었다.

- `billing/server.ts`의 `MOCK_CONFIG`(`BillingConfig`, 요금 정본)를 export
- `system/mock/billing.ts`가 자체 `UNIT_PRICE` 대신 `calculatePrice(MOCK_CONFIG).total`을
  써서 모든 기업이 인원과 무관하게 같은 기본료로 결제되게 함
- 기존 테스트가 `record.amount === record.memberCount * 9_900`을 정답으로 고정하고
  있었던 것도 함께 정정(인원이 달라도 금액이 같다는 사실을 검증하도록)

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`fix/billing-drop-seat-pricing#243`, base `develop`)
- [x] 커밋 컨벤션 준수
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음

**Z 필수**

- [ ] 🔐 권한 2축 검사 — 해당 없음
- [ ] 🧬 zod — 해당 없음
- [x] 🕵️ 정직성 — 회사마다 다른 인원인데 같은 금액을 보여주는 게 어색해 보일 수 있지만,
      그게 실제 정책(좌석 과금 없음)이다 — 잘못된 게 아니라 화면이 그동안 거짓말을 했었다
- [ ] 🎨 디자인 토큰 — 해당 없음(계산 로직만 변경)

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [ ] ♿ a11y — 해당 없음
- [x] ♻️ 재사용 확인 — 새 계산 로직을 만들지 않고 기존 `calculatePrice`·`BillingConfig` 재사용
- [ ] 🧪 loading/error/empty 3상태 — 해당 없음
- [ ] 브라우저 전용 API 관련 — 해당 없음

---

## 🔗 연관 이슈

Closes #243

---

## 💬 리뷰 포인트

- 회사별 AI 토큰·스토리지 초과분은 이 목 데이터(`ManagedCompany`)에 사용량 필드가 없어
  반영하지 못했습니다 — 기본료까지만 보여줍니다. 실제로는 회사마다 초과분이 다를 텐데,
  없는 사용량 데이터를 지어내는 대신 정직하게 기본료만 보여주는 쪽을 택했습니다.