### PR TITLE
[FEAT] SYSTEM 관리자 로그인 게이트 추가 #670

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,6 +71,9 @@ jobs:
             SYSTEM_ADMIN_ID=$SYSTEM_ADMIN_ID
             SYSTEM_ADMIN_PASSWORD=$SYSTEM_ADMIN_PASSWORD
             EOF
+            # ⚠️ 기본 umask로 만들어지면 644(다른 로컬 계정도 읽을 수 있다) — 관리자 비밀번호가
+            #    평문으로 든 파일이라 소유자만 읽고 쓰게 좁힌다.
+            chmod 600 /home/ubuntu/zebra/.env
 
             docker stop zebra-fe || true
             docker rm zebra-fe || true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,10 @@ jobs:
     env:
       SHA: ${{ github.sha }}
       BACKEND_API_URL: ${{ secrets.BACKEND_API_URL }}
+      # ⚠️ NEXT_PUBLIC_ 없는 서버 전용 값이라 빌드 시점에 굽지 않는다(BACKEND_API_URL과 같은 이유) —
+      #    배포 때마다 이 컨테이너 실행 시점의 .env로만 주입한다.
+      SYSTEM_ADMIN_ID: ${{ secrets.SYSTEM_ADMIN_ID }}
+      SYSTEM_ADMIN_PASSWORD: ${{ secrets.SYSTEM_ADMIN_PASSWORD }}
 
     steps:
       - name: Deploy via SSH (pull → restart container)
@@ -56,13 +60,17 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           port: 22
-          envs: IMAGE,SHA,BACKEND_API_URL
+          envs: IMAGE,SHA,BACKEND_API_URL,SYSTEM_ADMIN_ID,SYSTEM_ADMIN_PASSWORD
           script: |
             set -e
 
             docker pull $IMAGE:$SHA
 
-            echo "BACKEND_API_URL=$BACKEND_API_URL" > /home/ubuntu/zebra/.env
+            cat <<EOF > /home/ubuntu/zebra/.env
+            BACKEND_API_URL=$BACKEND_API_URL
+            SYSTEM_ADMIN_ID=$SYSTEM_ADMIN_ID
+            SYSTEM_ADMIN_PASSWORD=$SYSTEM_ADMIN_PASSWORD
+            EOF
 
             docker stop zebra-fe || true
             docker rm zebra-fe || true

--- a/src/app/(system)/layout.tsx
+++ b/src/app/(system)/layout.tsx
@@ -5,6 +5,8 @@ import { ScopedThemeProvider } from "@/components/common/scoped-theme";
 import { SystemSidebar } from "@/features/system/components/system-sidebar";
 import { SYSTEM_NAV } from "@/features/system/nav";
 import { SYSTEM_THEME_COOKIE } from "@/features/system/theme";
+import { SystemLoginForm } from "@/features/system-auth/components/system-login-form";
+import { hasSystemSession } from "@/features/system-auth/session";
 
 /*
   ⚠️ 아래 `cookies()` 호출 때문에 사실상 이미 동적이지만, 그 사실에 암묵적으로 의존하지 않고
@@ -29,12 +31,27 @@ export const dynamic = "force-dynamic";
  *    상자에 `.dark`만 붙이면 변수는 바뀌어도 글자색은 상속된 먹색 그대로라 어두운 바탕에
  *    어두운 글자가 된다. 실제로 제목과 큰 숫자가 통째로 안 보였다.
  *
- * ⚠️ 지금은 목업(더미) 단계다 — 로그인이 붙기 전까지 계정 정보는 고정값이다.
+ * ⚠️ **로그인이 붙었다**(2026-08-19). `/system/*`은 URL을 직접 두드리면 누구나 들어올 수 있던
+ *    자리라, 진입 즉시 여기서 세션을 확인한다 — 회사 로그인과는 다른 축이라 별도 쿠키
+ *    (`features/system-auth`)로 가른다. 세션이 없으면 사이드바 없이 로그인 폼만 그린다.
  */
 export default async function SystemLayout({ children }: { children: ReactNode }) {
   const store = await cookies();
   // 고른 적이 없으면 다크다 — `light`를 명시적으로 골랐을 때만 밝게 연다
   const initialDark = store.get(SYSTEM_THEME_COOKIE)?.value !== "light";
+  const authorized = await hasSystemSession();
+
+  if (!authorized) {
+    return (
+      <ScopedThemeProvider
+        initialDark={initialDark}
+        cookieName={SYSTEM_THEME_COOKIE}
+        className="app-shell bg-background text-foreground h-screen-z flex items-center justify-center overflow-hidden"
+      >
+        <SystemLoginForm />
+      </ScopedThemeProvider>
+    );
+  }
 
   return (
     <ScopedThemeProvider
@@ -42,7 +59,10 @@ export default async function SystemLayout({ children }: { children: ReactNode }
       cookieName={SYSTEM_THEME_COOKIE}
       className="app-shell bg-background text-foreground h-screen-z flex overflow-hidden"
     >
-      <SystemSidebar sections={SYSTEM_NAV} account={{ email: "admin@getz.kr" }} />
+      <SystemSidebar
+        sections={SYSTEM_NAV}
+        account={{ email: process.env.SYSTEM_ADMIN_ID ?? "admin" }}
+      />
       <div className="bg-background flex min-w-0 flex-1 flex-col overflow-hidden">{children}</div>
     </ScopedThemeProvider>
   );

--- a/src/features/system-auth/actions.ts
+++ b/src/features/system-auth/actions.ts
@@ -1,0 +1,46 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+import { type SystemCredentialErrors, validateSystemCredentials } from "./credentials";
+import { clearSystemSession, createSystemSession, verifySystemCredentials } from "./session";
+
+/** 로그인 결과 — `useActionState`가 그대로 들고 있는 모양(`features/auth/actions.ts`의 `LoginState`와 같은 문법) */
+export interface SystemLoginState {
+  errors: SystemCredentialErrors;
+  /** 아이디·비밀번호 중 어느 쪽이 틀렸는지 가르지 않는다 — 계정이 하나뿐이라 가를 것도 없다 */
+  error?: string;
+  /** 방금 적은 아이디 — 실패했을 때 되살린다(비밀번호는 안 돌려준다) */
+  adminId?: string;
+  /** 몇 번째 시도인가 — 화면이 입력칸의 `key`를 바꿔 되살리는 데 쓴다(React 19 폼 리셋) */
+  attempt: number;
+}
+
+export async function systemLoginAction(
+  prevState: SystemLoginState,
+  formData: FormData,
+): Promise<SystemLoginState> {
+  const adminId = String(formData.get("adminId") ?? "");
+  const password = String(formData.get("password") ?? "");
+
+  const keep = (state: Omit<SystemLoginState, "adminId" | "attempt">): SystemLoginState => ({
+    ...state,
+    adminId,
+    attempt: prevState.attempt + 1,
+  });
+
+  const errors = validateSystemCredentials({ adminId, password });
+  if (Object.keys(errors).length > 0) return keep({ errors });
+
+  if (!verifySystemCredentials(adminId, password)) {
+    return keep({ errors: {}, error: "아이디 또는 비밀번호가 올바르지 않습니다." });
+  }
+
+  await createSystemSession();
+  redirect("/system");
+}
+
+export async function systemLogoutAction(): Promise<void> {
+  await clearSystemSession();
+  redirect("/system");
+}

--- a/src/features/system-auth/actions.ts
+++ b/src/features/system-auth/actions.ts
@@ -20,7 +20,10 @@ export async function systemLoginAction(
   prevState: SystemLoginState,
   formData: FormData,
 ): Promise<SystemLoginState> {
-  const adminId = String(formData.get("adminId") ?? "");
+  // ⚠️ 아이디는 여기서 한 번만 trim한다. zod 스키마도 trim하지만 검증에만 쓰이고 값은 안
+  //    돌려주므로, 안 그러면 "admin "처럼 앞뒤 공백 있는 입력이 검증은 통과하고 실제 대조
+  //    (`verifySystemCredentials`)에서는 원본 그대로 걸려 안 틀린 값이 틀렸다고 나온다.
+  const adminId = String(formData.get("adminId") ?? "").trim();
   const password = String(formData.get("password") ?? "");
 
   const keep = (state: Omit<SystemLoginState, "adminId" | "attempt">): SystemLoginState => ({

--- a/src/features/system-auth/components/system-login-form.tsx
+++ b/src/features/system-auth/components/system-login-form.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { AlertCircle, KeyRound, ShieldCheck } from "lucide-react";
+import { useActionState } from "react";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { SubmitButton } from "@/features/auth/components/submit-button";
+
+import { systemLoginAction, type SystemLoginState } from "../actions";
+
+/**
+ * SYSTEM(서비스 운영자) 로그인 — 단일 계정, 기업 로그인과 완전히 분리된 화면.
+ *
+ * ⚠️ 별도 라우트(`/system/login`)를 만들지 않는다. `(system)/layout.tsx`가 세션이 없을 때
+ *    이 폼을 그 자리에 그대로 그린다 — URL을 조작해 `/system/*` 어디로 들어와도 같은
+ *    로그인 화면을 보게 하려는 목적이라, 라우트를 나누면 그 목적이 흐려진다.
+ */
+const INITIAL: SystemLoginState = { errors: {}, attempt: 0 };
+
+export function SystemLoginForm() {
+  const [state, formAction] = useActionState(systemLoginAction, INITIAL);
+  const errors = state.errors;
+
+  return (
+    <div className="border-border bg-card w-full max-w-[380px] rounded-2xl border p-10 shadow-[0_24px_60px_-28px_rgba(0,0,0,0.45)]">
+      <ShieldCheck className="text-muted-foreground size-[22px]" aria-hidden />
+      <h1 className="pt-3.5 text-[22px] leading-8 font-semibold tracking-[-0.4px]">
+        시스템 관리자 로그인
+      </h1>
+      <p className="text-muted-foreground pt-2 text-[13px] leading-5">
+        서비스 운영자만 접근할 수 있습니다.
+      </p>
+
+      <form action={formAction} noValidate className="flex flex-col gap-1.5 pt-6">
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="adminId">아이디</Label>
+          <Input
+            id="adminId"
+            key={`adminId-${state.attempt}`}
+            name="adminId"
+            type="text"
+            defaultValue={state.adminId}
+            autoComplete="username"
+            aria-invalid={errors.adminId !== undefined}
+            aria-describedby="adminId-error"
+          />
+          <p
+            id="adminId-error"
+            role="alert"
+            className="text-destructive flex min-h-4 items-center gap-1.5 text-[12px] leading-4"
+          >
+            {errors.adminId && <AlertCircle className="size-3.5 shrink-0" aria-hidden />}
+            <span className="translate-y-px">{errors.adminId}</span>
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="password" className="flex items-center gap-1.5">
+            <KeyRound className="text-muted-foreground size-3.5" aria-hidden />
+            <span className="translate-y-px">비밀번호</span>
+          </Label>
+          <Input
+            id="password"
+            name="password"
+            type="password"
+            autoComplete="current-password"
+            aria-invalid={errors.password !== undefined}
+            aria-describedby="password-error"
+          />
+          <p
+            id="password-error"
+            role="alert"
+            className="text-destructive flex min-h-4 items-center gap-1.5 text-[12px] leading-4"
+          >
+            {errors.password && <AlertCircle className="size-3.5 shrink-0" aria-hidden />}
+            <span className="translate-y-px">{errors.password}</span>
+          </p>
+        </div>
+
+        <SubmitButton>로그인</SubmitButton>
+
+        {state.error && (
+          <p
+            role="alert"
+            className="border-destructive/30 bg-destructive/5 text-destructive mt-3 flex items-start gap-2 rounded-lg border px-3.5 py-3 text-[12px] leading-[18px] break-keep"
+          >
+            <span className="flex h-[18px] shrink-0 items-center">
+              <AlertCircle className="size-3.5" aria-hidden />
+            </span>
+            {state.error}
+          </p>
+        )}
+      </form>
+    </div>
+  );
+}

--- a/src/features/system-auth/cookie.ts
+++ b/src/features/system-auth/cookie.ts
@@ -1,0 +1,10 @@
+/**
+ * 시스템 관리자 세션 쿠키의 이름과 수명.
+ *
+ * ⚠️ 회사 로그인 세션(`z_access_token`, `features/auth/cookie.ts`)과는 **완전히 다른 축**이다 —
+ *    시스템 관리자는 기업 계정이 아니라 서비스 운영자 단일 계정(env var)이라 별도 쿠키로 가른다.
+ */
+export const SYSTEM_SESSION_COOKIE = "z_system_session";
+
+/** 4시간 — 회사 세션(30분)보다 길게 둔다. 운영자는 하루 중 드문드문 여러 화면을 오간다. */
+export const SYSTEM_SESSION_MAX_AGE = 60 * 60 * 4;

--- a/src/features/system-auth/credentials.ts
+++ b/src/features/system-auth/credentials.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+/**
+ * 시스템 관리자 로그인 입력의 **스키마**와 검증.
+ *
+ * ⚠️ 여기서 보는 건 **모양뿐**이다(비었는지). 맞는 계정인지는 `session.ts`가 env var와
+ *    대조한다(§권한: 화면 검증은 편의일 뿐, 판정은 서버가 다시 본다).
+ */
+export const systemCredentialsSchema = z.object({
+  adminId: z.string().trim().min(1, "아이디를 입력해 주세요"),
+  password: z.string().min(1, "비밀번호를 입력해 주세요"),
+});
+
+export type SystemCredentials = z.infer<typeof systemCredentialsSchema>;
+export type SystemCredentialErrors = Partial<Record<keyof SystemCredentials, string>>;
+
+export function validateSystemCredentials(input: SystemCredentials): SystemCredentialErrors {
+  const result = systemCredentialsSchema.safeParse(input);
+  if (result.success) return {};
+
+  const errors: SystemCredentialErrors = {};
+  for (const issue of result.error.issues) {
+    const field = issue.path[0] as keyof SystemCredentials | undefined;
+    if (field && errors[field] === undefined) errors[field] = issue.message;
+  }
+  return errors;
+}

--- a/src/features/system-auth/session.ts
+++ b/src/features/system-auth/session.ts
@@ -23,7 +23,7 @@ import { SYSTEM_SESSION_COOKIE, SYSTEM_SESSION_MAX_AGE } from "./cookie";
  *    같은 이유로, 애초에 `/system`은 `proxy.ts`의 보호 목록에서 뺐다.
  */
 
-const SESSION_PAYLOAD = "system-admin";
+const SESSION_TAG = "system-admin";
 
 function requireEnvCredentials(): { id: string; password: string } {
   const id = process.env.SYSTEM_ADMIN_ID;
@@ -39,27 +39,67 @@ function sign(payload: string): string {
   return createHmac("sha256", `${id}:${password}`).update(payload).digest("hex");
 }
 
+/** 길이부터 맞춰 본다 — 다르면 `timingSafeEqual`이 그대로 던진다 */
+function timingSafeStringEqual(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  return bufA.length === bufB.length && timingSafeEqual(bufA, bufB);
+}
+
+/**
+ * ⚠️ 발급 시각을 페이로드에 함께 서명한다. 시각 없이 고정 문자열만 서명하면 쿠키의
+ *    `Max-Age`는 **브라우저만 지키는 약속**이라, 그 쿠키 값이 어디선가 그대로 새 나가면
+ *    (프록시 로그·백업·devtools export 등) 서버는 서명만 맞으면 영원히 받아 준다 —
+ *    발급 시각을 실어 서버가 직접 수명을 재는 쪽이 아니면 "4시간짜리 세션"이 이름뿐이다.
+ */
+function buildPayload(): string {
+  return `${SESSION_TAG}:${Math.floor(Date.now() / 1000)}`;
+}
+
 function isValidToken(token: string | undefined): boolean {
   if (!token) return false;
   const [payload, signature] = token.split(".");
-  if (!payload || !signature || payload !== SESSION_PAYLOAD) return false;
+  if (!payload || !signature) return false;
+
+  const [tag, issuedAtRaw] = payload.split(":");
+  if (tag !== SESSION_TAG) return false;
+
+  const issuedAt = Number(issuedAtRaw);
+  if (!Number.isFinite(issuedAt)) return false;
+
+  const ageSeconds = Math.floor(Date.now() / 1000) - issuedAt;
+  // 음수(미래 발급)면 위조됐거나 시계가 안 맞는 값이다 — 둘 다 거부한다
+  if (ageSeconds < 0 || ageSeconds > SYSTEM_SESSION_MAX_AGE) return false;
 
   const expected = Buffer.from(sign(payload));
   const actual = Buffer.from(signature);
-  // ⚠️ 길이가 다르면 timingSafeEqual이 던진다 — 비교 전에 길이부터 맞춰 본다
   return expected.length === actual.length && timingSafeEqual(expected, actual);
 }
 
-/** 입력값이 env var와 같은가 — 아이디·비밀번호 어느 쪽이 틀렸는지는 가르지 않는다(계정이 하나뿐이라 가를 것도 없다) */
+/**
+ * 입력값이 env var와 같은가 — 아이디·비밀번호 어느 쪽이 틀렸는지는 가르지 않는다(계정이
+ * 하나뿐이라 가를 것도 없다).
+ *
+ * ⚠️ `===`가 아니라 `timingSafeEqual`로 본다. 위 `isValidToken`이 서명값을 이렇게 비교하는
+ *    것과 같은 이유 — 문자열을 앞에서부터 비교하다 다른 글자에서 바로 멈추는 비교는,
+ *    반복 시도하며 응답 시간을 재면 몇 글자까지 맞았는지가 새 나간다. 계정이 하나뿐이라
+ *    이 계정 하나가 뚫리면 그걸로 끝이라 더 위험하다.
+ * ⚠️ **둘 다 항상 계산한다.** `idMatches && verify(password)`처럼 짧게 쓰면 아이디가 틀렸을
+ *    때 비밀번호 비교 자체를 건너뛰어, 그 건너뜀만으로도 "아이디가 틀렸다"는 타이밍이
+ *    새 나간다 — 그래서 두 결과를 각자 변수로 받아 두고 마지막에만 합친다.
+ */
 export function verifySystemCredentials(adminId: string, password: string): boolean {
   const expected = requireEnvCredentials();
-  return adminId === expected.id && password === expected.password;
+  const idMatches = timingSafeStringEqual(adminId, expected.id);
+  const passwordMatches = timingSafeStringEqual(password, expected.password);
+  return idMatches && passwordMatches;
 }
 
 export async function createSystemSession(): Promise<void> {
   const jar = await cookies();
   const isSecure = isSecureRequest((await headers()).get("x-forwarded-proto"));
-  const token = `${SESSION_PAYLOAD}.${sign(SESSION_PAYLOAD)}`;
+  const payload = buildPayload();
+  const token = `${payload}.${sign(payload)}`;
   jar.set(SYSTEM_SESSION_COOKIE, token, tokenCookieOptions(SYSTEM_SESSION_MAX_AGE, isSecure));
 }
 

--- a/src/features/system-auth/session.ts
+++ b/src/features/system-auth/session.ts
@@ -1,0 +1,75 @@
+import "server-only";
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+import { cookies, headers } from "next/headers";
+
+import { isSecureRequest, tokenCookieOptions } from "@/features/auth/cookie";
+
+import { SYSTEM_SESSION_COOKIE, SYSTEM_SESSION_MAX_AGE } from "./cookie";
+
+/**
+ * 시스템 관리자 로그인 — 단일 계정, 아이디·비밀번호가 **env var**(`SYSTEM_ADMIN_ID` /
+ * `SYSTEM_ADMIN_PASSWORD`)다. 운영자는 서비스 전체에 한 명뿐이라 DB 계정 없이 이걸로
+ * 충분하다(팀 결정, 2026-08-19).
+ *
+ * ⚠️ 쿠키 값은 **서명한다**(HMAC-SHA256). "authenticated" 문자열만 그대로 구우면 그 문자열을
+ *    아는 누구나 브라우저에서 쿠키를 직접 심어 들어올 수 있다 — 서명해야 시크릿(env var)을
+ *    아는 서버만 만들 수 있는 값이 된다.
+ * ⚠️ 서명 비밀키를 **따로 두지 않고 admin id·password로 만든다.** 로그인 비밀 자체가 이미
+ *    같은 env var라, 세 번째 시크릿을 추가해도 배포 쪽 값만 하나 늘 뿐 안전성은 안 늘어난다.
+ * ⚠️ `(system)/layout.tsx`에서만 쓴다. `proxy.ts`(Edge)는 이 파일을 import할 수 없다
+ *    (`server-only`) — 값을 봐야 하는 가드는 레이아웃에서 한다는 규칙(`proxy.ts` 상단 주석)과
+ *    같은 이유로, 애초에 `/system`은 `proxy.ts`의 보호 목록에서 뺐다.
+ */
+
+const SESSION_PAYLOAD = "system-admin";
+
+function requireEnvCredentials(): { id: string; password: string } {
+  const id = process.env.SYSTEM_ADMIN_ID;
+  const password = process.env.SYSTEM_ADMIN_PASSWORD;
+  if (!id || !password) {
+    throw new Error("SYSTEM_ADMIN_ID / SYSTEM_ADMIN_PASSWORD 환경변수가 설정되어 있지 않습니다.");
+  }
+  return { id, password };
+}
+
+function sign(payload: string): string {
+  const { id, password } = requireEnvCredentials();
+  return createHmac("sha256", `${id}:${password}`).update(payload).digest("hex");
+}
+
+function isValidToken(token: string | undefined): boolean {
+  if (!token) return false;
+  const [payload, signature] = token.split(".");
+  if (!payload || !signature || payload !== SESSION_PAYLOAD) return false;
+
+  const expected = Buffer.from(sign(payload));
+  const actual = Buffer.from(signature);
+  // ⚠️ 길이가 다르면 timingSafeEqual이 던진다 — 비교 전에 길이부터 맞춰 본다
+  return expected.length === actual.length && timingSafeEqual(expected, actual);
+}
+
+/** 입력값이 env var와 같은가 — 아이디·비밀번호 어느 쪽이 틀렸는지는 가르지 않는다(계정이 하나뿐이라 가를 것도 없다) */
+export function verifySystemCredentials(adminId: string, password: string): boolean {
+  const expected = requireEnvCredentials();
+  return adminId === expected.id && password === expected.password;
+}
+
+export async function createSystemSession(): Promise<void> {
+  const jar = await cookies();
+  const isSecure = isSecureRequest((await headers()).get("x-forwarded-proto"));
+  const token = `${SESSION_PAYLOAD}.${sign(SESSION_PAYLOAD)}`;
+  jar.set(SYSTEM_SESSION_COOKIE, token, tokenCookieOptions(SYSTEM_SESSION_MAX_AGE, isSecure));
+}
+
+/** 유효한 시스템 세션이 있는가 — `(system)/layout.tsx`가 이 값으로 로그인 폼과 실제 화면을 가른다 */
+export async function hasSystemSession(): Promise<boolean> {
+  const jar = await cookies();
+  return isValidToken(jar.get(SYSTEM_SESSION_COOKIE)?.value);
+}
+
+export async function clearSystemSession(): Promise<void> {
+  const jar = await cookies();
+  jar.delete(SYSTEM_SESSION_COOKIE);
+}

--- a/src/features/system/components/system-sidebar.tsx
+++ b/src/features/system/components/system-sidebar.tsx
@@ -1,12 +1,15 @@
 "use client";
 
+import { LogOut } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useFormStatus } from "react-dom";
 
 import { ZLogo } from "@/components/icons/z-logo";
 import { AUTHORITY, AUTHORITY_MARK_CLASS } from "@/constants/authority";
 import { SidebarItem } from "@/features/shell/components/sidebar-item";
 import type { NavSection } from "@/features/shell/nav";
+import { systemLogoutAction } from "@/features/system-auth/actions";
 import { cn } from "@/lib/utils";
 
 interface SystemSidebarProps {
@@ -104,7 +107,26 @@ export function SystemSidebar({ sections, account }: SystemSidebarProps) {
             {account.email}
           </p>
         </div>
+        {/* ⚠️ 나갈 문이 없으면 안 된다 — 세션이 4시간짜리라 만료 전에 직접 끊을 수 있어야 한다 */}
+        <form action={systemLogoutAction}>
+          <LogoutIconButton />
+        </form>
       </div>
     </aside>
+  );
+}
+
+function LogoutIconButton() {
+  const { pending } = useFormStatus();
+
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      aria-label={pending ? "로그아웃 중" : "로그아웃"}
+      className="text-muted-foreground hover:text-foreground hover:bg-foreground/5 focus-visible:ring-ring flex size-7 shrink-0 items-center justify-center rounded-md transition-colors focus-visible:ring-2 focus-visible:outline-hidden disabled:opacity-60"
+    >
+      <LogOut className="size-3.5" aria-hidden />
+    </button>
   );
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -25,7 +25,13 @@ import { PATHNAME_HEADER } from "@/lib/pathname-header";
  * ⚠️ 목으로 돌 때는 아무것도 안 한다 — 로그인시킬 서버가 없는데 막으면 화면 확인이 불가능하다.
  */
 
-/** 로그인해야 들어갈 수 있는 자리. 괄호 라우트 그룹은 URL에 안 붙으므로 실제 주소로 적는다. */
+/**
+ * 로그인해야 들어갈 수 있는 자리. 괄호 라우트 그룹은 URL에 안 붙으므로 실제 주소로 적는다.
+ *
+ * ⚠️ **`/system`은 여기 없다.** 시스템 관리자는 기업 계정과 다른 축(`features/system-auth`,
+ *    env var 단일 계정)이라 이 목록의 회사 세션 쿠키(`ACCESS_TOKEN_COOKIE`)로 판단하면
+ *    안 된다 — `(system)/layout.tsx`가 자기 쿠키로 직접 가드한다.
+ */
 const PROTECTED_PREFIXES = [
   "/owner",
   "/team",
@@ -34,7 +40,6 @@ const PROTECTED_PREFIXES = [
   "/app",
   "/onboarding",
   "/subscription",
-  "/system",
 ];
 
 const isMock = process.env.NEXT_PUBLIC_USE_MOCK !== "false";


### PR DESCRIPTION
## 📋 PR 타입

> 해당하는 타입을 선택해 주세요 (복수 선택 가능)

- [x] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] test — 테스트 코드
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] LEADER (팀장)
- [ ] MEMBER (사원)
- [x] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

> 무엇을 · 왜 바꿨는지 작성해 주세요

- `/system/*`이 URL 조작만으로 누구나 접근 가능하던 것을 막기 위해, 단일 관리자 계정(env var) 기반 로그인 게이트를 `(system)/layout.tsx`에 추가
- 로그인 성공 시 HMAC 서명한 httpOnly 쿠키(`z_system_session`, 4시간)를 발급하고, `(system)` 셸은 이 쿠키가 유효할 때만 렌더
- `proxy.ts`가 `/system`을 기업 로그인 세션(`ACCESS_TOKEN_COOKIE`)으로도 가리고 있었는데, 서로 다른 축이라 목록에서 제거하고 레이아웃 단독 가드로 정리
- 사이드바에 로그아웃 버튼 추가(세션이 4시간짜리라 만료 전에 직접 끊을 수 있어야 함)

---

## ✅ 작업 체크리스트

**기본**

- [ ] 브랜치 명명 규칙 준수 (`feature/meeting-capture#12` 꼴, base `develop`)
- [ ] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [ ] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`) — `.env.local`은 gitignore 대상, 실제 값은 GitHub Secrets로 별도 관리 예정

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 이 기능 자체는 리소스 소유권 축이 없음(단일 계정). 세션 유무 판정은 서버(레이아웃)에서 하고, 브라우저 JS는 판단에 관여하지 않음
- [x] 🧬 **zod** — `SystemCredentials` 타입이 `systemCredentialsSchema`에서 파생(`z.infer`), `safeParse`로 검증
- [x] 🕵️ **정직성** — 단일 계정·env var 기반이라는 점, 로그인 실패 문구가 아이디/비밀번호를 구분하지 않는다는 점을 코드 주석에 명시
- [x] 🎨 디자인 토큰 사용 (생 hex 하드코딩 없음) · 다크 값도 정의됨 — 기존 `AuthCard`/`SubmitButton` 톤 유지

**품질**

- [ ] ⚡ 최적화 (이미지 `next/image` · 폰트 `next/font` · 무거운 것 `next/dynamic` · 시맨틱 태그) — 해당 없음(이미지·폰트 없음)
- [x] ♿ a11y (label · role · alt · **키보드**) · DnD면 키보드 대체 경로
- [x] ♻️ 재사용 확인 (`components/ui` → `common` → 도메인 순으로 먼저 확인) — 기존 `Input`/`Label`/`SubmitButton` 재사용
- [ ] 🧪 `loading` / `error` / `empty` 3상태 — 해당 없음(로그인 성공/실패 두 상태뿐, 목록·조회 화면 아님)
- [ ] 브라우저 전용 API(STT · 녹음) 사용 시 **미지원 · 권한거부 안내** 있음 — 해당 없음

---

## 🔗 연관 이슈

Closes #670

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

> 리뷰어가 중점적으로 봐야 할 부분

- 세션 서명 비밀키를 따로 두지 않고 `SYSTEM_ADMIN_ID:SYSTEM_ADMIN_PASSWORD`로 만들었습니다(세 번째 시크릿을 안 늘리려는 의도) — 괜찮은 절충인지 확인 부탁드립니다.
- **로컬 dev 서버를 재시작해야 `.env.local`의 새 env var가 반영됩니다**(Next가 기동 시점에만 읽음) — 재시작 후 `/system` 접속 → 로그인 폼 노출 → `admin`/`admin` 로그인 → 대시보드 진입 → 로그아웃까지 직접 확인해 주세요. 이미 떠 있는 서버를 임의로 재시작하지 않아 라이브 확인은 못 했습니다.
- 배포 환경에는 `SYSTEM_ADMIN_ID`/`SYSTEM_ADMIN_PASSWORD`를 GitHub Secrets → 실제 배포 서비스(Amplify/ECS/EC2, 아직 미정)의 시크릿으로 매핑하는 절차가 별도로 필요합니다.

---

## 📝 추가 메모

단일 계정 로그인이라 브루트포스에 약합니다. rate limit은 지금 범위에서 뺐습니다(팀 확인 후 필요하면 별도 이슈로).