### PR TITLE
[FIX] 보드 DnD 키보드 대체 경로 추가 #609

### DIFF
--- a/src/features/board/components/board-card.tsx
+++ b/src/features/board/components/board-card.tsx
@@ -1,23 +1,31 @@
 "use client";
 
 import { useDraggable } from "@dnd-kit/core";
+import { ArrowRight } from "lucide-react";
+import type { ReactNode } from "react";
 
 import { ProjectTag } from "@/components/common/project-tag";
 import { StatusDot } from "@/components/common/status-dot";
+import { Button } from "@/components/ui/button";
 import { ACTION_DELAYED_LABEL } from "@/constants/action";
 import { formatMonthDayWeekday } from "@/lib/date";
+import { directionParticle } from "@/lib/korean";
 import { pickPaletteColor } from "@/lib/palette";
 import { cn } from "@/lib/utils";
 
-import type { BoardCard as BoardCardModel } from "../types";
+import { BOARD_COLUMN_LABEL, type BoardCard as BoardCardModel, type BoardColumnId } from "../types";
 
 interface BoardCardProps {
   card: BoardCardModel;
   isDelayed: boolean;
 }
 
+interface BoardCardBodyProps extends BoardCardProps {
+  actions?: ReactNode;
+}
+
 /** 카드 내용 — 실제 카드와 드래그 중 떠다니는 사본(`BoardCardOverlay`)이 같이 쓴다. */
-function BoardCardBody({ card, isDelayed }: BoardCardProps) {
+function BoardCardBody({ card, isDelayed, actions }: BoardCardBodyProps) {
   const due = formatMonthDayWeekday(card.dueDate);
   return (
     <>
@@ -71,6 +79,8 @@ function BoardCardBody({ card, isDelayed }: BoardCardProps) {
             </span>
           )}
         </div>
+
+        {actions}
       </div>
     </>
   );
@@ -141,6 +151,12 @@ function ColorEdge({ tag }: { tag: string }) {
   );
 }
 
+interface BoardCardMoveProps {
+  /** 지금 이 카드가 옮겨 갈 수 있는 유일한 칸(§canMoveCard) — 없으면 버튼을 안 그린다. */
+  moveTarget: BoardColumnId | null;
+  onMove: () => void;
+}
+
 /**
  * 보드 카드 한 장 — 드래그 핸들은 카드 전체(클릭해서 상세로 이동하는 화면이 아니라 옮기는 화면).
  * ⚠️ **드래그 중엔 내용을 비운 빈 자리만 남긴다** — 실제로 손에 들려 움직이는 모습은
@@ -148,10 +164,21 @@ function ColorEdge({ tag }: { tag: string }) {
  *    두고 `transform`까지 얹었더니, 사본과 원본이 같이 움직여 겹쳐 보이는 "반사"처럼
  *    보였다(2026-08-09 디자인 리뷰) — 원본은 **제자리에 고정된 빈 칸**으로만 남기고
  *    (transform 제거, 내용 숨김), 움직이는 건 사본 하나뿐이어야 한다.
+ * ⚠️ **`tabIndex: -1`로 dnd-kit의 기본 포커스를 끈다**(#609). `useDraggable`은 등록된
+ *    센서와 무관하게 이 div에 `role="button" tabIndex=0`을 항상 붙이는데, 이 보드엔
+ *    `PointerSensor`만 있어 Tab으로 여기 와서 Enter를 눌러도 아무 일도 안 났다 — 누르면
+ *    반응해야 하는데 안 하는 가짜 버튼이었다. 진짜 키보드 경로는 아래 [옮기기] 버튼이다
+ *    (CLAUDE.md §a11y "DnD 보드는 키보드 대체 경로 필수").
  */
-export function BoardCard({ card, isDelayed }: BoardCardProps) {
+export function BoardCard({
+  card,
+  isDelayed,
+  moveTarget,
+  onMove,
+}: BoardCardProps & BoardCardMoveProps) {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: card.id,
+    attributes: { tabIndex: -1 },
   });
 
   return (
@@ -173,7 +200,32 @@ export function BoardCard({ card, isDelayed }: BoardCardProps) {
         isDragging && "opacity-40 [&>*]:invisible",
       )}
     >
-      <BoardCardBody card={card} isDelayed={isDelayed} />
+      <BoardCardBody
+        card={card}
+        isDelayed={isDelayed}
+        actions={
+          moveTarget && (
+            <Button
+              variant="ghost"
+              size="xs"
+              className="text-muted-foreground hover:text-foreground self-end"
+              /*
+                ⚠️ 드래그 핸들(이 카드 전체)의 pointerdown이 먼저 안 채가게 막는다 — 안 그러면
+                   버튼을 눌러도 dnd-kit이 드래그 시작으로 먼저 잡아챈다.
+              */
+              onPointerDown={(event) => event.stopPropagation()}
+              onClick={(event) => {
+                event.stopPropagation();
+                onMove();
+              }}
+            >
+              {BOARD_COLUMN_LABEL[moveTarget]}
+              {directionParticle(BOARD_COLUMN_LABEL[moveTarget])} 옮기기
+              <ArrowRight />
+            </Button>
+          )
+        }
+      />
     </div>
   );
 }

--- a/src/features/board/components/board-column.tsx
+++ b/src/features/board/components/board-column.tsx
@@ -20,6 +20,9 @@ interface BoardColumnProps {
   isDelayed: (card: BoardCardModel) => boolean;
   /** 지금 드래그 중인 카드가 여기로 못 오면(§canMoveCard) 놓는 순간 시각적으로도 알린다. */
   isInvalidTarget: boolean;
+  /** 카드별 키보드 대체 경로(§canMoveCard) — 갈 수 있는 칸이 없으면 null(#609). */
+  moveTargetOf: (card: BoardCardModel) => BoardColumnId | null;
+  onMoveCard: (card: BoardCardModel, to: BoardColumnId) => void;
 }
 
 /**
@@ -55,7 +58,15 @@ const COLUMN_TONE: Record<
   },
 };
 
-export function BoardColumn({ id, label, cards, isDelayed, isInvalidTarget }: BoardColumnProps) {
+export function BoardColumn({
+  id,
+  label,
+  cards,
+  isDelayed,
+  isInvalidTarget,
+  moveTargetOf,
+  onMoveCard,
+}: BoardColumnProps) {
   const { setNodeRef, isOver } = useDroppable({ id });
   const tone = COLUMN_TONE[id];
   const isBlocked = isOver && isInvalidTarget;
@@ -150,7 +161,18 @@ export function BoardColumn({ id, label, cards, isDelayed, isInvalidTarget }: Bo
             {isBlocked ? BOARD_BLOCKED_HINT : BOARD_EMPTY_HINT}
           </p>
         ) : (
-          cards.map((card) => <BoardCard key={card.id} card={card} isDelayed={isDelayed(card)} />)
+          cards.map((card) => {
+            const moveTarget = moveTargetOf(card);
+            return (
+              <BoardCard
+                key={card.id}
+                card={card}
+                isDelayed={isDelayed(card)}
+                moveTarget={moveTarget}
+                onMove={() => moveTarget && onMoveCard(card, moveTarget)}
+              />
+            );
+          })
         )}
       </div>
     </div>

--- a/src/features/board/components/board-view.test.tsx
+++ b/src/features/board/components/board-view.test.tsx
@@ -15,7 +15,8 @@ jest.mock("./board-leave-guard", () => ({
   BoardLeaveGuard: () => null,
 }));
 
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import type { BoardCard } from "../types";
 import { BoardView } from "./board-view";
@@ -63,5 +64,65 @@ describe("BoardView — 페이지 레벨 empty state", () => {
     expect(screen.getByText("할 일")).toBeInTheDocument();
     expect(screen.getByText("진행중")).toBeInTheDocument();
     expect(screen.getByText("완료")).toBeInTheDocument();
+  });
+});
+
+/*
+  ⚠️ 회귀 방지(#609) — DnD 보드가 `PointerSensor`만 걸려 있어 키보드·스크린리더로는 카드를
+     옮길 방법이 없었다(CLAUDE.md §a11y "DnD 보드는 키보드 대체 경로 필수" 위반). 카드마다
+     [옮기기] 버튼을 대체 경로로 붙였다 — 드래그와 같은 `canMoveCard` 규칙을 타므로, 버튼도
+     드래그와 똑같이 저장 전 미리보기(override)로만 반영되고 [저장하기]를 눌러야 확정된다.
+*/
+/** 카드는 옮겨지면 다른 칸(다른 부모)으로 리마운트된다 — 매번 다시 찾아야 한다. */
+function findCard(title: string): HTMLElement {
+  return screen.getByText(title).closest('[class*="rounded-[20px]"]') as HTMLElement;
+}
+
+describe("BoardCard — 키보드 대체 경로 [옮기기] 버튼(#609)", () => {
+  it("할 일 카드는 [진행중으로 옮기기] 버튼만 있고, 누르면 진행중으로 옮겨져 저장 대기가 잡힌다", async () => {
+    const user = userEvent.setup();
+    const todoCard = card({ title: "예정 작업", startDate: "2026-08-20" });
+    render(<BoardView boardType="my-action" cards={[todoCard]} todayIso={TODAY} />);
+
+    expect(
+      within(findCard("예정 작업")).getByRole("button", { name: "진행중으로 옮기기" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "저장하기" })).toBeDisabled();
+
+    await user.click(
+      within(findCard("예정 작업")).getByRole("button", { name: "진행중으로 옮기기" }),
+    );
+
+    expect(screen.getByRole("button", { name: "저장하기 (1)" })).toBeInTheDocument();
+    expect(
+      within(findCard("예정 작업")).getByRole("button", { name: "할 일로 옮기기" }),
+    ).toBeInTheDocument();
+  });
+
+  it("버튼으로 옮긴 뒤 되돌리기 버튼을 누르면 override가 지워지고 저장 대기가 풀린다", async () => {
+    const user = userEvent.setup();
+    const todoCard = card({ title: "예정 작업", startDate: "2026-08-20" });
+    render(<BoardView boardType="my-action" cards={[todoCard]} todayIso={TODAY} />);
+
+    await user.click(
+      within(findCard("예정 작업")).getByRole("button", { name: "진행중으로 옮기기" }),
+    );
+    await user.click(within(findCard("예정 작업")).getByRole("button", { name: "할 일로 옮기기" }));
+
+    expect(screen.getByRole("button", { name: "저장하기" })).toBeDisabled();
+    expect(
+      within(findCard("예정 작업")).getByRole("button", { name: "진행중으로 옮기기" }),
+    ).toBeInTheDocument();
+  });
+
+  it("완료 카드는 [진행중으로 옮기기] 버튼만 있다 — 할 일로는 못 간다", () => {
+    const doneCard = card({ title: "끝난 작업", isDone: true });
+    render(<BoardView boardType="my-action" cards={[doneCard]} todayIso={TODAY} />);
+
+    const cardEl = findCard("끝난 작업");
+    expect(within(cardEl).getByRole("button", { name: "진행중으로 옮기기" })).toBeInTheDocument();
+    expect(
+      within(cardEl).queryByRole("button", { name: "할 일로 옮기기" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/features/board/components/board-view.tsx
+++ b/src/features/board/components/board-view.tsx
@@ -119,14 +119,11 @@ export function BoardView({ boardType, cards, todayIso }: BoardViewProps) {
     setActiveInvalidTarget(canMoveCard(originalColumnOf(card), targetColumn) ? null : targetColumn);
   }
 
-  function handleDragEnd(event: DragEndEvent) {
-    setActiveInvalidTarget(null);
-    setActiveId(null);
-    setActiveWidth(null);
-    if (!event.over) return;
-    const card = cards.find((c) => c.id === event.active.id);
-    if (!card) return;
-    const to = event.over.id as BoardColumnId;
+  /**
+   * 카드를 `to` 칸으로 옮긴다 — 드래그 드롭과 키보드 대체 경로(§BoardCard [옮기기] 버튼,
+   * #609)가 **같은 함수**를 쓴다. 따로 적어 두면 한쪽만 규칙이 바뀌었을 때 어긋난다.
+   */
+  function moveCard(card: BoardCard, to: BoardColumnId) {
     if (columnOf(card) === to) return; // 화면에 이미 보이는 칸으로 또 놓은 것 — 아무것도 안 한다.
 
     const originalColumn = originalColumnOf(card);
@@ -144,6 +141,30 @@ export function BoardView({ boardType, cards, todayIso }: BoardViewProps) {
       return;
     }
     setOverrides((prev) => ({ ...prev, [card.id]: to }));
+  }
+
+  /**
+   * 카드가 지금 옮겨 갈 수 있는 **유일한** 칸(§canMoveCard) — 없으면 null.
+   * `canMoveCard`가 각 칸에서 자기 자신 말고 갈 수 있는 칸을 하나만 허용하므로(할 일→진행중·
+   * 진행중→완료·완료→진행중), 원래 칸에 있으면 그 하나뿐인 목적지를, 이미 override로 옮겨져
+   * 있으면 원래 칸으로 되돌리는 쪽을 돌려준다 — 규칙은 `canMoveCard` 하나에서만 가져온다.
+   */
+  function moveTargetFor(card: BoardCard): BoardColumnId | null {
+    const original = originalColumnOf(card);
+    if (columnOf(card) !== original) return original;
+    return (
+      BOARD_COLUMNS.find((column) => column !== original && canMoveCard(original, column)) ?? null
+    );
+  }
+
+  function handleDragEnd(event: DragEndEvent) {
+    setActiveInvalidTarget(null);
+    setActiveId(null);
+    setActiveWidth(null);
+    if (!event.over) return;
+    const card = cards.find((c) => c.id === event.active.id);
+    if (!card) return;
+    moveCard(card, event.over.id as BoardColumnId);
   }
 
   function handleConfirm() {
@@ -185,11 +206,9 @@ export function BoardView({ boardType, cards, todayIso }: BoardViewProps) {
   */
   if (cards.length === 0) {
     /*
-      ⚠️ description은 **조작 중립**이다("드래그" 같은 특정 입력 방식 안내 금지) — CLAUDE.md
-         §a11y "DnD 보드는 키보드 대체 경로 필수". 지금 보드는 `PointerSensor`만 걸려 있고
-         `KeyboardSensor`·카드 이동 버튼 같은 대체 경로가 없어(오래된 규약 위반, 별건 이슈로
-         분리) 스크린리더·키보드 사용자에게 "드래그해서 옮길 수 있다"고 미리 알리면 카드가
-         도착한 뒤 그 지시를 따르지 못한다. 대체 경로가 붙기 전에는 조작 안내를 아예 안 한다.
+      ⚠️ description은 **조작 중립**이다("드래그" 같은 특정 입력 방식 안내 금지) — 카드가
+         0건이라 옮길 대상 자체가 없다. 조작 방법(드래그든 [옮기기] 버튼이든)을 적어도
+         뜻이 없는 자리라 아예 안 적는다.
     */
     return (
       <div className="flex min-h-0 flex-1 flex-col">
@@ -251,6 +270,8 @@ export function BoardView({ boardType, cards, todayIso }: BoardViewProps) {
               */
               isDelayed={isDelayedInView}
               isInvalidTarget={activeInvalidTarget === columnId}
+              moveTargetOf={moveTargetFor}
+              onMoveCard={moveCard}
             />
           ))}
         </div>


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

- 보드 칸반(`BoardView`)이 `PointerSensor`만 걸려 있어 키보드·스크린리더로는 카드를 옮길 방법이 없었다(CLAUDE.md §a11y "DnD 보드는 키보드 대체 경로 필수" 위반).
- 카드마다 `canMoveCard` 규칙을 그대로 타는 **[옮기기] 버튼**을 대체 경로로 붙였다 — 드래그와 같은 `moveCard` 함수를 공유해 규칙이 두 벌로 갈라지지 않는다.
- dnd-kit이 등록된 센서와 무관하게 카드 전체 div에 붙이던 `role="button" tabIndex=0`(눌러도 반응 없는 가짜 버튼)은 `tabIndex: -1`로 껐다 — 진짜 키보드 경로는 새 버튼이다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 권한 2축 검사 — 해당 없음(권한과 무관한 순수 UI 상호작용 대체 경로)
- [x] 🧬 zod — 해당 없음(서버 스키마 변경 없음)
- [x] 🕵️ 정직성 — 해당 없음(목·미구현·폴백 아님)
- [x] 🎨 디자인 토큰 사용 — 기존 `Button`(`ghost`/`xs`) 재사용, 새 색 없음

**품질**

- [x] ⚡ 최적화 — 해당 없음(신규 무거운 리소스 없음)
- [x] ♿ a11y — **이 PR의 본론**: DnD 키보드 대체 경로 추가
- [x] ♻️ 재사용 확인 — `components/ui/button` 그대로 사용
- [x] 🧪 `loading`/`error`/`empty` 3상태 — 해당 없음(기존 보드 상태 그대로)
- [x] 브라우저 전용 API — 해당 없음

---

## 🔗 연관 이슈

Closes #609

---

## 💬 리뷰 포인트

- `moveCard`(드래그·버튼 공용) / `moveTargetFor`(카드별 유일한 목적지 칸 계산)가 `canMoveCard` 하나만 근거로 삼도록 짰다 — 규칙이 바뀌면 여기 안 고쳐도 따라간다.
- `BoardCard`에서 버튼의 `onPointerDown`에 `stopPropagation`을 건 이유(드래그 핸들이 먼저 pointerdown을 채가는 것 방지)를 확인해 주세요.

---

## 📝 추가 메모

- `KeyboardSensor`(dnd-kit 내장 방향키 드래그)는 도입하지 않았다 — 이 보드는 `@dnd-kit/sortable` 목록이 아니라 3칸짜리 컨테이너 이동이라 픽셀 델타 기반 방향키 이동이 "다음 칸으로 점프"라는 의도를 깔끔히 표현하지 못한다. 이슈 본문이 제안한 대로 **명시적 [옮기기] 버튼**이 더 예측 가능하고 스크린리더 친화적이라 이 방식으로 갔다.