### PR TITLE
[FIX] upload.test.ts 재시도 테스트가 병렬 실행 시 플레이키 #684

### DIFF
--- a/src/features/meeting/capture/upload.test.ts
+++ b/src/features/meeting/capture/upload.test.ts
@@ -76,48 +76,74 @@ it("presigned URL 경로에서 S3 키를 정확히 뽑아 complete에 실어 보
   });
 });
 
+/**
+ * 재시도 사이 `sleep(RETRY_DELAY_MS = 500ms)`가 **실 `setTimeout`**이라, 병렬 jest 워커
+ * CPU 경합이 걸리면 3초 안팎이면 끝날 일이 15초를 넘겨 타임아웃이 났다. 재시도 로직만
+ *검증하는 아래 두 테스트는 **fake timers**로 시간을 앞으로 감아 실 대기 없이 돌린다 —
+ * 로직은 그대로 두고 테스트만 실 시간 의존성을 뗀다. 아래 다른 테스트("순서대로 하나씩")는
+ * fetch 목이 자체 `setTimeout(5)`으로 동시성을 재기 때문에 fake timers를 전역으로 걸면 안
+ * 된다 — 그래서 두 테스트 안에서만 켜고 finally에서 원복한다.
+ */
+async function drainRetries(flushPromise: Promise<void>): Promise<void> {
+  // 각 조각당 최대 (MAX_UPLOAD_ATTEMPTS - 1)회 = 2회 sleep, 최대 4조각을 넉넉히 덮는다.
+  for (let i = 0; i < 12; i += 1) {
+    await jest.advanceTimersByTimeAsync(500);
+  }
+  await flushPromise;
+}
+
 it("PUT이 실패해도 같은 조각을 재시도해서 결국 올린다", async () => {
-  presignMock.mockResolvedValue(batch(0, [1]));
-  const onFailure = jest.fn();
-  (global.fetch as jest.Mock)
-    .mockResolvedValueOnce({ ok: false, status: 500 })
-    .mockResolvedValueOnce({ ok: false, status: 500 })
-    .mockResolvedValueOnce({ ok: true });
+  jest.useFakeTimers();
+  try {
+    presignMock.mockResolvedValue(batch(0, [1]));
+    const onFailure = jest.fn();
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({ ok: false, status: 500 })
+      .mockResolvedValueOnce({ ok: false, status: 500 })
+      .mockResolvedValueOnce({ ok: true });
 
-  const uploader = createSliceUploader(9, { onFailure });
-  uploader.enqueue(new Blob(["a"]));
-  await uploader.flush();
+    const uploader = createSliceUploader(9, { onFailure });
+    uploader.enqueue(new Blob(["a"]));
+    await drainRetries(uploader.flush());
 
-  expect(global.fetch).toHaveBeenCalledTimes(3); // 같은 presignedUrl로 세 번째 만에 성공
-  expect(completeMock).toHaveBeenCalledTimes(1);
-  expect(onFailure).not.toHaveBeenCalled();
-}, 10_000);
+    expect(global.fetch).toHaveBeenCalledTimes(3); // 같은 presignedUrl로 세 번째 만에 성공
+    expect(completeMock).toHaveBeenCalledTimes(1);
+    expect(onFailure).not.toHaveBeenCalled();
+  } finally {
+    jest.useRealTimers();
+  }
+});
 
 it("재시도까지 다 실패한 조각이 연속 3개면 알리고, 그다음 성공하면 실패 횟수가 되돌아간다", async () => {
-  presignMock.mockResolvedValue(batch(0, [1, 2, 3, 4]));
-  const onFailure = jest.fn();
-  /*
-    조각 1·2·3은 매 시도 실패(각 3번씩 재시도 후 포기 = 9번), 조각 4는 그 뒤 첫 시도부터
-    성공한다(10번째 호출) — 호출 순번으로 세는 게 개별 mockResolvedValueOnce를 9개
-    늘어놓는 것보다 개수를 세기 쉽다.
-  */
-  let callCount = 0;
-  (global.fetch as jest.Mock).mockImplementation(async () => {
-    callCount += 1;
-    return { ok: callCount > 9, status: 500 };
-  });
+  jest.useFakeTimers();
+  try {
+    presignMock.mockResolvedValue(batch(0, [1, 2, 3, 4]));
+    const onFailure = jest.fn();
+    /*
+      조각 1·2·3은 매 시도 실패(각 3번씩 재시도 후 포기 = 9번), 조각 4는 그 뒤 첫 시도부터
+      성공한다(10번째 호출) — 호출 순번으로 세는 게 개별 mockResolvedValueOnce를 9개
+      늘어놓는 것보다 개수를 세기 쉽다.
+    */
+    let callCount = 0;
+    (global.fetch as jest.Mock).mockImplementation(async () => {
+      callCount += 1;
+      return { ok: callCount > 9, status: 500 };
+    });
 
-  const uploader = createSliceUploader(9, { onFailure });
-  uploader.enqueue(new Blob(["a"]));
-  uploader.enqueue(new Blob(["b"]));
-  uploader.enqueue(new Blob(["c"]));
-  uploader.enqueue(new Blob(["d"]));
-  await uploader.flush();
+    const uploader = createSliceUploader(9, { onFailure });
+    uploader.enqueue(new Blob(["a"]));
+    uploader.enqueue(new Blob(["b"]));
+    uploader.enqueue(new Blob(["c"]));
+    uploader.enqueue(new Blob(["d"]));
+    await drainRetries(uploader.flush());
 
-  expect(global.fetch).toHaveBeenCalledTimes(10); // (3+3+3)번 재시도 + 마지막 1번
-  expect(onFailure).toHaveBeenCalledTimes(1); // 조각 3개 연속 포기한 시점에 딱 한 번
-  expect(completeMock).toHaveBeenCalledTimes(1); // 조각 4만 성공해 complete까지 감
-}, 15_000);
+    expect(global.fetch).toHaveBeenCalledTimes(10); // (3+3+3)번 재시도 + 마지막 1번
+    expect(onFailure).toHaveBeenCalledTimes(1); // 조각 3개 연속 포기한 시점에 딱 한 번
+    expect(completeMock).toHaveBeenCalledTimes(1); // 조각 4만 성공해 complete까지 감
+  } finally {
+    jest.useRealTimers();
+  }
+});
 
 it("순서대로, 하나씩 올린다 — 동시에 여러 조각을 PUT하지 않는다", async () => {
   presignMock.mockResolvedValue(batch(0, [1, 2, 3]));


### PR DESCRIPTION
## 📋 PR 타입

- [x] fix — 버그 수정
- [x] test — 테스트 코드

---

## 🗂 작업 영역

- [x] 공통 · 인프라

---

## 🙋 관련 역할

- [x] 공통

---

## 📝 작업 내용

`src/features/meeting/capture/upload.test.ts`의 재시도 관련 두 테스트가 병렬 jest 실행 시 CPU 경합이 걸리면 15초 타임아웃을 넘겨 실패하던 플레이키를 없앤다.

- 재시도 로직만 검증하는 두 테스트에만 국지적으로 `jest.useFakeTimers()` 적용(try/finally로 `useRealTimers` 복원).
- 공용 헬퍼 `drainRetries`가 `advanceTimersByTimeAsync(500)`을 12회 반복해 최악(3조각 × 2sleep = 6회) 대비 2배 여유로 감아준다.
- `10_000`/`15_000` 타임아웃 마커 제거 — 이제 필요 없다.

**같은 파일 안의 다른 테스트에 fake timers를 전역 적용하지 않은 이유**: "순서대로 하나씩" 동시성 검증 테스트는 fetch 목이 `setTimeout(5)`으로 인플라이트 카운트를 측정하는 구조라, 전역 fake timers를 걸면 그 자체를 못 재게 된다. 그래서 두 재시도 테스트 안에서만 켰다 끈다.

**결과 측정**:
- 이전: 3초+, CPU 부하 시 15초 타임아웃
- 지금: 0.28~0.29초 일관, 반복 실행·병렬 실행 모두 안정
- 전체 스위트 병렬: 30초+ → 3초

`upload.ts`(프로덕션 코드)는 안 건드렸다 — 로직은 그대로다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`fix/flaky-upload-test#684`, base `develop`)
- [x] 커밋 컨벤션 준수 (`type: 제목 #{이슈번호}`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거
- [x] 민감 정보 없음 (토큰 · 키 · `.env`)

**Z 필수**

- [ ] 🔐 권한 2축 검사 — 해당 없음
- [ ] 🧬 zod — 해당 없음
- [x] 🕵️ 정직성 — 테스트가 실 시간에 의존해 조용히 실패하지 않게 함(잘못 통과·잘못 실패 모두 방지)
- [ ] 🎨 디자인 토큰 — 해당 없음

**품질**

- [x] ⚡ 최적화 — 테스트 실행 시간 30초+ → 3초 (CI 시간 절감)
- [ ] ♿ a11y — 해당 없음
- [x] ♻️ 재사용 확인 — `drainRetries` 헬퍼로 두 테스트가 같은 방식으로 재시도 대기를 소진
- [ ] `loading`/`error`/`empty` — 테스트 파일 변경, 해당 없음
- [ ] 브라우저 전용 API — 해당 없음

---

## 🔗 연관 이슈

Closes #684

---

## 📸 스크린샷 (선택)

| Before | After |
| ------ | ----- |
|        |       |

---

## 💬 리뷰 포인트

- `jest.useFakeTimers()`를 두 테스트 안에서만 켰다가 finally에서 원복 — 다른 테스트에 부작용 없는지
- `drainRetries`의 12회 반복이 실제 최악 케이스(6회 sleep)에 대비해 여유가 적절한지

---

## 📝 추가 메모

- 확인법: 개별 실행 3회 반복 통과, 전체 병렬 3초 통과 확인
- 가벼운 적대적 리뷰(독립 리뷰어 2명 — 정합성·커버리지) findings 0건


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 회의 캡처 업로드의 재시도 성공 및 연속 실패 알림 테스트가 가상 타이머를 사용하도록 개선되었습니다.
  * 재시도 지연 처리와 타이머 복원이 안정적으로 수행되도록 보완해 테스트 실행의 일관성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->