### PR TITLE
[FIX] 오너 대시보드 두 카드 제목 줄 밑줄 통일 #666

### DIFF
--- a/src/app/(shell)/(authority)/owner/(dashboard)/page.tsx
+++ b/src/app/(shell)/(authority)/owner/(dashboard)/page.tsx
@@ -154,7 +154,14 @@ export default async function OwnerDashboardPage() {
         {/* ⚠️ 여기도 높이를 고정하지 않는다 — 다섯 건이 하드 캡이라 자라 봐야 다섯 줄이다.
             고정했을 때는 머리 줄 높이를 20px 적게 잡아 **마지막 줄이 잘려** 나갔다. */}
         <section className="border-border bg-card flex flex-col overflow-hidden rounded-2xl border">
-          <div className="border-border flex shrink-0 items-baseline justify-between gap-3 border-b px-7 pt-6 pb-3">
+          {/*
+            ⚠️ **제목 줄에 선을 안 긋는다**(2026-08-19, 위 "팀장 현황"과 통일). 이 카드만 보면
+               `border-b`가 있어도 이상하지 않지만, 같은 화면 바로 위 카드는 표 머리띠가
+               구분선 역할을 대신해서 `border-b`가 없다 — 한 화면 안에서 제목 줄 하나는 선이
+               있고 하나는 없으면, 글자 크기·굵기가 완전히 같아도 "제목이 서로 다르게
+               생겼다"로 읽힌다. 목록 쪽엔 띠가 없어 대신 여백(`pb-3`)만으로 가른다.
+          */}
+          <div className="flex shrink-0 items-baseline justify-between gap-3 px-7 pt-6 pb-3">
             <h2 className="text-[17px] leading-7 font-semibold tracking-[-0.3px]">
               최근 프로젝트 회의
             </h2>


### PR DESCRIPTION
Closes #666

## 무엇
"팀장 현황"·"최근 프로젝트 회의" 제목 글자 스타일은 동일한데(H2 17px·semibold, 좌표까지 픽셀 단위로 동일 확인), 한쪽만 밑줄이 있어 같은 화면에서 제목 줄 규칙이 달라 보였습니다.

## 원인
- 팀장 현황: 아래가 표라 머리띠가 구분선 역할 → 의도적으로 `border-b` 없음(기존 주석에 이유 명시)
- 최근 프로젝트 회의: 아래가 목록(띠 없음) → `border-b` 있음

각자 콘텐츠 기준으론 맞지만 나란히 보면 어긋납니다.

## 어떻게
"최근 프로젝트 회의"의 `border-b`를 빼서 "팀장 현황"과 같은 철학으로 통일 — 제목 줄엔 선을 안 긋고, 여백(`pb-3`)만으로 가릅니다.

## 확인법
- 브라우저에서 두 `h2`의 부모 `border-bottom-width` 직접 측정 → 수정 전 `0px`/`1px solid` → 수정 후 둘 다 `0px`
- 스크린샷으로 시각 확인
- 전체 테스트 1,617개 통과, 타입·린트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 최근 프로젝트 회의 카드의 제목 영역에서 하단 테두리를 제거했습니다.
  * 제목과 목록이 여백으로 더 명확하게 구분되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->