### PR TITLE
[FIX] 보드 저장 실패 시 원인이 토스트 문구 하나로 가려지던 것 #676

### DIFF
--- a/src/features/board/actions.ts
+++ b/src/features/board/actions.ts
@@ -85,8 +85,14 @@ async function commitBoardChangesLive(
   */
   let currentCards: BoardCard[];
   try {
-    currentCards = boardType === "project" ? await getProjectBoard() : await getMyActionBoard("");
-  } catch {
+    // ⚠️ `getMyActionBoard()`를 인자 없이 부른다 — 실연동에서는 `GET /api/actions`가 이미
+    //    토큰의 본인 소유분만 돌려주므로 assigneeName이 필요 없다(mock 분기 전용 파라미터).
+    //    예전엔 빈 문자열("")을 넘겼는데, 그건 이 분기가 실수로 mock 쪽을 타게 되면 "담당자
+    //    이름이 빈 문자열"로 필터링돼 카드가 전부 사라지는 걸 아무 신호 없이 통과시키는
+    //    지뢰였다 — 지금은 값이 없으면 mock 쪽이 바로 던지고, 여기서 잡아 로그를 남긴다.
+    currentCards = boardType === "project" ? await getProjectBoard() : await getMyActionBoard();
+  } catch (error) {
+    console.error("보드 카드 현재 상태 조회 실패", error);
     return { appliedCount: 0 };
   }
 

--- a/src/features/board/components/board-view.tsx
+++ b/src/features/board/components/board-view.tsx
@@ -199,7 +199,10 @@ export function BoardView({ boardType, cards, todayIso }: BoardViewProps) {
           return;
         }
         toast.success(`${appliedCount}건 반영했습니다`);
-      } catch {
+      } catch (error) {
+        // 토스트 문구 하나로는 "카드가 서버 목록에 없었다"와 "예외가 났다"를 구분할 수 없다 —
+        // 재현 시 콘솔에서 실제 원인을 보게 남겨둔다.
+        console.error("보드 카드 이동 반영 실패", error);
         setConfirmOpen(false);
         toast.error("옮기지 못했습니다");
       }

--- a/src/features/board/server.ts
+++ b/src/features/board/server.ts
@@ -58,8 +58,12 @@ export async function getProjectBoard(): Promise<BoardCard[]> {
  * ⚠️ 팀 액션은 여기 안 나온다(§상태 정책) — 팀 액션 완료 여부는 하위 개인 액션 집계로
  *    파생되지, 사람이 보드에서 직접 옮기는 대상이 아니다.
  */
-export async function getMyActionBoard(assigneeName: string): Promise<BoardCard[]> {
+export async function getMyActionBoard(assigneeName?: string): Promise<BoardCard[]> {
   if (isMock) {
+    // ⚠️ mock 분기는 이 값 없이는 아무것도 못 고른다 — 빈 문자열("")을 넘기면 전부 필터링돼
+    //    "카드가 0건"으로 조용히 보이는 게 제일 위험하다. 없으면 바로 던져서 호출부
+    //    (`commitBoardChangesLive`)의 기존 catch가 appliedCount: 0으로 잡게 한다.
+    if (!assigneeName) throw new Error("getMyActionBoard: mock 분기는 assigneeName이 필요하다");
     const cards: BoardCard[] = [];
     for (const [teamActionIdText, items] of Object.entries(TEAM_ACTION_PERSONAL_ITEMS_MOCK)) {
       const teamAction = TEAM_ACTION_DETAIL_MOCK[Number(teamActionIdText)];


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정

---

## 🗂 작업 영역

- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

- `handleConfirm`의 `catch` 블록이 실제 에러를 그냥 버리던 것을 고쳐 `console.error`로 남긴다 — "옮기지 못했습니다" 토스트 문구 하나로는 카드가 서버 목록에서 안 찾아진 건지, 예외가 난 건지 구분이 안 됐다.
- `getMyActionBoard`의 `assigneeName`을 필수 `string` → 선택 `string?`으로 바꾸고, mock 분기는 값이 없으면 바로 던지게 한다. 실연동 호출부(`commitBoardChangesLive`)가 예전엔 `getMyActionBoard("")`처럼 빈 문자열을 하드코딩해서 불렀는데, 지금은 실연동에서 이 값을 안 써서 우연히 안전했을 뿐 — 나중에 이 분기가 mock 쪽을 타게 리팩터링되면 "담당자 이름이 빈 문자열"로 필터링돼 카드가 전부 조용히 사라지는 지뢰였다. 지금은 값 없이 호출하고, mock 분기가 그 상황에서 바로 던져서 기존 `catch`(→ `appliedCount: 0`)로 잡히게 만들었다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`fix/board-save-error-visibility#676`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 권한 2축 검사 — 해당 없음(권한 로직 변경 없음, 에러 가시성 개선만)
- [ ] 🧬 zod — 해당 없음
- [x] 🕵️ 정직성 — 실패를 조용히 숨기지 않고 콘솔에 원인이 남게 함
- [ ] 🎨 디자인 토큰 — 해당 없음(UI 변경 없음)

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [ ] ♿ a11y — 해당 없음
- [x] ♻️ 재사용 확인 — 기존 `try/catch` 구조·토스트 문구 그대로 재사용, 새 UI 없음
- [ ] 🧪 `loading` / `error` / `empty` 3상태 — 해당 없음(기존 에러 토스트 유지, 로깅만 추가)
- [ ] 브라우저 전용 API 사용 시 안내 — 해당 없음

---

## 🔗 연관 이슈

Closes #676

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- `getMyActionBoard`를 인자 없이 부르는 게 실연동 경로에서 진짜 안전한지(라이브 분기가 이 값을 정말 안 쓰는지) 코드 재확인
- mock 분기에서 값 없이 호출될 경우 던지는 게 기존 호출부의 `catch` 구조와 잘 맞물리는지

---

## 📝 추가 메모

- 확인법: `npx tsc --noEmit` / `npx eslint <변경 파일> --max-warnings=0` / `npx jest --silent src/features/board`(20 tests) 전부 통과
- 가벼운 적대적 리뷰(독립 리뷰어 2명 — 정합성/회귀 관점)로 사전 검증, findings 0건


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 실연동 환경에서 보드 카드 조회가 올바르게 처리되도록 개선했습니다.
  * 보드 카드 조회 또는 이동 반영에 실패해도 앱이 중단되지 않고, 실패 안내가 정상적으로 표시됩니다.
  * 오류 원인 확인을 위한 진단 정보가 기록되어 문제 대응이 쉬워졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->