### PR TITLE
[FIX] 검토 화면 시작일 과거 방어 + 회의 상세 하달 액션 조회 연동 #637

### DIFF
--- a/src/features/handover/components/offboarding-form.tsx
+++ b/src/features/handover/components/offboarding-form.tsx
@@ -10,6 +10,7 @@ import { Label } from "@/components/ui/label";
 import { HANDOVER_TYPE } from "@/constants/domain";
 
 import { submitHandoverAction } from "../actions";
+import { handoverDateMin } from "../lib";
 import type { HandoverContext } from "../types";
 import { HandoverActionListCard } from "./handover-action-list-card";
 
@@ -35,7 +36,13 @@ export function OffboardingForm({ context }: OffboardingFormProps) {
   const [resultOpen, setResultOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
 
-  const canSubmit = description.trim().length > 0 && Boolean(lastWorkingDay) && actions.length > 0;
+  /*
+    ⚠️ **넘길 액션이 없어도 신청은 열려 있다**(#637). WORKFLOW §7 · 아래 목록 카드
+       (`HandoverActionListCard`)의 "넘길 액션이 없어도 인수인계서는 신청할 수 있습니다"
+       문구와 정책이 같다 — 담당하고 있던 액션이 실제로 하나도 없는 팀장 오프보딩도
+       인수인계서는 남긴다(설명·마지막 근무일이 인수인계 기록의 본체).
+  */
+  const canSubmit = description.trim().length > 0 && Boolean(lastWorkingDay);
 
   function handleConfirm() {
     setConfirmError(null);
@@ -75,6 +82,7 @@ export function OffboardingForm({ context }: OffboardingFormProps) {
           <DatePickerField
             id="offboarding-last-working-day"
             value={lastWorkingDay}
+            min={handoverDateMin()}
             onChange={setLastWorkingDay}
             /* ⚠️ 상한이지 고정폭이 아니다 — 좁은 화면에서 224를 못 박으면 카드 밖으로 나간다 */
             className="w-full max-w-56"

--- a/src/features/handover/components/vacation-form.tsx
+++ b/src/features/handover/components/vacation-form.tsx
@@ -18,7 +18,7 @@ import {
 import { AUTHORITY, HANDOVER_TYPE } from "@/constants/domain";
 
 import { submitHandoverAction } from "../actions";
-import { sortActionsForVacation } from "../lib";
+import { handoverDateMin, sortActionsForVacation } from "../lib";
 import type { HandoverContext } from "../types";
 import { HandoverActionListCard } from "./handover-action-list-card";
 
@@ -121,6 +121,7 @@ export function VacationForm({ context }: VacationFormProps) {
                 <DatePickerField
                   id="vacation-start"
                   value={startDate}
+                  min={handoverDateMin()}
                   max={endDate || undefined}
                   onChange={(next) => handleDateChange({ startDate: next })}
                   className="w-full"
@@ -133,7 +134,7 @@ export function VacationForm({ context }: VacationFormProps) {
                 <DatePickerField
                   id="vacation-end"
                   value={endDate}
-                  min={startDate || undefined}
+                  min={startDate || handoverDateMin()}
                   onChange={(next) => handleDateChange({ endDate: next })}
                   className="w-full"
                 />

--- a/src/features/handover/lib.ts
+++ b/src/features/handover/lib.ts
@@ -36,6 +36,17 @@ export type SubmitHandoverPayload =
  *    그런 필드가 없다. 생성 뒤 건별 `PATCH .../items/{actionId}/reassign`으로 따로 보내야
  *    한다(§4 재배정 오케스트레이션, 아직 미구현 — 별도 작업).
  */
+/**
+ * 신청 화면 달력의 최소 선택값 — 내일 이후만 허용한다(#637).
+ * 휴직 시작 · 오프보딩 마지막 근무일 두 곳에서 쓴다. 종료일은 별도로 시작일 이후만
+ * 허용해 상한이 자연히 이어지게 한다(WORKFLOW §7).
+ */
+export function handoverDateMin(): string {
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  return tomorrow.toISOString().slice(0, 10);
+}
+
 export function toHandoverCreateRequestBody(payload: SubmitHandoverPayload) {
   if (payload.type === HANDOVER_TYPE.VACATION) {
     return {

--- a/src/features/meeting/mapper.ts
+++ b/src/features/meeting/mapper.ts
@@ -19,6 +19,7 @@ import type {
   MeetingContentPending,
   MeetingDetail,
   MeetingListItem,
+  MeetingOutput,
   ScriptChunk,
 } from "./view-types";
 
@@ -799,6 +800,41 @@ export function toMeetingDetailView(
 function outputKindLabelOf(teamId: number | null | undefined): string {
   if (teamId === undefined) return "액션";
   return teamId === null ? "팀 액션" : "개인 액션";
+}
+
+/**
+ * 회의별 액션 조회(FR-AC-09, `GET /api/meetings/{id}/actions`) 한 줄 → 산출물 카드 한 줄.
+ *
+ * ⚠️ **BE `MeetingActionItem` 경로는 회의 상세 화면 내부 조회라 `projectTag`·`projectName`·
+ *    `sourceMeetingTitle`을 일부러 비워 준다**(BE `ActionSummaryResponse` 주석). 우리 화면도
+ *    회의 안이라 그 값이 없어도 산출물 카드 그리기에 지장이 없다.
+ * ⚠️ TEAM 액션은 `assigneeName`이 null · PERSONAL 액션은 `teamName`이 null로 온다 —
+ *    화면 계약(`MeetingOutput.assignee`)은 non-null 문자열이라 정본 문구로 접는다
+ *    (§정직성 · 목 경로 `outputsOf`의 "담당자 미정"과 같은 자리).
+ * ⚠️ **`href`는 BE `actionType`으로 가른다.** TEAM은 팀 액션 상세(프로젝트 하위), PERSONAL은
+ *    개인 액션 상세로 가는 게 목 경로와 같다.
+ */
+type BeMeetingActionSummary = {
+  id: number;
+  actionType: "TEAM" | "PERSONAL";
+  title: string;
+  status: MeetingOutput["status"];
+  dueDate: string;
+  assigneeName: string | null;
+  teamName: string | null;
+  projectId: number;
+};
+
+export function toMeetingOutput(be: BeMeetingActionSummary): MeetingOutput {
+  const isTeam = be.actionType === "TEAM";
+  return {
+    id: be.id,
+    name: be.title,
+    assignee: isTeam ? (be.teamName ?? "부서 미정") : (be.assigneeName ?? "담당자 미정"),
+    status: be.status,
+    dueDate: be.dueDate,
+    href: isTeam ? `/app/projects/${be.projectId}/team/${be.id}` : `/app/actions/${be.id}`,
+  };
 }
 
 /** BE 안건 → 화면 계약 — 이름만 옮긴다. `null`(안건 없음·미배포)은 그대로 `null`이다. */

--- a/src/features/meeting/review/actions.ts
+++ b/src/features/meeting/review/actions.ts
@@ -153,15 +153,25 @@ export async function confirmActionDistributionAction(
     }
 
     /* ② 판정 — 고친 칸만 MODIFY, 그대로면 CONFIRM(값 실으면 422라 changes로 가른다) */
+    /*
+      ⚠️ **시작일이 비거나 오늘 이하면 내일로 클램프한다**(2026-08-18 FE 방어, #637).
+         BE `Action.applyHumanReview`가 `plannedStartDate`를 "익일부터 프로젝트 마감일 사이"로
+         강제해서(Action.java:285-293) 오늘 이하 값이 실려 나가면 확정이 400으로 튕긴다.
+         AI가 회의 당시 기준으로 뽑아 둔 값이 그대로 남아 있으면 오늘 기준으로는 과거 값이라
+         그 케이스가 실제로 잡혔다(#637 발견). 프로젝트 마감일은 여기서 모르므로 상한은 못
+         씌운다 — 상한 초과분은 BE 예외 문구가 사용자에게 보인다.
+    */
+    const plannedStartFallback = tomorrowIsoDate();
     for (const draft of payload.reviewed) {
       const changes = draft.changes ?? {};
+      const plannedStartDate = clampToTomorrowOrLater(draft.plannedStartDate, plannedStartFallback);
       const value = {
         ...(changes.assigneeId !== undefined ? { assigneeMemberId: changes.assigneeId } : {}),
         ...(changes.teamId !== undefined ? { teamId: changes.teamId } : {}),
         ...(changes.dueDate !== undefined ? { dueDate: changes.dueDate } : {}),
         ...(changes.title !== undefined ? { title: changes.title } : {}),
         ...(changes.description !== undefined ? { detail: changes.description } : {}),
-        ...(draft.plannedStartDate ? { plannedStartDate: draft.plannedStartDate } : {}),
+        plannedStartDate,
       };
       const isModify = Object.keys(changes).length > 0;
 
@@ -170,12 +180,7 @@ export async function confirmActionDistributionAction(
         accessToken,
         json: isModify
           ? { decision: "MODIFY", value }
-          : {
-              decision: "CONFIRM",
-              ...(draft.plannedStartDate
-                ? { value: { plannedStartDate: draft.plannedStartDate } }
-                : {}),
-            },
+          : { decision: "CONFIRM", value: { plannedStartDate } },
       });
     }
 
@@ -201,13 +206,13 @@ export async function confirmActionDistributionAction(
       /* ⚠️ **만들자마자 적는다.** 뒤 호출이 실패해도 "이건 이미 만들어졌다"가 남아야 한다 */
       createdManuals.push({ localId: manual.localId, actionId: added.actionId });
 
-      if (manual.startDate) {
-        await serverApi(ep.meetingReviewDecision(id, added.actionId), {
-          method: "PATCH",
-          accessToken,
-          json: { decision: "MODIFY", value: { plannedStartDate: manual.startDate } },
-        });
-      }
+      /* 시작일도 ② 판정 쪽 클램프와 같은 규칙 — 오늘 이하면 내일로 채운다(#637). */
+      const plannedStartDate = clampToTomorrowOrLater(manual.startDate, plannedStartFallback);
+      await serverApi(ep.meetingReviewDecision(id, added.actionId), {
+        method: "PATCH",
+        accessToken,
+        json: { decision: "MODIFY", value: { plannedStartDate } },
+      });
     }
 
     /* ④ 확정 — 여기서부터 액션이 각자의 보드로 나간다. Host 아니면 BE가 403으로 막는다. */
@@ -260,6 +265,22 @@ const CONFIRM_FAILURE_LABEL: Record<string, string> = {
   STILL_PENDING: "미검토 액션",
   UNRESOLVED_GAP: "미확인 발화 구간",
 };
+
+/** YYYY-MM-DD의 "내일" — 조회 폴백(`action/mapper.ts`)과 방향이 같다(§할일 칸으로 떨어지게). */
+function tomorrowIsoDate(): string {
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  return tomorrow.toISOString().slice(0, 10);
+}
+
+/**
+ * 시작일이 비어 있거나 오늘 이하면 내일(`fallback`)로 밀어 준다.
+ * ISO YYYY-MM-DD는 문자열 비교가 곧 시각 비교라 `Date` 파싱 없이 그대로 가른다.
+ */
+function clampToTomorrowOrLater(value: string | undefined, fallback: string): string {
+  if (!value) return fallback;
+  return value < fallback ? fallback : value;
+}
 
 function composeConfirmFailureMessage(error: unknown): string {
   if (!(error instanceof ApiError) || !error.details || error.details.length === 0) {

--- a/src/features/meeting/review/components/action-review-row.tsx
+++ b/src/features/meeting/review/components/action-review-row.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/constants/meeting";
 import { cn } from "@/lib/utils";
 
-import { formatAssigneeLabel } from "../lib";
+import { formatAssigneeLabel, reviewStartDateMin } from "../lib";
 import type { AiActionDraft, AssigneeOption, TeamOption } from "../types";
 import { InlineEditableField } from "./inline-editable-field";
 
@@ -260,6 +260,7 @@ export function ActionReviewRow({
             <DatePickerField
               aria-label="시작일"
               value={draft.startDate}
+              min={reviewStartDateMin()}
               max={draft.dueDate}
               onChange={onStartDateChange}
               className="w-[140px]"

--- a/src/features/meeting/review/components/manual-draft-form.tsx
+++ b/src/features/meeting/review/components/manual-draft-form.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/components/ui/select";
 import { REVIEW_ASSIGNMENT_TARGET_LABEL } from "@/constants/meeting";
 
-import { formatAssigneeLabel } from "../lib";
+import { formatAssigneeLabel, reviewStartDateMin } from "../lib";
 import type { AssigneeOption, ManualDraftInput, TeamOption } from "../types";
 
 interface ManualDraftFormProps {
@@ -129,6 +129,7 @@ export function ManualDraftForm({
         <DatePickerField
           aria-label="시작일"
           value={startDate}
+          min={reviewStartDateMin()}
           max={dueDate || undefined}
           onChange={setStartDate}
           className="w-full sm:w-[180px]"

--- a/src/features/meeting/review/lib.ts
+++ b/src/features/meeting/review/lib.ts
@@ -4,3 +4,15 @@ import type { AssigneeOption } from "./types";
 export function formatAssigneeLabel(option: AssigneeOption): string {
   return option.roleLabel ? `${option.name} ${option.roleLabel}` : option.name;
 }
+
+/**
+ * 시작일 달력의 최소 선택값 — 오늘 이후만 허용한다(#637).
+ * ⚠️ BE `Action.applyHumanReview`가 `plannedStartDate`를 "익일부터 프로젝트 마감일 사이"로
+ *    강제한다(Action.java:285-293). 오늘 이하 값을 실어 보내면 확정이 400으로 튕겨서
+ *    사용자에겐 "입력값이 올바르지 않습니다"만 뜬다 — 달력에서 미리 막는다.
+ */
+export function reviewStartDateMin(): string {
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  return tomorrow.toISOString().slice(0, 10);
+}

--- a/src/features/meeting/server.transcripts-real.test.ts
+++ b/src/features/meeting/server.transcripts-real.test.ts
@@ -67,18 +67,23 @@ beforeEach(() => {
 
 describe("getMeetingDetail — 실서버, 발화 기록 조회", () => {
   it("끝난 회의는 발화 기록을 조회해 시각순으로 채운다", async () => {
-    serverApiMock.mockResolvedValueOnce(meetingDetail()).mockResolvedValueOnce({
-      utterances: [utterance({ transcriptId: 1, seq: 0, startOffsetMs: 0, content: "시작합니다" })],
-      nextCursor: null,
-    });
+    serverApiMock
+      .mockResolvedValueOnce(meetingDetail())
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce({
+        utterances: [
+          utterance({ transcriptId: 1, seq: 0, startOffsetMs: 0, content: "시작합니다" }),
+        ],
+        nextCursor: null,
+      });
 
     const result = await getMeetingDetail("100", HOST);
 
     expect(result.kind).toBe("ok");
     if (result.kind !== "ok") return;
     expect(result.detail.script).toEqual([{ at: "10:00", text: "시작합니다" }]);
-    // GET 회의 상세 1회 + GET 발화 1페이지 = 2회
-    expect(serverApiMock).toHaveBeenCalledTimes(2);
+    // GET 회의 상세 1회 + GET 산출물 1회 + GET 발화 1페이지 = 3회
+    expect(serverApiMock).toHaveBeenCalledTimes(3);
   });
 
   /*
@@ -88,6 +93,7 @@ describe("getMeetingDetail — 실서버, 발화 기록 조회", () => {
   it("nextCursor가 있으면 다음 페이지를 이어 받는다", async () => {
     serverApiMock
       .mockResolvedValueOnce(meetingDetail())
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce({
         utterances: [
           utterance({ transcriptId: 1, seq: 0, startOffsetMs: 0, content: "첫 페이지" }),
@@ -109,9 +115,9 @@ describe("getMeetingDetail — 실서버, 발화 기록 조회", () => {
       { at: "10:00", text: "첫 페이지" },
       { at: "10:01", text: "둘째 페이지" },
     ]);
-    expect(serverApiMock).toHaveBeenCalledTimes(3);
+    expect(serverApiMock).toHaveBeenCalledTimes(4);
     // 두 번째 발화 호출은 첫 페이지가 준 커서를 그대로 되돌려줘야 한다
-    expect(serverApiMock.mock.calls[2]![0]).toContain("cursor=page2");
+    expect(serverApiMock.mock.calls[3]![0]).toContain("cursor=page2");
   });
 
   /*
@@ -136,6 +142,7 @@ describe("getMeetingDetail — 실서버, 발화 기록 조회", () => {
   it("페이지 경계에서 transcriptId가 겹치면 중복을 거른다", async () => {
     serverApiMock
       .mockResolvedValueOnce(meetingDetail())
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce({
         utterances: [
           utterance({ transcriptId: 1, seq: 0, startOffsetMs: 0, content: "첫 페이지" }),
@@ -165,7 +172,7 @@ describe("getMeetingDetail — 실서버, 발화 기록 조회", () => {
 
   /* ⚠️ 커서가 끝없이 이어지는 BE 결함이 나도 화면이 영원히 안 끝나면 안 된다 */
   it("커서가 안 끊기면 상한에서 멈춘다", async () => {
-    serverApiMock.mockResolvedValueOnce(meetingDetail());
+    serverApiMock.mockResolvedValueOnce(meetingDetail()).mockResolvedValueOnce([]);
     // 이후 모든 호출은 nextCursor가 있는 페이지를 계속 준다
     serverApiMock.mockResolvedValue({ utterances: [utterance()], nextCursor: "again" });
 
@@ -173,8 +180,8 @@ describe("getMeetingDetail — 실서버, 발화 기록 조회", () => {
 
     expect(result.kind).toBe("ok");
     if (result.kind !== "ok") return;
-    // 회의 상세 1 + 최대 50페이지 = 51회를 넘지 않는다
-    expect(serverApiMock.mock.calls.length).toBeLessThanOrEqual(51);
+    // 회의 상세 1 + GET 산출물 1 + 최대 50페이지 = 52회를 넘지 않는다
+    expect(serverApiMock.mock.calls.length).toBeLessThanOrEqual(52);
     expect(result.detail.script!.length).toBeGreaterThan(0);
   });
 });

--- a/src/features/meeting/server.ts
+++ b/src/features/meeting/server.ts
@@ -27,6 +27,7 @@ import {
   toMeetingCaptureInfo,
   toMeetingDetailView,
   toMeetingListItem,
+  toMeetingOutput,
   toScriptChunks,
 } from "./mapper";
 import { findMockMeeting, listMockMeetings } from "./mock/meetings";
@@ -454,22 +455,68 @@ async function getLiveMeetingDetail(id: string, viewer: Actor): Promise<MeetingD
   });
 
   /*
-    ⚠️ **`pendingReason`이 있으면 발화 기록을 안 물어본다.** 화면이 그 칸을 안 그리는데
+    ⚠️ **`pendingReason`이 있으면 산출물·발화 기록을 안 물어본다.** 화면이 그 칸을 안 그리는데
        (`meeting-detail-view.tsx` — 안내 카드만 뜬다) 조회부터 하면 헛수고다. 회의가 아직
-       안 끝났으면 발화 자체가 없을 수도 있다.
-    ⚠️ **비대면 회의도 안 물어본다**(WORKFLOW.md §3-1-A — 실시간 캡처가 아니라 화자 귀속 근거인
-       자막 청크 자체가 없다, "온라인으로 진행된 회의입니다" 문구로 그 자리를 대신한다).
-       `detail.startAt`도 `null`이라 `toScriptChunks`의 기준 시각을 만들 수 없다.
+       안 끝났으면 하달·발화 자체가 없다.
+    ⚠️ 산출물 조회(#637 연동)는 발화 기록(`startAt` 필요)과 조건이 갈린다 — 발화는 비대면
+       회의(startAt=null)에서 못 부르지만 산출물은 회의 종료·확정이 된 이상 부를 수 있다.
+       그래서 산출물부터 채운 뒤, `startAt`이 있을 때만 발화 기록을 이어 붙인다.
   */
-  if (view.pendingReason !== null || detail.startAt === null) {
+  if (view.pendingReason !== null) {
     return { kind: "ok", detail: view };
+  }
+
+  const outputs = await fetchMeetingOutputs(Number(id), accessToken);
+  const withOutputs = { ...view, outputs };
+
+  if (detail.startAt === null) {
+    return { kind: "ok", detail: withOutputs };
   }
 
   const utterances = await fetchAllTranscripts(Number(id), accessToken);
   return {
     kind: "ok",
-    detail: { ...view, script: toScriptChunks(new Date(detail.startAt), utterances) },
+    detail: {
+      ...withOutputs,
+      script: toScriptChunks(new Date(detail.startAt), utterances),
+    },
   };
+}
+
+/**
+ * 회의별 하달 액션 조회(FR-AC-09, #637 연동).
+ *
+ * ⚠️ **실패해도 화면을 세우지 않는다.** 상단(제목·안건·참석자)은 이미 온전한 상태고,
+ *    산출물 칸만 못 그리면 매퍼가 준 `null`(=미연동과 같은 자리)로 그대로 두면 된다 —
+ *    "다른 칸까지 통째로 에러 화면"은 정보 손실이 크다(§정직성 · script 조회와 같은 결).
+ * ⚠️ **응답이 `null`(BE 결함)이거나 배열이 아니면 미연동과 같은 자리에 두지 않고 빈 배열로
+ *    돌린다** — 여기까지 왔으면 회의 요약이 끝난 상태라 "물어봤는데 실제로 0건"이 나올
+ *    수 있고, 그 자리는 화면이 "하달된 게 없습니다"로 정직하게 답할 자리다.
+ */
+async function fetchMeetingOutputs(
+  meetingId: number,
+  accessToken: string,
+): Promise<MeetingOutput[] | null> {
+  try {
+    const raw = await serverApi<unknown>(ep.meetingActions(meetingId), { accessToken });
+    if (!Array.isArray(raw)) return [];
+    return raw
+      .filter((item): item is Parameters<typeof toMeetingOutput>[0] => {
+        if (typeof item !== "object" || item === null) return false;
+        const summary = item as Record<string, unknown>;
+        return (
+          typeof summary.id === "number" &&
+          (summary.actionType === "TEAM" || summary.actionType === "PERSONAL") &&
+          typeof summary.title === "string" &&
+          typeof summary.status === "string" &&
+          typeof summary.dueDate === "string" &&
+          typeof summary.projectId === "number"
+        );
+      })
+      .map(toMeetingOutput);
+  } catch {
+    return null;
+  }
 }
 
 /**


### PR DESCRIPTION
## 📋 PR 타입

> 해당하는 타입을 선택해 주세요 (복수 선택 가능)

- [ ] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

- 회의 검토 확정 시 `plannedStartDate`가 비어있거나 오늘 이하(과거)면 내일로 클램프
- 검토 화면·인수인계 신청(휴직 시작일/오프보딩 마지막 근무일) 달력에 `min=내일` UI 방어 추가
- 오프보딩 신청 버튼이 담당 액션 0건일 때 비활성화되던 정책 불일치 버그 수정
- 회의 상세 "산출물(outputs)" 실API 연동 — `GET /api/meetings/{id}/actions` 별도 조회로 채움(기존 `outputs: null` 고정 상태였음)
- BE `Action.applyHumanReview`가 `plannedStartDate`를 "익일~프로젝트 마감일" 범위로 강제하는데, AI가 회의 시점 기준으로 뽑은 값이 그대로 실리면 과거 값이 되어 확정이 400(`입력값이 올바르지 않습니다`)으로 튕기던 걸 재현·확인
- `HandoverActionListCard`의 "넘길 액션이 없어도 인수인계서는 신청할 수 있습니다" 정책 문구와 실제 버튼 조건(`actions.length > 0`)이 어긋나 있던 버그
- 회의 상세 화면에 하달된 액션 목록이 항상 "아직 표시할 수 없습니다"로만 보이던 문제 — BE API는 이미 존재하는데 FE 미연동 상태였음

---

## ✅ 작업 체크리스트

**기본**

- [ ] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [ ] 불필요한 `console` · 주석 처리된 코드 제거
- [ ] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**(회의 담당자 등), 그리고 **서버(Server Action/BFF)에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [ ] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시 (조용히 "되는 척" 금지)
- [ ] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그)
- [ ] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [ ] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인)
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음

---

## 🔗 연관 이슈

Closes #637

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- `npx tsc --noEmit` 0 에러
- `npx jest` 1555/1555 통과 (신규 outputs 조회 호출로 mock 순서가 밀려 깨졌던 `server.transcripts-real.test.ts` 4건도 mock 큐 보정하여 재통과 확인)
- 시작일 과거값 확정 시 400 재현 → 클램프 적용 후 정상 확정 확인
- 오프보딩: 담당 액션 0건 상태에서 신청 버튼 활성화 확인

---

## 📝 추가 메모
