### PR TITLE
[FIX] system 도메인 접근 시 NotificationProvider 없음 런타임 에러를 고친다 #658

### DIFF
--- a/src/app/(system)/system/(dashboard)/layout.tsx
+++ b/src/app/(system)/system/(dashboard)/layout.tsx
@@ -7,7 +7,7 @@ import { PageHeader } from "@/features/shell/components/page-header";
 export default function SystemDashboardLayout({ children }: { children: ReactNode }) {
   return (
     <>
-      <PageHeader title="대시보드" icon={LayoutDashboard} />
+      <PageHeader title="대시보드" icon={LayoutDashboard} showNotifications={false} />
       {children}
     </>
   );

--- a/src/app/(system)/system/approval/layout.tsx
+++ b/src/app/(system)/system/approval/layout.tsx
@@ -10,7 +10,7 @@ import { PageHeader } from "@/features/shell/components/page-header";
 export default function SystemApprovalLayout({ children }: { children: ReactNode }) {
   return (
     <>
-      <PageHeader title="기업 가입 승인" icon={ClipboardCheck} />
+      <PageHeader title="기업 가입 승인" icon={ClipboardCheck} showNotifications={false} />
       {children}
     </>
   );

--- a/src/app/(system)/system/billing/layout.tsx
+++ b/src/app/(system)/system/billing/layout.tsx
@@ -6,7 +6,7 @@ import { PageHeader } from "@/features/shell/components/page-header";
 export default function SystemBillingLayout({ children }: { children: ReactNode }) {
   return (
     <>
-      <PageHeader title="구독·매출 관리" icon={CreditCard} />
+      <PageHeader title="구독·매출 관리" icon={CreditCard} showNotifications={false} />
       {children}
     </>
   );

--- a/src/app/(system)/system/companies/layout.tsx
+++ b/src/app/(system)/system/companies/layout.tsx
@@ -6,7 +6,7 @@ import { PageHeader } from "@/features/shell/components/page-header";
 export default function SystemCompaniesLayout({ children }: { children: ReactNode }) {
   return (
     <>
-      <PageHeader title="기업 관리" icon={Building2} />
+      <PageHeader title="기업 관리" icon={Building2} showNotifications={false} />
       {children}
     </>
   );

--- a/src/app/(system)/system/monitor/layout.tsx
+++ b/src/app/(system)/system/monitor/layout.tsx
@@ -6,7 +6,7 @@ import { PageHeader } from "@/features/shell/components/page-header";
 export default function SystemMonitorLayout({ children }: { children: ReactNode }) {
   return (
     <>
-      <PageHeader title="시스템 모니터링" icon={Activity} />
+      <PageHeader title="시스템 모니터링" icon={Activity} showNotifications={false} />
       {children}
     </>
   );

--- a/src/app/(system)/system/notice/layout.tsx
+++ b/src/app/(system)/system/notice/layout.tsx
@@ -6,7 +6,7 @@ import { PageHeader } from "@/features/shell/components/page-header";
 export default function SystemNoticeLayout({ children }: { children: ReactNode }) {
   return (
     <>
-      <PageHeader title="공지 관리" icon={Megaphone} />
+      <PageHeader title="공지 관리" icon={Megaphone} showNotifications={false} />
       {children}
     </>
   );

--- a/src/features/shell/components/page-header.tsx
+++ b/src/features/shell/components/page-header.tsx
@@ -19,6 +19,18 @@ interface PageHeaderProps {
   backTo?: { href: string; label: string };
   /** 오른쪽 액션 — 버튼 하나 또는 몇 개. 없으면 비워둔다 */
   action?: ReactNode;
+  /**
+   * 종(`NotificationBell`) 표시 여부 — 기본 `true`.
+   *
+   * ⚠️ **`(system)` 화면은 반드시 `false`를 넘긴다.** 이 헤더는 `(shell)` 전용이라
+   *    문서에 그렇게 적혀 있지만, 사이드바·상단바 높이를 맞추려고 `(system)` 레이아웃
+   *    6곳이 그대로 가져다 썼다 — `NotificationBell`은 `(shell)`의 `NotificationProvider`
+   *    (회의 알림·SSE, `memberId` 기준)가 있어야만 동작해서, 그 프로바이더가 없는
+   *    `(system)` 트리에서 그대로 그리면 "NotificationProvider 안에서만 쓸 수 있습니다"
+   *    런타임 에러로 죽는다. `(system)` 운영자는 애초에 워크스페이스 회원이 아니라
+   *    이 알림과 무관하다(§라우트 그룹: `(system)`은 완전히 별도 셸).
+   */
+  showNotifications?: boolean;
 }
 
 /**
@@ -37,7 +49,14 @@ interface PageHeaderProps {
  * ⚠️ 높이(56px)는 **사이드바 로고 줄과 같은 값**이다. 한쪽만 고치면 두 경계선이 어긋나
  *    화면 왼쪽 위에 계단이 생긴다 — 바꿀 때 `role-sidebar`·`system-sidebar`를 같이 본다.
  */
-export function PageHeader({ title, icon: Icon, meta, backTo, action }: PageHeaderProps) {
+export function PageHeader({
+  title,
+  icon: Icon,
+  meta,
+  backTo,
+  action,
+  showNotifications = true,
+}: PageHeaderProps) {
   return (
     <header className="border-border bg-background flex h-[56px] shrink-0 items-center border-b px-8">
       {/*
@@ -97,7 +116,7 @@ export function PageHeader({ title, icon: Icon, meta, backTo, action }: PageHead
           종·테마 전환은 화면마다 두지 않고 여기 한 자리에 고정한다 — 다른 서비스들이 그렇듯
           오른쪽 위, 테마 전환 바로 왼쪽에 종을 둔다(2026-08-16, #602 후속).
         */}
-        <NotificationBell />
+        {showNotifications && <NotificationBell />}
         <ThemeToggle />
       </div>
     </header>


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정
- [ ] feature — 새로운 기능 추가
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [x] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [x] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

- `PageHeader`에 `showNotifications?: boolean`(기본 `true`) 옵션을 추가해 `NotificationBell`
  렌더링 여부를 호출부가 정할 수 있게 한다
- `(system)/*` 하위 6개 레이아웃 전부 `showNotifications={false}`로 명시해, `NotificationProvider`가
  없는 `(system)` 트리에서 `NotificationBell`이 컨텍스트를 찾다 던지던 런타임 에러를 없앤다
- `(shell)` 쪽은 값을 안 넘겨 기본 동작(종 표시) 그대로 유지된다

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`fix/system-page-header-notification-provider#{이슈번호}`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [ ] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 해당 없음(렌더링 크래시 수정, 권한 로직 변경 없음)
- [x] 🧬 **zod** — 해당 없음
- [x] 🕵️ **정직성** — 해당 없음(목·미구현 아님)
- [x] 🎨 디자인 토큰 사용 — 신규 스타일 없음(조건부 렌더링만 추가)

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [x] ♿ a11y — 종 아이콘이 없는 화면에서 그 자리에 남는 요소가 없어 포커스 순서가 깨지지 않음(테마 토글만 남음)
- [x] ♻️ 재사용 확인 — `(system)`용 헤더를 새로 만들지 않고 기존 `PageHeader`에 옵션만 추가
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 해당 없음(렌더링 조건 수정)
- [ ] 브라우저 전용 API — 해당 없음

---

## 🔗 연관 이슈

Closes #658

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
| `/system/*` 진입 시 런타임 에러 오버레이 | 정상 렌더링, 상단바에 종 아이콘 없이 테마 토글만 표시 |

---

## 💬 리뷰 포인트

- `(system)` 상단바에서 종 아이콘이 빠진 자리가 레이아웃상 어색하지 않은지(테마 토글만 남는 구성)
- `showNotifications` 이름이 앞으로 `(system)`에 알림 기능이 생길 가능성까지 고려했을 때 적절한지

---

## 📝 추가 메모

`npm run typecheck` 클린, 관련 6개 레이아웃 + `page-header.tsx` 린트 클린, `shell`/`system`
테스트 스위트 88건 통과. 브라우저로 `/system` 재진입해 콘솔 에러·실패 청크 없이 200 응답만
오는 것도 확인했다(이전엔 이 시점에 런타임 에러 오버레이가 떴다).