### PR TITLE
test: handover parseHandoverType 폴백 회귀 방지 추가 #690

### DIFF
--- a/src/features/handover/lib.test.ts
+++ b/src/features/handover/lib.test.ts
@@ -1,4 +1,12 @@
-import { handoverDateMin, isDueWithinRange } from "./lib";
+import { HANDOVER_TYPE } from "@/constants/domain";
+
+import {
+  DEFAULT_HANDOVER_TYPE,
+  HANDOVER_TYPE_TABS,
+  handoverDateMin,
+  isDueWithinRange,
+  parseHandoverType,
+} from "./lib";
 
 /**
  * 신청 화면의 날짜 경계 규칙 회귀 방지 — 인접한 `team-handover/mapper.test.ts`와 짝을
@@ -69,5 +77,48 @@ describe("isDueWithinRange — 휴직 기간 안 마감 판정 (양끝 포함, 2
 
   it("종료일이 비어 있으면 판정 불가로 `false`를 준다", () => {
     expect(isDueWithinRange("2026-08-15", "2026-08-10", "")).toBe(false);
+  });
+});
+
+describe("parseHandoverType — 외부 문자열을 신뢰 가능한 HandoverType으로 좁힌다", () => {
+  it("유효한 `VACATION`은 그대로 통과한다", () => {
+    expect(parseHandoverType(HANDOVER_TYPE.VACATION)).toBe(HANDOVER_TYPE.VACATION);
+  });
+
+  it("유효한 `OFFBOARDING`은 그대로 통과한다", () => {
+    expect(parseHandoverType(HANDOVER_TYPE.OFFBOARDING)).toBe(HANDOVER_TYPE.OFFBOARDING);
+  });
+
+  /*
+    ⚠️ **폴백 규칙 회귀 방지** — URL 쿼리·폼 초기값이 비어 있거나 알 수 없는 값일 때
+       `undefined`가 그대로 새 나가면 탭 컴포넌트가 미선택 상태로 열려 사용자가 아무것도
+       못 누른다. 화면상 원인이 안 보이는 사고라 함수 경계에서 반드시 좁힌다.
+  */
+  it("`undefined`는 `DEFAULT_HANDOVER_TYPE`(휴직)로 폴백한다", () => {
+    expect(parseHandoverType(undefined)).toBe(DEFAULT_HANDOVER_TYPE);
+    expect(DEFAULT_HANDOVER_TYPE).toBe(HANDOVER_TYPE.VACATION);
+  });
+
+  it("빈 문자열은 DEFAULT로 폴백한다", () => {
+    expect(parseHandoverType("")).toBe(DEFAULT_HANDOVER_TYPE);
+  });
+
+  it("알 수 없는 값은 DEFAULT로 폴백한다 — 대소문자 · 오타 · 옛 값 전부 동일", () => {
+    expect(parseHandoverType("vacation")).toBe(DEFAULT_HANDOVER_TYPE);
+    expect(parseHandoverType("LEAVE")).toBe(DEFAULT_HANDOVER_TYPE);
+    expect(parseHandoverType("RETIRE")).toBe(DEFAULT_HANDOVER_TYPE);
+  });
+});
+
+describe("HANDOVER_TYPE_TABS — 탭 순서·라벨 계약", () => {
+  /*
+    ⚠️ 탭 순서는 사용자 학습에 남는 UI 규약이다 — 뒤집히면 자주 쓰는 [휴직] 탭이 두 번째로
+       밀려 사용자가 매번 [오프보딩]에서 시작한다. 순서·라벨 둘 다 고정한다.
+  */
+  it("휴직이 먼저, 오프보딩이 뒤 — 두 탭만 있다", () => {
+    expect(HANDOVER_TYPE_TABS).toEqual([
+      { type: HANDOVER_TYPE.VACATION, label: "휴직" },
+      { type: HANDOVER_TYPE.OFFBOARDING, label: "오프보딩" },
+    ]);
   });
 });


### PR DESCRIPTION
## 📋 PR 타입

- [x] test — 테스트 코드

---

## 🗂 작업 영역

- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계

---

## 🙋 관련 역할

- [x] LEADER (팀장)
- [x] MEMBER (사원)

---

## 📝 작업 내용

- `src/features/handover/lib.test.ts`에 `parseHandoverType` · `HANDOVER_TYPE_TABS` 회귀 방지 6케이스 추가.
- 유효 값(`VACATION` · `OFFBOARDING`)은 그대로 통과, `undefined` · 빈 문자열 · 알 수 없는 값은 전부 `DEFAULT_HANDOVER_TYPE`(`VACATION`)로 폴백하는지 각 경계에서 고정.
- `HANDOVER_TYPE_TABS`는 순서(휴직 먼저)·라벨(휴직 / 오프보딩) 고정. 뒤집히면 사용자가 매번 `[오프보딩]`에서 시작하게 됨.

**왜 이 스코프인가**
- `parseHandoverType`는 URL 쿼리·폼 초기값처럼 **외부 문자열이 신뢰 경계를 넘는 자리**다. `undefined`가 새 나가면 탭이 미선택 상태로 열려 사용자가 아무것도 못 누르는 사고가 되는데, 이 폴백은 함수 시그니처만 보고는 근거가 드러나지 않아 회귀 위험이 있다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`test/handover-lib-parse-type-fallback#690`, base `test/handover-lib-date-boundary#688`)
- [x] 커밋 컨벤션 준수 (`test: 제목 #690`)
- [x] 아래 `Closes #`에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 없음
- [x] 민감 정보 없음

**Z 필수**

- [x] 🔐 권한 2축 검사 — 순수 함수 테스트라 해당 없음
- [x] 🧬 zod — 매퍼가 아니라 lib이라 해당 없음
- [x] 🕵️ 정직성 — 검증하는 규칙이 코드 주석의 확정 정책과 1:1 대응
- [x] 🎨 디자인 토큰 — 해당 없음

**품질**

- [x] ⚡ 최적화 — 해당 없음
- [x] ♿ a11y — 해당 없음
- [x] ♻️ 재사용 확인 — 인접한 `team-handover/mapper.test.ts` 패턴 그대로 따름
- [x] 🧪 loading / error / empty — 해당 없음
- [x] 브라우저 전용 API — 해당 없음

---

## 🔗 연관 이슈

Closes #690

---

## 📸 스크린샷 (선택)

해당 없음 — 테스트 코드.

---

## 💬 리뷰 포인트

- **PR base가 develop이 아닌 `test/handover-lib-date-boundary#688`(#689)이다.** Day 1 PR을 먼저 병합해야 이 PR이 clean diff로 develop에 붙는다 — 스택 PR 의도. #689가 병합되면 base가 자동으로 develop으로 바뀐다.
- 알 수 없는 값 케이스에 `"vacation"`(소문자)·`"LEAVE"`·`"RETIRE"`를 골랐다. 팀 안에서 옛 값을 잘못 재사용하는 경우를 폭넓게 잡기 위함이다.

---

## 📝 추가 메모

Day 3(후속): `toHandoverCreateRequestBody` BE 필드명 변환 회귀 방지 이어감.