### PR TITLE
[FIX] 회의·보드·내 액션·팀 액션·결제 화면의 목 인물/주소 하드코딩 제거 #678

### DIFF
--- a/src/app/(shell)/(authority)/manage/billing/(overview)/page.tsx
+++ b/src/app/(shell)/(authority)/manage/billing/(overview)/page.tsx
@@ -8,9 +8,6 @@ import { getViewer } from "@/features/shell/viewer";
 import { canAccessManageScope } from "@/lib/permission";
 import { canManageBilling } from "@/lib/permission";
 
-/** 이 도메인은 항상 더미라 진짜 세션 값이 없다 — 카드 등록 흐름만 확인하는 자리표시자. */
-const MOCK_COMPANY_ID = 1;
-
 export const metadata: Metadata = {
   title: "구독",
 };
@@ -42,13 +39,12 @@ export default async function OwnerBillingPage() {
 
   const canManage = canManageBilling(viewer);
 
-  /*
-    ⚠️ `requestCardAuth`의 customerKey로 실어 보낼 기업 id — 이 도메인이 더미라 진짜
-       세션 값 대신 자리표시자를 쓴다(위 상수 참고).
-  */
-  const companyId = MOCK_COMPANY_ID;
-
   return (
-    <BillingView overview={overview} config={config} canManage={canManage} companyId={companyId} />
+    <BillingView
+      overview={overview}
+      config={config}
+      canManage={canManage}
+      companyId={viewer.companyId}
+    />
   );
 }

--- a/src/app/(shell)/(authority)/team/action/page.tsx
+++ b/src/app/(shell)/(authority)/team/action/page.tsx
@@ -25,7 +25,7 @@ export default async function TeamActionPage() {
   const viewer = await getViewer();
   if (!canAccessTeamScope(viewer)) return <AccessDenied homeHref={roleHome(viewer.role)} />;
 
-  const firstPage = await getTeamActionsPage(0);
+  const firstPage = await getTeamActionsPage(viewer.teamName, 0);
 
   return (
     <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
@@ -34,6 +34,7 @@ export default async function TeamActionPage() {
         initialPage={firstPage.page}
         initialTotalPages={firstPage.totalPages}
         initialTotalCount={firstPage.totalCount}
+        teamName={viewer.teamName}
       />
     </main>
   );

--- a/src/app/(shell)/app/board/page.tsx
+++ b/src/app/(shell)/app/board/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
 
 export default async function BoardPage() {
   const viewer = await getViewer();
-  const { boardType, cards } = await loadBoardForRole(viewer.role);
+  const { boardType, cards } = await loadBoardForRole(viewer.role, viewer.name);
 
   return (
     <main className="flex min-h-0 flex-1 flex-col overflow-hidden px-8 py-7">

--- a/src/app/(shell)/app/my/actions/page.tsx
+++ b/src/app/(shell)/app/my/actions/page.tsx
@@ -2,22 +2,25 @@ import type { Metadata } from "next";
 
 import { MyActionListView } from "@/features/action/components/my-action-list-view";
 import { getMyActionsPage } from "@/features/action/server";
+import { getViewer } from "@/features/shell/viewer";
 
 export const metadata: Metadata = {
   title: "내 액션",
 };
 
-// ⚠️ 로그인 전이라 실제 담당자를 알 수 없다 — 팀 대시보드 목과 같은 대표 인물(이하윤)로 대신한다.
-//    세션이 붙으면 실연동 분기(server.ts)는 이 값을 안 쓰고 토큰의 본인 소유분만 받는다.
-const MOCK_ASSIGNEE_NAME = "이하윤";
-
 /**
  * ⚠️ **첫 페이지만 서버가 렌더**한다(CLAUDE.md §목록·페이지네이션) — 2페이지부터는
  *    `MyActionListView`가 스크롤 끝에서 서버 액션으로 이어 붙인다. 화면 전체를
  *    `use client`로 만들면 조회 전체가 클라이언트로 넘어간다(§핵심 4원칙 ①).
+ * ⚠️ `assigneeName`은 `getViewer()`에서 받는다 — 이 경로는 `/app/*` 공용 워크벤치라
+ *    목 모드 기본값은 대표(OWNER)다(`viewer.ts`의 `mockRoleFor`, `?as=member`로 미리보기
+ *    가능). 여기서 이름을 "이하윤"으로 하드코딩해 두면 **누가 보든 항상 이하윤의 개인
+ *    액션**이 뜬다 — 화면이 지금 보고 있는 사람과 다른 사람의 데이터를 보여주는
+ *    것이라 실제 소유권 버그다(`getMyActionBoard`와 같은 종류의 지뢰).
  */
 export default async function MyActionsPage() {
-  const firstPage = await getMyActionsPage(MOCK_ASSIGNEE_NAME, 0);
+  const viewer = await getViewer();
+  const firstPage = await getMyActionsPage(viewer.name, 0);
 
   return (
     <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">
@@ -26,7 +29,7 @@ export default async function MyActionsPage() {
         initialPage={firstPage.page}
         initialTotalPages={firstPage.totalPages}
         initialTotalCount={firstPage.totalCount}
-        assigneeName={MOCK_ASSIGNEE_NAME}
+        assigneeName={viewer.name}
       />
     </main>
   );

--- a/src/app/api/meetings/[meetingId]/captions/stream/route.ts
+++ b/src/app/api/meetings/[meetingId]/captions/stream/route.ts
@@ -1,7 +1,7 @@
 import type { NextRequest } from "next/server";
 
 import { ensureAccessToken } from "@/features/auth/session";
-import { ep } from "@/lib/endpoints";
+import { BACKEND_BASE_URL, ep } from "@/lib/endpoints";
 
 /**
  * 자막 SSE 중계(CAP-13) — **BFF**.
@@ -20,8 +20,6 @@ import { ep } from "@/lib/endpoints";
 export const runtime = "nodejs";
 /** 스트림이라 캐시가 있으면 안 된다 — 한 사람의 자막이 다른 사람에게 간다 */
 export const dynamic = "force-dynamic";
-
-const BASE_URL = process.env.BACKEND_API_URL ?? "http://localhost:8080";
 
 export async function GET(
   request: NextRequest,
@@ -49,7 +47,7 @@ export async function GET(
 
   let upstream: Response;
   try {
-    upstream = await fetch(`${BASE_URL}${ep.captionsStream(meetingIdNumber)}`, {
+    upstream = await fetch(`${BACKEND_BASE_URL}${ep.captionsStream(meetingIdNumber)}`, {
       headers: {
         Authorization: `Bearer ${accessToken}`,
         Accept: "text/event-stream",

--- a/src/app/api/notifications/stream/route.ts
+++ b/src/app/api/notifications/stream/route.ts
@@ -1,7 +1,7 @@
 import type { NextRequest } from "next/server";
 
 import { ensureAccessToken } from "@/features/auth/session";
-import { ep } from "@/lib/endpoints";
+import { BACKEND_BASE_URL, ep } from "@/lib/endpoints";
 
 /**
  * 개인 알림 SSE 중계 — **BFF**(CLAUDE.md §렌더링·데이터: "BFF가 스트림을 중계하고 토큰을 주입한다").
@@ -26,8 +26,6 @@ export const runtime = "nodejs";
 /** 스트림이라 캐시가 있으면 안 된다 — 한 사람의 알림이 다른 사람에게 간다 */
 export const dynamic = "force-dynamic";
 
-const BASE_URL = process.env.BACKEND_API_URL ?? "http://localhost:8080";
-
 export async function GET(request: NextRequest) {
   /*
     ⚠️ **`getAccessToken()`이 아니라 `ensureAccessToken()`이다.** 이 경로는 `proxy.ts`
@@ -49,7 +47,7 @@ export async function GET(request: NextRequest) {
 
   let upstream: Response;
   try {
-    upstream = await fetch(`${BASE_URL}${ep.notificationStream()}`, {
+    upstream = await fetch(`${BACKEND_BASE_URL}${ep.notificationStream()}`, {
       headers: {
         Authorization: `Bearer ${accessToken}`,
         Accept: "text/event-stream",

--- a/src/features/action/actions.ts
+++ b/src/features/action/actions.ts
@@ -25,9 +25,11 @@ export async function fetchMyActionsPageAction(
   return getMyActionsPage(assigneeName, safePage);
 }
 
+/** ⚠️ `teamName`은 mock 분기 전용이다 — 실연동은 JWT teamId로 이미 자동 스코프한다(server.ts). */
 export async function fetchTeamActionsPageAction(
+  teamName: string | undefined,
   page: number,
 ): Promise<PaginatedResult<TeamActionListItem>> {
   const safePage = Number.isFinite(page) ? Math.max(0, Math.trunc(page)) : 0;
-  return getTeamActionsPage(safePage);
+  return getTeamActionsPage(teamName, safePage);
 }

--- a/src/features/action/components/team-action-list-view.tsx
+++ b/src/features/action/components/team-action-list-view.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useCallback } from "react";
+
 import { InfiniteListFooter } from "@/components/common/infinite-list-footer";
 import { isDelayed } from "@/constants/domain";
 import type { TimelineActionInput } from "@/features/member/action-timeline";
@@ -59,6 +61,8 @@ interface TeamActionListViewProps {
   initialPage: number;
   initialTotalPages: number;
   initialTotalCount: number;
+  /** ⚠️ mock 분기 전용 — 실연동은 JWT teamId로 이미 자동 스코프한다(server.ts). */
+  teamName: string | undefined;
 }
 
 export function TeamActionListView({
@@ -66,7 +70,13 @@ export function TeamActionListView({
   initialPage,
   initialTotalPages,
   initialTotalCount,
+  teamName,
 }: TeamActionListViewProps) {
+  const fetchPage = useCallback(
+    (page: number) => fetchTeamActionsPageAction(teamName, page),
+    [teamName],
+  );
+
   const { items, totalCount, hasMore, isLoadingMore, error, loadMore, sentinelRef } =
     useInfiniteScrollList({
       initialItems,
@@ -74,7 +84,7 @@ export function TeamActionListView({
       initialTotalPages,
       initialTotalCount,
       getId,
-      fetchPage: fetchTeamActionsPageAction,
+      fetchPage,
     });
 
   const groups = groupTeamActionsByProject(items);

--- a/src/features/action/server.test.ts
+++ b/src/features/action/server.test.ts
@@ -8,6 +8,7 @@ import { groupMyActionsByProject, groupTeamActionsByProject, toTeamActionListIte
 import { getMyActionsPage, getTeamActionsPage } from "./server";
 
 const ASSIGNEE = "이하윤";
+const TEAM = "개발팀";
 
 describe("내 액션 목록 한 페이지 (getMyActionsPage)", () => {
   it("마감 임박순(dueDate asc)으로 정렬해 돌려준다 — 서버 정렬과 같은 순서", async () => {
@@ -34,7 +35,7 @@ describe("내 액션 목록 한 페이지 (getMyActionsPage)", () => {
 
 describe("팀 액션 목록 한 페이지 (getTeamActionsPage)", () => {
   it("평평한 목록으로 온다 — 줄마다 프로젝트 정보를 갖고 있어 화면이 다시 묶을 수 있다", async () => {
-    const result = await getTeamActionsPage(0);
+    const result = await getTeamActionsPage(TEAM, 0);
     expect(result.items.length).toBeGreaterThan(0);
     for (const item of result.items) {
       expect(item.projectId).toEqual(expect.any(Number));
@@ -44,8 +45,8 @@ describe("팀 액션 목록 한 페이지 (getTeamActionsPage)", () => {
   });
 
   it("마감 임박순으로 자르고 totalCount는 페이지가 바뀌어도 같다", async () => {
-    const first = await getTeamActionsPage(0, 2);
-    const second = await getTeamActionsPage(1, 2);
+    const first = await getTeamActionsPage(TEAM, 0, 2);
+    const second = await getTeamActionsPage(TEAM, 1, 2);
     expect(first.totalCount).toBe(second.totalCount);
     expect(first.totalPages).toBe(Math.ceil(first.totalCount / 2));
     const dueDates = first.items.map((item) => item.dueDate);
@@ -53,8 +54,8 @@ describe("팀 액션 목록 한 페이지 (getTeamActionsPage)", () => {
   });
 
   it("다음 페이지는 앞 페이지와 id가 겹치지 않는다 — 이어 붙일 때 중복이 없다", async () => {
-    const first = await getTeamActionsPage(0, 2);
-    const second = await getTeamActionsPage(1, 2);
+    const first = await getTeamActionsPage(TEAM, 0, 2);
+    const second = await getTeamActionsPage(TEAM, 1, 2);
     expect(first.items).toHaveLength(2);
     expect(second.page).toBe(1);
     expect(second.items.length).toBeGreaterThan(0);

--- a/src/features/action/server.ts
+++ b/src/features/action/server.ts
@@ -19,9 +19,6 @@ import {
 import { PERSONAL_ACTION_DETAIL_MOCK } from "./mock/action-detail";
 import type { MyActionListItem, PersonalActionDetail, TeamActionListItem } from "./types";
 
-/** 로그인 팀장의 팀 — 세션 붙기 전까지 mock 분기에서만 쓰는 고정값(board/server.ts와 같은 인물). */
-const MOCK_LEADER_TEAM = "개발팀";
-
 /** 개인 액션 상세(`/app/actions/:actionId`). 못 찾으면 `null`(호출부가 404). */
 export async function getPersonalActionDetail(
   actionId: string,
@@ -66,11 +63,14 @@ export const ACTION_PAGE_SIZE = 20;
  *    돌려준다(board/server.ts와 같은 이유). 파라미터는 mock 분기 전용으로 시그니처만 유지한다.
  */
 export async function getMyActionsPage(
-  assigneeName: string,
+  assigneeName: string | undefined,
   page: number,
   pageSize: number = ACTION_PAGE_SIZE,
 ): Promise<PaginatedResult<MyActionListItem>> {
   if (isMock) {
+    // ⚠️ 값 없이 mock 분기를 타면 전부 필터링돼 "액션이 0건"으로 조용히 보이는 게 제일
+    //    위험하다(`getMyActionBoard`와 같은 이유) — 바로 던져서 호출부가 알아채게 한다.
+    if (!assigneeName) throw new Error("getMyActionsPage: mock 분기는 assigneeName이 필요하다");
     const list: MyActionListItem[] = [];
     for (const items of Object.values(TEAM_ACTION_PERSONAL_ITEMS_MOCK)) {
       for (const item of items) {
@@ -145,13 +145,18 @@ export async function getMyActionsPage(
  *    (`sort=dueDate&order=asc`, [확인] BE `action/presentation/api/TeamActionController.java`
  *    list — sort=dueDate|createdAt, order, page 0-base, size 기본 20).
  * ⚠️ 실연동은 `GET /api/team/actions`가 JWT teamId로 이미 자동 스코프하므로 팀명을 안 넘긴다.
- *    mock은 세션이 없어 팀명 필터가 필요하다(board/server.ts와 같은 이유).
+ *    mock은 세션이 없어 팀명 필터가 필요하다(board/server.ts와 같은 이유) — 호출부
+ *    (`/team/action` 페이지)가 `getViewer().teamName`을 실어 보낸다.
  */
 export async function getTeamActionsPage(
+  teamName: string | undefined,
   page: number,
   pageSize: number = ACTION_PAGE_SIZE,
 ): Promise<PaginatedResult<TeamActionListItem>> {
   if (isMock) {
+    // ⚠️ 값 없이 mock 분기를 타면 전부 필터링돼 "팀 액션이 0건"으로 조용히 보이는 게 제일
+    //    위험하다(`getMyActionBoard`와 같은 이유) — 바로 던져서 호출부가 알아채게 한다.
+    if (!teamName) throw new Error("getTeamActionsPage: mock 분기는 teamName이 필요하다");
     const list: TeamActionListItem[] = [];
     /*
       ⚠️ 목은 팀 액션을 **태그로** 찾는데 태그는 프로젝트끼리 겹칠 수 있다(GOODS가 둘,
@@ -163,7 +168,7 @@ export async function getTeamActionsPage(
     const seen = new Set<number>();
     for (const project of TOP_LEVEL_PROJECTS) {
       for (const action of PROJECT_TEAM_ACTIONS_MOCK[project.tag] ?? []) {
-        if (action.team !== MOCK_LEADER_TEAM) continue;
+        if (action.team !== teamName) continue;
         if (seen.has(action.id)) continue;
         seen.add(action.id);
         /*

--- a/src/features/auth/session.ts
+++ b/src/features/auth/session.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import { cookies, headers } from "next/headers";
 
-import { ep } from "@/lib/endpoints";
+import { BACKEND_BASE_URL, ep } from "@/lib/endpoints";
 
 import {
   ACCESS_TOKEN_COOKIE,
@@ -13,8 +13,6 @@ import {
   REFRESH_TOKEN_MAX_AGE,
   tokenCookieOptions,
 } from "./cookie";
-
-const BASE_URL = process.env.BACKEND_API_URL ?? "http://localhost:8080";
 
 /**
  * 세션 — **httpOnly 쿠키 한 곳**(CLAUDE.md §렌더링·데이터: `localStorage` 토큰 금지).
@@ -102,7 +100,7 @@ async function reissueTokens(
   keepSignedIn: boolean,
 ): Promise<SessionTokens | null> {
   try {
-    const response = await fetch(`${BASE_URL}${ep.refresh()}`, {
+    const response = await fetch(`${BACKEND_BASE_URL}${ep.refresh()}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ refreshToken, keepSignedIn }),

--- a/src/features/board/server.ts
+++ b/src/features/board/server.ts
@@ -107,15 +107,16 @@ export async function getMyActionBoard(assigneeName: string): Promise<BoardCard[
 
 /**
  * 권한에 따라 오너=프로젝트 보드, 팀장·사원=본인 개인 액션 보드를 고른다.
- * ⚠️ `assigneeName`은 로그인한 그 사람 이름이어야 한다 — 로그인 전인 지금은 대시보드 목에서도
- *    쓰는 대표 인물(김서준·이하윤)로 대신한다. 세션이 붙으면 `viewer.name`으로 바꾼다.
+ * ⚠️ `assigneeName`은 호출부(`getViewer()`가 이미 가진 `viewer.name`)에서 받는다 — 여기서
+ *    역할만 보고 이름을 다시 추측하면(예전엔 `role === LEADER ? "김서준" : "이하윤"`),
+ *    목 인물 명단이 하나라도 바뀌었을 때 조용히 어긋난다(`getMyActionBoard`와 같은 지뢰).
  */
 export async function loadBoardForRole(
   role: Authority,
+  assigneeName: string,
 ): Promise<{ boardType: BoardType; cards: BoardCard[] }> {
   if (role === AUTHORITY.OWNER) {
     return { boardType: "project", cards: await getProjectBoard() };
   }
-  const assigneeName = role === AUTHORITY.LEADER ? "김서준" : "이하윤";
   return { boardType: "my-action", cards: await getMyActionBoard(assigneeName) };
 }

--- a/src/features/meeting/actions.ts
+++ b/src/features/meeting/actions.ts
@@ -337,9 +337,12 @@ export async function getMeetingSummaryAction(meetingId: string): Promise<Meetin
  *    화면은 SCHEDULED일 때만 [회의 취소]를 보여주지만, 서버에서 다시 확인한다.
  */
 export async function cancelMeetingAction(meetingId: string): Promise<CancelMeetingResult> {
-  const actor = getMockActor();
-
   if (isMock) {
+    // ⚠️ `getMockActor()`는 항상 고정 OWNER다 — 실서버 분기는 이 값을 안 읽으므로 밖에
+    //    두면 "쓰는 것처럼 보이지만 실제로는 실서버에서 안 쓰이는" 상태로 방치되고,
+    //    나중에 실서버 분기가 actor 기반 검사를 추가하면 조용히 가짜 OWNER를 받는다
+    //    (`board/actions.ts`의 `getMyActionBoard("")`와 같은 지뢰).
+    const actor = getMockActor();
     const meeting = findMockMeeting(meetingId);
     if (!meeting) return { error: "회의를 찾을 수 없습니다" };
     if (!canManageMeeting(actor, { hostId: meeting.hostId })) {
@@ -412,9 +415,10 @@ export async function updateMeetingAction(
   const checked = checkMeetingTitle(String(formData.get("title") ?? ""));
   if (!checked.ok) return { error: checked.error, saved: null };
 
-  const actor = getMockActor();
-
   if (isMock) {
+    // ⚠️ `getMockActor()`는 항상 고정 OWNER다 — cancelMeetingAction과 같은 이유로
+    //    실서버 분기가 안 읽는 이 값을 밖에서 만들지 않는다.
+    const actor = getMockActor();
     const meeting = findMockMeeting(meetingId);
     if (!meeting) return { error: "회의를 찾을 수 없습니다", saved: null };
     if (!canManageMeeting(actor, { hostId: meeting.hostId })) {
@@ -524,10 +528,12 @@ export async function updateMeetingScheduleAction(
   const errors = validateMeetingEditDraft(draft);
   if (Object.keys(errors).length > 0) return { errors, saved: null };
 
-  const actor = getMockActor();
   const title = draft.title.trim();
 
   if (isMock) {
+    // ⚠️ `getMockActor()`는 항상 고정 OWNER다 — cancelMeetingAction과 같은 이유로
+    //    실서버 분기가 안 읽는 이 값을 밖에서 만들지 않는다.
+    const actor = getMockActor();
     const meeting = findMockMeeting(meetingId);
     if (!meeting) return { errors: { title: "회의를 찾을 수 없습니다" }, saved: null };
     if (!canManageMeeting(actor, { hostId: meeting.hostId })) {

--- a/src/features/shell/components/nav-preview.tsx
+++ b/src/features/shell/components/nav-preview.tsx
@@ -27,6 +27,7 @@ const person = (role: Authority, name: string, isAdmin = false): Viewer => ({
   name,
   role,
   isAdmin,
+  companyId: 1,
 });
 
 /**

--- a/src/features/shell/viewer.ts
+++ b/src/features/shell/viewer.ts
@@ -22,6 +22,13 @@ import { isMock } from "@/mocks/config";
 */
 export interface Viewer extends Actor {
   name: string;
+  /**
+   * 세션의 기업 id — 결제(`requestCardAuth`의 customerKey)처럼 BE가 principal의
+   * companyId와 대조하는 값에 쓴다.
+   * ⚠️ 목에서는 `MOCK_COMPANY_ID` 하나로 고정한다 — 화면마다 따로 자리표시자를 박아 두면
+   *    (billing 페이지가 그랬다) 실연동 전환 때 그 자리를 다 찾아야 한다(§Mock → Live 격리막).
+   */
+  companyId: number;
 }
 
 /**
@@ -40,6 +47,9 @@ export interface Viewer extends Actor {
   ⚠️ 비워 두면 **팀 범위로 도는 화면이 목에서 통째로 빈다**(2026-08-13 채움) — 참석자 피커의
      "자기 팀만"과 예약 폼의 "상위 팀 액션" 목록이 둘 다 `teamName`으로 걸러서다.
 */
+/** 목 전용 — 이 도메인이 아직 세션을 안 읽는 동안 회사 하나로 고정한다. */
+const MOCK_COMPANY_ID = 1;
+
 const MOCK_PEOPLE: Record<Authority, { id: number; name: string; teamName?: string }> = {
   [AUTHORITY.OWNER]: { id: 1, name: "대표 계정" },
   [AUTHORITY.LEADER]: { id: 2, name: "김서준", teamName: "개발팀" },
@@ -84,7 +94,14 @@ export async function getViewer(): Promise<Viewer> {
     const role = previewRoleFrom(search) ?? mockRoleFor(pathname);
     const person = MOCK_PEOPLE[role];
 
-    return { id: person.id, name: person.name, role, isAdmin: false, teamName: person.teamName };
+    return {
+      id: person.id,
+      name: person.name,
+      role,
+      isAdmin: false,
+      teamName: person.teamName,
+      companyId: MOCK_COMPANY_ID,
+    };
   }
 
   /*
@@ -105,5 +122,6 @@ export async function getViewer(): Promise<Viewer> {
     isAdmin: me.isAdmin,
     teamId: me.teamId ?? undefined,
     teamName: me.teamName ?? undefined,
+    companyId: me.companyId,
   };
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { BACKEND_BASE_URL } from "./endpoints";
 import { isErrorTag } from "./error-tag";
 import { pushLokiLog } from "./loki";
 
@@ -17,9 +18,6 @@ import { pushLokiLog } from "./loki";
  * ⚠️ `message`는 **화면에 그대로 띄울 한국어 문장**이다. 코드로 문구를 조립하지 않는다.
  * ⚠️ 실패의 `errorCode`(`HO-016` 등)는 **분기용**이다 — 사람에게 보여 주는 건 `message`다.
  */
-
-/** BE 주소. 서버에서만 읽으므로 `NEXT_PUBLIC_`을 붙이지 않는다 — 브라우저에 나갈 값이 아니다. */
-const BASE_URL = process.env.BACKEND_API_URL ?? "http://localhost:8080";
 
 interface ApiEnvelope<T> {
   httpStatus: number;
@@ -119,7 +117,7 @@ export async function serverApi<T>(path: string, init: ApiInit = {}): Promise<T>
   */
   const timeout = AbortSignal.timeout(timeoutMs ?? DEFAULT_TIMEOUT_MS);
 
-  const response = await fetch(`${BASE_URL}${path}`, {
+  const response = await fetch(`${BACKEND_BASE_URL}${path}`, {
     cache: "no-store",
     signal: signal ? AbortSignal.any([signal, timeout]) : timeout,
     ...rest,

--- a/src/lib/endpoints.ts
+++ b/src/lib/endpoints.ts
@@ -18,6 +18,14 @@
  *      진행 중이다. 지우기 전에 **그 도메인 담당자·이슈를 먼저 본다.**
  */
 /**
+ * BE 주소 — 서버 쪽 fetch 호출부(`lib/api.ts`·`proxy.ts`·`auth/session.ts`·알림/자막 SSE
+ * BFF 라우트)가 전부 여기서 가져온다. 예전엔 각자 `process.env.BACKEND_API_URL ?? "http://
+ * localhost:8080"`을 따로 적어 뒀는데, 그러면 폴백을 고칠 때 한 곳을 빠뜨려도 타입 에러가
+ * 안 난다 — 이 파일은 `server-only`가 아니라 `proxy.ts`(Edge)에서도 그대로 쓸 수 있다.
+ */
+export const BACKEND_BASE_URL = process.env.BACKEND_API_URL ?? "http://localhost:8080";
+
+/**
  * 목록 3종(`GET /api/projects`·`/api/actions`·`/api/team/actions`)이 공유하는 쿼리 파라미터.
  * ⚠️ **`sort`는 여기 없다.** 컨트롤러마다 화이트리스트가 달라서(프로젝트만 `name`을 받는다)
  *    한 타입에 몰아 두면 액션 목록에 `sort=name`을 보내도 타입이 안 막는다 — BE는 모르는

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -9,7 +9,7 @@ import {
   REFRESH_TOKEN_MAX_AGE,
   tokenCookieOptions,
 } from "@/features/auth/cookie";
-import { ep } from "@/lib/endpoints";
+import { BACKEND_BASE_URL, ep } from "@/lib/endpoints";
 import { PATHNAME_HEADER } from "@/lib/pathname-header";
 
 /**
@@ -43,7 +43,6 @@ const PROTECTED_PREFIXES = [
 ];
 
 const isMock = process.env.NEXT_PUBLIC_USE_MOCK !== "false";
-const BASE_URL = process.env.BACKEND_API_URL ?? "http://localhost:8080";
 
 function withPathname(request: NextRequest) {
   /*
@@ -125,7 +124,7 @@ async function reissue(
   keepSignedIn: boolean,
 ): Promise<{ accessToken: string; refreshToken: string } | null> {
   try {
-    const response = await fetch(`${BASE_URL}${ep.refresh()}`, {
+    const response = await fetch(`${BACKEND_BASE_URL}${ep.refresh()}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ refreshToken, keepSignedIn }),


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정
- [x] refactor — 리팩토링

---

## 🗂 작업 영역

- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [x] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [x] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

`getMyActionBoard("")` 지뢰(#676)를 고치면서 같은 종류의 하드코딩을 전수 조사했고, 확실히 하드코딩으로 확인된 것만 고쳤다(죽은 코드·중복 로직 등 나머지는 이번 범위에서 뺐다).

- **`Viewer`에 `companyId` 추가**(`features/shell/viewer.ts`) — mock은 상수 하나로, 실연동은 `getMe().companyId`로 채운다. 결제 화면(`manage/billing`)이 `MOCK_COMPANY_ID = 1` 하드코딩 대신 이 값을 쓴다.
- **`/app/my/actions`** — `getViewer()`를 아예 안 부르고 `"이하윤"`을 고정으로 쓰던 것을 고쳤다. 팀장으로 미리보기(`?as=leader`)해도 무조건 이하윤의 개인 액션이 뜨던 소유권 버그였다.
- **`board/server.ts`의 `loadBoardForRole`** — 호출부가 이미 가진 `viewer.name`을 무시하고 role로 이름을 재추측하던 것을 파라미터로 받게 바꿨다.
- **`action/server.ts`의 `getMyActionsPage`/`getTeamActionsPage`** — `assigneeName`/`teamName`을 `getMyActionBoard`와 같은 패턴(선택 파라미터 + mock 분기에서 값 없으면 즉시 throw)으로 통일하고, 함수 본문에 박혀 있던 `MOCK_LEADER_TEAM = "개발팀"` 상수를 제거해 호출부(`/team/action`)가 `viewer.teamName`을 실어 보내게 했다.
- **`meeting/actions.ts`** — `cancelMeetingAction`/`updateMeetingAction`/`updateMeetingScheduleAction` 3곳에서 `getMockActor()`가 `isMock` 분기 밖에서 무조건 호출되던 것을 블록 안으로 옮겼다. 지금은 실서버 분기가 이 값을 안 읽어서 우연히 안전했을 뿐, 나중에 실서버 분기에 actor 기반 검사가 추가되면 조용히 가짜 OWNER를 받는 지뢰였다.
- **`BACKEND_API_URL` 폴백 통합** — `lib/api.ts`·`proxy.ts`·`auth/session.ts`·알림 SSE·자막 SSE 라우트 5곳에 복붙돼 있던 `process.env.BACKEND_API_URL ?? "http://localhost:8080"`을 `lib/endpoints.ts`의 `BACKEND_BASE_URL` 하나로 합쳤다(`server-only`가 없는 파일이라 Edge 미들웨어인 `proxy.ts`에서도 그대로 쓸 수 있다).

**이번에 일부러 안 건드린 것**: `team-handover/server.ts`의 `FIXED_LEADER_NAME`/`FIXED_TEAM_NAME`은 같은 하드코딩 패턴이지만 인수인계 중간승인 액터 스탬핑까지 얽혀있고 테스트 픽스처도 이 값을 직접 참조해서, 더 큰 리팩터가 필요해 이번 범위에서 뺐다.

**검증 중 발견한 별개 이슈(이번 diff가 만든 것도 고친 것도 아님)**: `/app/my/actions`에 CLAUDE.md가 말하는 "OWNER 접근 불가" 가드가 실제로는 코드에 없다. Owner가 직접 URL로 들어가면 빈 목록만 조용히 뜬다 — 별도 이슈로 남겨둔다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`fix/mock-identity-hardcoding#678`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 권한 2축 검사 — 역할 가드는 그대로 두고, 리소스 소유권(누구의 데이터를 보여줄지)이 실제 로그인 사람과 일치하도록 고쳤다
- [ ] 🧬 zod — 해당 없음(스키마 변경 없음)
- [x] 🕵️ 정직성 — 값 없이 mock 분기를 타면 빈 목록으로 조용히 넘어가지 않고 바로 던지게 함
- [ ] 🎨 디자인 토큰 — 해당 없음(UI 변경 없음)

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [ ] ♿ a11y — 해당 없음
- [x] ♻️ 재사용 확인 — `my-action-list-view`의 기존 `assigneeName` prop 패턴을 `team-action-list-view`에도 그대로 재사용
- [ ] 🧪 `loading` / `error` / `empty` 3상태 — 해당 없음(기존 3상태 유지)
- [ ] 브라우저 전용 API 사용 시 안내 — 해당 없음

---

## 🔗 연관 이슈

Closes #678

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- `docs/WORKFLOW.md` 대조 결과 5개 항목(내 액션·보드·팀 액션·결제·회의 취소수정) 전부 정책과 일치 확인함 — 특히 `/team/action`의 "로그인 Leader의 소속 팀만" 규칙과 일치하는지 재확인 부탁
- `getMockActor()`를 `isMock` 블록 안으로 옮긴 3곳이 실서버 분기 동작에 정말 영향이 없는지(실서버 분기는 이 값을 안 읽는다는 전제) 재확인 부탁

---

## 📝 추가 메모

- 확인법: `npx tsc --noEmit` / `npx eslint <변경 파일 18개> --max-warnings=0` / `npx jest --silent`(전체 155 스위트·1631건) / `npx next build`(Edge 미들웨어 번들 포함) 전부 통과
- 가벼운 적대적 리뷰(독립 리뷰어 3명 — 정합성/엣지런타임/스코프버그 관점)로 사전 검증, findings 0건
- 브라우저로 `/app/board`(오너·`?as=leader`)·`/app/my/actions`(오너·`?as=member`)·`/team/action`·`/manage/billing` 직접 렌더 확인 — 보는 사람에 따라 다른 데이터가 정상적으로 뜨는지 확인함
