### PR TITLE
[FIX] Dockerfile standalone 빌드에 public/ 미복사 — 정적 자산 전부 404 #663

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,10 @@ RUN addgroup --system --gid 1001 nodejs \
 
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+# ⚠️ standalone 빌드는 서버 코드만 담는다 — public/(favicon·정적 이미지 등)은
+#    Next.js가 번들에 안 넣어서 여기서 따로 복사해야 한다(공식 문서 명시 사항).
+#    빠지면 존재하지 않는 게 아니라 전부 404로 죽는다(#663 — og-landing.png 재현).
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 
 USER nextjs
 EXPOSE 3000


### PR DESCRIPTION
Closes #663

## 무엇
배포 사이트에서 `public/` 정적 자산이 **전부 404**였습니다. PR #661(OG 이미지)이 develop→main까지 갔는데도 카톡 미리보기가 안 떠서 파고들다 발견했습니다.

## 원인
`output: "standalone"`(next.config)은 서버 코드 + 최소 node_modules만 담습니다. `public/`·`.next/static`은 Next.js 공식 문서가 **수동 복사**를 요구하는데, Dockerfile엔 `.next/static`만 있고 `public/`이 빠져 있었습니다.

## 검증 — 실제 Docker 빌드로 확인
로컬에서 Docker 데몬 띄우고 직접 빌드·실행했습니다(추측 아님):
- 빌드: `docker build` 성공, `COPY .../public ./public` 단계 정상 실행
- 실행: 컨테이너 띄워서 `curl localhost:3011/og-landing.png` → **200, PNG 1200×630, 302KB**(수정 전엔 배포 사이트에서 404 + Next.js 자체 404 HTML 응답)
- `favicon.ico`는 여전히 404지만 **무관**합니다 — 이 프로젝트는 `src/app/icon.png`·`icon.svg` 컨벤션을 쓰고 그 라우트(`/icon.png`)는 200 정상,애초에 `public/favicon.ico` 파일이 없습니다.

## 확인법
- 배포 후 `curl -I https://www.z-groupware.site/og-landing.png` → 200
- 카카오 공유 디버거에서 미리보기 이미지 정상 표시(캐시 초기화 필요할 수 있음)

⚠️ 배포 파이프라인 직결 변경이라 로컬 Docker 빌드·실행으로 직접 검증했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)