### PR TITLE
[FIX] 화면 배율 로그인 이후 스코프 + 보드 DnD 배율 보정 + 온보딩 테마 토글 #648

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import { NavHistoryTracker } from "@/components/common/nav-history";
 import { ThemeProvider } from "@/components/common/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
+import { AppScaleScope } from "@/features/appearance/components/app-scale-scope";
 import { SCALE_BOOT_SCRIPT } from "@/features/appearance/scale";
 
 const geistSans = Geist({
@@ -79,6 +80,11 @@ export default function RootLayout({
             화면에는 아무것도 안 그린다(`components/common/nav-history`).
           */}
           <NavHistoryTracker />
+          {/*
+            배율을 로그인 이후 화면에만 붙였다 뗀다 — 부트 스크립트는 문서 로드 때 한 번뿐이라
+            클라이언트 내비게이션(로그인 → 워크스페이스, 워크스페이스 → 랜딩)은 이게 맡는다.
+          */}
+          <AppScaleScope />
         </ThemeProvider>
       </body>
     </html>

--- a/src/features/appearance/components/app-scale-scope.tsx
+++ b/src/features/appearance/components/app-scale-scope.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
+
+import { DEFAULT_SCALE, isScaledPath, parseScale } from "../scale";
+import { readScale, subscribeScale } from "../scale-store";
+
+/**
+ * 배율을 **로그인 이후 화면에만** 붙였다 떼는 스위치(§scale `SCALED_PATH_PREFIXES`).
+ *
+ * 첫 페인트는 `SCALE_BOOT_SCRIPT`(같은 경로 판정)가 이미 맞춰 놓는다 — 여기는
+ * **클라이언트 내비게이션** 몫이다. 부트 스크립트는 문서 로드 때 한 번만 돌아서,
+ * 로그인 → 워크스페이스처럼 페이지를 새로 안 여는 이동에서는 아무도 배율을
+ * 다시 계산하지 않았다. 그 반대(워크스페이스 → 랜딩)도 마찬가지라, 마이페이지에서
+ * 75%를 고르면 랜딩까지 75%로 굳었다.
+ *
+ * ⚠️ 판정은 `isScaledPath` 한 곳이다 — 여기서 경로 목록을 다시 적지 않는다.
+ * ⚠️ `subscribeScale`을 같이 듣는다 — 다른 탭에서 배율을 바꿔도 이 탭이 따라온다.
+ *    (같은 탭의 변경은 배율 카드가 변수를 직접 만지지만, 구독이 겹쳐도 같은 값이라 무해하다.)
+ * ⚠️ 렌더는 없다(`null`) — 루트 레이아웃에 놓여도 서버 렌더 결과에 영향을 주지 않는다.
+ */
+export function AppScaleScope() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    const root = document.documentElement;
+
+    const apply = () => {
+      const scale = parseScale(readScale());
+      if (isScaledPath(pathname) && scale !== DEFAULT_SCALE) {
+        root.style.setProperty("--app-scale", String(scale / 100));
+      } else {
+        root.style.removeProperty("--app-scale");
+      }
+    };
+
+    apply();
+    return subscribeScale(apply);
+  }, [pathname]);
+
+  return null;
+}

--- a/src/features/appearance/scale.test.ts
+++ b/src/features/appearance/scale.test.ts
@@ -1,9 +1,11 @@
 import {
   DEFAULT_SCALE,
+  isScaledPath,
   nextScaleByKey,
   parseScale,
   recommendScale,
   SCALE_BOOT_SCRIPT,
+  SCALED_PATH_PREFIXES,
   SCREEN_SCALES,
   suggestScale,
 } from "./scale";
@@ -95,6 +97,9 @@ describe("SCALE_BOOT_SCRIPT", () => {
   const scaleVar = () => document.documentElement.style.getPropertyValue("--app-scale");
 
   it("100%는 아무것도 세우지 않는다 — 기본값 `1`로 둔다", () => {
+    // ⚠️ 앱 경로에서 돌아야 이 테스트가 "100% 건너뛰기"를 검증한다 — 공개 경로면
+    //    경로 게이트에 막혀 어떤 값이든 안 세워지므로, 통과해도 아무것도 증명 못 한다
+    window.history.pushState({}, "", "/app/board");
     localStorage.setItem("z:screen-scale", "100");
     document.documentElement.style.removeProperty("--app-scale");
 
@@ -103,7 +108,9 @@ describe("SCALE_BOOT_SCRIPT", () => {
     expect(scaleVar()).toBe("");
   });
 
-  it("고른 배율을 `--app-scale`로 세운다", () => {
+  it("고른 배율을 `--app-scale`로 세운다 — 로그인 이후 경로에서", () => {
+    // ⚠️ 부트 스크립트는 경로를 본다(2026-08-19) — 앱 경로가 아니면 안 건다
+    window.history.pushState({}, "", "/app/board");
     localStorage.setItem("z:screen-scale", "90");
 
     new Function(SCALE_BOOT_SCRIPT)();
@@ -111,11 +118,24 @@ describe("SCALE_BOOT_SCRIPT", () => {
     expect(scaleVar()).toBe("0.9");
   });
 
+  it("공개 화면(랜딩·로그인)에서는 저장된 배율이 있어도 안 건다", () => {
+    localStorage.setItem("z:screen-scale", "75");
+    for (const path of ["/", "/login"]) {
+      window.history.pushState({}, "", path);
+      document.documentElement.style.removeProperty("--app-scale");
+
+      new Function(SCALE_BOOT_SCRIPT)();
+
+      expect(scaleVar()).toBe("");
+    }
+  });
+
   /*
     ⚠️ 목록 **첫 자리**의 값이다. 전에는 `indexOf(s) > 0`으로 걸러서 100%를 건너뛰었는데,
        줄이는 배율이 앞에 붙자 75%가 통째로 무시됐다 — 목록이 바뀌어도 안 깨지는지 본다.
   */
   it("목록 첫 값(75%)도 걸린다", () => {
+    window.history.pushState({}, "", "/app/board");
     localStorage.setItem("z:screen-scale", "75");
 
     new Function(SCALE_BOOT_SCRIPT)();
@@ -189,5 +209,32 @@ describe("nextScaleByKey", () => {
   it("방향키가 아니면 null — 부르는 쪽이 기본 동작을 막지 않게", () => {
     expect(nextScaleByKey(100, "Enter")).toBeNull();
     expect(nextScaleByKey(100, "a")).toBeNull();
+  });
+});
+
+describe("isScaledPath — 배율은 로그인 이후 화면만", () => {
+  it.each([
+    "/app/board",
+    "/app",
+    "/manage/members/3",
+    "/onboarding/2",
+    "/my",
+    "/team/action",
+    "/subscription",
+  ])("%s → 적용", (path) => {
+    expect(isScaledPath(path)).toBe(true);
+  });
+
+  it.each(["/", "/login", "/register", "/plans", "/terms", "/privacy", "/mypage"])(
+    "%s → 미적용 (공개 화면·접두사 오인)",
+    (path) => {
+      expect(isScaledPath(path)).toBe(false);
+    },
+  );
+
+  it("부트 스크립트도 같은 경로 목록을 쓴다 — 두 판정이 어긋나면 첫 페인트만 배율이 새거나 빠진다", () => {
+    for (const prefix of SCALED_PATH_PREFIXES) {
+      expect(SCALE_BOOT_SCRIPT).toContain(`"${prefix}"`);
+    }
   });
 });

--- a/src/features/appearance/scale.ts
+++ b/src/features/appearance/scale.ts
@@ -119,6 +119,56 @@ export function suggestScale(input: { viewportWidth: number; hasChosen: boolean 
 }
 
 /**
+ * 배율이 적용되는 경로 — **로그인 이후 화면만**(2026-08-19).
+ *
+ * 배율은 "1440 기준으로 짠 워크스페이스를 내 기기에 맞추는" 설정이라, 랜딩·로그인 같은
+ * 공개 화면까지 줄이면 처음 온 사람의 첫 화면이 이유 없이 작아 보인다 — 마이페이지에서
+ * 75%를 고르면 랜딩까지 75%로 굳던 문제의 원인이 이것이다(값이 `localStorage`라
+ * 화면 구분 없이 전역으로 읽혔다).
+ *
+ * ⚠️ 접두사는 **정확히 그 경로이거나 `접두사/`로 시작**해야 맞는다 — `/my`가 `/mypage`를
+ *    잡아먹지 않게 한다(`isScaledPath`).
+ * ⚠️ 라우트 그룹이 늘면 여기에 추가한다 — 부트 스크립트와 `AppScaleScope`가 같은 목록을 쓴다.
+ */
+export const SCALED_PATH_PREFIXES = [
+  "/app",
+  "/owner",
+  "/manage",
+  "/team",
+  "/my",
+  "/onboarding",
+  "/subscription",
+  "/system",
+] as const;
+
+/** 이 경로에서 배율을 적용하나 — 로그인 이후 화면(§SCALED_PATH_PREFIXES)만 true. */
+export function isScaledPath(pathname: string): boolean {
+  return SCALED_PATH_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+
+/**
+ * 지금 걸려 있는 배율 값 — **좌표를 직접 다루는 코드가 나눠 쓰는 자리.**
+ *
+ * `transform: scale()`은 그리기만 줄이고 레이아웃 좌표는 그대로 둔다. 그래서
+ * 포인터 좌표(화면 px)를 레이아웃 좌표(px)로 바꿔 쓰는 코드는 이 값으로 나눠야 한다 —
+ * 대표적으로 dnd-kit `DragOverlay`(보드)가 그렇다(§scaleCompensation).
+ *
+ * ⚠️ **rect끼리만 비교하는 코드는 이 값이 필요 없다.** `clientY`와 `getBoundingClientRect()`는
+ *    둘 다 배율이 적용된 값이라 포함 여부 판정에서는 배율이 약분된다(§rooms/grid-slot).
+ *    이 함수를 부르기 전에, 정말 좌표계가 섞이는 자리인지부터 확인한다.
+ * ⚠️ 서버·테스트(jsdom)처럼 `document`가 없거나 변수가 안 읽히면 1이다 — 배율 보정이
+ *    빠질 뿐 좌표 자체는 성립한다.
+ */
+export function getAppScale(): number {
+  if (typeof document === "undefined") return 1;
+  const raw = getComputedStyle(document.documentElement).getPropertyValue("--app-scale");
+  const value = Number.parseFloat(raw);
+  return Number.isFinite(value) && value > 0 ? value : 1;
+}
+
+/**
  * 첫 페인트 전에 도는 부트 스크립트.
  *
  * ⚠️ **하이드레이션까지 기다리면 안 된다.** 새로고침마다 100%로 한 번 그려졌다가 확대되면서
@@ -133,5 +183,8 @@ export function suggestScale(input: { viewportWidth: number; hasChosen: boolean 
  * ⚠️ **`zoom`이 아니라 `--app-scale` 변수 하나만 세운다**(2026-08-06 전환). 실제로 줄이는 일은
  *    `globals.css`의 `body`가 `transform: scale()`로 한다 — `zoom`은 배율을 레이아웃에 섞어
  *    좌표를 다루는 코드를 전부 어긋나게 했다(DECISIONS §화면 배율).
+ * ⚠️ **로그인 이후 경로에서만 건다**(§SCALED_PATH_PREFIXES). 첫 페인트 몫은 여기,
+ *    클라이언트 내비게이션 몫은 `AppScaleScope`가 맡는다 — 판정 로직은 한쪽(`isScaledPath`)이고
+ *    이 스크립트는 같은 목록을 직렬화해서 쓴다.
  */
-export const SCALE_BOOT_SCRIPT = `try{var s=Number(localStorage.getItem("${SCALE_STORAGE_KEY}"));if(s!==${DEFAULT_SCALE}&&[${SCREEN_SCALES.join(",")}].indexOf(s)>=0){document.documentElement.style.setProperty("--app-scale",String(s/100))}}catch(e){}`;
+export const SCALE_BOOT_SCRIPT = `try{var p=location.pathname;var pre=${JSON.stringify(SCALED_PATH_PREFIXES)};var ok=false;for(var i=0;i<pre.length;i++){if(p===pre[i]||p.indexOf(pre[i]+"/")===0){ok=true;break}}if(ok){var s=Number(localStorage.getItem("${SCALE_STORAGE_KEY}"));if(s!==${DEFAULT_SCALE}&&[${SCREEN_SCALES.join(",")}].indexOf(s)>=0){document.documentElement.style.setProperty("--app-scale",String(s/100))}}}catch(e){}`;

--- a/src/features/board/components/board-view.tsx
+++ b/src/features/board/components/board-view.tsx
@@ -6,6 +6,7 @@ import {
   type DragOverEvent,
   DragOverlay,
   type DragStartEvent,
+  type Modifier,
   PointerSensor,
   useSensor,
   useSensors,
@@ -17,9 +18,10 @@ import { toast } from "sonner";
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
 import { EmptyState } from "@/components/common/empty-state";
 import { Button } from "@/components/ui/button";
+import { getAppScale } from "@/features/appearance/scale";
 
 import { commitBoardChangesAction } from "../actions";
-import { canMoveCard, getBoardColumn, isCardDelayed } from "../lib";
+import { canMoveCard, compensateOverlayForScale, getBoardColumn, isCardDelayed } from "../lib";
 import {
   BOARD_COLUMN,
   BOARD_COLUMN_LABEL,
@@ -33,6 +35,14 @@ import {
 import { BoardCardOverlay } from "./board-card";
 import { BoardColumn } from "./board-column";
 import { BoardLeaveGuard } from "./board-leave-guard";
+
+/**
+ * 화면 배율이 걸렸을 때 `DragOverlay`가 커서를 따라오게 하는 보정(§lib
+ * `compensateOverlayForScale`). ⚠️ `DndContext`가 아니라 **여기(그리기)에만** 건다 —
+ * 칸 판정은 화면 px끼리라 이미 맞고, 같이 보정하면 반대로 어긋난다.
+ */
+const appScaleOverlayModifier: Modifier = ({ transform, activeNodeRect }) =>
+  compensateOverlayForScale(transform, activeNodeRect, getAppScale());
 
 interface BoardViewProps {
   boardType: BoardType;
@@ -256,7 +266,7 @@ export function BoardView({ boardType, cards, todayIso }: BoardViewProps) {
         </div>
 
         {/* ⚠️ 포털로 최상단에 그린다 — 칼럼의 overflow-y-auto에 안 잘린다(2026-08-09 디자인 리뷰). */}
-        <DragOverlay>
+        <DragOverlay modifiers={[appScaleOverlayModifier]}>
           {activeCard && (
             <div style={{ width: activeWidth ?? undefined }}>
               {/* ⚠️ 손에 든 사본도 **칸 기준**으로 판정한다 — 아니면 `완료`로 끌고 가는

--- a/src/features/board/lib.test.ts
+++ b/src/features/board/lib.test.ts
@@ -1,4 +1,10 @@
-import { canMoveCard, getBoardColumn, groupCardsByColumn, isCardDelayed } from "./lib";
+import {
+  canMoveCard,
+  compensateOverlayForScale,
+  getBoardColumn,
+  groupCardsByColumn,
+  isCardDelayed,
+} from "./lib";
 import type { BoardCard } from "./types";
 
 const TODAY = new Date("2026-08-06T09:00:00");
@@ -94,5 +100,34 @@ describe("groupCardsByColumn", () => {
     expect(groups.TODO.map((c) => c.id)).toEqual([1]);
     expect(groups.IN_PROGRESS.map((c) => c.id)).toEqual([2]);
     expect(groups.DONE.map((c) => c.id)).toEqual([3]);
+  });
+});
+
+describe("compensateOverlayForScale — 배율 좌표 보정", () => {
+  const rect = { top: 200, left: 400 };
+
+  it("배율 1이면 원본 그대로다 — 배율 없는 화면은 영향이 없어야 한다", () => {
+    const transform = { x: 120, y: 80, scaleX: 1, scaleY: 1 };
+    expect(compensateOverlayForScale(transform, rect, 1)).toBe(transform);
+  });
+
+  it("80%에서 그려지는 자리 s×(rect+t)가 화면 기대치 rect+Δ와 일치한다", () => {
+    const scale = 0.8;
+    const delta = { x: 500, y: 300, scaleX: 1, scaleY: 1 };
+    const t = compensateOverlayForScale(delta, rect, scale);
+    // 검산: 브라우저가 실제로 그리는 자리(레이아웃 × s)가 커서 기대 자리와 같은가
+    expect(scale * (rect.left + t.x)).toBeCloseTo(rect.left + delta.x);
+    expect(scale * (rect.top + t.y)).toBeCloseTo(rect.top + delta.y);
+  });
+
+  it("이동량 0이어도 초기 위치 몫은 보정된다 — 집자마자 카드가 어긋나던 원인", () => {
+    const t = compensateOverlayForScale({ x: 0, y: 0, scaleX: 1, scaleY: 1 }, rect, 0.75);
+    expect(0.75 * (rect.left + t.x)).toBeCloseTo(rect.left);
+    expect(0.75 * (rect.top + t.y)).toBeCloseTo(rect.top);
+  });
+
+  it("rect가 없으면(측정 전) 원본 그대로다 — 없는 값으로 지어내 보정하지 않는다", () => {
+    const transform = { x: 10, y: 10, scaleX: 1, scaleY: 1 };
+    expect(compensateOverlayForScale(transform, null, 0.8)).toBe(transform);
   });
 });

--- a/src/features/board/lib.ts
+++ b/src/features/board/lib.ts
@@ -77,3 +77,34 @@ export function groupCardsByColumn(
   }
   return groups;
 }
+
+/**
+ * `DragOverlay` 좌표를 화면 배율만큼 보정한다(§appearance/scale `getAppScale`).
+ *
+ * `body`에 `transform: scale(--app-scale)`(origin `0 0`)이 걸려 있고, 오버레이는
+ * 포털로 그 `body` 안에 그려진다. dnd-kit은 오버레이의 초기 위치(`activeNodeRect`)와
+ * 이동량(`transform`)을 **화면 px**로 재는데, 그려지는 쪽은 **레이아웃 px**라
+ * 배율(s)이 걸리면 초기 위치·이동량이 전부 s배로 눌려 카드가 커서를 못 따라온다
+ * (2026-08-19 보고 — 커서와 카드가 점점 벌어지는 문제).
+ *
+ * 원하는 것: 화면에서 `rect + Δ` 자리에 보이는 것.
+ * 그려지는 자리: `s × (rect + t)` (t = 우리가 넘길 transform).
+ * 풀면 `t = Δ/s + rect × (1/s − 1)` — 초기 위치 몫과 이동량 몫이 둘 다 들어간다.
+ *
+ * ⚠️ **충돌 판정은 건드리면 안 된다.** 칸 판정(rect 교차)은 전부 화면 px끼리라 이미 맞다 —
+ *    그래서 `DndContext`가 아니라 **`DragOverlay`의 `modifiers`에만** 건다(그리기 전용).
+ * ⚠️ 배율 1이면 원본 그대로 돌려준다 — 보정이 항등이어야 배율 없는 화면이 영향을 안 받는다.
+ */
+export function compensateOverlayForScale<T extends { x: number; y: number }>(
+  transform: T,
+  activeNodeRect: { top: number; left: number } | null,
+  scale: number,
+): T {
+  if (scale === 1 || scale <= 0 || !activeNodeRect) return transform;
+  const stretch = 1 / scale - 1;
+  return {
+    ...transform,
+    x: transform.x / scale + activeNodeRect.left * stretch,
+    y: transform.y / scale + activeNodeRect.top * stretch,
+  };
+}

--- a/src/features/onboarding/components/onboarding-shell.tsx
+++ b/src/features/onboarding/components/onboarding-shell.tsx
@@ -4,6 +4,7 @@ import { Check } from "lucide-react";
 import { type ReactNode, useState } from "react";
 
 import { BrandBar } from "@/components/common/brand-bar";
+import { ThemeToggle } from "@/components/common/theme-toggle";
 import { cn } from "@/lib/utils";
 
 import { ONBOARDING_STEP_LABEL, ONBOARDING_TOTAL_STEPS, type OnboardingStep } from "../types";
@@ -35,13 +36,21 @@ export function OnboardingShell({ step, isDone = false, children }: OnboardingSh
     <div className="bg-background bg-dot-grid h-screen-z flex flex-col overflow-hidden overscroll-none">
       <BrandBar
         right={
-          isDone ? (
-            <span className="text-foreground text-[12px] leading-[18px]">완료</span>
-          ) : (
-            <span className="text-muted-foreground/70 text-[12px] leading-[18px] tabular-nums">
-              단계 <span className="text-foreground">{step}</span> / {ONBOARDING_TOTAL_STEPS}
-            </span>
-          )
+          /*
+            ⚠️ 테마 토글을 여기 둔다(2026-08-19) — 온보딩은 셸(사이드바) 밖이라 마이페이지의
+               테마 설정에 닿을 수 없는데, 처음 여는 화면이 눈부시면 바꿀 방법이 없었다.
+               전역 테마(next-themes)를 그대로 바꾸므로 워크스페이스에 들어가도 이어진다.
+          */
+          <span className="flex items-center gap-2">
+            <ThemeToggle />
+            {isDone ? (
+              <span className="text-foreground text-[12px] leading-[18px]">완료</span>
+            ) : (
+              <span className="text-muted-foreground/70 text-[12px] leading-[18px] tabular-nums">
+                단계 <span className="text-foreground">{step}</span> / {ONBOARDING_TOTAL_STEPS}
+              </span>
+            )}
+          </span>
         }
       />
 


### PR DESCRIPTION
## 📋 PR 타입

> 해당하는 타입을 선택해 주세요 (복수 선택 가능)

- [ ] feature — 새로운 기능 추가
- [x] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [x] 공통

---

## 📝 작업 내용

배율(`--app-scale`) 뿌리가 같은 세 건을 한 PR로 묶었습니다.

1. **보드 드래그 커서 어긋남 보정** — `DragOverlay`가 배율 걸린 `body` 포털에 그려져 초기 위치·이동량이 배율만큼 눌리던 것. 그리기 전용 modifier(`compensateOverlayForScale`)만 추가하고 **칸 판정은 건드리지 않았습니다** (rect 교차는 화면 px끼리라 이미 맞음 — 같이 보정하면 반대로 어긋남).
2. **배율을 로그인 이후 화면으로 스코프** — 마이페이지에서 75%를 고르면 랜딩까지 75%로 굳던 것. 경로 판정(`isScaledPath`)은 한 곳이고, 첫 페인트는 부트 스크립트·클라이언트 내비게이션은 새 `AppScaleScope`가 같은 목록을 씁니다.
3. **온보딩 상단바 다크/화이트 토글** — 온보딩은 셸 밖이라 테마 설정에 닿을 수 없었습니다. 공용 `ThemeToggle`을 단계 표시 옆에 달았고, 전역 테마라 워크스페이스로 이어집니다.
4. 보드 커서 어긋남·캘린더 클릭 보고(2026-08-19)가 배율 의심으로 들어옴. 회의실 캘린더는 클릭 판정이 rect 포함 방식이라 배율이 약분되는 구조로 확인 — **이 PR 범위 밖**, 재현 조건 대기.

---

## ✅ 작업 체크리스트

**기본**

- [ ] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [ ] 불필요한 `console` · 주석 처리된 코드 제거
- [ ] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 **권한 2축 검사** — 역할 가드 + **리소스 소유권**(회의 담당자 등), 그리고 **서버(Server Action/BFF)에서 재검사**
- [ ] 🧬 **zod** — 타입이 스키마에서 파생(`z.infer`) · 매퍼에 `safeParse`
- [ ] 🕵️ **정직성** — 목 · 미구현 · 폴백이면 주석과 화면에 명시 (조용히 "되는 척" 금지)
- [ ] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨

**품질**

- [ ] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그)
- [ ] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [ ] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인)
- [ ] 🧪 `loading` / `error` / `empty` 3상태
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음

---

## 🔗 연관 이슈

Closes #648

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- 마이페이지 배율 75% → 랜딩(`/`)·로그인은 100% 유지, `/app/*`·온보딩은 75%
- 75% 상태로 보드 카드 드래그 → 사본이 커서에 붙어 다님 (실측: 브라우저에서 드래그 중 오버레이 rect 대조, 오차 0.3px)
- `/app/board` → 캘린더로 클라이언트 이동해도 배율 유지
- `/onboarding/1` 상단바 토글 → 다크 전환·복귀
- `/my`는 배율 적용, `/mypage` 같은 접두사 오인은 테스트로 차단
- 타입·린트 통과 · 관련 테스트 248개 통과 (좌표 검산 4개 · 경로 스코프 · 부트 스크립트 게이트 신규)

---

## 📝 추가 메모
