### PR TITLE
test: handover 생성 바디 필드명 변환 회귀 방지 추가 #692

### DIFF
--- a/src/features/handover/lib.test.ts
+++ b/src/features/handover/lib.test.ts
@@ -6,6 +6,7 @@ import {
   handoverDateMin,
   isDueWithinRange,
   parseHandoverType,
+  toHandoverCreateRequestBody,
 } from "./lib";
 
 /**
@@ -120,5 +121,113 @@ describe("HANDOVER_TYPE_TABS — 탭 순서·라벨 계약", () => {
       { type: HANDOVER_TYPE.VACATION, label: "휴직" },
       { type: HANDOVER_TYPE.OFFBOARDING, label: "오프보딩" },
     ]);
+  });
+});
+
+describe("toHandoverCreateRequestBody — FE payload → BE 생성 요청 바디", () => {
+  /*
+    ⚠️ **필드명 변환 회귀 방지 (BE 인수인계 문서 §2·§5)**. 이 경계가 어긋나면 서버가 400만
+       튕겨서 사용자 화면엔 "입력값이 올바르지 않습니다"만 뜨고 실제 원인은 안 보인다 —
+       유형별로 필드 목록·이름·자정 접미사를 하나하나 잡는다.
+  */
+
+  describe("VACATION(휴직)", () => {
+    it("필드명을 BE 계약으로 바꾸고 시작·종료에 자정 `T00:00:00`을 붙인다", () => {
+      const body = toHandoverCreateRequestBody({
+        type: HANDOVER_TYPE.VACATION,
+        startDate: "2026-09-01",
+        endDate: "2026-09-05",
+        actionIds: [11, 22, 33],
+        assignments: { 11: 100, 22: 200 },
+      });
+
+      expect(body).toEqual({
+        handoverType: HANDOVER_TYPE.VACATION,
+        leaveStartAt: "2026-09-01T00:00:00",
+        leaveEndAt: "2026-09-05T00:00:00",
+        selectedActionIds: [11, 22, 33],
+      });
+    });
+
+    /*
+      ⚠️ `assignments`(팀장 본인 휴직의 자가 재배정 맵)는 **생성 바디에 안 실린다** — 별도
+         `PATCH .../items/{actionId}/reassign`으로 나간다(lib.ts L35-37). 여기에 새 나가면
+         BE가 알 수 없는 필드를 받거나 매퍼 순서가 깨진다.
+    */
+    it("`assignments`는 생성 바디에 들어가지 않는다", () => {
+      const body = toHandoverCreateRequestBody({
+        type: HANDOVER_TYPE.VACATION,
+        startDate: "2026-09-01",
+        endDate: "2026-09-05",
+        actionIds: [],
+        assignments: { 11: 100 },
+      });
+
+      expect(body).not.toHaveProperty("assignments");
+    });
+
+    it("오프보딩 전용 필드(`lastWorkingDay`·`note`)는 들어가지 않는다", () => {
+      const body = toHandoverCreateRequestBody({
+        type: HANDOVER_TYPE.VACATION,
+        startDate: "2026-09-01",
+        endDate: "2026-09-05",
+        actionIds: [1],
+        assignments: {},
+      });
+
+      expect(body).not.toHaveProperty("lastWorkingDay");
+      expect(body).not.toHaveProperty("note");
+    });
+  });
+
+  describe("OFFBOARDING(오프보딩)", () => {
+    it("`description → note` · `lastWorkingDay`는 그대로 · 필드명을 BE 계약으로 바꾼다", () => {
+      const body = toHandoverCreateRequestBody({
+        type: HANDOVER_TYPE.OFFBOARDING,
+        description: "9월 10일부로 퇴사합니다.",
+        lastWorkingDay: "2026-09-10",
+        actionIds: [7, 8],
+      });
+
+      expect(body).toEqual({
+        handoverType: HANDOVER_TYPE.OFFBOARDING,
+        lastWorkingDay: "2026-09-10",
+        note: "9월 10일부로 퇴사합니다.",
+        selectedActionIds: [7, 8],
+      });
+    });
+
+    it("휴직 전용 필드(`leaveStartAt`·`leaveEndAt`)는 들어가지 않는다", () => {
+      const body = toHandoverCreateRequestBody({
+        type: HANDOVER_TYPE.OFFBOARDING,
+        description: "인수인계 완료",
+        lastWorkingDay: "2026-09-10",
+        actionIds: [],
+      });
+
+      expect(body).not.toHaveProperty("leaveStartAt");
+      expect(body).not.toHaveProperty("leaveEndAt");
+    });
+  });
+
+  it("두 유형 모두 `actionIds → selectedActionIds`로 이름이 바뀐다 — 공통 계약", () => {
+    const vacation = toHandoverCreateRequestBody({
+      type: HANDOVER_TYPE.VACATION,
+      startDate: "2026-09-01",
+      endDate: "2026-09-05",
+      actionIds: [1, 2],
+      assignments: {},
+    });
+    const offboarding = toHandoverCreateRequestBody({
+      type: HANDOVER_TYPE.OFFBOARDING,
+      description: "인수인계",
+      lastWorkingDay: "2026-09-10",
+      actionIds: [1, 2],
+    });
+
+    expect(vacation).not.toHaveProperty("actionIds");
+    expect(offboarding).not.toHaveProperty("actionIds");
+    expect(vacation.selectedActionIds).toEqual([1, 2]);
+    expect(offboarding.selectedActionIds).toEqual([1, 2]);
   });
 });


### PR DESCRIPTION
## 📋 PR 타입

- [x] test — 테스트 코드

---

## 🗂 작업 영역

- [x] 업무 — 보드 · 액션 · 프로젝트 · 인수인계

---

## 🙋 관련 역할

- [x] LEADER (팀장)
- [x] MEMBER (사원)

---

## 📝 작업 내용

`src/features/handover/lib.test.ts`에 `toHandoverCreateRequestBody` 회귀 방지 6케이스 추가.

**VACATION**
- 필드명 매핑 (`type→handoverType`·`startDate→leaveStartAt`·`endDate→leaveEndAt`·`actionIds→selectedActionIds`)
- 시작·종료에 자정 `T00:00:00` 접미사 붙는지 고정
- `assignments`는 생성 바디에 안 실림 (별도 `PATCH /items/{actionId}/reassign`)
- 오프보딩 전용 필드(`lastWorkingDay`·`note`) 유입 방지

**OFFBOARDING**
- `description → note` 매핑
- `lastWorkingDay`는 그대로
- 휴직 전용 필드(`leaveStartAt`·`leaveEndAt`) 유입 방지

**공통**
- 두 유형 모두 `actionIds → selectedActionIds` 이름 변환 확인

**왜 이 스코프인가**
- 이 함수가 조용히 어긋나면 서버가 400만 튕겨서 사용자 화면에 "입력값이 올바르지 않습니다"만 뜨고 실제 원인은 안 보이는 사고가 된다. 필드 하나라도 이름을 잘못 두면 인수인계 생성 자체가 안 되는 경계라 스펙 그대로 잡아 둔다.

---

## ✅ 작업 체크리스트

**기본**

- [x] 브랜치 명명 규칙 준수 (`test/handover-lib-create-body#692`, base `test/handover-lib-parse-type-fallback#690`)
- [x] 커밋 컨벤션 준수 (`test: 제목 #692`)
- [x] `Closes #`에 이슈 번호 기입
- [x] 불필요한 `console` · 주석 처리된 코드 없음
- [x] 민감 정보 없음

**Z 필수**

- [x] 🔐 권한 2축 검사 — 순수 함수 테스트라 해당 없음
- [x] 🧬 zod — lib 매퍼가 아니라 payload 변환이라 해당 없음 (별도 액션·매퍼 스펙에서 검증)
- [x] 🕵️ 정직성 — 검증 규칙이 BE 인수인계 문서 §2·§5와 1:1 대응
- [x] 🎨 디자인 토큰 — 해당 없음

**품질**

- [x] ⚡ 최적화 — 해당 없음
- [x] ♿ a11y — 해당 없음
- [x] ♻️ 재사용 확인 — 기존 `team-handover/mapper.test.ts` 패턴 그대로
- [x] 🧪 loading / error / empty — 해당 없음
- [x] 브라우저 전용 API — 해당 없음

---

## 🔗 연관 이슈

Closes #692

---

## 📸 스크린샷 (선택)

해당 없음 — 테스트 코드.

---

## 💬 리뷰 포인트

- **PR base가 develop이 아니라 `test/handover-lib-parse-type-fallback#690`(#691)이다.** 스택 PR 마지막 조각 — #689 → #691 → 이 PR 순서로 병합돼야 clean diff. #691이 병합되면 base가 자동으로 develop으로 바뀐다.
- `not.toHaveProperty` 를 반복해서 쓴 이유 — `toEqual`로 잡을 수도 있지만, "이 필드가 새 나가면 안 된다"는 의도를 테스트 이름과 assertion에 함께 남겨 두면 규칙이 뒤집혔을 때 실패 메시지가 규칙을 그대로 말해 준다.

---

## 📝 추가 메모

이 PR로 `handover/lib.ts` 회귀 방지선 3-part 시리즈 완료:
- #689 (Day 1) — 날짜 경계 (`handoverDateMin` · `isDueWithinRange`)
- #691 (Day 2) — 폴백 (`parseHandoverType` · `HANDOVER_TYPE_TABS`)
- 이 PR (Day 3) — 필드명 변환 (`toHandoverCreateRequestBody`)

남은 lib 함수 `sortActionsForVacation`은 별도 이슈로 이어갈지 팀 판단에 맡김.