### PR TITLE
[FIX] 인수인계서 관리 화면의 팀장/팀 하드코딩 제거 #680

### DIFF
--- a/src/app/(shell)/(authority)/team/handover/[handoverId]/page.tsx
+++ b/src/app/(shell)/(authority)/team/handover/[handoverId]/page.tsx
@@ -26,7 +26,7 @@ export default async function TeamHandoverDetailPage({ params }: TeamHandoverDet
   const id = Number(handoverId);
   if (!Number.isInteger(id)) notFound();
 
-  const handover = await getTeamHandoverDetail(id);
+  const handover = await getTeamHandoverDetail(id, viewer.teamName);
   if (!handover) notFound();
 
   return (

--- a/src/app/(shell)/(authority)/team/handover/page.tsx
+++ b/src/app/(shell)/(authority)/team/handover/page.tsx
@@ -18,14 +18,12 @@ export const metadata: Metadata = {
 /**
  * 팀원(신청자) 인수인계서 목록 — 팀장 중간 승인을 기다리는 신청만 보인다
  * (WORKFLOW.md §7). 이미 중간 승인된 건은 오너의 최종 승인 대기로 넘어가 여기서 할 일이 없다.
- * ⚠️ 세션이 없어(§team-handover/server.ts) 지금은 고정 스코프(김서준·개발팀)로 렌더링한다 —
- *    `/team/(dashboard)`와 같은 전례.
  */
 export default async function TeamHandoverPage() {
   const viewer = await getViewer();
   if (!canAccessTeamScope(viewer)) return <AccessDenied homeHref={roleHome(viewer.role)} />;
 
-  const items = await listTeamHandovers();
+  const items = await listTeamHandovers(viewer.teamName, viewer.id);
 
   return (
     <main className="scrollbar-hidden min-h-0 flex-1 overflow-y-auto px-8 py-7">

--- a/src/features/team-handover/actions.real.test.ts
+++ b/src/features/team-handover/actions.real.test.ts
@@ -3,7 +3,6 @@ jest.mock("@/mocks/config", () => ({ isMock: false }));
 jest.mock("@/features/auth/session", () => ({ requireAccessToken: jest.fn() }));
 jest.mock("@/features/shell/viewer", () => ({ getViewer: jest.fn() }));
 jest.mock("./server", () => ({
-  FIXED_LEADER_NAME: "김서준",
   getTeamHandoverDetail: jest.fn(),
 }));
 jest.mock("@/lib/api", () => ({

--- a/src/features/team-handover/actions.ts
+++ b/src/features/team-handover/actions.ts
@@ -15,7 +15,7 @@ import { ep } from "@/lib/endpoints";
 import { canApproveMid } from "@/lib/permission";
 import { isMock } from "@/mocks/config";
 
-import { FIXED_LEADER_NAME, getTeamHandoverDetail } from "./server";
+import { getTeamHandoverDetail } from "./server";
 import type { TeamHandoverAssignment, TeamMemberOption } from "./types";
 
 const LIST_PATH = "/team/handover";
@@ -89,14 +89,17 @@ export async function commitHandoverReassignments(
  * ⚠️ **재배정 반영은 `board/actions.ts`와 같은 방식**이다(mock) — `TEAM_ACTION_PERSONAL_ITEMS_MOCK`
  *    항목을 직접 mutate한다(별도 격리 저장소를 새로 두지 않는다).
  * ⚠️ **실서버 분기만 팀 스코프를 검사한다**(2026-08-15) — mock 로스터엔 숫자 팀 id가 없어
- *    (`server.ts`의 `teamId: 0` 참고) mock 분기는 종전처럼 `/team/(dashboard)`와 같은
- *    고정 스코프(김서준 · 개발팀)로 그대로 둔다. **진짜 방어선은 BE다**(§권한: 화면 숨김은
- *    UX일 뿐) — 이건 그 앞에 세우는 1차 가드일 뿐이라 BE 쪽 스코프 검증과 별개로 먼저 넣는다.
+ *    (`server.ts`의 `teamId: 0` 참고) `canApproveMid`의 teamId 대조를 mock에서 그대로
+ *    쓸 수 없다. 대신 `getViewer().teamName`으로 mock 데이터를 좁힌다(#678과 같은 이유로
+ *    "김서준·개발팀" 고정값은 제거했다) — **진짜 방어선은 BE다**(§권한: 화면 숨김은 UX일
+ *    뿐) — 이건 그 앞에 세우는 1차 가드일 뿐이라 BE 쪽 스코프 검증과 별개로 먼저 넣는다.
  */
 export async function completeTeamHandoverAction(
   handoverId: number,
   assignments: TeamHandoverAssignment[],
 ): Promise<{ isSuccess: boolean; message?: string }> {
+  const viewer = await getViewer();
+
   /*
     ⚠️ `getTeamHandoverDetail`은 404·403만 `null`로 접는다 — 그 외 실패(통신 장애 등)는
        그대로 다시 던진다. 여기서도 잡아야 페이지가 안 죽는다(2026-08-15, 같은 사고 —
@@ -104,7 +107,7 @@ export async function completeTeamHandoverAction(
   */
   let handover: Awaited<ReturnType<typeof getTeamHandoverDetail>>;
   try {
-    handover = await getTeamHandoverDetail(handoverId);
+    handover = await getTeamHandoverDetail(handoverId, viewer.teamName);
   } catch {
     return {
       isSuccess: false,
@@ -114,7 +117,6 @@ export async function completeTeamHandoverAction(
   if (!handover) return { isSuccess: false, message: "이미 처리됐거나 없는 인수인계서입니다" };
 
   if (!isMock) {
-    const viewer = await getViewer();
     if (!canApproveMid(viewer, { teamId: handover.teamId })) {
       return { isSuccess: false, message: "이 인수인계서를 승인할 권한이 없습니다" };
     }
@@ -148,7 +150,7 @@ export async function completeTeamHandoverAction(
     for (const assignment of assignments) {
       reassignHandoverItem(assignment, teammateById);
     }
-    completeMockHandoverMidApproval(handoverId, FIXED_LEADER_NAME, todayIso());
+    completeMockHandoverMidApproval(handoverId, viewer.name, todayIso());
   } else {
     try {
       await commitHandoverReassignments(handoverId, handover.memberId, assignments);
@@ -181,9 +183,11 @@ export async function rejectTeamHandoverAction(
 ): Promise<{ isSuccess: boolean; message?: string }> {
   if (!reason.trim()) return { isSuccess: false, message: "반려 사유를 입력해 주세요" };
 
+  const viewer = await getViewer();
+
   let handover: Awaited<ReturnType<typeof getTeamHandoverDetail>>;
   try {
-    handover = await getTeamHandoverDetail(handoverId);
+    handover = await getTeamHandoverDetail(handoverId, viewer.teamName);
   } catch {
     return {
       isSuccess: false,
@@ -193,7 +197,6 @@ export async function rejectTeamHandoverAction(
   if (!handover) return { isSuccess: false, message: "이미 처리됐거나 없는 인수인계서입니다" };
 
   if (!isMock) {
-    const viewer = await getViewer();
     if (!canApproveMid(viewer, { teamId: handover.teamId })) {
       return { isSuccess: false, message: "이 인수인계서를 반려할 권한이 없습니다" };
     }

--- a/src/features/team-handover/server.ts
+++ b/src/features/team-handover/server.ts
@@ -21,15 +21,6 @@ import type {
 } from "./types";
 
 /**
- * ⚠️ 세션이 아직 없다(`getViewer()`는 항상 OWNER를 반환) — `/team/(dashboard)`와 같은 이유로
- *    이 스코프는 지금 고정이다(김서준 · 개발팀). 세션이 붙으면 `canApproveMid(viewer, {teamId})`로
- *    게이트하고 이 상수 대신 `viewer.teamName`/`viewer.id`를 쓴다.
- */
-export const FIXED_LEADER_ID = 2;
-export const FIXED_LEADER_NAME = "김서준";
-const FIXED_TEAM_NAME = "개발팀";
-
-/**
  * 타임라인용 "인계 액션" — `member/mock/managed.ts`의 개인 액션 목록은 `startDate`가 없어
  * 기간 바를 못 그린다. 대신 `leader-handover`가 쓴 것과 같은 소스(`TEAM_ACTION_PERSONAL_ITEMS_MOCK`)
  * 에서 이 신청자 명의 항목만 골라 쓴다(완료 건은 재배정 대상이 아니라 뺀다).
@@ -82,12 +73,21 @@ async function fetchTeammates(
     .map((member) => ({ id: member.memberId, name: member.name, roleLabel: member.roleName }));
 }
 
-/** 목록 — 팀장 중간 승인을 기다리는 팀원 신청만(이미 승인된 건은 여기서 할 일이 없다). */
-export async function listTeamHandovers(): Promise<TeamHandoverListItem[]> {
+/**
+ * 목록 — 팀장 중간 승인을 기다리는 팀원 신청만(이미 승인된 건은 여기서 할 일이 없다).
+ * ⚠️ `teamName`·`leaderId`는 호출부(`getViewer()`)에서 받는다 — 예전엔 "김서준·개발팀"으로
+ *    고정해 뒀는데, 목 인물 명단이 바뀌면 조용히 어긋나는 지뢰였다(`getMyActionBoard`와
+ *    같은 종류, #678). 실연동은 `GET /api/handovers`가 토큰의 팀만 돌려주므로 안 쓴다.
+ */
+export async function listTeamHandovers(
+  teamName: string | undefined,
+  leaderId: number,
+): Promise<TeamHandoverListItem[]> {
   if (isMock) {
+    if (!teamName) throw new Error("listTeamHandovers: mock 분기는 teamName이 필요하다");
     const members = await listManagedMembers();
     const teammates = members.filter(
-      (member) => member.teamName === FIXED_TEAM_NAME && member.id !== FIXED_LEADER_ID,
+      (member) => member.teamName === teamName && member.id !== leaderId,
     );
 
     const details = await Promise.all(teammates.map((member) => getManagedMember(member.id)));
@@ -124,21 +124,27 @@ export async function listTeamHandovers(): Promise<TeamHandoverListItem[]> {
   return summaries.map(toTeamHandoverListItem);
 }
 
-/** 상세 — 이미 중간 승인됐거나 신청이 없으면 `null`(화면이 `notFound()`를 부른다). */
+/**
+ * 상세 — 이미 중간 승인됐거나 신청이 없으면 `null`(화면이 `notFound()`를 부른다).
+ * ⚠️ `teamName`은 호출부(`getViewer()`)에서 받는다 — `listTeamHandovers`와 같은 이유로
+ *    고정값 대신 실제 로그인 팀장의 팀을 쓴다.
+ */
 export async function getTeamHandoverDetail(
   handoverId: number,
+  teamName: string | undefined,
 ): Promise<TeamHandoverDetail | null> {
   if (isMock) {
+    if (!teamName) throw new Error("getTeamHandoverDetail: mock 분기는 teamName이 필요하다");
     const memberId = handoverId;
     const detail = await getManagedMember(memberId);
-    if (!detail || detail.member.teamName !== FIXED_TEAM_NAME) return null;
+    if (!detail || detail.member.teamName !== teamName) return null;
 
     const handover = detail.pendingHandover;
     if (!handover || handover.midApproval) return null;
 
     const members = await listManagedMembers();
     const teammates = members
-      .filter((member) => member.teamName === FIXED_TEAM_NAME && member.id !== memberId)
+      .filter((member) => member.teamName === teamName && member.id !== memberId)
       .map((member) => ({ id: member.id, name: member.name, roleLabel: member.roleLabel }));
 
     return {


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정
- [x] refactor — 리팩토링

---

## 🗂 작업 영역

- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계

---

## 🙋 관련 역할

- [x] LEADER (팀장)

---

## 📝 작업 내용

#678에서 범위를 뺐던 `team-handover/server.ts`의 마지막 하드코딩을 고친다.

- `FIXED_LEADER_ID = 2`·`FIXED_LEADER_NAME = "김서준"`·`FIXED_TEAM_NAME = "개발팀"` 상수 제거.
- `listTeamHandovers(teamName, leaderId)`·`getTeamHandoverDetail(handoverId, teamName)`로 시그니처 변경 — `getMyActionBoard`와 같은 패턴(mock 분기는 값 없으면 즉시 throw).
- 호출부 4곳이 전부 `getViewer()`가 준 실제 값을 실어 보내도록 스레딩:
  - `/team/handover` 목록 페이지 → `listTeamHandovers(viewer.teamName, viewer.id)`
  - `/team/handover/:handoverId` 상세 페이지 → `getTeamHandoverDetail(id, viewer.teamName)`
  - `completeTeamHandoverAction`/`rejectTeamHandoverAction` → `getViewer()`를 (기존엔 `!isMock` 분기 안에서만 불렀는데) 맨 위에서 한 번만 불러 `teamName`을 `getTeamHandoverDetail`에 넘기고, mock 중간승인 액터 스탬프도 `FIXED_LEADER_NAME` 대신 `viewer.name`을 쓴다.
- **부수적으로 발견**: 지우려던 상수 위 주석이 "세션이 없어 `getViewer()`는 항상 OWNER를 반환한다"고 돼 있었는데, 실제로는 `viewer.ts`가 2026-08-13에 `/team/*` 경로를 LEADER로 매핑하도록 채워지면서 이미 사실이 아니었다(`/team/handover`는 정확히 김서준을 돌려주고 있었다). 코드는 우연히 맞물려 있었지만 주석이 stale했다 — 이번에 정리했다.

**바뀌지 않은 것**: 실연동(`!isMock`) 분기의 `canApproveMid(viewer, {teamId})` 팀 스코프 검사는 그대로다. 이번 변경은 mock 분기가 스코프를 잡는 방식(상수 → 파라미터)만 건드린다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`fix/team-handover-hardcoding#680`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 권한 2축 검사 — 실연동 `canApproveMid` 팀 스코프 검사는 그대로 유지, mock 분기의 소유권 판정 기준만 실제 로그인 사람으로 교정
- [ ] 🧬 zod — 해당 없음
- [x] 🕵️ 정직성 — mock 분기는 값 없이는 조용히 빈 목록을 만들지 않고 바로 던지게 함
- [ ] 🎨 디자인 토큰 — 해당 없음(UI 변경 없음)

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [ ] ♿ a11y — 해당 없음
- [x] ♻️ 재사용 확인 — `getMyActionBoard`(#676)·`getMyActionsPage`/`getTeamActionsPage`(#678)와 같은 "선택 파라미터 + mock 분기 throw" 패턴 재사용
- [ ] 🧪 `loading` / `error` / `empty` 3상태 — 해당 없음
- [ ] 브라우저 전용 API 사용 시 안내 — 해당 없음

---

## 🔗 연관 이슈

Closes #680

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- `completeTeamHandoverAction`/`rejectTeamHandoverAction`에서 `getViewer()`를 무조건 맨 위로 옮긴 게 실연동 분기 동작에 영향 없는지(기존엔 `!isMock` 안에서만 불렀음) 재확인 부탁
- 주석 정정(stale했던 "getViewer()는 항상 OWNER" 부분)이 다른 문서·주석과 안 어긋나는지

---

## 📝 추가 메모

- 확인법: `npx tsc --noEmit` / `npx eslint <변경 파일 5개> --max-warnings=0` / `npx jest --silent`(전체 155 스위트·1631건) / `npx next build` 전부 통과
- 가벼운 적대적 리뷰(독립 리뷰어 2명 — 정합성/WORKFLOW.md 정책일치)로 사전 검증, findings 0건
- 브라우저로 `/team/handover` 목록·상세 직접 렌더 확인 — 김서준(팀장)으로 정상 로드, 이하윤의 휴직 인수인계서 1건 정상 표시
