### PR TITLE
[FIX] /app/my/actions에 OWNER 접근 가드 누락 (CLAUDE.md 원칙 위반) #682

### DIFF
--- a/src/app/(shell)/app/my/actions/page.test.tsx
+++ b/src/app/(shell)/app/my/actions/page.test.tsx
@@ -1,0 +1,75 @@
+/*
+  ⚠️ 회귀 방지 — CLAUDE.md §라우트 그룹: "`/app/my/actions`는 OWNER 접근 불가."
+     사이드바에서 OWNER에게 이 항목을 안 보이는데(§nav-config.MEMBER_TOP), 화면 숨김은
+     UX일 뿐이고 URL을 직접 치면 통과됐다 — 이 화면의 `canAccessPersonalScope` 가드가
+     그 문을 잡는다. 가드가 빠지거나 `canAccessPersonalScope`가 뒤집히면 이 테스트가 잡는다.
+     (`/team/action`의 #614 회귀 테스트와 같은 방식.)
+*/
+jest.mock("server-only", () => ({}));
+
+jest.mock("@/features/shell/viewer", () => ({
+  getViewer: jest.fn(),
+}));
+
+jest.mock("@/features/shell/home", () => ({
+  roleHome: jest.fn(() => "/"),
+}));
+
+jest.mock("@/lib/permission", () => ({
+  canAccessPersonalScope: jest.fn(),
+}));
+
+jest.mock("@/features/action/server", () => ({
+  getMyActionsPage: jest.fn(async () => ({
+    items: [],
+    page: 0,
+    totalPages: 1,
+    totalCount: 0,
+  })),
+}));
+
+jest.mock("@/components/common/access-denied", () => ({
+  AccessDenied: () => <div data-testid="access-denied" />,
+}));
+
+jest.mock("@/features/action/components/my-action-list-view", () => ({
+  MyActionListView: () => <div data-testid="my-action-list" />,
+}));
+
+import { render, screen } from "@testing-library/react";
+
+import { getMyActionsPage } from "@/features/action/server";
+import { getViewer } from "@/features/shell/viewer";
+import { canAccessPersonalScope } from "@/lib/permission";
+
+import MyActionsPage from "./page";
+
+describe("/app/my/actions — 개인 스코프 진입 가드", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getViewer as jest.Mock).mockResolvedValue({ role: "member", name: "이하윤" });
+  });
+
+  it("LEADER/MEMBER는 내 액션 목록을 본다", async () => {
+    (canAccessPersonalScope as jest.Mock).mockReturnValue(true);
+
+    const ui = await MyActionsPage();
+    render(ui);
+
+    expect(screen.getByTestId("my-action-list")).toBeInTheDocument();
+    expect(screen.queryByTestId("access-denied")).not.toBeInTheDocument();
+  });
+
+  it("OWNER는 조회 전에 AccessDenied로 막고 목록 조회를 안 부른다", async () => {
+    (getViewer as jest.Mock).mockResolvedValue({ role: "owner", name: "대표 계정" });
+    (canAccessPersonalScope as jest.Mock).mockReturnValue(false);
+
+    const ui = await MyActionsPage();
+    render(ui);
+
+    expect(screen.getByTestId("access-denied")).toBeInTheDocument();
+    expect(screen.queryByTestId("my-action-list")).not.toBeInTheDocument();
+    // ⚠️ 가드에 막혔으면 목록 조회가 아예 안 나가야 한다(빈 목록으로라도 조용히 통과 금지)
+    expect(getMyActionsPage).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(shell)/app/my/actions/page.tsx
+++ b/src/app/(shell)/app/my/actions/page.tsx
@@ -1,8 +1,11 @@
 import type { Metadata } from "next";
 
+import { AccessDenied } from "@/components/common/access-denied";
 import { MyActionListView } from "@/features/action/components/my-action-list-view";
 import { getMyActionsPage } from "@/features/action/server";
+import { roleHome } from "@/features/shell/home";
 import { getViewer } from "@/features/shell/viewer";
+import { canAccessPersonalScope } from "@/lib/permission";
 
 export const metadata: Metadata = {
   title: "내 액션",
@@ -12,14 +15,17 @@ export const metadata: Metadata = {
  * ⚠️ **첫 페이지만 서버가 렌더**한다(CLAUDE.md §목록·페이지네이션) — 2페이지부터는
  *    `MyActionListView`가 스크롤 끝에서 서버 액션으로 이어 붙인다. 화면 전체를
  *    `use client`로 만들면 조회 전체가 클라이언트로 넘어간다(§핵심 4원칙 ①).
- * ⚠️ `assigneeName`은 `getViewer()`에서 받는다 — 이 경로는 `/app/*` 공용 워크벤치라
- *    목 모드 기본값은 대표(OWNER)다(`viewer.ts`의 `mockRoleFor`, `?as=member`로 미리보기
- *    가능). 여기서 이름을 "이하윤"으로 하드코딩해 두면 **누가 보든 항상 이하윤의 개인
- *    액션**이 뜬다 — 화면이 지금 보고 있는 사람과 다른 사람의 데이터를 보여주는
- *    것이라 실제 소유권 버그다(`getMyActionBoard`와 같은 종류의 지뢰).
+ * ⚠️ **OWNER는 못 들어간다**(CLAUDE.md §라우트 그룹, `/my/(dashboard)`와 같은 패턴).
+ *    사이드바가 OWNER에게 이 항목을 안 보이지만, 화면 숨김은 UX일 뿐이고 URL을 직접
+ *    치면 통과된다 — 화면 쪽 가드는 여기서 잡는다(§권한: 화면 숨김은 보안이 아니다).
+ *    이 자리는 `permission.ts`가 `canAccessPersonalScope`로 이미 준비해 두었다.
+ * ⚠️ `assigneeName`은 `getViewer()`에서 받는다 — 여기서 이름을 하드코딩하면 누가 보든
+ *    같은 사람의 개인 액션이 뜬다(§소유권, `getMyActionBoard`와 같은 종류의 지뢰).
  */
 export default async function MyActionsPage() {
   const viewer = await getViewer();
+  if (!canAccessPersonalScope(viewer)) return <AccessDenied homeHref={roleHome(viewer.role)} />;
+
   const firstPage = await getMyActionsPage(viewer.name, 0);
 
   return (


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정
- [x] test — 테스트 코드

---

## 🗂 작업 영역

- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계

---

## 🙋 관련 역할

- [x] OWNER (대표)

---

## 📝 작업 내용

CLAUDE.md는 `/app/my/actions`를 "OWNER 접근 불가"로 명시하고, 사이드바(`nav-config.ts`)도 이 항목을 OWNER에게 안 보인다. `permission.ts:195`엔 이 화면 전용 `canAccessPersonalScope` 가드까지 이미 만들어져 있는데, 정작 `page.tsx`엔 그 가드가 안 걸려 있어서 OWNER가 URL을 직접 치면 빈 목록이 정상 페이지처럼 렌더됐다("화면 숨김은 UX일 뿐 보안이 아니다" 원칙 위반).

- `/app/my/actions/page.tsx`에 `canAccessPersonalScope` 가드 추가 — `/my/(dashboard)/page.tsx`와 완전히 같은 패턴(`getViewer()` 직후 가드 실패 시 `AccessDenied` 반환).
- 회귀 방지 테스트 `page.test.tsx` 신규 — `/team/action/page.test.tsx`(#614)와 같은 방식. LEADER/MEMBER는 통과, OWNER는 AccessDenied로 막혀 `getMyActionsPage`가 아예 안 불리는지 검증.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`fix/my-actions-owner-guard#682`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [x] 🔐 권한 2축 검사 — 화면 레벨 가드를 추가해 URL 직접 접근도 막는다(§권한: 화면 숨김은 UX일 뿐 보안이 아니다)
- [ ] 🧬 zod — 해당 없음
- [x] 🕵️ 정직성 — OWNER에게 "빈 목록"을 정상 페이지처럼 보이지 않고 403으로 정확히 알린다
- [ ] 🎨 디자인 토큰 — 해당 없음

**품질**

- [ ] ⚡ 최적화 — 해당 없음
- [ ] ♿ a11y — `AccessDenied` 컴포넌트 재사용(기존 접근성 그대로)
- [x] ♻️ 재사용 확인 — `canAccessPersonalScope` 기존 함수 재사용, `AccessDenied` 기존 컴포넌트 재사용, 테스트 골격도 `/team/action` 기존 패턴 재사용
- [x] 🧪 `loading` / `error` / `empty` 3상태 — 기존 3상태 유지
- [ ] 브라우저 전용 API 사용 시 안내 — 해당 없음

---

## 🔗 연관 이슈

Closes #682

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
| OWNER 접속 시 "0건" 빈 목록이 정상 페이지처럼 렌더 | OWNER 접속 시 403 AccessDenied 화면 |

---

## 💬 리뷰 포인트

- `canAccessPersonalScope`가 이미 있는데 왜 지금까지 이 화면에 안 붙어 있었는지(과거 리팩터 때 빠진 것인지) 확인 부탁 — 다른 `/app/*` 하위 페이지들에도 같은 유형의 갭이 남아있을 가능성
- 새 테스트가 `/team/action` 회귀 방지 테스트(#614)와 같은 결이라 안전한지

---

## 📝 추가 메모

- 확인법: `npx tsc --noEmit` / `npx eslint <변경 파일> --max-warnings=0` / `npx jest --silent`(전체 156 스위트·1633건, 새 테스트 2건 포함) 전부 통과
- 브라우저로 OWNER 접속 시 403, `?as=member` 미리보기 시 정상 렌더 직접 확인
- 가벼운 적대적 리뷰(독립 리뷰어 2명 — 정합성/CLAUDE.md·WORKFLOW.md 정책일치) findings 0건
