### PR TITLE
test: handover 신청 lib 날짜 경계 회귀 방지 추가 #688

### DIFF
--- a/src/features/handover/lib.test.ts
+++ b/src/features/handover/lib.test.ts
@@ -1,0 +1,73 @@
+import { handoverDateMin, isDueWithinRange } from "./lib";
+
+/**
+ * 신청 화면의 날짜 경계 규칙 회귀 방지 — 인접한 `team-handover/mapper.test.ts`와 짝을
+ * 이룬다. 정책이 정정된 자리(§lib 주석)를 콕 집어 고정한다.
+ * ⚠️ 여기서는 순수 함수만 다룬다 — 서버·매퍼 통합은 별도 스펙이 잡는다.
+ */
+
+describe("handoverDateMin — 휴직 시작·오프보딩 마지막 근무일 달력의 최소 선택값 (#637)", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("오늘의 다음 날짜를 `YYYY-MM-DD`로 돌려준다", () => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-08-20T09:00:00"));
+
+    expect(handoverDateMin()).toBe("2026-08-21");
+  });
+
+  it("월말은 다음 달 1일로 넘긴다 — 자리수 자릿수(`08` → `09`) 회귀", () => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-08-31T09:00:00"));
+
+    expect(handoverDateMin()).toBe("2026-09-01");
+  });
+
+  it("연말은 다음 해 1월 1일로 넘긴다 — 연·월 동시 롤오버", () => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-12-31T09:00:00"));
+
+    expect(handoverDateMin()).toBe("2027-01-01");
+  });
+});
+
+describe("isDueWithinRange — 휴직 기간 안 마감 판정 (양끝 포함, 2026-08-08 확정)", () => {
+  it("기간 안쪽 마감은 포함이다", () => {
+    expect(isDueWithinRange("2026-08-15", "2026-08-10", "2026-08-20")).toBe(true);
+  });
+
+  /*
+    ⚠️ **양끝 포함 규칙 회귀 방지** — "시작일부터"를 미포함으로 오해하면 시작일 당일 마감이
+       인계 목록에서 조용히 빠져 사용자가 인계 대상을 놓친다(§정직성). 종료일도 같은 이유.
+  */
+  it("시작일과 같은 날 마감은 포함이다", () => {
+    expect(isDueWithinRange("2026-08-10", "2026-08-10", "2026-08-20")).toBe(true);
+  });
+
+  it("종료일과 같은 날 마감은 포함이다", () => {
+    expect(isDueWithinRange("2026-08-20", "2026-08-10", "2026-08-20")).toBe(true);
+  });
+
+  it("시작일 하루 전 마감은 미포함이다", () => {
+    expect(isDueWithinRange("2026-08-09", "2026-08-10", "2026-08-20")).toBe(false);
+  });
+
+  it("종료일 하루 뒤 마감은 미포함이다", () => {
+    expect(isDueWithinRange("2026-08-21", "2026-08-10", "2026-08-20")).toBe(false);
+  });
+
+  it("하루짜리 휴직(시작=종료)은 그 하루가 포함이다", () => {
+    expect(isDueWithinRange("2026-08-10", "2026-08-10", "2026-08-10")).toBe(true);
+  });
+
+  /*
+    ⚠️ 시작·종료 중 한 쪽이 아직 안 정해진 상태(폼 초기값)에서 호출되면 판정할 근거가 없다 —
+       `true`를 돌려 배지가 뜨면 사용자에게 잘못된 안내가 된다. 함수는 명시적으로 `false`를 준다.
+  */
+  it("시작일이 비어 있으면 판정 불가로 `false`를 준다", () => {
+    expect(isDueWithinRange("2026-08-15", "", "2026-08-20")).toBe(false);
+  });
+
+  it("종료일이 비어 있으면 판정 불가로 `false`를 준다", () => {
+    expect(isDueWithinRange("2026-08-15", "2026-08-10", "")).toBe(false);
+  });
+});


### PR DESCRIPTION
## 📋 PR 타입

- [x] test — 테스트 코드
- [ ] feature — 새로운 기능 추가
- [ ] fix — 버그 수정
- [ ] style — 코드 스타일 수정 (로직 변경 없음)
- [ ] refactor — 리팩토링
- [ ] docs — 문서 수정
- [ ] design — UI/UX 변경
- [ ] chore — 설정/빌드 작업
- [ ] merge

---

## 🗂 작업 영역

- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계
- [ ] 워크벤치 — 회의 · 캡처 · AI검토 · 회의실
- [ ] 조직 — 역할별 대시보드 · 사원/회의실 관리 · 구독
- [ ] 공유 셸 · 디자인 시스템 ⚠️ (셸 담당자만, 별도 PR)
- [ ] 공통 · 인프라

---

## 🙋 관련 역할

- [x] LEADER (팀장)
- [x] MEMBER (사원)
- [ ] OWNER (대표)
- [ ] ADMIN (관리자)
- [ ] SYSTEM (서비스 운영자 — 확장, 데모 제외)
- [ ] 공통

---

## 📝 작업 내용

- `src/features/handover/lib.test.ts` 신설 — 인접한 `team-handover`엔 있으나 `handover`엔 없던 회귀 방지선을 채운다.
- `handoverDateMin()` 3케이스 — 다음 날짜 · 월말 → 다음 달 1일 · 연말 → 다음 해 1월 1일 (jest fake timers).
- `isDueWithinRange` 8케이스 — **양끝 포함 규칙(2026-08-08 확정)** 을 시작·종료 각 경계에서 고정. 하루짜리 휴직 · 시작/종료 빈 값 폴백까지 포함.

**왜 이 스코프인가**
- `handover/lib.ts`의 순수 함수 5개(`handoverDateMin` · `parseHandoverType` · `isDueWithinRange` · `sortActionsForVacation` · `toHandoverCreateRequestBody`)가 통째로 무테스트 상태. 특히 `isDueWithinRange`의 "양끝 포함"은 주석에만 근거가 남아 있어 규칙이 조용히 뒤집혀도 CI가 못 잡는다.
- 한 번에 다 덮으면 리뷰 폭이 넓어져, **날짜 경계**만 먼저 잡고 나머지(폴백 · 필드명 변환)는 후속 PR로 이어간다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`test/handover-lib-date-boundary#688`, base `develop`)
- [x] 커밋 컨벤션 준수 (`test: 제목 #688`)
- [x] 아래 `Closes #` 에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 제거 (해당 없음 — 신규 테스트만)
- [x] 민감 정보 없음

**Z 필수**

- [x] 🔐 **권한 2축 검사** — 순수 함수 유닛 테스트라 해당 없음
- [x] 🧬 **zod** — 매퍼가 아니라 lib이라 해당 없음
- [x] 🕵️ **정직성** — 테스트가 확인하는 규칙은 코드 주석의 확정 정책과 1:1 대응
- [x] 🎨 디자인 토큰 — 로직 테스트라 해당 없음

**품질**

- [x] ⚡ 최적화 — 해당 없음 (테스트 코드)
- [x] ♿ a11y — 해당 없음
- [x] ♻️ 재사용 확인 — jest fake timers 패턴은 `src/lib/api.test.ts` · `src/features/auth/use-password-reset-cooldown.test.ts` 등에서 이미 쓰인다
- [x] 🧪 `loading` / `error` / `empty` — 해당 없음
- [x] 브라우저 전용 API — 해당 없음

---

## 🔗 연관 이슈

Closes #688

---

## 📸 스크린샷 (선택)

해당 없음 — 테스트 코드.

---

## 💬 리뷰 포인트

- `handoverDateMin` 테스트가 로컬 시간대 기준(`T09:00:00`, Z 없음)으로 시스템 시각을 세팅했다. 이유: 함수 내부가 `toISOString().slice(0, 10)`으로 UTC 문자열을 잘라내므로, 시각이 자정 근처면 로컬↔UTC 경계에서 결과가 갈릴 수 있다. 정오 근처 값으로 세팅해 그 경계를 피했다.
- `isDueWithinRange`의 "양끝 포함" 판정은 `handover/lib.ts` L82-85 주석(2026-08-08 확정)이 근거다. 규칙이 다시 바뀌면 이 테스트부터 손대야 한다.

---

## 📝 추가 메모

후속 이슈로 이어갈 것:
- `parseHandoverType(undefined)` 폴백 규칙 회귀 방지
- `toHandoverCreateRequestBody` BE 필드명 변환(`type`→`handoverType` 등) 회귀 방지
- `sortActionsForVacation` 정렬·기본 미체크 규칙 회귀 방지